### PR TITLE
Update AWS-Deployment-Guide.md with minimal requirements

### DIFF
--- a/site/content/en/docs/administration/basics/AWS-Deployment-Guide.md
+++ b/site/content/en/docs/administration/basics/AWS-Deployment-Guide.md
@@ -22,11 +22,25 @@ There are two ways of deploying the CVAT.
    [installation instructions](/docs/administration/basics/installation/).
    The additional step is to add a [security group and rule to allow incoming connections](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html).
 
+**minimal requirements**
+
+Tested instances : t2. Crashes were reported by `cvat_redis` due to low memory. Consult [this blog post](https://docs.keydb.dev/blog/2019/12/16/blog-post/) for more details.
+t2.2xlarge | t2.xlarge and lower
+---|---
+✅ | ❌
+
 For any of above, don't forget to set the `CVAT_HOST` environment variable to the exposed
 AWS public IP address or hostname:
 
 ```bash
 export CVAT_HOST=your-instance.amazonaws.com
+```
+
+You can also create a `.env` file in the cvat repository. The adress is saved even when restarting the server.
+
+```bash
+cd cvat/
+echo CVAT_HOST=your-instance.amazonaws.com > .env
 ```
 
 In case of problems with using hostname, you can also use the public IPV4 instead of hostname.


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Deployment on AWS instance documentation is missing minimal requirement infos.
I report only what has been tested on my end, with version 2.7.6. A global table with the version which introduced `cvat_redis` and instance minimal requirements would be helpful. 
The `.env` tip is nice and saved me a lot of time when crashes happened (only need to restart instance from AWS console and skip the `export` step)

### How has this been tested?
Deploying on AWS instances and noticing frequent crashes after update after update to 2.7.6.
This has been reported and documented in #7085

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
