### PR TITLE
feat: Disable django disk usage health check

### DIFF
--- a/changelog.d/20231125_005843_Podesta_remove_disk_health_check.md
+++ b/changelog.d/20231125_005843_Podesta_remove_disk_health_check.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Django's health-check no longer checks for disk usage.
+  (<https://github.com/opencv/cvat/pull/7180>)

--- a/cvat/settings/production.py
+++ b/cvat/settings/production.py
@@ -12,3 +12,9 @@ NUCLIO['HOST'] = os.getenv('CVAT_NUCLIO_HOST', 'nuclio')
 # https://github.com/moggers87/django-sendfile2
 SENDFILE_BACKEND = 'django_sendfile.backends.nginx'
 SENDFILE_URL = '/'
+
+# Checking for disk usage should be the user responsibility
+# https://django-health-check.readthedocs.io/en/stable/settings.html
+HEALTH_CHECK = {
+    'DISK_USAGE_MAX': None,
+}

--- a/cvat/settings/testing_rest.py
+++ b/cvat/settings/testing_rest.py
@@ -20,7 +20,6 @@ ANALYTICS_CHECK_JOB_DELAY = 10000
 IMPORT_CACHE_CLEAN_DELAY = timedelta(seconds=30)
 
 # The tests should not fail due to high disk utilization of CI infrastructure that we have no control over
-# But let's keep this check enabled
 HEALTH_CHECK = {
-    'DISK_USAGE_MAX': 100,  # percent
+    'DISK_USAGE_MAX': None,
 }


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Currently, CVAT's server completely stops working once disk usage on the drive reaches over 90% usage. This is simply a default setting, that has never been changed: [heatlh-check docs](https://django-health-check.readthedocs.io/en/stable/settings.html). As it is a django thing, it is not documented anywhere on CVAT docs.

Not only it should not be CVAT's responsibility to check disk usage, the check is not very useful, as it checks for percentage use. So even though I may have terabytes of free disk on my server, it still breaks it if I have over 90% usage.

There are several issues related to this, to name a few:
Fixes #5449 
Related #5724, #5685, #6664, #6757, #6564 

Maybe it makes sense to reintroduce a similar feature in the future, but as is, I share @azhavoro view [here](https://github.com/opencv/cvat/issues/5724#issuecomment-1659731758), that it creates more problems than it solves. But to be sensible I believe it should at least:
 1. Do not fail silently to the end user.
 2. Trigger a warning instead of effectively blocking the server.
 3. Check for both percent disk free and total disk free.

### How has this been tested?
Images have been successfully built and used with the changes.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
