### PR TITLE
[GSoC2024] Added additional security headers

### DIFF
--- a/changelog.d/20240319_014508_mann.compi.md
+++ b/changelog.d/20240319_014508_mann.compi.md
@@ -1,0 +1,4 @@
+### Security
+
+- Added security headers.
+  (<https://github.com/opencv/cvat/pull/7626>)

--- a/cvat-ui/react_nginx.conf
+++ b/cvat-ui/react_nginx.conf
@@ -23,7 +23,7 @@ server {
         add_header X-Frame-Options "deny";
         add_header Referrer-Policy "strict-origin-when-cross-origin";
         add_header X-Content-Type-Options "nosniff";
-        add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://app.cvat.ai; font-src 'self' https://fonts.gstatic.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; manifest-src 'self'; worker-src 'self'; 
     }
 
     location /assets {

--- a/cvat-ui/react_nginx.conf
+++ b/cvat-ui/react_nginx.conf
@@ -21,6 +21,9 @@ server {
         add_header Cross-Origin-Embedder-Policy "credentialless";
         add_header Expires 0;
         add_header X-Frame-Options "deny";
+        add_header Referrer-Policy "strict-origin-when-cross-origin";
+        add_header X-Content-Type-Options "nosniff";
+        add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
     }
 
     location /assets {

--- a/cvat/nginx.conf
+++ b/cvat/nginx.conf
@@ -49,7 +49,10 @@ http {
     add_header X-Frame-Options deny;
     add_header Referrer-Policy "strict-origin-when-cross-origin";
     add_header X-Content-Type-Options "nosniff";
-    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+    add_header X-Frame-Options "deny";
+    add_header Referrer-Policy "strict-origin-when-cross-origin";
+    add_header X-Content-Type-Options "nosniff";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://app.cvat.ai; font-src 'self' https://fonts.gstatic.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; manifest-src 'self'; worker-src 'self'; 
 
     server_name _;
 

--- a/cvat/nginx.conf
+++ b/cvat/nginx.conf
@@ -47,6 +47,9 @@ http {
     client_max_body_size 1G;
 
     add_header X-Frame-Options deny;
+    add_header Referrer-Policy "strict-origin-when-cross-origin";
+    add_header X-Content-Type-Options "nosniff";
+    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
 
     server_name _;
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->
Fixes #7398 
Added security headers for Referrer-Policy, X-Content-Type-Options, Content-Security-Policy.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Referring to Issue #7398, Added additional security headers. Added to address the deduction in security score rating third party scanners.

1. `Referrer-Policy "strict-origin-when-cross-origin";`: Limit the referrer information sent when a user navigates away from the website

2. `X-Content-Type-Options "nosniff";`: Prevent browsers from attempting to MIME-sniff the content type of a response to reduce risk of XSS and Content Injection

3. `Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;`: Set rules to limit what resources a browser can load from out site to reduce the risk of XSS and Data Injection.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
