### PR TITLE
Remove gratuitous non-ASCII characters

### DIFF
--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/approximation-accuracy.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/approximation-accuracy.tsx
@@ -35,7 +35,7 @@ export function thresholdFromAccuracy(approxPolyAccuracy: number): number {
     let threshold = 0;
     if (approxPolyMaxDistance > 0) {
         if (approxPolyMaxDistance <= 8) {
-            // −2.75x+7y+1=0 linear made from two points (1; 0.25) and (8; 3)
+            // -2.75x+7y+1=0 linear made from two points (1; 0.25) and (8; 3)
             threshold = (2.75 * approxPolyMaxDistance - 1) / 7;
         } else {
             // 4 for 9, 8 for 10, 16 for 11, 32 for 12, 64 for 13

--- a/cvat-ui/src/index.html
+++ b/cvat-ui/src/index.html
@@ -16,7 +16,6 @@
             name="description"
             content="Computer Vision Annotation Tool (CVAT) is a free, open source, web-based image and video annotation tool which is used for labeling data for computer vision algorithms. CVAT supports the primary tasks of supervised machine learning: object detection, image classification, and image segmentation. CVAT allows users to annotate data for each of these cases"
         />
-        <meta name="”robots”" content="index, follow" />
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wght@8..144,400;8..144,500;8..144,600;8..144,700;8..144,800&family=Sora&display=swap" rel="stylesheet">    </head>

--- a/cvat-ui/src/reducers/notifications-reducer.ts
+++ b/cvat-ui/src/reducers/notifications-reducer.ts
@@ -355,7 +355,7 @@ export default function (state = defaultState, action: AnyAction): Notifications
                         ...state.messages.auth,
                         requestPasswordResetDone: {
                             message: `Check your email for a link to reset your password.
-                            If it doesn’t appear within a few minutes, check your spam folder.`,
+                            If it doesn't appear within a few minutes, check your spam folder.`,
                         },
                     },
                 },

--- a/cvat/apps/iam/permissions.py
+++ b/cvat/apps/iam/permissions.py
@@ -198,9 +198,9 @@ class OpenPolicyAgentPermission(metaclass=ABCMeta):
             q_objects.append(Q())
 
         # By default, a QuerySet will not eliminate duplicate rows. If your
-        # query spans multiple tables (e.g. members__user_id, owner_id), it’s
+        # query spans multiple tables (e.g. members__user_id, owner_id), it's
         # possible to get duplicate results when a QuerySet is evaluated.
-        # That’s when you’d use distinct().
+        # That's when you'd use distinct().
         return queryset.filter(q_objects[0]).distinct()
 
     @classmethod

--- a/tests/cypress/e2e/actions_objects/case_99_save_filtered_object_in_AAM.js
+++ b/tests/cypress/e2e/actions_objects/case_99_save_filtered_object_in_AAM.js
@@ -40,7 +40,7 @@ context('Save filtered object in AAM.', () => {
     });
 
     describe(`Testing case "${caseId}"`, () => {
-        it(`Set filter label == “${labelName}”.`, () => {
+        it(`Set filter label == "${labelName}".`, () => {
             cy.addFiltersRule(0);
             cy.setFilter({
                 groupIndex: 0,

--- a/tests/cypress/e2e/actions_objects2/case_16_z_order_features.js
+++ b/tests/cypress/e2e/actions_objects2/case_16_z_order_features.js
@@ -63,7 +63,7 @@ context('Actions on polygon', () => {
             cy.get('.cvat-canvas-container').click();
         });
 
-        it('Second shape is over the first shape', () => {
+        it('Second shape is over the first shape', () => {
             // The larger the index of an element in the array the closer it is to us
             cy.get('.cvat_canvas_shape').then(($canvasShape) => {
                 expect(Number($canvasShape[1].id.match(/\d+$/))).to.be.equal(2);
@@ -76,7 +76,7 @@ context('Actions on polygon', () => {
             cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
         });
 
-        it('First shape is over the second shape', () => {
+        it('First shape is over the second shape', () => {
             // The larger the index of an element in the array the closer it is to us
             cy.get('.cvat_canvas_shape').then(($canvasShape) => {
                 expect(Number($canvasShape[1].id.match(/\d+$/))).to.be.equal(1);

--- a/tests/cypress/e2e/actions_objects2/case_17_lock_hide_features.js
+++ b/tests/cypress/e2e/actions_objects2/case_17_lock_hide_features.js
@@ -218,7 +218,7 @@ context('Lock/hide features.', () => {
                 cy.contains('Labels').click();
             });
         });
-        it('Repeat hide/lock for one of the labels. Objects with other labels weren’t affected.', () => {
+        it("Repeat hide/lock for one of the labels. Objects with other labels weren't affected.", () => {
             const objectsSameLabel = ['cvat_canvas_shape_1', 'cvat_canvas_shape_2', 'cvat_canvas_shape_3'];
             cy.get('.cvat-objects-sidebar-labels-list').within(() => {
                 // Hide and lock all object with "Main task" label (#cvat_canvas_shape_1-3).

--- a/tests/cypress/e2e/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/e2e/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -33,7 +33,7 @@ context('Changing a default value for an attribute.', () => {
     });
 
     describe(`Testing case "${caseId}", issue 2968`, () => {
-        it('Add a label, add text (leave it’s value empty by default) & checkbox attributes.', () => {
+        it('Add a label, add text (leave its value empty by default) & checkbox attributes.', () => {
             cy.intercept('PATCH', '/api/tasks/**').as('patchTask');
             cy.addNewLabel({ name: additionalLabel }, additionalAttrsLabel);
             cy.wait('@patchTask').its('response.statusCode').should('equal', 200);


### PR DESCRIPTION
In `cvat-ui/src/index.html`, the meta element seems useless (the default is already to index and follow; I'm not even sure `index` and `follow` are valid values). So just remove it entirely.

<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Bug Fixes**
	- Corrected formatting of HTML meta tags for proper syntax.
	- Enhanced error handling and messaging in the notifications system for better clarity.
	- Updated test case descriptions for consistency and readability.

- **Chores**
	- Minor documentation updates for consistency in comments across various files.
	- Adjusted string formatting in Cypress test cases for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->