### PR TITLE
[GSoC2024] Modified Attribute Serializer to retain values after request

### DIFF
--- a/changelog.d/20240407_000430_mann.compi_multilines_attribute_issue.md
+++ b/changelog.d/20240407_000430_mann.compi_multilines_attribute_issue.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Corrected handling multiline text attributes so they don’t get converted into comma-separated values by REST API
+  (<https://github.com/opencv/cvat/pull/7736>)

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -225,10 +225,7 @@ class UserSerializer(serializers.ModelSerializer):
 
 class DelimitedStringListField(serializers.ListField):
     def to_representation(self, value):
-        if isinstance(value, str):
-            value = value.split('\n')
-
-        return super().to_representation(value)
+        return super().to_representation(value.split('\n'))
 
     def to_internal_value(self, data):
         return '\n'.join(super().to_internal_value(data))


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context

Fixing #6502: While creating or editing a multiline text attribute on a label, it was replacing the default newlines with commas.

![image](https://github.com/cvat-ai/cvat/assets/89384052/9aa7e0aa-8904-4581-b0da-4b9edeff9f48)

This behavior was not appropriate. The cause of this issue was identified as the `DelimitedStringListField` serializer:

https://github.com/cvat-ai/cvat/blob/70a7cc0944ea1684defce29687d56529f7a24455/cvat/apps/engine/serializers.py#L226-L240

The fix was implemented by overriding the `to_representation()` method in the parent `AttributeSerializer`. This method converts the `ListField` into a list with only a single object with the text concatenated if the `input_type` in the context is 'text'.

Nested Label Serializers:
- `LabelSerializer`
  - `SublabelSerializer`
    - `AttributeSerializer`
      - `DelimitedStringListField`

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Changes persist as intended in the Tasks, Projects and Job views. 

![Screenshot 2024-04-07 at 12 22 01 AM](https://github.com/cvat-ai/cvat/assets/89384052/72bb2d22-f9ac-4eba-8051-79e47621e9b2)

![Screenshot 2024-04-07 at 12 22 19 AM](https://github.com/cvat-ai/cvat/assets/89384052/46cca131-e5b3-47b0-82b4-4db7830ee445)

![image](https://github.com/cvat-ai/cvat/assets/89384052/53991dcb-c9e2-4125-9fc4-9baa1305daff)

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
