### PR TITLE
[GSoC2024] - fix/handling-multiline-text-attribute

### DIFF
--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -239,6 +239,13 @@ class AttributeSerializer(serializers.ModelSerializer):
         model = models.AttributeSpec
         fields = ('id', 'name', 'mutable', 'input_type', 'default_value', 'values')
 
+    def to_representation(self, instance):
+        attribute = super().to_representation(instance)
+        if attribute.get('input_type') == models.AttributeType.TEXT:
+            attribute['values'] = ["\n".join(attribute['values'])]
+
+        return attribute
+
 class SublabelSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(required=False)
     attributes = AttributeSerializer(many=True, source='attributespec_set', default=[],


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->
This PR fixes the issue of multiline text attributes not being displayed correctly. Initially, the multiline attribute values were separated by commas rather than newlines.
<!-- Provide a general summary of your changes in the Title above -->
Modified the serialized values to replace commas with newlines.
### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The issue fixed in this PR is [ REST API handles multiline attributes incorrect way #6502 ](https://github.com/cvat-ai/cvat/issues/6502)

The screenshot for serialized attribute value
![Screenshot from 2024-04-08 15-43-08](https://github.com/cvat-ai/cvat/assets/76646497/3268e7d6-4dee-45a2-bd62-2ad0052eb731)

The screenshot for the payload
![Screenshot from 2024-04-08 15-37-28](https://github.com/cvat-ai/cvat/assets/76646497/bf98da16-31b8-49e4-9cbc-c295dfd28afe)

### How has this been tested?
Logged the sterilized data in the backend as well as the frontend for multiple attributes.
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
~~- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->~~
~~- [ ] I have updated the documentation accordingly~~
~~- [ ] I have added tests to cover my changes~~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
~~- [ ] I have increased versions of npm packages if it is necessary~~
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
