### PR TITLE
Fix spurious failures in `case_17_lock_hide_features.js`

### DIFF
--- a/tests/cypress/e2e/actions_objects2/case_17_lock_hide_features.js
+++ b/tests/cypress/e2e/actions_objects2/case_17_lock_hide_features.js
@@ -103,12 +103,7 @@ context('Lock/hide features.', () => {
     });
 
     beforeEach(() => {
-        cy.document().then((doc) => {
-            const tooltips = Array.from(doc.querySelectorAll('.ant-tooltip'));
-            if (tooltips.length > 0) {
-                cy.get('.ant-tooltip').invoke('hide');
-            }
-        });
+        cy.hideTooltips();
     });
 
     describe(`Testing case "${caseId}"`, () => {

--- a/tests/cypress/e2e/issues_prs/issue_2485_navigation_empty_frames.js
+++ b/tests/cypress/e2e/issues_prs/issue_2485_navigation_empty_frames.js
@@ -38,7 +38,6 @@ context('Navigation to empty frames', () => {
     });
 
     beforeEach(() => {
-        cy.wait(500); // wait while tooltips are opened
         cy.hideTooltips();
     });
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1528,6 +1528,8 @@ Cypress.Commands.add('interactAnnotationObjectMenu', (parentSelector, button) =>
 });
 
 Cypress.Commands.add('hideTooltips', () => {
+    cy.wait(500); // wait while tooltips are opened
+
     cy.document().then((doc) => {
         const tooltips = Array.from(doc.querySelectorAll('.ant-tooltip'));
         if (tooltips.length > 0) {


### PR DESCRIPTION

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
#7654 changed the sidebar layout in such a way that mousing over the "Switch hidden property" button for an object can show a tooltip that obscures the "Switch hidden property for all" button. This is exactly what happens in this test at the end of the "Go to polygon" section.

The test is supposed to work around this, by hiding the tooltips before each section, but the workaround is insufficiently robust. Sometimes, the workaround executes _before_ the tooltip is shown, so it does nothing. Then the tooltip appears and covers up the "Switch hidden property for all" button. Then the next section tries to click this button, and fails.

Fix this by taking another workaround from `issue_2485_navigation_empty_frames.js`, moving it into the `hideTooltips` command, and then using that command in `case_17_lock_hide_features.js`.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
