### PR TITLE
Improve code for working with the OPA bundle

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -167,7 +167,6 @@
             "env": {
                 "CVAT_SERVERLESS": "1",
                 "ALLOWED_HOSTS": "*",
-                "IAM_OPA_BUNDLE": "1",
                 "DJANGO_LOG_SERVER_HOST": "localhost",
                 "DJANGO_LOG_SERVER_PORT": "8282"
             },

--- a/cvat/apps/iam/apps.py
+++ b/cvat/apps/iam/apps.py
@@ -1,8 +1,4 @@
-import os
-from attr.converters import to_bool
 from django.apps import AppConfig
-
-from .utils import create_opa_bundle
 
 class IAMConfig(AppConfig):
     name = 'cvat.apps.iam'
@@ -10,6 +6,3 @@ class IAMConfig(AppConfig):
     def ready(self):
         from .signals import register_signals
         register_signals(self)
-
-        if to_bool(os.environ.get("IAM_OPA_BUNDLE", False)):
-            create_opa_bundle()

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -436,9 +436,6 @@ os.makedirs(CLOUD_STORAGE_ROOT, exist_ok=True)
 TMP_FILES_ROOT = os.path.join(DATA_ROOT, 'tmp')
 os.makedirs(TMP_FILES_ROOT, exist_ok=True)
 
-IAM_OPA_BUNDLE_PATH = os.path.join(STATIC_ROOT, 'opa', 'bundle.tar.gz')
-os.makedirs(Path(IAM_OPA_BUNDLE_PATH).parent, exist_ok=True)
-
 # logging is known to be unreliable with RQ when using async transports
 vector_log_handler = os.getenv('VECTOR_EVENT_HANDLER', 'AsynchronousLogstashHandler')
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,6 @@ services:
       DJANGO_MODWSGI_EXTRA_ARGS: ''
       ALLOWED_HOSTS: '*'
       ADAPTIVE_AUTO_ANNOTATION: 'false'
-      IAM_OPA_BUNDLE: '1'
       NUMPROCS: 2
       CVAT_ANALYTICS: 1
       CVAT_BASE_URL:

--- a/helm-chart/templates/cvat_backend/server/deployment.yml
+++ b/helm-chart/templates/cvat_backend/server/deployment.yml
@@ -59,8 +59,6 @@ spec:
             value: {{ $localValues.envs.ALLOWED_HOSTS | squote}}
           - name: DJANGO_MODWSGI_EXTRA_ARGS
             value: {{ $localValues.envs.DJANGO_MODWSGI_EXTRA_ARGS}}
-          - name: IAM_OPA_BUNDLE
-            value: "1"
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
           {{- with concat .Values.cvat.backend.additionalEnv $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
There are three changes here:

* Don't save the bundle to a file. There seems to be no reason to do that; the bundle is very small (<8000 bytes), and we already load it fully into memory to generate the ETag, so just generate it in memory and keep it there.

  This also fixes a possible race condition where a server process starts to read the bundle file right as another server process starts up and overwrites it.

* Generate the bundle on-demand rather than at startup. This obviates the need for the `IAM_OPA_BUNDLE` environment variable.

* Generate the ETag once, instead of on every request. There's no reason to hash the same bundle over and over.

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
A patch I'm working on (the sequel to #7734) requires the bundle to be generated on-demand (and it seems to me like a simpler approach in general). Removing the bundle file was a consequence of that. The etag change I implemented because I was updating the related code anyway, and it seemed like a good idea.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I checked that the `/api/auth/rules` endpoint still works and that OPA is still getting 304 responses on repeat requests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
