### PR TITLE
Mask stays pixelated during editing

### DIFF
--- a/changelog.d/20240410_160047_boris_pixelated_masks_layer.md
+++ b/changelog.d/20240410_160047_boris_pixelated_masks_layer.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- When user starts editing a mask, it becomes smoother (not pixelated)
+  (<https://github.com/cvat-ai/cvat/pull/7747>)

--- a/cvat-canvas/src/scss/canvas.scss
+++ b/cvat-canvas/src/scss/canvas.scss
@@ -430,6 +430,8 @@ g.cvat_canvas_shape_occluded {
 }
 
 .cvat_masks_canvas_wrapper {
+    @extend .cvat_canvas_pixelized;
+
     z-index: 3;
     display: none;
 }

--- a/cvat-canvas/src/typescript/masksHandler.ts
+++ b/cvat-canvas/src/typescript/masksHandler.ts
@@ -90,6 +90,8 @@ export class MasksHandlerImpl implements MasksHandler {
                 opacity: 0.75,
                 left: this.latestMousePos.x - this.tool.size / 2,
                 top: this.latestMousePos.y - this.tool.size / 2,
+                strokeWidth: 1,
+                stroke: 'white',
             };
             this.brushMarker = this.tool.form === 'circle' ? new fabric.Circle({
                 ...common,

--- a/cvat-canvas/src/typescript/masksHandler.ts
+++ b/cvat-canvas/src/typescript/masksHandler.ts
@@ -90,12 +90,10 @@ export class MasksHandlerImpl implements MasksHandler {
                 opacity: 0.75,
                 left: this.latestMousePos.x - this.tool.size / 2,
                 top: this.latestMousePos.y - this.tool.size / 2,
-                stroke: 'white',
-                strokeWidth: 1,
             };
             this.brushMarker = this.tool.form === 'circle' ? new fabric.Circle({
                 ...common,
-                radius: this.tool.size / 2,
+                radius: Math.round(this.tool.size / 2),
             }) : new fabric.Rect({
                 ...common,
                 width: this.tool.size,
@@ -473,7 +471,7 @@ export class MasksHandlerImpl implements MasksHandler {
                 if (tool.form === 'circle') {
                     shape = new fabric.Circle({
                         ...shapeProperties,
-                        radius: tool.size / 2,
+                        radius: Math.round(tool.size / 2),
                     });
                 } else if (tool.form === 'square') {
                     shape = new fabric.Rect({


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Drawn and editable mask before the patch:
![image](https://github.com/cvat-ai/cvat/assets/40690378/ce45d27b-89cf-4f17-8a15-e57ae1168015)

After the patch:
![image](https://github.com/cvat-ai/cvat/assets/40690378/1d39bca5-54cf-4422-ac06-d3b26158069f)


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
