### PR TITLE
[GSoC2024] Fix difficult two point polyline dragging

### DIFF
--- a/changelog.d/20240416_014253_128531452+Andy-W-Developer_fix_polyline_dragging.md
+++ b/changelog.d/20240416_014253_128531452+Andy-W-Developer_fix_polyline_dragging.md
@@ -1,0 +1,5 @@
+### Changed
+
+- The stroke width of two point polylines now increases when
+  unpinned and activated for easier dragging
+  (<https://github.com/cvat-ai/cvat/pull/7764>)

--- a/cvat-canvas/package.json
+++ b/cvat-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-canvas",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "type": "module",
   "description": "Part of Computer Vision Annotation Tool which presents its canvas library",
   "main": "src/canvas.ts",

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -634,10 +634,17 @@ export class CanvasViewImpl implements CanvasView, Listener {
         // Transform all drawn shapes and text
         for (const key of Object.keys(this.svgShapes)) {
             const clientID = +key;
+            const state = this.drawnStates[clientID];
             const object = this.svgShapes[clientID];
-            object.attr({
-                'stroke-width': consts.BASE_STROKE_WIDTH / this.geometry.scale,
-            });
+            if (object.hasClass('cvat_canvas_shape_activated') && !state.pinned && state.shapeType === 'polyline' && state.points.length === 4) {
+                object.attr({
+                    'stroke-width': (consts.BASE_STROKE_WIDTH * 4) / this.geometry.scale,
+                });
+            } else {
+                object.attr({
+                    'stroke-width': consts.BASE_STROKE_WIDTH / this.geometry.scale,
+                });
+            }
             if (object.type === 'circle') {
                 object.attr('r', `${this.configuration.controlPointsSize / this.geometry.scale}`);
             }
@@ -2265,6 +2272,12 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 (shape as any).off('dragstart');
                 (shape as any).off('dragend');
                 (shape as any).draggable(false);
+
+                if (drawnState.shapeType === 'polyline' && drawnState.points.length === 4) {
+                    shape.attr({
+                        'stroke-width': consts.BASE_STROKE_WIDTH / this.geometry.scale,
+                    });
+                }
             }
 
             if (drawnState.shapeType !== 'points') {
@@ -2389,6 +2402,12 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     ...(state.shapeType === 'mask' ? { snapToGrid: 1 } : {}),
                 })
                 .on('dragstart', (): void => {
+                    if (state.shapeType === 'polyline' && state.points.length === 4) {
+                        shape.attr({
+                            'stroke-width': consts.BASE_STROKE_WIDTH / this.geometry.scale,
+                        });
+                    }
+
                     this.mode = Mode.DRAG;
                     hideText();
                     (shape as any).on('remove.drag', (): void => {
@@ -2450,7 +2469,19 @@ export class CanvasViewImpl implements CanvasView, Listener {
                             }),
                         );
                     }
+
+                    if (state.shapeType === 'polyline' && state.points.length === 4) {
+                        shape.attr({
+                            'stroke-width': (consts.BASE_STROKE_WIDTH * 4) / this.geometry.scale,
+                        });
+                    }
                 });
+
+            if (state.shapeType === 'polyline' && state.points.length === 4) {
+                shape.attr({
+                    'stroke-width': (consts.BASE_STROKE_WIDTH * 4) / this.geometry.scale,
+                });
+            }
         }
 
         if (state.shapeType !== 'points') {
@@ -2489,6 +2520,12 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     snapToAngle: this.snapToAngleResize,
                 })
                 .on('resizestart', (): void => {
+                    if (state.shapeType === 'polyline' && state.points.length === 4) {
+                        shape.attr({
+                            'stroke-width': consts.BASE_STROKE_WIDTH / this.geometry.scale,
+                        });
+                    }
+
                     this.mode = Mode.RESIZE;
                     resized = false;
                     hideDirection();
@@ -2541,6 +2578,12 @@ export class CanvasViewImpl implements CanvasView, Listener {
                                 },
                             }),
                         );
+                    }
+
+                    if (!state.pinned && state.shapeType === 'polyline' && state.points.length === 4) {
+                        shape.attr({
+                            'stroke-width': (consts.BASE_STROKE_WIDTH * 4) / this.geometry.scale,
+                        });
                     }
                 });
         } else {


### PR DESCRIPTION
### Motivation and context
Fix #6841
It is hard to drag two point polylines because they are small and need the cursor to be placed exactly on itself.

Implemented by increasing the appropriate (polyline, 2 points, unpinned and activated) shapes stroke-width attr.
If it is a drag or resize event, the stroke-width will be reset so that the annotator sees exactly what position or size the final polyline will be.
The new stroke-width is manually set to consts.BASE_STROKE_WIDTH * 4.

![Screenshot](https://github.com/cvat-ai/cvat/assets/128531452/ff2bc732-8682-4f5d-9a4a-229420da6ed1)
My cursor isn't captured but the draggable area is correctly resized with the activated polyline.


https://github.com/cvat-ai/cvat/assets/128531452/ad4472ca-639d-451a-a4f5-cedc2772cef2
Shows the behavior when activated/deactivated, dragged, resized and pinned/unpinned.

There is a lot of repeated code but I decided to not put everything in a function or add a new STROKE_WIDTH constant because this is for a very specific case - a two point polyline that is unpinned and activate, and the function would look very out of place, let me know if this should be changed.

### How has this been tested?
Branch: develop, fbc2610d2

Manually hover, deselect, resize, drag, pin and unpin two point polylines.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->


- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
~~- [ ] I have updated the documentation accordingly~~
~~- [ ] I have added tests to cover my changes~~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.

### Issues
- [x] Clicking on the resize handler or dragging, without actually resizing or dragging won't automatically resize the polyline back up.

Ideally (in my opinion) this would be implemented:
 - With no changes to the shape.
 - With no custom drag behavior and no function overrides so that default svg.draggable.js is still used.
 - Use distance to the shape and trigger svg.draggable functions with mouse events instead so that the annotator can click on an area around the activated shape (in addition to the default behavior.)

As of now, that is the only way I can think of to drag a shape without changing the shapes size, as svg.draggable is attached to the shape itself.

The reason for wanting to avoid temporarily changing the shapes size is to completely avoid a situation where it may be possible to save polylines with the increased size, a number of polylines close together may also make selecting more difficult from the increased size of one of the polyline, although the annotator could use the sidebar.

When implemented as an event firing function that takes a shape, it can also be applied to other shapes, as this problem can also exist if they are overly small, I tested this by making a rect with a very small dimensions.

### Reasons for not implementing the above
DragHandler is not exported and I was unable to trigger svg.draggables init with fired events of my own.

I'm certain that I've gotten quite a few details wrong, if this is a better implementation, please correct me and I'll work on it afterwards!