### PR TITLE
[GSoC2024] Top Bar Disabled in Model Page (Resolved Issue#7762)

### DIFF
--- a/changelog.d/20240414_114237_kavikumarceo_resolved_issue_7762.md
+++ b/changelog.d/20240414_114237_kavikumarceo_resolved_issue_7762.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Made the top bar to get enabled when models are available in model page.
+  (<https://github.com/cvat-ai/cvat/pull/7765>)

--- a/cvat-ui/src/components/models-page/models-page.tsx
+++ b/cvat-ui/src/components/models-page/models-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) 2022-2024 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/models-page/models-page.tsx
+++ b/cvat-ui/src/components/models-page/models-page.tsx
@@ -56,7 +56,7 @@ function ModelsPageComponent(): JSX.Element {
     return (
         <div className='cvat-models-page'>
             <TopBar
-                disabled
+                disabled={!((totalCount && !pageOutOfBounds))}
                 query={updatedQuery}
                 onApplySearch={(search: string | null) => {
                     dispatch(


### PR DESCRIPTION
I've modified the top bar to get enabled when there are models available.

Fix: #7762 