### PR TITLE
[GSoC2024]Import annotations keeping current ones(#4747)

### DIFF
--- a/changelog.d/20240415_193335_ebayego_keep_old_annotations_on_import.md
+++ b/changelog.d/20240415_193335_ebayego_keep_old_annotations_on_import.md
@@ -1,0 +1,4 @@
+### Added
+
+- Added a feature that allows to keep current annotations without deleting them when new ones are imported, by checking the option.
+  (<https://github.com/cvat-ai/cvat/pull/7771>)

--- a/cvat-ui/src/actions/import-actions.ts
+++ b/cvat-ui/src/actions/import-actions.ts
@@ -71,6 +71,7 @@ export const importDatasetAsync = (
     sourceStorage: Storage,
     file: File | string,
     convMaskToPoly: boolean,
+    keepOldAnnotations: boolean,
 ): ThunkAction => (
     async (dispatch, getState) => {
         const resource = instance instanceof core.classes.Project ? 'dataset' : 'annotation';
@@ -86,6 +87,7 @@ export const importDatasetAsync = (
                 await instance.annotations
                     .importDataset(format, useDefaultSettings, sourceStorage, file, {
                         convMaskToPoly,
+                        keepOldAnnotations,
                         updateStatusCallback: (message: string, progress: number) => (
                             dispatch(importActions.importDatasetUpdateStatus(
                                 instance, Math.floor(progress * 100), message,
@@ -97,7 +99,10 @@ export const importDatasetAsync = (
                     throw Error('Only one importing of annotation/dataset allowed at the same time');
                 }
                 dispatch(importActions.importDataset(instance, format));
-                await instance.annotations.upload(format, useDefaultSettings, sourceStorage, file, { convMaskToPoly });
+                await instance.annotations.upload(format, useDefaultSettings, sourceStorage, file, {
+                    convMaskToPoly,
+                    keepOldAnnotations,
+                });
             } else { // job
                 if (state.import.tasks.dataset.current?.[instance.taskId]) {
                     throw Error('Annotations is being uploaded for the task');
@@ -108,7 +113,10 @@ export const importDatasetAsync = (
 
                 dispatch(importActions.importDataset(instance, format));
 
-                await instance.annotations.upload(format, useDefaultSettings, sourceStorage, file, { convMaskToPoly });
+                await instance.annotations.upload(format, useDefaultSettings, sourceStorage, file, {
+                    convMaskToPoly,
+                    keepOldAnnotations,
+                });
                 await instance.logger.log(EventScope.uploadAnnotations);
                 await instance.annotations.clear(true);
                 await instance.actions.clear();

--- a/cvat-ui/src/components/import-dataset/styles.scss
+++ b/cvat-ui/src/components/import-dataset/styles.scss
@@ -36,8 +36,14 @@
 .cvat-modal-import-switch-conv-mask-to-poly {
     display: table-cell;
 }
+.cvat-modal-import-switch-keep-old-annotations {
+    display: table-cell;
+}
 
 .cvat-modal-import-switch-use-default-storage-container,
 .cvat-modal-import-switch-conv-mask-to-poly-container {
+    width: 100%;
+}
+.cvat-modal-import-switch-keep-old-annotations-container {
     width: 100%;
 }

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -696,7 +696,10 @@ class JobAnnotation:
             db_job=self.db_job,
             create_callback=self.create,
         )
-        self.delete()
+
+        keep_old_annotations = options.get('keep_old_annotations', True)
+        if not keep_old_annotations:
+            self.delete()
 
         temp_dir_base = self.db_job.get_tmp_dirname()
         os.makedirs(temp_dir_base, exist_ok=True)
@@ -796,7 +799,9 @@ class TaskAnnotation:
             db_task=self.db_task,
             create_callback=self.create,
         )
-        self.delete()
+        keep_old_annotations = options.get('keep_old_annotations', True)
+        if not keep_old_annotations:
+            self.delete()
 
         temp_dir_base = self.db_task.get_tmp_dirname()
         os.makedirs(temp_dir_base, exist_ok=True)
@@ -910,25 +915,25 @@ def export_task(task_id, dst_file, format_name, server_url=None, save_images=Fal
         task.export(f, exporter, host=server_url, save_images=save_images)
 
 @transaction.atomic
-def import_task_annotations(src_file, task_id, format_name, conv_mask_to_poly):
+def import_task_annotations(src_file, task_id, format_name, conv_mask_to_poly, keep_old_annotations):
     task = TaskAnnotation(task_id)
     task.init_from_db()
 
     importer = make_importer(format_name)
     with open(src_file, 'rb') as f:
         try:
-            task.import_annotations(f, importer, conv_mask_to_poly=conv_mask_to_poly)
+            task.import_annotations(f, importer, conv_mask_to_poly=conv_mask_to_poly, keep_old_annotations=keep_old_annotations)
         except (DatasetError, DatasetImportError, DatasetNotFoundError) as ex:
             raise CvatImportError(str(ex))
 
 @transaction.atomic
-def import_job_annotations(src_file, job_id, format_name, conv_mask_to_poly):
+def import_job_annotations(src_file, job_id, format_name, conv_mask_to_poly, keep_old_annotations):
     job = JobAnnotation(job_id)
     job.init_from_db()
 
     importer = make_importer(format_name)
     with open(src_file, 'rb') as f:
         try:
-            job.import_annotations(f, importer, conv_mask_to_poly=conv_mask_to_poly)
+            job.import_annotations(f, importer, conv_mask_to_poly=conv_mask_to_poly, keep_old_annotations=keep_old_annotations)
         except (DatasetError, DatasetImportError, DatasetNotFoundError) as ex:
             raise CvatImportError(str(ex))


### PR DESCRIPTION
This pull request keeps the current annotations without deleting them when new ones are imported, joining the current ones with the new ones.

### Motivation and context
This change is linked to issue #4747, and it arises from the need to preserve the current annotations instead of deleting them when new ones are imported. Now, in the annotations import window, there will be an option to keep the current annotations or not to keep them. To achieve this, the mentioned switch option has been added in the import window, and also a new API flag is created, which takes the value of the switch and forwards it to the backend logic, where it is processed and, if true, does not delete the current annotations.
![image](https://github.com/cvat-ai/cvat/assets/59049189/c2d238a5-779c-4094-aa0a-fca84d568fa3)

### How has this been tested?
I have manually tested importing annotations with different formats and types, including having current annotations of all possible types to cover all possible cases. It has also been tested when the "keep old annotations" option is not checked, and in all cases, it works correctly. 
As for the code tests, if the current tests run successfully, it means that the new functionality of not deleting the annotations works correctly, as this is True by default. I am currently working on coding the tests to verify that importing also works when the current annotations are deleted.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

The test checkbox has not been checked due to the explanation provided in the previous section. I will mark it once the coded tests are developed.

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
