### PR TITLE
Fixed showing annotations at 0 frame

### DIFF
--- a/changelog.d/20240423_142255_klakhov_fix_missing_annotations.md
+++ b/changelog.d/20240423_142255_klakhov_fix_missing_annotations.md
@@ -1,0 +1,4 @@
+### Fixed 
+
+- Annotations are not shown on the `0` frame
+  (<https://github.com/cvat-ai/cvat/pull/7796>)

--- a/changelog.d/20240423_142255_klakhov_fix_missing_annotations.md
+++ b/changelog.d/20240423_142255_klakhov_fix_missing_annotations.md
@@ -1,4 +1,4 @@
-### Fixed 
+### Fixed
 
-- Annotations are not shown on the `0` frame
+- Annotations are not shown on the `0` frame sometimes
   (<https://github.com/cvat-ai/cvat/pull/7796>)

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -554,6 +554,11 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
         }
 
         this.data.imageID = frameData.number;
+
+        const prevZLayer = this.data.zLayer;
+        const prevObjects = this.data.objects;
+        this.data.zLayer = zLayer;
+        this.data.objects = objectStates;
         frameData
             .data((): void => {
                 this.data.image = null;
@@ -596,8 +601,6 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
                 }
 
                 this.notify(UpdateReasons.IMAGE_CHANGED);
-                this.data.zLayer = zLayer;
-                this.data.objects = objectStates;
                 this.notify(UpdateReasons.OBJECTS_UPDATED);
             })
             .catch((exception: unknown): void => {
@@ -608,6 +611,8 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
                     } else {
                         this.data.exception = new Error('Unknown error occured when fetching image data');
                     }
+                    this.data.objects = prevObjects;
+                    this.data.zLayer = prevZLayer;
                     this.notify(UpdateReasons.DATA_FAILED);
                 }
             });

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -555,6 +555,9 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
 
         this.data.imageID = frameData.number;
 
+        // We set objects immideately to avoid outdated data in case if setup() is called
+        // multiple times before the frameData.data() promise is resolved.
+        // If promise is rejected we restore previous objects
         const prevZLayer = this.data.zLayer;
         const prevObjects = this.data.objects;
         this.data.zLayer = zLayer;
@@ -611,8 +614,11 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
                     } else {
                         this.data.exception = new Error('Unknown error occured when fetching image data');
                     }
-                    this.data.objects = prevObjects;
-                    this.data.zLayer = prevZLayer;
+                    // Restore only relevant data in case if setup() is called multiple times
+                    if (this.data.objects === objectStates && this.data.zLayer === zLayer) {
+                        this.data.objects = prevObjects;
+                        this.data.zLayer = prevZLayer;
+                    }
                     this.notify(UpdateReasons.DATA_FAILED);
                 }
             });

--- a/cvat-core/package.json
+++ b/cvat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-core",
-  "version": "15.0.2",
+  "version": "15.0.3",
   "type": "module",
   "description": "Part of Computer Vision Tool which presents an interface for client-side integration",
   "main": "src/api.ts",

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.63.6",
+  "version": "1.63.7",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/annotation-page/annotation-page.tsx
+++ b/cvat-ui/src/components/annotation-page/annotation-page.tsx
@@ -28,6 +28,7 @@ import { readLatestFrame } from 'utils/remember-latest-frame';
 interface Props {
     job: any | null | undefined;
     fetching: boolean;
+    annotationsInitialized: boolean;
     frameNumber: number;
     workspace: Workspace;
     getJob(): void;
@@ -38,7 +39,7 @@ interface Props {
 
 export default function AnnotationPageComponent(props: Props): JSX.Element {
     const {
-        job, fetching, workspace, frameNumber, getJob, closeJob, saveLogs, changeFrame,
+        job, fetching, annotationsInitialized, workspace, frameNumber, getJob, closeJob, saveLogs, changeFrame,
     } = props;
     const prevJob = usePrevious(job);
     const prevFetching = usePrevious(fetching);
@@ -124,7 +125,7 @@ export default function AnnotationPageComponent(props: Props): JSX.Element {
         }
     }, [job, fetching, prevJob, prevFetching]);
 
-    if (job === null) {
+    if (job === null || !annotationsInitialized) {
         return <Spin size='large' className='cvat-spinner' />;
     }
 

--- a/cvat-ui/src/containers/annotation-page/annotation-page.tsx
+++ b/cvat-ui/src/containers/annotation-page/annotation-page.tsx
@@ -24,6 +24,7 @@ interface StateToProps {
     job: any | null | undefined;
     frameNumber: number;
     fetching: boolean;
+    annotationsInitialized: boolean;
     workspace: Workspace;
 }
 
@@ -46,6 +47,9 @@ function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
                     number: frameNumber,
                 },
             },
+            annotations: {
+                initialized: annotationsInitialized,
+            },
         },
     } = state;
 
@@ -54,6 +58,7 @@ function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
         fetching,
         workspace,
         frameNumber,
+        annotationsInitialized,
     };
 }
 

--- a/cvat-ui/src/reducers/annotation-reducer.ts
+++ b/cvat-ui/src/reducers/annotation-reducer.ts
@@ -104,6 +104,7 @@ const defaultState: AnnotationState = {
         states: [],
         filters: [],
         resetGroupFlag: false,
+        initialized: false,
         history: {
             undo: [],
             redo: [],
@@ -143,6 +144,10 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                     instance: null,
                     requestedId: action.payload.requestedId,
                     fetching: true,
+                },
+                annotations: {
+                    ...state.annotations,
+                    initialized: false,
                 },
             };
         }
@@ -842,11 +847,21 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                     activatedStateID: updateActivatedStateID(states, activatedStateID),
                     states,
                     history,
+                    initialized: true,
                     zLayer: {
                         min: minZ,
                         max: maxZ,
                         cur: clamp(state.annotations.zLayer.cur, minZ, maxZ),
                     },
+                },
+            };
+        }
+        case AnnotationActionTypes.FETCH_ANNOTATIONS_FAILED: {
+            return {
+                ...state,
+                annotations: {
+                    ...state.annotations,
+                    initialized: true,
                 },
             };
         }

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -760,6 +760,7 @@ export interface AnnotationState {
         states: any[];
         filters: object[];
         resetGroupFlag: boolean;
+        initialized: boolean;
         history: {
             undo: [string, number][];
             redo: [string, number][];


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
After the PR #7714 annotations are not loaded to the store with `GET_JOB_SUCCESS` action, instead we load them in separate async action `fetchAnnotationsAsync`. 
That leads to the problem: `CanvasWrapper` component is initially mounted with empty `annotations` array. That leads to such function calls: `updateCanvas` -> ` canvasInstance.setup` -> [the promise is created](https://github.com/cvat-ai/cvat/blob/develop/cvat-canvas/src/typescript/canvasModel.ts#L600) that will set this.data.objects to empty array.
Then the annotations are put to the store, `CanvasWrapper` runs update hook, where the chain is called again: `updateCanvas` -> ` canvasInstance.setup` -> but instead of promise, [the objects are assigned right away](https://github.com/cvat-ai/cvat/blob/develop/cvat-canvas/src/typescript/canvasModel.ts#L551). After that when the first promise will be executed the objects will be empty which leads to empty canvas wihout annotations.

This PR fixes the problem by introducing `initialized` state status for annotations so `CanvasWrapper` is not mounted before annotations are loaded. (+it removes one unnecessary re-render) 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
