### PR TITLE
Save video if test failed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -385,6 +385,13 @@ jobs:
           name: cypress_screenshots_${{ matrix.specs }}
           path: ${{ github.workspace }}/tests/cypress/screenshots
 
+      - name: Uploading cypress videos as an artifact
+        if: failure()
+        uses: actions/upload-artifact@v3.1.1
+        with:
+          name: cypress_videos_${{ matrix.specs }}
+          path: ${{ github.workspace }}/tests/cypress/videos
+
   publish_dev_images:
     if: github.ref == 'refs/heads/develop'
     needs: [rest_api_testing, unit_testing, e2e_testing]

--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress');
 const plugins = require('./cypress/plugins/index');
 
 module.exports = defineConfig({
-    video: false,
+    video: true,
     viewportWidth: 1300,
     viewportHeight: 960,
     defaultCommandTimeout: 25000,

--- a/tests/cypress/e2e/actions_projects_models/registration_involved/base_actions_project_task_user.js
+++ b/tests/cypress/e2e/actions_projects_models/registration_involved/base_actions_project_task_user.js
@@ -109,7 +109,7 @@ context('Base actions on the project', () => {
             cy.goToProjectsList();
             cy.openProject(projectName);
             getProjectID(projectName);
-            cy.get('.cvat-tasks-list-item-fail').then((countTasks) => {
+            cy.get('.cvat-tasks-list-item').then((countTasks) => {
                 // The number of created tasks is greater than zero
                 expect(countTasks.length).to.be.gt(0);
             });

--- a/tests/cypress/e2e/actions_projects_models/registration_involved/base_actions_project_task_user.js
+++ b/tests/cypress/e2e/actions_projects_models/registration_involved/base_actions_project_task_user.js
@@ -109,7 +109,7 @@ context('Base actions on the project', () => {
             cy.goToProjectsList();
             cy.openProject(projectName);
             getProjectID(projectName);
-            cy.get('.cvat-tasks-list-item').then((countTasks) => {
+            cy.get('.cvat-tasks-list-item-fail').then((countTasks) => {
                 // The number of created tasks is greater than zero
                 expect(countTasks.length).to.be.gt(0);
             });

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -41,5 +41,11 @@ module.exports = (on, config) => {
         }
         return launchOptions;
     });
+
+    on('after:spec', (spec, results) => {
+        if (results.stats.failures === 0 && results.video) {
+            fs.unlinkSync(results.video);
+        }
+    });
     return config;
 };

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -43,7 +43,7 @@ module.exports = (on, config) => {
     });
 
     on('after:spec', (spec, results) => {
-        if (results.stats.failures === 0 && results.video) {
+        if (results && results.stats.failures === 0 && results.video) {
             fs.unlinkSync(results.video);
         }
     });


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Sometimes test base_actions_project_task_user  is fails([#7796](https://github.com/cvat-ai/cvat/actions/runs/8833341965/job/24252842117#step:9:673), [#7800](https://github.com/cvat-ai/cvat/actions/runs/8828380984/job/24237619992#step:9:673)). We need to save the video of the test to understand the cause of the fails.
### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Enabled video recording for test runs in Cypress.
	- Added an event handler to delete video files post-test if no failures occur.
	- Modified CSS class selector in a Cypress test script.
	- Added a step to upload Cypress videos as an artifact in case of failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->