### PR TITLE
Fixed incorrect Cloud Storage request by ID

### DIFF
--- a/changelog.d/20240429_145914_boris_fixed_incorrect_cs_request.md
+++ b/changelog.d/20240429_145914_boris_fixed_incorrect_cs_request.md
@@ -1,4 +1,4 @@
 ### Fixed
 
-- Infinite loading cloud storage update page when a lot of cloud storage are available for a user
+- Infinite loading cloud storage update page when a lot of cloud storages are available for a user
   (<https://github.com/cvat-ai/cvat/pull/7823>)

--- a/changelog.d/20240429_145914_boris_fixed_incorrect_cs_request.md
+++ b/changelog.d/20240429_145914_boris_fixed_incorrect_cs_request.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Infinite loading cloud storage update page when a lot of cloud storage are available for a user
+  (<https://github.com/cvat-ai/cvat/pull/7823>)

--- a/cvat-core/src/server-proxy.ts
+++ b/cvat-core/src/server-proxy.ts
@@ -1937,18 +1937,21 @@ async function getCloudStorages(filter = {}): Promise<SerializedCloudStorage[] &
 
     let response = null;
     try {
+        if ('id' in filter) {
+            response = await Axios.get(`${backendAPI}/cloudstorages/${filter.id}`);
+            return Object.assign([response.data], { count: 1 });
+        }
+
         response = await Axios.get(`${backendAPI}/cloudstorages`, {
             params: {
                 ...filter,
                 page_size: 12,
             },
         });
+        return Object.assign(response.data.results, { count: response.data.count });
     } catch (errorData) {
         throw generateError(errorData);
     }
-
-    response.data.results.count = response.data.count;
-    return response.data.results;
 }
 
 async function getCloudStorageContent(id: number, path: string, nextToken?: string, manifestPath?: string):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
GET `/api/cloudstorages` does not support ID query parameter. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Enhanced cloud storage retrieval in the application, allowing users to fetch details for a specific cloud storage or a list with pagination if no specific ID is provided.
    - Fixed issue causing infinite loading on the cloud storage update page when multiple options were available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->