### PR TITLE
helm-chart: prevent Traefik from ignoring the backend ingress rule

### DIFF
--- a/changelog.d/20240507_140615_roman_allow_empty_services.md
+++ b/changelog.d/20240507_140615_roman_allow_empty_services.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- \[Helm\] Prevented spurious 200 OK responses from API endpoints
+  before the backend is ready
+  (<https://github.com/cvat-ai/cvat/pull/7859>)

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.0
+version: 0.12.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -454,6 +454,9 @@ traefik:
             RequestProtocol: keep
             RouterName: keep
             StartUTC: keep
+  providers:
+    kubernetesIngress:
+      allowEmptyServices: true
 
 smokescreen:
   opts: ''


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
There is a condition that may occur during Kubernetes deployment, where the frontend service already has an endpoint (i.e. the frontend pod), but the backend service does not. For example, the backend pod may not have started yet or the service controller may not have had time to react to the backend pod.

In this case, when Traefik serves a request with an `/api/...` path, it will see that it matches the `/api` rule, but since the corresponding service has no endpoints, it will _skip_ that rule and try other rules. And since the `/` rule matches everything, it will then route the request to the frontend.

This is confusing and unhelpful, and more importantly, it makes health checks return the wrong result. Since the frontend will serve `index.html` to every request, a request to `/api/server/health/` or `/api/server/about` will return a 200 code, even though the server isn't actually up.

Because of this bug, I have observed weird failures in the Helm workflow, where the "Wait for CVAT to be ready" step completes, but CVAT is not actually ready. (FYI: The failures I've seen are actually in a private repo, but the failure condition could occur in this repo too. It's just more likely in a private repo, because GitHub uses smaller runners in private repos.)

The fix is simple: use the `allowEmptyServices` Traefik setting, which disables the rule skipping behavior. With this setting on, Traefik will return a 503 response for backend URLs until the backend service gains an endpoint.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I deployed the Helm chart, then ran a `kubectl delete deployments.apps cvat-backend-server` to simulate the server being unavailable. Then I curled the `/api/server/health/` endpoint.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue to prevent incorrect 200 OK responses from API endpoints before backend readiness.

- **New Features**
	- Updated Helm chart to support configurations that allow empty services in the Kubernetes Ingress provider.

- **Documentation**
	- Updated version in Helm chart documentation from `0.12.0` to `0.12.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->