### PR TITLE
Update helm

### DIFF
--- a/changelog.d/20240515_144240_andrey_helm_update.md
+++ b/changelog.d/20240515_144240_andrey_helm_update.md
@@ -1,4 +1,4 @@
-### Added <!-- pick one -->
+### Added
 
-- [Helm] Ability to specify ServiceAccount for backend pods
+- \[Helm\] Ability to specify ServiceAccount for backend pods
   (<https://github.com/cvat-ai/cvat/pull/7894>)

--- a/changelog.d/20240515_144240_andrey_helm_update.md
+++ b/changelog.d/20240515_144240_andrey_helm_update.md
@@ -1,0 +1,4 @@
+### Added <!-- pick one -->
+
+- [Helm] Ability to specify ServiceAccount for backend pods
+  (<https://github.com/cvat-ai/cvat/pull/7894>)

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -51,7 +51,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-The name of the service account to use
+The name of the service account to use for backend pods
 */}}
 {{- define "cvat.backend.serviceAccountName" -}}
 {{- default "default" .Values.cvat.backend.serviceAccount.name }}

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -51,14 +51,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Create the name of the service account to use
+The name of the service account to use
 */}}
-{{- define "cvat.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "cvat.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{- define "cvat.backend.serviceAccountName" -}}
+{{- default "default" .Values.cvat.backend.serviceAccount.name }}
 {{- end }}
 
 {{- define "cvat.sharedBackendEnv" }}
@@ -98,10 +94,14 @@ Create the name of the service account to use
 - name: CVAT_POSTGRES_PORT
   value: "{{ .Values.postgresql.service.ports.postgresql }}"
 {{- else }}
+{{- if .Values.postgresql.external.host }}
 - name: CVAT_POSTGRES_HOST
   value: "{{ .Values.postgresql.external.host }}"
+{{- end }}
+{{- if .Values.postgresql.external.port }}
 - name: CVAT_POSTGRES_PORT
   value: "{{ .Values.postgresql.external.port }}"
+{{- end}}
 {{- end }}
 - name: CVAT_POSTGRES_USER
   valueFrom:

--- a/helm-chart/templates/cvat_backend/initializer/job.yml
+++ b/helm-chart/templates/cvat_backend/initializer/job.yml
@@ -37,6 +37,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "cvat.backend.serviceAccountName" . }}
       containers:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}

--- a/helm-chart/templates/cvat_backend/server/deployment.yml
+++ b/helm-chart/templates/cvat_backend/server/deployment.yml
@@ -45,6 +45,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "cvat.backend.serviceAccountName" . }}
       containers:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
@@ -57,8 +58,6 @@ spec:
           env:
           - name: ALLOWED_HOSTS
             value: {{ $localValues.envs.ALLOWED_HOSTS | squote}}
-          - name: DJANGO_MODWSGI_EXTRA_ARGS
-            value: {{ $localValues.envs.DJANGO_MODWSGI_EXTRA_ARGS}}
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
           {{- with concat .Values.cvat.backend.additionalEnv $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}

--- a/helm-chart/templates/cvat_backend/utils/deployment.yml
+++ b/helm-chart/templates/cvat_backend/utils/deployment.yml
@@ -45,6 +45,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "cvat.backend.serviceAccountName" . }}
       containers:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}

--- a/helm-chart/templates/cvat_backend/worker_analyticsreports/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_analyticsreports/deployment.yml
@@ -45,6 +45,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "cvat.backend.serviceAccountName" . }}
       containers:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}

--- a/helm-chart/templates/cvat_backend/worker_annotation/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_annotation/deployment.yml
@@ -45,6 +45,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "cvat.backend.serviceAccountName" . }}
       containers:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}

--- a/helm-chart/templates/cvat_backend/worker_export/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_export/deployment.yml
@@ -45,6 +45,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "cvat.backend.serviceAccountName" . }}
       containers:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}

--- a/helm-chart/templates/cvat_backend/worker_import/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_import/deployment.yml
@@ -45,6 +45,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "cvat.backend.serviceAccountName" . }}
       containers:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}

--- a/helm-chart/templates/cvat_backend/worker_qualityreports/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_qualityreports/deployment.yml
@@ -45,6 +45,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "cvat.backend.serviceAccountName" . }}
       containers:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}

--- a/helm-chart/templates/cvat_backend/worker_webhooks/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_webhooks/deployment.yml
@@ -45,6 +45,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "cvat.backend.serviceAccountName" . }}
       containers:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -19,9 +19,7 @@ cvat:
     additionalVolumeMounts: []
     # -- The service account the backend pods will use to interact with the Kubernetes API
     serviceAccount:
-      # If set, the specified service account is used
-      # otherwise default service account is used
-      name: ""
+      name: default
 
     initializer:
       labels: {}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -17,6 +17,11 @@ cvat:
     additionalEnv: []
     additionalVolumes: []
     additionalVolumeMounts: []
+    # -- The service account the backend pods will use to interact with the Kubernetes API
+    serviceAccount:
+      # If set, the specified service account is used
+      # otherwise default service account is used
+      name: ""
 
     initializer:
       labels: {}
@@ -36,7 +41,6 @@ cvat:
       tolerations: []
       envs:
         ALLOWED_HOSTS: "*"
-        DJANGO_MODWSGI_EXTRA_ARGS: ""
       additionalEnv: []
       additionalVolumes: []
       additionalVolumeMounts: []
@@ -275,9 +279,11 @@ postgresql:
   #See https://github.com/bitnami/charts/blob/master/bitnami/postgresql/ for more info
   enabled: true # false for external db
   external:
-    host: 127.0.0.1
-    port: 5432
- # If not external following config will be applied by default
+    # Ignored if an empty value is set
+    host: ""
+    # Ignored if an empty value is set
+    port: ""
+  # If not external following config will be applied by default
   auth:
     existingSecret: "{{ .Release.Name }}-postgres-secret"
     username: cvat


### PR DESCRIPTION
Added ability to specify ServiceAccount for backend pods
Removed passing of DJANGO_MODWSGI_EXTRA_ARGS env variable to server pod
Do not set database host and port env variables if they are empty

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to specify a ServiceAccount for backend pods in Helm.

- **Improvements**
  - Updated Helm chart version to 0.13.0.
  - Enhanced logic for setting environment variables based on external PostgreSQL configurations.

- **Removals**
  - Removed `DJANGO_MODWSGI_EXTRA_ARGS` environment variable setting.

- **Documentation**
  - Added a changelog entry detailing the new ServiceAccount feature for backend pods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->