### PR TITLE
Fix login when email domain contains capital symbols and user was created after invitation to some org

### DIFF
--- a/changelog.d/20240524_130047_maria_fix_issue_with_login_when_email_domain_contains_capital_symbols.md
+++ b/changelog.d/20240524_130047_maria_fix_issue_with_login_when_email_domain_contains_capital_symbols.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Login when the domain of a user email contains capital symbols and a  user was created after being invited to an org
+  (<https://github.com/cvat-ai/cvat/pull/7906>)

--- a/changelog.d/20240524_130047_maria_fix_issue_with_login_when_email_domain_contains_capital_symbols.md
+++ b/changelog.d/20240524_130047_maria_fix_issue_with_login_when_email_domain_contains_capital_symbols.md
@@ -1,4 +1,4 @@
 ### Fixed
 
-- Login when the domain of a user email contains capital symbols and a  user was created after being invited to an org
+- Login when the domain of a user email contains capital symbols and a user was created after being invited to an org
   (<https://github.com/cvat-ai/cvat/pull/7906>)

--- a/cvat/apps/organizations/serializers.py
+++ b/cvat/apps/organizations/serializers.py
@@ -103,7 +103,8 @@ class InvitationWriteSerializer(serializers.ModelSerializer):
             user_email = membership_data['user']['email']
             user = User.objects.create_user(username=user_email, email=user_email)
             user.set_unusable_password()
-            email = EmailAddress.objects.create(user=user, email=user_email, primary=True, verified=False)
+            # User.objects.create_user(...) normalizes passed email and user.email can be different from original user_email
+            email = EmailAddress.objects.create(user=user, email=user.email, primary=True, verified=False)
             user.save()
             email.save()
             del membership_data['user']


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved email creation process to ensure the use of the normalized email from the user object, enhancing data consistency and reducing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->