### PR TITLE
Array.toReversed replaced by Array.reduceRight because of better comp…

### DIFF
--- a/changelog.d/20240520_130757_boris_replaced_function.md
+++ b/changelog.d/20240520_130757_boris_replaced_function.md
@@ -1,0 +1,4 @@
+### Added|Changed|Deprecated|Removed|Fixed|Security <!-- pick one -->
+
+- Slice function may not work in Google Chrome < 110
+  (<https://github.com/cvat-ai/cvat/pull/7916>)

--- a/changelog.d/20240520_130757_boris_replaced_function.md
+++ b/changelog.d/20240520_130757_boris_replaced_function.md
@@ -1,4 +1,4 @@
-### Added|Changed|Deprecated|Removed|Fixed|Security <!-- pick one -->
+### Fixed
 
 - Slice function may not work in Google Chrome < 110
   (<https://github.com/cvat-ai/cvat/pull/7916>)

--- a/cvat-canvas/src/typescript/shared.ts
+++ b/cvat-canvas/src/typescript/shared.ts
@@ -1,4 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
+// Copyright (C) 2024 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/shared.ts
+++ b/cvat-canvas/src/typescript/shared.ts
@@ -535,5 +535,15 @@ export function segmentsFromPoints(points: number[], circuit = false): Segment[]
     }, []);
 }
 
+export function toReversed<T>(array: Array<T>): Array<T> {
+    // actually toReversed already exists in ESMA specification
+    // but not all CVAT customers uses a browser fresh enough to use it
+    // instead of using a library with polyfills I will prefer just to rewrite it with reduceRight
+    return array.reduceRight<Array<T>>((acc, val: T) => {
+        acc.push(val);
+        return acc;
+    }, []);
+}
+
 export type Segment = [[number, number], [number, number]];
 export type PropType<T, Prop extends keyof T> = T[Prop];

--- a/cvat-canvas/src/typescript/sliceHandler.ts
+++ b/cvat-canvas/src/typescript/sliceHandler.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) 2023-2024 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/sliceHandler.ts
+++ b/cvat-canvas/src/typescript/sliceHandler.ts
@@ -30,7 +30,7 @@ type EnhancedSliceData = {
 function toReversed<T>(array: Array<T>): Array<T> {
     // actually toReversed already exists in ESMA specification
     // but not all CVAT customers uses a browser fresh enough to use it
-    // instead of using a polyfills library I will prefer just to rewrite it with reduceRight
+    // instead of using a library with polyfills I will prefer just to rewrite it with reduceRight
     return array.reduceRight<Array<T>>((acc, val: T) => {
         acc.push(val);
         return acc;

--- a/cvat-canvas/src/typescript/sliceHandler.ts
+++ b/cvat-canvas/src/typescript/sliceHandler.ts
@@ -6,6 +6,7 @@ import * as SVG from 'svg.js';
 import {
     stringifyPoints, translateToCanvas, translateFromCanvas, translateToSVG,
     findIntersection, zipChannels, Segment, findClosestPointOnSegment, segmentsFromPoints,
+    toReversed,
 } from './shared';
 import {
     Geometry, SliceData, Configuration, CanvasHint,
@@ -26,16 +27,6 @@ type EnhancedSliceData = {
     state: any;
     shapeType: 'mask' | 'polygon';
 };
-
-function toReversed<T>(array: Array<T>): Array<T> {
-    // actually toReversed already exists in ESMA specification
-    // but not all CVAT customers uses a browser fresh enough to use it
-    // instead of using a library with polyfills I will prefer just to rewrite it with reduceRight
-    return array.reduceRight<Array<T>>((acc, val: T) => {
-        acc.push(val);
-        return acc;
-    }, []);
-}
 
 function drawOverOffscreenCanvas(context: OffscreenCanvasRenderingContext2D, image: CanvasImageSource): void {
     context.fillStyle = 'black';
@@ -304,7 +295,7 @@ export class SliceHandlerImpl implements SliceHandler {
                 const d2 = Math.sqrt((p2[0] - p[0]) ** 2 + (p2[1] - p[1]) ** 2);
 
                 if (d2 > d1) {
-                    contour2.push(...toReversed(otherPoints).flat());
+                    contour2.push(...toReversed<[number, number]>(otherPoints).flat());
                 } else {
                     contour2.push(...otherPoints.flat());
                 }
@@ -321,7 +312,7 @@ export class SliceHandlerImpl implements SliceHandler {
                     ...firstSegmentPoint, // first intersection
                     // intermediate points (reversed if intersections order was swopped)
                     ...(firstSegmentIdx === firstIntersectedSegmentIdx ?
-                        intermediatePoints : toReversed(intermediatePoints)
+                        intermediatePoints : toReversed<[number, number]>(intermediatePoints)
                     ).flat(),
                     // second intersection
                     ...secondSegmentPoint,
@@ -334,7 +325,7 @@ export class SliceHandlerImpl implements SliceHandler {
                     ...firstSegmentPoint, // first intersection
                     // intermediate points (reversed if intersections order was swopped)
                     ...(firstSegmentIdx === firstIntersectedSegmentIdx ?
-                        intermediatePoints : toReversed(intermediatePoints)
+                        intermediatePoints : toReversed<[number, number]>(intermediatePoints)
                     ).flat(),
                     ...secondSegmentPoint,
                     // all the previous contours points N, N-1, .. until (including) the first intersected segment

--- a/cvat-canvas/src/typescript/sliceHandler.ts
+++ b/cvat-canvas/src/typescript/sliceHandler.ts
@@ -27,6 +27,16 @@ type EnhancedSliceData = {
     shapeType: 'mask' | 'polygon';
 };
 
+function toReversed<T>(array: Array<T>): Array<T> {
+    // actually toReversed already exists in ESMA specification
+    // but not all CVAT customers uses a browser fresh enough to use it
+    // instead of using a polyfills library I will prefer just to rewrite it with reduceRight
+    return array.reduceRight<Array<T>>((acc, val: T) => {
+        acc.push(val);
+        return acc;
+    }, []);
+}
+
 function drawOverOffscreenCanvas(context: OffscreenCanvasRenderingContext2D, image: CanvasImageSource): void {
     context.fillStyle = 'black';
     context.globalCompositeOperation = 'source-over';
@@ -295,7 +305,7 @@ export class SliceHandlerImpl implements SliceHandler {
 
                 if (d2 > d1) {
                     // @ts-ignore error TS2551 (need to update typescript up to 5.2)
-                    contour2.push(...otherPoints.toReversed().flat());
+                    contour2.push(...toReversed(otherPoints).flat());
                 } else {
                     contour2.push(...otherPoints.flat());
                 }
@@ -313,7 +323,7 @@ export class SliceHandlerImpl implements SliceHandler {
                     // intermediate points (reversed if intersections order was swopped)
                     ...(firstSegmentIdx === firstIntersectedSegmentIdx ?
                         // @ts-ignore error TS2551 (need to update typescript up to 5.2)
-                        intermediatePoints : intermediatePoints.toReversed()
+                        intermediatePoints : toReversed(intermediatePoints)
                     ).flat(),
                     // second intersection
                     ...secondSegmentPoint,
@@ -327,7 +337,7 @@ export class SliceHandlerImpl implements SliceHandler {
                     // intermediate points (reversed if intersections order was swopped)
                     ...(firstSegmentIdx === firstIntersectedSegmentIdx ?
                         // @ts-ignore error TS2551 (need to update typescript up to 5.2)
-                        intermediatePoints : intermediatePoints.toReversed()
+                        intermediatePoints : toReversed(intermediatePoints)
                     ).flat(),
                     ...secondSegmentPoint,
                     // all the previous contours points N, N-1, .. until (including) the first intersected segment

--- a/cvat-canvas/src/typescript/sliceHandler.ts
+++ b/cvat-canvas/src/typescript/sliceHandler.ts
@@ -304,7 +304,6 @@ export class SliceHandlerImpl implements SliceHandler {
                 const d2 = Math.sqrt((p2[0] - p[0]) ** 2 + (p2[1] - p[1]) ** 2);
 
                 if (d2 > d1) {
-                    // @ts-ignore error TS2551 (need to update typescript up to 5.2)
                     contour2.push(...toReversed(otherPoints).flat());
                 } else {
                     contour2.push(...otherPoints.flat());
@@ -322,7 +321,6 @@ export class SliceHandlerImpl implements SliceHandler {
                     ...firstSegmentPoint, // first intersection
                     // intermediate points (reversed if intersections order was swopped)
                     ...(firstSegmentIdx === firstIntersectedSegmentIdx ?
-                        // @ts-ignore error TS2551 (need to update typescript up to 5.2)
                         intermediatePoints : toReversed(intermediatePoints)
                     ).flat(),
                     // second intersection
@@ -336,7 +334,6 @@ export class SliceHandlerImpl implements SliceHandler {
                     ...firstSegmentPoint, // first intersection
                     // intermediate points (reversed if intersections order was swopped)
                     ...(firstSegmentIdx === firstIntersectedSegmentIdx ?
-                        // @ts-ignore error TS2551 (need to update typescript up to 5.2)
                         intermediatePoints : toReversed(intermediatePoints)
                     ).flat(),
                     ...secondSegmentPoint,


### PR DESCRIPTION
…atibility

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
- reduceRight supported from Chrome v3
- toReversed supported from Chrome v110

I saw some exceptions in analytics, where our users can't use slice function because their browsers are outdated. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved array reversal operations to enhance performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->