### PR TITLE
Fixed conflicts highlight crash in case of hidden by `zOrder` objects

### DIFF
--- a/changelog.d/20240521_182333_klakhov_fix_conflicts_render.md
+++ b/changelog.d/20240521_182333_klakhov_fix_conflicts_render.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- UI crash on hovering conflict related to hidden objects
+  (<https://github.com/cvat-ai/cvat/pull/7917>)

--- a/cvat-canvas/package.json
+++ b/cvat-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-canvas",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "type": "module",
   "description": "Part of Computer Vision Annotation Tool which presents its canvas library",
   "main": "src/canvas.ts",

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -651,6 +651,15 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
     }
 
     public highlight(clientIDs: number[], severity: HighlightSeverity | null): void {
+        if (clientIDs.length !== 0) {
+            const states = clientIDs.map((id) => (
+                this.objects.find((_state: any): boolean => _state.clientID === id)
+            ));
+            if (states.some((state) => !state)) {
+                return;
+            }
+        }
+
         this.data.highlightedElements = {
             elementsIDs: clientIDs,
             severity,

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -651,17 +651,12 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
     }
 
     public highlight(clientIDs: number[], severity: HighlightSeverity | null): void {
-        if (clientIDs.length !== 0) {
-            const states = clientIDs.map((id) => (
-                this.objects.find((_state: any): boolean => _state.clientID === id)
-            ));
-            if (states.some((state) => !state)) {
-                return;
-            }
-        }
+        const elementsIDs = clientIDs.filter((id: number): boolean => (
+            this.objects.find((_state: any): boolean => _state.clientID === id)
+        ));
 
         this.data.highlightedElements = {
-            elementsIDs: clientIDs,
+            elementsIDs,
             severity,
         };
 

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.63.10",
+  "version": "1.63.11",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/annotation-page/review/issues-aggregator.tsx
+++ b/cvat-ui/src/components/annotation-page/review/issues-aggregator.tsx
@@ -138,7 +138,7 @@ export default function IssueAggregatorComponent(): JSX.Element | null {
                         _state.objectType === mainAnnotationsConflict.type
                     ));
 
-                    if (state && state.zOrder <= annotationsZLayer) {
+                    if (state && state.zOrder <= annotationsZLayer && !state.hidden) {
                         const points = canvasInstance.setupConflictRegions(state);
                         if (points) {
                             return {

--- a/cvat-ui/src/components/annotation-page/review/issues-aggregator.tsx
+++ b/cvat-ui/src/components/annotation-page/review/issues-aggregator.tsx
@@ -38,6 +38,7 @@ export default function IssueAggregatorComponent(): JSX.Element | null {
     const issuesResolvedHidden = useSelector((state: CombinedState): boolean => state.review.issuesResolvedHidden);
     const canvasInstance = useSelector((state: CombinedState) => state.annotation.canvas.instance);
     const canvasIsReady = useSelector((state: CombinedState): boolean => state.annotation.canvas.ready);
+    const annotationsZLayer = useSelector((state: CombinedState): number => state.annotation.annotations.zLayer.cur);
     const newIssuePosition = useSelector((state: CombinedState): number[] | null => state.review.newIssuePosition);
     const issueFetching = useSelector((state: CombinedState): number | null => state.review.fetching.issueId);
     const [geometry, setGeometry] = useState<Canvas['geometry'] | null>(null);
@@ -137,7 +138,7 @@ export default function IssueAggregatorComponent(): JSX.Element | null {
                         _state.objectType === mainAnnotationsConflict.type
                     ));
 
-                    if (state) {
+                    if (state && state.zOrder <= annotationsZLayer) {
                         const points = canvasInstance.setupConflictRegions(state);
                         if (points) {
                             return {
@@ -158,7 +159,7 @@ export default function IssueAggregatorComponent(): JSX.Element | null {
         } else {
             setConflictMapping([]);
         }
-    }, [geometry, objectStates, showConflicts, canvasReady, qualityConflicts]);
+    }, [geometry, objectStates, showConflicts, canvasReady, qualityConflicts, annotationsZLayer]);
 
     if (!canvasReady || !geometry) {
         return null;

--- a/cvat-ui/src/components/annotation-page/review/issues-aggregator.tsx
+++ b/cvat-ui/src/components/annotation-page/review/issues-aggregator.tsx
@@ -1,11 +1,11 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) 2023-2024 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 
 import './styles.scss';
 import React, { useState, useEffect, useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 
 import { ActiveControl, CombinedState } from 'reducers';
 import { Canvas } from 'cvat-canvas/src/typescript/canvas';
@@ -32,26 +32,42 @@ interface ConflictMappingElement {
 
 export default function IssueAggregatorComponent(): JSX.Element | null {
     const dispatch = useDispatch();
-    const [expandedIssue, setExpandedIssue] = useState<number | null>(null);
-    const frameIssues = useSelector((state: CombinedState): any[] => state.review.frameIssues);
-    const issuesHidden = useSelector((state: CombinedState): boolean => state.review.issuesHidden);
-    const issuesResolvedHidden = useSelector((state: CombinedState): boolean => state.review.issuesResolvedHidden);
-    const canvasInstance = useSelector((state: CombinedState) => state.annotation.canvas.instance);
-    const canvasIsReady = useSelector((state: CombinedState): boolean => state.annotation.canvas.ready);
-    const annotationsZLayer = useSelector((state: CombinedState): number => state.annotation.annotations.zLayer.cur);
-    const newIssuePosition = useSelector((state: CombinedState): number[] | null => state.review.newIssuePosition);
-    const issueFetching = useSelector((state: CombinedState): number | null => state.review.fetching.issueId);
-    const [geometry, setGeometry] = useState<Canvas['geometry'] | null>(null);
 
-    const qualityConflicts = useSelector((state: CombinedState) => state.review.frameConflicts);
-    const objectStates = useSelector((state: CombinedState) => state.annotation.annotations.states);
-    const showConflicts = useSelector((state: CombinedState) => state.settings.shapes.showGroundTruth);
-    const highlightedConflict = useSelector((state: CombinedState) => state.annotation.annotations.highlightedConflict);
+    const {
+        frameIssues,
+        issuesHidden,
+        issuesResolvedHidden,
+        canvasInstance,
+        canvasIsReady,
+        annotationsZLayer,
+        newIssuePosition,
+        issueFetching,
+        qualityConflicts,
+        objectStates,
+        showConflicts,
+        highlightedConflict,
+        activeControl,
+    } = useSelector((state: CombinedState) => ({
+        frameIssues: state.review.frameIssues,
+        issuesHidden: state.review.issuesHidden,
+        issuesResolvedHidden: state.review.issuesResolvedHidden,
+        canvasInstance: state.annotation.canvas.instance,
+        canvasIsReady: state.annotation.canvas.ready,
+        annotationsZLayer: state.annotation.annotations.zLayer.cur,
+        newIssuePosition: state.review.newIssuePosition,
+        issueFetching: state.review.fetching.issueId,
+        qualityConflicts: state.review.frameConflicts,
+        objectStates: state.annotation.annotations.states,
+        showConflicts: state.settings.shapes.showGroundTruth,
+        highlightedConflict: state.annotation.annotations.highlightedConflict,
+        activeControl: state.annotation.canvas.activeControl,
+    }), shallowEqual);
+
+    const [expandedIssue, setExpandedIssue] = useState<number | null>(null);
+    const [geometry, setGeometry] = useState<Canvas['geometry'] | null>(null);
 
     const highlightedObjectsIDs = highlightedConflict?.annotationConflicts
         ?.map((annotationConflict: AnnotationConflict) => annotationConflict.serverID);
-
-    const activeControl = useSelector((state: CombinedState) => state.annotation.canvas.activeControl);
 
     const canvasReady = canvasInstance instanceof Canvas && canvasIsReady;
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Related #7775

- Made conflicts rendering responsive to changes in zOrder
- Conflicts are shown and highlightened only when main object is not hidden

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced annotation rendering logic based on z-order for better visual clarity.

- **Bug Fixes**
  - Added validation for clientIDs in the highlight method to prevent errors.

- **Version Updates**
  - Updated version of `cvat-canvas` to 2.20.2.
  - Updated version of `cvat-ui` to 1.63.11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->