### PR TITLE
Fix missing serviceName field in kvrocks (issue #7741)

### DIFF
--- a/changelog.d/20240521_151421_nlerche_fix_missing_serviceName.md
+++ b/changelog.d/20240521_151421_nlerche_fix_missing_serviceName.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fix missing serviceName field in kvrocks (issue #7741)
+  (<https://github.com/cvat-ai/cvat/pull/7924>)

--- a/helm-chart/templates/cvat_kvrocks/statefulset.yml
+++ b/helm-chart/templates/cvat_kvrocks/statefulset.yml
@@ -15,6 +15,7 @@ spec:
       {{- include "cvat.labels" . | nindent 6 }}
       app: cvat-app
       tier: kvrocks
+  serviceName: {{ .Release.Name }}-kvrocks
   template:
     metadata:
       labels:


### PR DESCRIPTION
Add the serviceName field to the kvrocks StatefulSet as per the Kubernetes specification. This change ensures that the service name is correctly associated with the StatefulSet pods, allowing for proper DNS resolution and service discovery within the cluster. 

Fixes #7741 

### Motivation and context
The Helm installation is currently failing as reported in issue #7741 

### How has this been tested?


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Resolved the issue of a missing `serviceName` field in `kvrocks`, ensuring proper configuration and improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->