### PR TITLE
Fixed couple of not stable Cypress tests

### DIFF
--- a/tests/cypress/e2e/features/single_object_annotation.js
+++ b/tests/cypress/e2e/features/single_object_annotation.js
@@ -87,6 +87,7 @@ context('Single object annotation mode', { scrollBehavior: false }, () => {
                 ...params,
             },
         });
+        cy.get('.cvat-canvas-container').should('not.exist');
         cy.get('.cvat-canvas-container').should('exist').and('be.visible');
     }
 

--- a/tests/cypress/support/commands_organizations.js
+++ b/tests/cypress/support/commands_organizations.js
@@ -8,6 +8,7 @@
 function openOrganizationsMenu() {
     cy.get('.cvat-header-menu-user-dropdown')
         .should('exist').and('be.visible').click();
+    cy.wait(500); // animation
     cy.get('.cvat-header-menu')
         .should('exist')
         .and('be.visible')


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test stability for single object annotation by ensuring the absence of certain elements before visibility checks.
  - Introduced a delay for animation in the organization menu test to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->