### PR TITLE
Fixed .ant-modal-wrapper kept after closing saving modal

### DIFF
--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
@@ -479,7 +479,7 @@
 
 .cvat-objects-sidebar-state-item-elements {
     padding: $grid-unit-size * 0.5;
-    border: 1px solid rgba($color: white, $alpha: 0);
+    border: 1px solid rgba($color: white, $alpha: 0%);
 }
 
 .cvat-objects-sidebar-state-item-elements.cvat-objects-sidebar-state-active-element {

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
@@ -479,17 +479,11 @@
 
 .cvat-objects-sidebar-state-item-elements {
     padding: $grid-unit-size * 0.5;
-    border: 1px solid $object-item-border-color;
-    border-bottom: 0;
-
-    &:last-child {
-        border-bottom: 1px solid $object-item-border-color;
-    }
+    border: 1px solid rgba($color: white, $alpha: 0);
 }
 
 .cvat-objects-sidebar-state-item-elements.cvat-objects-sidebar-state-active-element {
-    border: 2px dashed $object-item-border-color;
-    padding: 0;
+    border: 1px dashed $object-item-border-color;
 }
 
 .cvat-objects-sidebar-show-ground-truth-active {

--- a/cvat-ui/src/components/annotation-page/styles.scss
+++ b/cvat-ui/src/components/annotation-page/styles.scss
@@ -522,4 +522,8 @@
     span.anticon {
         margin-left: $grid-unit-size * 2;
     }
+
+    .ant-modal-footer {
+        margin: 0;
+    }
 }

--- a/cvat-ui/src/components/annotation-page/top-bar/left-group.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/left-group.tsx
@@ -91,17 +91,18 @@ function LeftGroup(props: Props): JSX.Element {
     return (
         <>
             <GlobalHotKeys keyMap={subKeyMap} handlers={handlers} />
-            <Modal
-                destroyOnClose
-                className='cvat-saving-job-modal'
-                title='Saving changes on the server'
-                open={saving}
-                footer={[]}
-                closable={false}
-            >
-                <Text>CVAT is saving your annotations, please wait </Text>
-                <LoadingOutlined />
-            </Modal>
+            { saving && (
+                <Modal
+                    open
+                    destroyOnClose
+                    className='cvat-saving-job-modal'
+                    closable={false}
+                    footer={[]}
+                >
+                    <Text>CVAT is saving your annotations, please wait </Text>
+                    <LoadingOutlined />
+                </Modal>
+            )}
             <Col className='cvat-annotation-header-left-group'>
                 <AnnotationMenuContainer />
                 <SaveButtonComponent

--- a/cvat-ui/src/components/models-page/styles.scss
+++ b/cvat-ui/src/components/models-page/styles.scss
@@ -15,12 +15,6 @@
     .cvat-models-page-top-bar {
         padding-bottom: $grid-unit-size;
     }
-
-    >div:nth-child(2) {
-        &:not(.cvat-empty-models-list) {
-            height: 90%;
-        }
-    }
 }
 
 .cvat-empty-models-list {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Resolved #7946
Resolved #7945

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated modal footer styling to have zero margin on the annotation page.
  - Removed specific CSS rule targeting div elements by position on the models page.

- **Refactor**
  - Improved conditional rendering logic for the save modal on the annotation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->