### PR TITLE
Fix a non-deterministic webhook test

### DIFF
--- a/tests/python/rest_api/test_webhooks_sender.py
+++ b/tests/python/rest_api/test_webhooks_sender.py
@@ -208,7 +208,7 @@ class TestWebhookIntersection:
         assert response.status_code == HTTPStatus.CREATED
 
         project_id = response.json()["id"]
-        events_1 = ["create:task", "update:project"]
+        events_1 = ["create:task", "update:issue"]
         events_2 = ["create:task", "create:issue"]
         webhook_id_1 = create_webhook(events_1, "project", project_id=project_id)["id"]
         webhook_id_2 = create_webhook(events_2, "project", project_id=project_id)["id"]


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
`test_two_project_webhooks_intersection` is supposed to trigger each webhook once. However, the first one of these webhooks actually gets triggered twice, because creating a task causes the project's `updated_date` to be bumped, which triggers an `update:project` event.

The test still passes a lot of the time (I guess because the second delivery doesn't appear immediately?), but sometimes it fails. It's very easy to make it fail consistently, though - just add a `sleep(5)` before the `get_deliveries` calls.

Fix this by changing the first webhook's second event to something that will not be triggered.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test cases to improve accuracy of webhook event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->