### PR TITLE
Using dedicated event to store working time

### DIFF
--- a/changelog.d/20240529_154845_boris_dedicated_event_for_wt.md
+++ b/changelog.d/20240529_154845_boris_dedicated_event_for_wt.md
@@ -1,4 +1,4 @@
 ### Changed
 
-- CVAT now stores user's working time in ad hoc event type
+- CVAT now stores users' working time in events of a dedicated type
   (<https://github.com/cvat-ai/cvat/pull/7958>)

--- a/changelog.d/20240529_154845_boris_dedicated_event_for_wt.md
+++ b/changelog.d/20240529_154845_boris_dedicated_event_for_wt.md
@@ -1,0 +1,4 @@
+### Changed
+
+- CVAT now stores user's working time in ad hoc event type
+  (<https://github.com/cvat-ai/cvat/pull/7958>)

--- a/cvat-ui/src/actions/annotation-actions.ts
+++ b/cvat-ui/src/actions/annotation-actions.ts
@@ -925,14 +925,7 @@ export function getJobAsync({
                 throw new Error('Requested resource id is not valid');
             }
 
-            const loadJobEvent = await logger.log(
-                EventScope.loadJob,
-                {
-                    task_id: taskID,
-                    job_id: jobID,
-                },
-                true,
-            );
+            const loadJobEvent = await logger.log(EventScope.loadJob, {}, true);
 
             getCore().config.globalObjectsCounter = 0;
             const [job] = await cvat.jobs.get({ jobID });
@@ -979,7 +972,12 @@ export function getJobAsync({
                 }
             }
 
-            loadJobEvent.close(await jobInfoGenerator(job));
+            loadJobEvent.close({
+                ...await jobInfoGenerator(job),
+                jobID: job.id,
+                taskID: job.taskId,
+                projectID: job.projectId,
+            });
 
             const openTime = Date.now();
             dispatch({

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -550,25 +550,25 @@ class ServerLogsAPITestCase(ApiTestBase):
         create_db_users(cls)
         cls.data = {
             "events": [{
-                "scope": "test:scope1",
-                "timestamp": "2019-01-29T12:34:56.000000Z",
-                "task": 1,
-                "job": 1,
-                "proj": 2,
+                "scope": "debug:info",
+                "timestamp": "2024-05-30T17:05:13.776Z",
+                "task_id": 1,
+                "job_id": 1,
+                "project_id": 2,
                 "organization": 2,
                 "count": 1,
                 "payload": json.dumps({
-                    "client_id": 12321235123,
+                    "client_id": 123456,
                     "message": "just test message",
                     "name": "add point",
                     "is_active": True,
                 }),
             },
             {
-                "timestamp": "2019-02-24T12:34:56.000000Z",
-                "scope": "test:scope2",
+                "timestamp": "2024-05-30T17:05:14.776Z",
+                "scope": "debug:info",
             }],
-            "timestamp": "2019-02-24T12:34:58.000000Z",
+            "timestamp": "2024-05-30T17:05:15.776Z",
         }
 
 

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -135,7 +135,7 @@ def user_name(instance=None):
 
 def user_email(instance=None):
     current_user = get_user(instance)
-    return _get_value(current_user, "email")
+    return _get_value(current_user, "email") or None
 
 def organization_slug(instance):
     if isinstance(instance, Organization):
@@ -666,7 +666,7 @@ def handle_client_events_push(request, data: dict):
             "timestamp": data["events"][0]["timestamp"],
             "user_id": request.user.id,
             "user_name": request.user.username,
-            "user_email": request.user.email,
+            "user_email": request.user.email or None,
             "org_id": getattr(org, "id", None),
             "org_slug": getattr(org, "slug", None),
         }

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -602,7 +602,6 @@ def handle_client_events_push(request, data: dict):
     def get_end_timestamp(event: dict) -> datetime.datetime:
         if event["scope"] in COLLAPSED_EVENT_SCOPES:
             return event["timestamp"] + datetime.timedelta(milliseconds=event["duration"])
-
         return event["timestamp"]
 
     def generate_wt_event(
@@ -640,10 +639,9 @@ def handle_client_events_push(request, data: dict):
 
     working_time_dict = {}
     for event in data["events"]:
-        current_ids = read_ids(event)
         working_time = datetime.timedelta()
-
         timestamp = event["timestamp"]
+
         if timestamp > previous_end_timestamp:
             t_diff = timestamp - previous_end_timestamp
             if t_diff < TIME_THRESHOLD:
@@ -658,8 +656,9 @@ def handle_client_events_push(request, data: dict):
 
         if previous_ids not in working_time_dict:
             working_time_dict[previous_ids] = datetime.timedelta()
+
         working_time_dict[previous_ids] += working_time
-        previous_ids = current_ids
+        previous_ids = read_ids(event)
 
     if data["events"]:
         common = {

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -2,45 +2,36 @@
 #
 # SPDX-License-Identifier: MIT
 
+import datetime
+import json
+import traceback
 from copy import deepcopy
 from typing import Optional, Union
-import datetime
-import traceback
-import json
+
 import rq
-
-from rest_framework.views import exception_handler
-from rest_framework.exceptions import NotAuthenticated
+from crum import get_current_request, get_current_user
 from rest_framework import status
-from crum import get_current_user, get_current_request
+from rest_framework.exceptions import NotAuthenticated
+from rest_framework.views import exception_handler
 
-from cvat.apps.engine.models import (
-    Project,
-    Task,
-    Job,
-    User,
-    CloudStorage,
-    Issue,
-    Comment,
-    Label,
-)
-from cvat.apps.engine.serializers import (
-    ProjectReadSerializer,
-    TaskReadSerializer,
-    JobReadSerializer,
-    BasicUserSerializer,
-    CloudStorageReadSerializer,
-    IssueReadSerializer,
-    CommentReadSerializer,
-    LabelSerializer,
-)
-from cvat.apps.engine.models import ShapeType
-from cvat.apps.organizations.models import Membership, Organization, Invitation
-from cvat.apps.organizations.serializers import OrganizationReadSerializer, MembershipReadSerializer, InvitationReadSerializer
+from cvat.apps.engine.models import (CloudStorage, Comment, Issue, Job, Label,
+                                     Project, ShapeType, Task, User)
+from cvat.apps.engine.serializers import (BasicUserSerializer,
+                                          CloudStorageReadSerializer,
+                                          CommentReadSerializer,
+                                          IssueReadSerializer,
+                                          JobReadSerializer, LabelSerializer,
+                                          ProjectReadSerializer,
+                                          TaskReadSerializer)
+from cvat.apps.organizations.models import Invitation, Membership, Organization
+from cvat.apps.organizations.serializers import (InvitationReadSerializer,
+                                                 MembershipReadSerializer,
+                                                 OrganizationReadSerializer)
 
-from .serializers import EventSerializer
-from .event import event_scope, record_server_event
 from .cache import get_cache
+from .event import event_scope, record_server_event
+from .serializers import EventSerializer
+
 
 def project_id(instance):
     if isinstance(instance, Project):

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -679,5 +679,6 @@ def handle_client_events_push(request, data: dict):
                     scope=WORKING_TIME_SCOPE,
                     request_id=request_id(),
                     payload=json.loads(event.validated_data['payload']),
-                    **{key: value for key, value in event.validated_data.items() if key not in ['scope', 'payload']}
+                    timestamp=str(event.validated_data['timestamp'].timestamp()),
+                    **{key: value for key, value in event.validated_data.items() if key not in ['scope', 'payload', 'timestamp']}
                 )

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -676,7 +676,8 @@ def handle_client_events_push(request, data: dict):
             if event:
                 event.is_valid(raise_exception=True)
                 record_server_event(
-                    scope=event.validated_data['scope'],
+                    scope=WORKING_TIME_SCOPE,
                     request_id=request_id(),
-                    payload=event.validated_data
+                    payload=json.loads(event.validated_data['payload']),
+                    **{key: value for key, value in event.validated_data.items() if key not in ['scope', 'payload']}
                 )

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -602,16 +602,13 @@ def handle_client_events_push(request, data: dict):
     TIME_THRESHOLD = datetime.timedelta(seconds=100)
     WORKING_TIME_SCOPE = 'send:working_time'
     WORKING_TIME_RESOLUTION = datetime.timedelta(milliseconds=1)
+    COLLAPSED_EVENT_SCOPES = frozenset(("change:frame",))
     org = request.iam_context["organization"]
 
     def read_ids(event: dict) -> tuple[int | None, int | None, int | None]:
-        job_id = event.get("job_id")
-        task_id = event.get("task_id")
-        project_id = event.get("project_id")
-        return (job_id, task_id, project_id)
+        return event.get("job_id"), event.get("task_id"), event.get("project_id")
 
     def get_end_timestamp(event: dict) -> datetime.datetime:
-        COLLAPSED_EVENT_SCOPES = frozenset(("change:frame",))
         if event["scope"] in COLLAPSED_EVENT_SCOPES:
             return event["timestamp"] + datetime.timedelta(milliseconds=event["duration"])
 

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -598,13 +598,13 @@ def handle_viewset_exception(exc, context):
 
     return response
 
-def handle_client_events_push(request, data):
+def handle_client_events_push(request, data: dict):
     TIME_THRESHOLD = datetime.timedelta(seconds=100)
     WORKING_TIME_SCOPE = 'send:working_time'
     WORKING_TIME_RESOLUTION = datetime.timedelta(milliseconds=1)
     org = request.iam_context["organization"]
 
-    def read_ids(event) -> tuple[int | None, int | None, int | None]:
+    def read_ids(event: dict) -> tuple[int | None, int | None, int | None]:
         job_id = event.get("job_id")
         task_id = event.get("task_id")
         project_id = event.get("project_id")

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -39,7 +39,7 @@ from cvat.apps.engine.models import ShapeType
 from cvat.apps.organizations.models import Membership, Organization, Invitation
 from cvat.apps.organizations.serializers import OrganizationReadSerializer, MembershipReadSerializer, InvitationReadSerializer
 
-from .serializers import ClientEventsSerializer, EventSerializer
+from .serializers import EventSerializer
 from .event import event_scope, record_server_event
 from .cache import get_cache
 

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -661,21 +661,22 @@ def handle_client_events_push(request, data: dict):
         working_time_dict[previous_ids] += working_time
         previous_ids = current_ids
 
-    common = {
-        "timestamp": datetime.datetime.now(datetime.timezone.utc),
-        "user_id": request.user.id,
-        "user_name": request.user.username,
-        "user_email": request.user.email,
-        "org_id": getattr(org, "id", None),
-        "org_slug": getattr(org, "slug", None),
-    }
+    if data["events"]:
+        common = {
+            "timestamp": data["events"][0]["timestamp"],
+            "user_id": request.user.id,
+            "user_name": request.user.username,
+            "user_email": request.user.email,
+            "org_id": getattr(org, "id", None),
+            "org_slug": getattr(org, "slug", None),
+        }
 
-    for ids in working_time_dict:
-        event = generate_wt_event(ids, working_time_dict[ids], common)
-        if event:
-            event.is_valid(raise_exception=True)
-            record_server_event(
-                scope=event.validated_data['scope'],
-                request_id=request_id(),
-                payload=event.validated_data
-            )
+        for ids in working_time_dict:
+            event = generate_wt_event(ids, working_time_dict[ids], common)
+            if event:
+                event.is_valid(raise_exception=True)
+                record_server_event(
+                    scope=event.validated_data['scope'],
+                    request_id=request_id(),
+                    payload=event.validated_data
+                )

--- a/cvat/apps/events/serializers.py
+++ b/cvat/apps/events/serializers.py
@@ -6,7 +6,6 @@ import datetime
 import json
 
 from rest_framework import serializers
-from rest_framework.serializers import ValidationError
 
 
 class EventSerializer(serializers.Serializer):
@@ -61,12 +60,12 @@ class ClientEventsSerializer(serializers.Serializer):
         for event in data["events"]:
             scope = event["scope"]
             if scope not in ClientEventsSerializer.ALLOWED_SCOPES:
-                raise ValidationError(f"Event scope **{scope}** is not allowed from client")
+                raise serializers.ValidationError({ "scope": f"Event scope **{scope}** is not allowed from client" })
 
             try:
                 payload = json.loads(event.get("payload", "{}"))
             except json.JSONDecodeError:
-                raise serializers.ValidationError("JSON payload is not valid in passed event")
+                raise serializers.ValidationError({ "payload": "JSON payload is not valid in passed event" })
 
             event.update({
                 "timestamp": event["timestamp"] + time_correction,

--- a/cvat/apps/events/serializers.py
+++ b/cvat/apps/events/serializers.py
@@ -22,7 +22,7 @@ class EventSerializer(serializers.Serializer):
     job_id = serializers.IntegerField(required=False, allow_null=True)
     user_id = serializers.IntegerField(required=False, allow_null=True)
     user_name = serializers.CharField(required=False, allow_null=True)
-    user_email = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    user_email = serializers.CharField(required=False, allow_null=True)
     org_id = serializers.IntegerField(required=False, allow_null=True)
     org_slug = serializers.CharField(required=False, allow_null=True)
     payload = serializers.CharField(required=False, allow_null=True)

--- a/cvat/apps/events/serializers.py
+++ b/cvat/apps/events/serializers.py
@@ -7,6 +7,7 @@ import json
 
 from rest_framework import serializers
 
+
 class EventSerializer(serializers.Serializer):
     scope = serializers.CharField(required=True)
     obj_name = serializers.CharField(required=False, allow_null=True)

--- a/cvat/apps/events/serializers.py
+++ b/cvat/apps/events/serializers.py
@@ -42,16 +42,19 @@ class ClientEventsSerializer(serializers.Serializer):
         receive_time = datetime.datetime.now(datetime.timezone.utc)
         time_correction = receive_time - send_time
 
-        for event in data["events"]:
-            timestamp = event["timestamp"]
+        if data["previous_event"]:
+            data["previous_event"].update({
+                "timestamp": data["previous_event"]["timestamp"] + time_correction,
+            })
 
+        for event in data["events"]:
             try:
                 json_payload = json.loads(event.get("payload", "{}"))
             except json.JSONDecodeError:
                 raise serializers.ValidationError("JSON payload is not valid in passed event")
 
             event.update({
-                "timestamp": str(timestamp + time_correction),
+                "timestamp": event["timestamp"] + time_correction,
                 "source": "client",
                 "org_id": org_id,
                 "org_slug": org_slug,

--- a/cvat/apps/events/serializers.py
+++ b/cvat/apps/events/serializers.py
@@ -118,8 +118,8 @@ class ClientEventsSerializer(serializers.Serializer):
             previous_job_id = job_id
 
             try:
-                json_payload = json.dumps(json.loads(event.get("payload", "{}")))
-            except:
+                json_payload = json.loads(event.get("payload", "{}"))
+            except json.JSONDecodeError:
                 raise serializers.ValidationError("JSON payload is not valid in passed event")
 
             event.update({
@@ -130,7 +130,7 @@ class ClientEventsSerializer(serializers.Serializer):
                 "user_id": request.user.id,
                 "user_name": request.user.username,
                 "user_email": request.user.email,
-                "payload": json_payload,
+                "payload": json.dumps(json_payload),
             })
 
         common = {

--- a/cvat/apps/events/serializers.py
+++ b/cvat/apps/events/serializers.py
@@ -35,11 +35,24 @@ class ClientEventsSerializer(serializers.Serializer):
     _WORKING_TIME_SCOPE = 'send:working_time'
     _TIME_THRESHOLD = datetime.timedelta(seconds=100)
     _WORKING_TIME_RESOLUTION = datetime.timedelta(milliseconds=1)
-    _PROHIBITED_CLIENT_SCOPES = frozenset((_WORKING_TIME_SCOPE,))
     _COLLAPSED_EVENT_SCOPES = frozenset(("change:frame",))
+    _PROHIBITED_CLIENT_SCOPES = frozenset((
+        _WORKING_TIME_SCOPE,
+        'create:project', 'update:project', 'delete:project',
+        'create:task', 'update:task', 'delete:task',
+        'create:job', 'update:job', 'delete:job',
+        'create:organization', 'update:organization', 'delete:organization',
+        'create:user', 'update:user', 'delete:user',
+        'create:cloudstorage', 'update:cloudstorage', 'delete:cloudstorage',
+        'create:issue', 'update:issue', 'delete:issue',
+        'create:comment', 'update:comment', 'delete:comment',
+        'create:annotations', 'update:annotations', 'delete:annotations',
+        'create:label', 'update:label', 'delete:label',
+        'export:dataset', 'import:dataset',
+    ))
 
     @classmethod
-    def _generate_wt_event(cls, job_id: int | None, wt: datetime.timedelta, common: dict) -> EventSerializer:
+    def _generate_wt_event(cls, job_id: int | None, wt: datetime.timedelta, common: dict) -> EventSerializer | None:
         if wt.total_seconds():
             task_id = None
             project_id = None
@@ -145,6 +158,7 @@ class ClientEventsSerializer(serializers.Serializer):
 
         for job_id in working_time_per_job:
             event = ClientEventsSerializer._generate_wt_event(job_id, working_time_per_job[job_id], common)
-            data["events"].append(event.validated_data)
+            if event:
+                data["events"].append(event.validated_data)
 
         return data

--- a/cvat/apps/events/serializers.py
+++ b/cvat/apps/events/serializers.py
@@ -32,10 +32,11 @@ class ClientEventsSerializer(serializers.Serializer):
     events = EventSerializer(many=True, default=[])
     previous_event = EventSerializer(default=None, allow_null=True, write_only=True)
     timestamp = serializers.DateTimeField()
+    _WORKING_TIME_SCOPE = 'send:working_time'
     _TIME_THRESHOLD = datetime.timedelta(seconds=100)
     _WORKING_TIME_RESOLUTION = datetime.timedelta(milliseconds=1)
+    _PROHIBITED_CLIENT_SCOPES = frozenset((_WORKING_TIME_SCOPE,))
     _COLLAPSED_EVENT_SCOPES = frozenset(("change:frame",))
-    _WORKING_TIME_SCOPE = 'send:working_time'
 
     @classmethod
     def _generate_wt_event(cls, job_id: int | None, wt: datetime.timedelta, common: dict) -> EventSerializer:

--- a/cvat/apps/events/serializers.py
+++ b/cvat/apps/events/serializers.py
@@ -123,7 +123,7 @@ class ClientEventsSerializer(serializers.Serializer):
                 raise serializers.ValidationError("JSON payload is not valid in passed event")
 
             event.update({
-                "timestamp": str((timestamp + time_correction).timestamp()),
+                "timestamp": str(timestamp + time_correction),
                 "source": "client",
                 "org_id": org_id,
                 "org_slug": org_slug,
@@ -134,7 +134,7 @@ class ClientEventsSerializer(serializers.Serializer):
             })
 
         common = {
-            "timestamp": str(receive_time.timestamp()),
+            "timestamp": str(receive_time),
             "user_id": request.user.id,
             "user_name": request.user.username,
             "user_email": request.user.email,
@@ -144,6 +144,6 @@ class ClientEventsSerializer(serializers.Serializer):
 
         for job_id in working_time_per_job:
             event = ClientEventsSerializer._generate_wt_event(job_id, working_time_per_job[job_id], common)
-            data["events"].append(event.to_internal_value())
+            data["events"].append(event.validated_data)
 
         return data

--- a/cvat/apps/events/serializers.py
+++ b/cvat/apps/events/serializers.py
@@ -36,20 +36,6 @@ class ClientEventsSerializer(serializers.Serializer):
     _TIME_THRESHOLD = datetime.timedelta(seconds=100)
     _WORKING_TIME_RESOLUTION = datetime.timedelta(milliseconds=1)
     _COLLAPSED_EVENT_SCOPES = frozenset(("change:frame",))
-    _PROHIBITED_CLIENT_SCOPES = frozenset((
-        _WORKING_TIME_SCOPE,
-        'create:project', 'update:project', 'delete:project',
-        'create:task', 'update:task', 'delete:task',
-        'create:job', 'update:job', 'delete:job',
-        'create:organization', 'update:organization', 'delete:organization',
-        'create:user', 'update:user', 'delete:user',
-        'create:cloudstorage', 'update:cloudstorage', 'delete:cloudstorage',
-        'create:issue', 'update:issue', 'delete:issue',
-        'create:comment', 'update:comment', 'delete:comment',
-        'create:annotations', 'update:annotations', 'delete:annotations',
-        'create:label', 'update:label', 'delete:label',
-        'export:dataset', 'import:dataset',
-    ))
 
     @classmethod
     def _generate_wt_event(cls, job_id: int | None, wt: datetime.timedelta, common: dict) -> EventSerializer | None:

--- a/cvat/apps/events/serializers.py
+++ b/cvat/apps/events/serializers.py
@@ -22,7 +22,7 @@ class EventSerializer(serializers.Serializer):
     job_id = serializers.IntegerField(required=False, allow_null=True)
     user_id = serializers.IntegerField(required=False, allow_null=True)
     user_name = serializers.CharField(required=False, allow_null=True)
-    user_email = serializers.CharField(required=False, allow_null=True)
+    user_email = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     org_id = serializers.IntegerField(required=False, allow_null=True)
     org_slug = serializers.CharField(required=False, allow_null=True)
     payload = serializers.CharField(required=False, allow_null=True)

--- a/cvat/apps/events/views.py
+++ b/cvat/apps/events/views.py
@@ -3,20 +3,22 @@
 # SPDX-License-Identifier: MIT
 
 from django.conf import settings
-from rest_framework import status, viewsets
-from rest_framework.response import Response
-from rest_framework.exceptions import PermissionDenied
-from drf_spectacular.utils import OpenApiResponse, OpenApiParameter, extend_schema
 from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (OpenApiParameter, OpenApiResponse,
+                                   extend_schema)
+from rest_framework import status, viewsets
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
 
-
-from cvat.apps.iam.filters import ORGANIZATION_OPEN_API_PARAMETERS
+from cvat.apps.engine.log import vlogger
 from cvat.apps.events.permissions import EventsPermission
 from cvat.apps.events.serializers import ClientEventsSerializer
-from cvat.apps.engine.log import vlogger
+from cvat.apps.iam.filters import ORGANIZATION_OPEN_API_PARAMETERS
+
 from .export import export
 from .handlers import handle_client_events_push
+
 
 class EventsViewSet(viewsets.ViewSet):
     serializer_class = None

--- a/cvat/apps/events/views.py
+++ b/cvat/apps/events/views.py
@@ -1,10 +1,11 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) 2023-2024 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 
 from django.conf import settings
 from rest_framework import status, viewsets
 from rest_framework.response import Response
+from rest_framework.exceptions import PermissionDenied
 from drf_spectacular.utils import OpenApiResponse, OpenApiParameter, extend_schema
 from drf_spectacular.types import OpenApiTypes
 from rest_framework.renderers import JSONRenderer
@@ -30,6 +31,11 @@ class EventsViewSet(viewsets.ViewSet):
     def create(self, request):
         serializer = ClientEventsSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
+
+        for event in request.data['events']:
+            scope = event['scope']
+            if scope in ClientEventsSerializer._PROHIBITED_CLIENT_SCOPES:
+                raise PermissionDenied(f'Event scope **{scope}** is not allowed from client')
 
         for event in serializer.data["events"]:
             message = JSONRenderer().render(event).decode('UTF-8')

--- a/cvat/apps/events/views.py
+++ b/cvat/apps/events/views.py
@@ -7,9 +7,9 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (OpenApiParameter, OpenApiResponse,
                                    extend_schema)
 from rest_framework import status, viewsets
-from rest_framework.serializers import ValidationError
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
+from rest_framework.serializers import ValidationError
 
 from cvat.apps.engine.log import vlogger
 from cvat.apps.events.permissions import EventsPermission

--- a/cvat/apps/events/views.py
+++ b/cvat/apps/events/views.py
@@ -55,11 +55,14 @@ class EventsViewSet(viewsets.ViewSet):
                 raise ValidationError(f'Event scope **{scope}** is not allowed from client')
 
         for event in serializer.validated_data["events"]:
-            message = JSONRenderer().render(event).decode('UTF-8')
+            message = JSONRenderer().render({
+                **event,
+                'timestamp': str(event["timestamp"].timestamp())
+            }).decode('UTF-8')
             vlogger.info(message)
 
         handle_client_events_push(request, serializer.validated_data)
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.validated_data, status=status.HTTP_201_CREATED)
 
     @extend_schema(summary='Get an event log',
         methods=['GET'],

--- a/cvat/apps/events/views.py
+++ b/cvat/apps/events/views.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) 2023 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -31,11 +31,6 @@ class EventsViewSet(viewsets.ViewSet):
     def create(self, request):
         serializer = ClientEventsSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
-
-        for event in request.data['events']:
-            scope = event['scope']
-            if scope in ClientEventsSerializer._PROHIBITED_CLIENT_SCOPES:
-                raise PermissionDenied(f'Event scope **{scope}** is not allowed from client')
 
         for event in serializer.data["events"]:
             message = JSONRenderer().render(event).decode('UTF-8')

--- a/cvat/apps/events/views.py
+++ b/cvat/apps/events/views.py
@@ -7,7 +7,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (OpenApiParameter, OpenApiResponse,
                                    extend_schema)
 from rest_framework import status, viewsets
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.serializers import ValidationError
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
@@ -22,7 +22,7 @@ from .handlers import handle_client_events_push
 
 class EventsViewSet(viewsets.ViewSet):
     serializer_class = None
-    PROHIBITED_CLIENT_SCOPES = frozenset((
+    SERVER_ONLY_SCOPES = frozenset((
         'create:project', 'update:project', 'delete:project',
         'create:task', 'update:task', 'delete:task',
         'create:job', 'update:job', 'delete:job',
@@ -51,8 +51,8 @@ class EventsViewSet(viewsets.ViewSet):
 
         for event in serializer.validated_data['events']:
             scope = event['scope']
-            if scope in EventsViewSet.PROHIBITED_CLIENT_SCOPES:
-                raise PermissionDenied(f'Event scope **{scope}** is not allowed from client')
+            if scope in EventsViewSet.SERVER_ONLY_SCOPES:
+                raise ValidationError(f'Event scope **{scope}** is not allowed from client')
 
         for event in serializer.validated_data["events"]:
             message = JSONRenderer().render(event).decode('UTF-8')

--- a/cvat/apps/events/views.py
+++ b/cvat/apps/events/views.py
@@ -54,6 +54,7 @@ class EventsViewSet(viewsets.ViewSet):
             if scope in EventsViewSet.SERVER_ONLY_SCOPES:
                 raise ValidationError(f'Event scope **{scope}** is not allowed from client')
 
+        handle_client_events_push(request, serializer.validated_data)
         for event in serializer.validated_data["events"]:
             message = JSONRenderer().render({
                 **event,
@@ -61,7 +62,6 @@ class EventsViewSet(viewsets.ViewSet):
             }).decode('UTF-8')
             vlogger.info(message)
 
-        handle_client_events_push(request, serializer.validated_data)
         return Response(serializer.validated_data, status=status.HTTP_201_CREATED)
 
     @extend_schema(summary='Get an event log',

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -7061,7 +7061,6 @@ components:
         user_email:
           type: string
           nullable: true
-          minLength: 1
         org_id:
           type: integer
           nullable: true

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -7061,6 +7061,7 @@ components:
         user_email:
           type: string
           nullable: true
+          minLength: 1
         org_id:
           type: integer
           nullable: true

--- a/site/content/en/docs/administration/advanced/analytics.md
+++ b/site/content/en/docs/administration/advanced/analytics.md
@@ -177,13 +177,15 @@ the end of the previous event and the end of the next event.
     - But if the difference is more then threshold (~100 seconds), the difference is not added to the working time
     - Regardless different events may have `duration` field, we consider only `change:frame`
     event as a continuous event when computing working time
+    - So, the only `duration` of the `change:frame` event is added to the working time.
+    Thresholding is not involved here.
 
 - After calculation, the server generates `send:working_time` events with time value in payload.
 These events may be, or not be bounded to a certain job/task/project.
 CVAT defines belonging of the working time based on events, that were used to calculate.
 
 - If Clickhouse was configured, CVAT saves the event in
-the database and later these events are used to compute analytics.
+the database and later these events are used to compute metrics for analytics.
 
 ### Request `id` for tracking
 

--- a/site/content/en/docs/administration/advanced/analytics.md
+++ b/site/content/en/docs/administration/advanced/analytics.md
@@ -165,17 +165,17 @@ Here is a short overview of how CVAT deals with the user's working time:
 
 - The user interface sends these events in bulk to the server.
   Currently, it uses the following triggers to send events:
-    - Periodical timer (~90 seconds)
-    - A user clicks the "Save" button on the annotation view
-    - A user opens the annotation view
-    - A user closes the annotation view (but not the tab/browser)
+  - Periodical timer (~90 seconds)
+  - A user clicks the "Save" button on the annotation view
+  - A user opens the annotation view
+  - A user closes the annotation view (but not the tab/browser)
 
 - When events reach the server, it calculates working time based on timestamps of the events.
 
 - The working time for an event is computed as the sum of the following:
-    - The difference between the start time of the event and the end time of
+  - The difference between the start time of the event and the end time of
     the previous event, if it is not more than 100 seconds.
-    - The duration of the event, for events of type `change:frame`.
+  - The duration of the event, for events of type `change:frame`.
 
 - After calculation, the server generates `send:working_time` events with time value in payload.
   These events may or may not be bound to a certain job/task/project,

--- a/site/content/en/docs/administration/advanced/analytics.md
+++ b/site/content/en/docs/administration/advanced/analytics.md
@@ -167,7 +167,7 @@ Client events:
 Here is a short overview of how CVAT deals with the user's working time:
 
 - The user interface collects events when a user interacts with the interface
-(resizing canvas, drawing objects, clicking buttons, etc)
+  (resizing canvas, drawing objects, clicking buttons, etc)
   The structure of one single event is described [here](#events-log-structure).
 
 - The user interface sends these events in bulk to the server.
@@ -186,7 +186,7 @@ Here is a short overview of how CVAT deals with the user's working time:
 
 - After calculation, the server generates `send:working_time` events with time value in payload.
   These events may or may not be bound to a certain job/task/project,
-depending on the client-side events that were used to generate them.
+  depending on the client-side events that were used to generate them.
 
 - CVAT saves the event in the database and later these events are used to compute metrics for analytics.
 

--- a/site/content/en/docs/administration/advanced/analytics.md
+++ b/site/content/en/docs/administration/advanced/analytics.md
@@ -159,29 +159,29 @@ Client events:
 
 Here is a short overview of how CVAT deals with the user's working time:
 
-  - The user interface collects events when a user interacts with the interface
+- The user interface collects events when a user interacts with the interface
 (resizing canvas, drawing objects, clicking buttons, etc)
 The structure of one single event is described [here](#events-log-structure).
 
-  - The user interface sends these events in bulk to the server.
+- The user interface sends these events in bulk to the server.
 Currently, it uses the following triggers to send events:
     - Periodical timer (~90 seconds)
     - A user clicks the "Save" button on the annotation view
     - A user opens the annotation view
     - A user closes the annotation view (but not the tab/browser)
 
-  - When events reach the server, it calculates working time based on timestamps of the events.
+- When events reach the server, it calculates working time based on timestamps of the events.
 
-  - The working time for an event is computed as the sum of the following:
+- The working time for an event is computed as the sum of the following:
     - The difference between the start time of the event and the end time of
     the previous event, if it is not more than 100 seconds.
     - The duration of the event, for events of type `change:frame`.
 
-  - After calculation, the server generates `send:working_time` events with time value in payload.
+- After calculation, the server generates `send:working_time` events with time value in payload.
 These events may or may not be bound to a certain job/task/project,
 depending on the client-side events that were used to generate them.
 
-  - CVAT saves the event in the database and later these events are used to compute metrics for analytics.
+- CVAT saves the event in the database and later these events are used to compute metrics for analytics.
 
 ### Request `id` for tracking
 

--- a/site/content/en/docs/administration/advanced/analytics.md
+++ b/site/content/en/docs/administration/advanced/analytics.md
@@ -161,10 +161,10 @@ Here is a short overview of how CVAT deals with the user's working time:
 
 - The user interface collects events when a user interacts with the interface
 (resizing canvas, drawing objects, clicking buttons, etc)
-The structure of one single event is described [here](#events-log-structure).
+  The structure of one single event is described [here](#events-log-structure).
 
 - The user interface sends these events in bulk to the server.
-Currently, it uses the following triggers to send events:
+  Currently, it uses the following triggers to send events:
     - Periodical timer (~90 seconds)
     - A user clicks the "Save" button on the annotation view
     - A user opens the annotation view
@@ -178,7 +178,7 @@ Currently, it uses the following triggers to send events:
     - The duration of the event, for events of type `change:frame`.
 
 - After calculation, the server generates `send:working_time` events with time value in payload.
-These events may or may not be bound to a certain job/task/project,
+  These events may or may not be bound to a certain job/task/project,
 depending on the client-side events that were used to generate them.
 
 - CVAT saves the event in the database and later these events are used to compute metrics for analytics.

--- a/site/content/en/docs/administration/advanced/analytics.md
+++ b/site/content/en/docs/administration/advanced/analytics.md
@@ -157,13 +157,13 @@ Client events:
 
 ### Working time calculation
 
-Here is a short overview of how CVAT understands the user's working time:
+Here is a short overview of how CVAT deals with the user's working time:
 
 - The user interface collects events when a user interacts with the interface
 (resizing canvas, drawing objects, clicking buttons, etc)
 The structure of one single event is described [here](#events-log-structure).
 
--  The user interface sends these events in bulks to the server.
+- The user interface sends these events in bulks to the server.
 Currently, it uses the following triggers to send events:
     - Periodical timer (~90 seconds)
     - A user clicks the "Save" button on the annotation view
@@ -182,7 +182,8 @@ the end of the previous event and the end of the next event.
 These events may be, or not be bounded to a certain job/task/project.
 CVAT defines belonging of the working time based on events, that were used to calculate.
 
-- If Clickhouse was configured, CVAT saves the event in the database and later these events are used to compute analytics.
+- If Clickhouse was configured, CVAT saves the event in
+the database and later these events are used to compute analytics.
 
 ### Request `id` for tracking
 

--- a/site/content/en/docs/administration/advanced/analytics.md
+++ b/site/content/en/docs/administration/advanced/analytics.md
@@ -159,33 +159,29 @@ Client events:
 
 Here is a short overview of how CVAT deals with the user's working time:
 
-- The user interface collects events when a user interacts with the interface
+  - The user interface collects events when a user interacts with the interface
 (resizing canvas, drawing objects, clicking buttons, etc)
 The structure of one single event is described [here](#events-log-structure).
 
-- The user interface sends these events in bulks to the server.
+  - The user interface sends these events in bulk to the server.
 Currently, it uses the following triggers to send events:
     - Periodical timer (~90 seconds)
     - A user clicks the "Save" button on the annotation view
     - A user opens the annotation view
     - A user closes the annotation view (but not the tab/browser)
 
-- When events reach the server, it calculates working time based on timestamps of the events.
+  - When events reach the server, it calculates working time based on timestamps of the events.
 
-- Working time is computed as a sum of time differences between
-the end of the previous event and the end of the next event.
-    - But if the difference is more then threshold (~100 seconds), the difference is not added to the working time
-    - Regardless different events may have `duration` field, we consider only `change:frame`
-    event as a continuous event when computing working time
-    - So, the only `duration` of the `change:frame` event is added to the working time.
-    Thresholding is not involved here.
+  - The working time for an event is computed as the sum of the following:
+    - The difference between the start time of the event and the end time of
+    the previous event, if it is not more than 100 seconds.
+    - The duration of the event, for events of type `change:frame`.
 
-- After calculation, the server generates `send:working_time` events with time value in payload.
-These events may be, or not be bounded to a certain job/task/project.
-CVAT defines belonging of the working time based on events, that were used to calculate.
+  - After calculation, the server generates `send:working_time` events with time value in payload.
+These events may or may not be bound to a certain job/task/project,
+depending on the client-side events that were used to generate them.
 
-- If Clickhouse was configured, CVAT saves the event in
-the database and later these events are used to compute metrics for analytics.
+  - CVAT saves the event in the database and later these events are used to compute metrics for analytics.
 
 ### Request `id` for tracking
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
- Parsing JSON payloads to get `working_time` in general leads to low performance in Clickhouse requests. This patch will not fix it right now, but with this patch, after a period of time we may switch to new quick approach to calculate working time.
- There will not be a lot of `send:working_time` events, we may store this scope of events for a longer time (e.g. 5 years instead of one by default). 
- Finally storing working time in such events like `click:element` or `send:exception`, or `debug:info` seems not logical. 
- Also, the history showed, that as result in different bugs, these events may sometime lose information about `job_id`, `task_id`, etc. 

Resolved #7884

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automatic working time tracking per job, enhancing time management and reporting.

- **Bug Fixes**
  - Improved event processing to ensure accurate timestamp updates and payload handling.

- **Refactor**
  - Streamlined internal logic for handling client events and working time calculations.

- **Security**
  - Added proper permission handling to prevent unauthorized access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->