### PR TITLE
Stabilized the cypress test for fix CI-nightly runs

### DIFF
--- a/tests/cypress/e2e/issues_prs2/issue_1568_cuboid_dump_annotation.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1568_cuboid_dump_annotation.js
@@ -37,6 +37,8 @@ context('Dump annotation if cuboid created.', () => {
                 format: exportFormat,
             };
             cy.exportJob(exportAnnotation);
+            cy.intercept('GET', '/api/jobs/**/annotations?**').as('getAnnotations');
+            cy.wait('@getAnnotations');
             cy.waitForDownload();
         });
 

--- a/tests/cypress/e2e/issues_prs2/issue_1568_cuboid_dump_annotation.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1568_cuboid_dump_annotation.js
@@ -37,8 +37,6 @@ context('Dump annotation if cuboid created.', () => {
                 format: exportFormat,
             };
             cy.exportJob(exportAnnotation);
-            cy.intercept('GET', '/api/jobs/**/annotations?**').as('getAnnotations');
-            cy.wait('@getAnnotations');
             cy.waitForDownload();
         });
 

--- a/tests/cypress/support/commands_projects.js
+++ b/tests/cypress/support/commands_projects.js
@@ -246,7 +246,7 @@ Cypress.Commands.add('restoreProject', (archiveWithBackup, sourceStorage = null)
 
 Cypress.Commands.add('getDownloadFileName', () => {
     cy.intercept('GET', '**=download').as('download');
-    cy.wait('@download').then((download) => {
+    cy.wait('@download', { requestTimeout: 10000 }).then((download) => {
         const filename = download.response.headers['content-disposition'].split(';')[1].split('filename=')[1];
         // need to remove quotes
         return filename.substring(1, filename.length - 1);

--- a/tests/cypress/support/commands_projects.js
+++ b/tests/cypress/support/commands_projects.js
@@ -246,7 +246,7 @@ Cypress.Commands.add('restoreProject', (archiveWithBackup, sourceStorage = null)
 
 Cypress.Commands.add('getDownloadFileName', () => {
     cy.intercept('GET', '**=download').as('download');
-    cy.wait('@download', { requestTimeout: 10000 }).then((download) => {
+    cy.wait('@download', { responseTimeout: 10000 }).then((download) => {
         const filename = download.response.headers['content-disposition'].split(';')[1].split('filename=')[1];
         // need to remove quotes
         return filename.substring(1, filename.length - 1);


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The test issue_1568_cuboid_dump_ annotation.js failed sometimes in CI-nightly run. The video of test show that the file does not download in the default 5 seconds, I increased the timeout.
### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by adding a mechanism to intercept and wait for specific network requests during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->