### PR TITLE
Added license information regarding '/serverless' directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,12 @@ up to 10x. Here is a list of the algorithms we support, and the platforms they c
 
 The code is released under the [MIT License](https://opensource.org/licenses/MIT).
 
-This software uses LGPL-licensed libraries from the [FFmpeg](https://www.ffmpeg.org) project.
+- The code contained within the `/serverless` directory is released under the **MIT License**.
+However, it may download and utilize various assets, such as source code, architectures, and weights, among others.
+These assets may be distributed under different licenses, including non-commercial licenses.
+It is** your responsibility to ensure compliance with the terms of these licenses before using the assets**.
+
+- This software uses LGPL-licensed libraries from the [FFmpeg](https://www.ffmpeg.org) project.
 The exact steps on how FFmpeg was configured and compiled can be found in the [Dockerfile](Dockerfile).
 
 FFmpeg is an open-source framework licensed under LGPL and GPL.

--- a/README.md
+++ b/README.md
@@ -212,12 +212,12 @@ up to 10x. Here is a list of the algorithms we support, and the platforms they c
 
 The code is released under the [MIT License](https://opensource.org/licenses/MIT).
 
-- The code contained within the `/serverless` directory is released under the **MIT License**.
+The code contained within the `/serverless` directory is released under the **MIT License**.
 However, it may download and utilize various assets, such as source code, architectures, and weights, among others.
 These assets may be distributed under different licenses, including non-commercial licenses.
-It is** your responsibility to ensure compliance with the terms of these licenses before using the assets**.
+It is your responsibility to ensure compliance with the terms of these licenses before using the assets.
 
-- This software uses LGPL-licensed libraries from the [FFmpeg](https://www.ffmpeg.org) project.
+This software uses LGPL-licensed libraries from the [FFmpeg](https://www.ffmpeg.org) project.
 The exact steps on how FFmpeg was configured and compiled can be found in the [Dockerfile](Dockerfile).
 
 FFmpeg is an open-source framework licensed under LGPL and GPL.


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README to include information about asset licenses in the `/serverless` directory and user compliance responsibilities.
  - Clarified that FFmpeg is LGPL-licensed and provided details on its configuration in the Dockerfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->