### PR TITLE
Fixed exception: State cannot be updated during editing, need to finish current editing first

### DIFF
--- a/changelog.d/20240612_162647_boris_fixed_issue.md
+++ b/changelog.d/20240612_162647_boris_fixed_issue.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Exception: State cannot be updated during editing, need to finish current editing first
+  (<https://github.com/cvat-ai/cvat/pull/8019>)

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/brush-tools.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/brush-tools.tsx
@@ -164,7 +164,7 @@ function BrushTools(): React.ReactPortal | null {
 
         const updateEditableState = (e: Event): void => {
             const evt = e as CustomEvent;
-            if (evt.type === 'canvas.editstart' && evt.detail.state) {
+            if (evt.type === 'canvas.editstart' && evt.detail?.state?.shapeType === ShapeType.MASK) {
                 setEditableState(evt.detail.state);
             } else if (editableState) {
                 setEditableState(null);
@@ -179,7 +179,7 @@ function BrushTools(): React.ReactPortal | null {
             canvasInstance.html().addEventListener('canvas.drawstart', showToolset);
             canvasInstance.html().addEventListener('canvas.editstart', showToolset);
             canvasInstance.html().addEventListener('canvas.editstart', updateEditableState);
-            canvasInstance.html().addEventListener('canvas.editdone', updateEditableState);
+            canvasInstance.html().addEventListener('canvas.edited', updateEditableState);
         }
 
         return () => {
@@ -191,7 +191,7 @@ function BrushTools(): React.ReactPortal | null {
                 canvasInstance.html().removeEventListener('canvas.drawstart', showToolset);
                 canvasInstance.html().removeEventListener('canvas.editstart', showToolset);
                 canvasInstance.html().removeEventListener('canvas.editstart', updateEditableState);
-                canvasInstance.html().removeEventListener('canvas.editdone', updateEditableState);
+                canvasInstance.html().removeEventListener('canvas.edited', updateEditableState);
             }
         };
     }, [visible, editableState, currentTool]);


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where state updates were incorrectly handled during editing. Now, state updates occur only after the editing process is complete.
  
- **Refactor**
  - Updated event listener names for consistency, changing from `canvas.editdone` to `canvas.edited`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->