### PR TITLE
Fixed couple of not stable tests

### DIFF
--- a/tests/cypress/e2e/actions_objects/case_37_object_make_copy.js
+++ b/tests/cypress/e2e/actions_objects/case_37_object_make_copy.js
@@ -134,12 +134,12 @@ context('Object make a copy.', () => {
 
         // Disabled part of the test for the Firefox browser due to possible problems
         // positioning the element and completing the trigger() construct for moving the mouse cursor over the element.
-        it('Make a copy via object context menu.', { browser: '!firefox', scrollBehavior: false }, () => {
+        it('Make a copy via object context menu.', { browser: '!firefox' }, () => {
             let coordX = 100;
             const coordY = 400;
             for (let id = 1; id < countObject; id++) {
                 // Point doesn't have a context menu
-                cy.get(`#cvat_canvas_shape_${id}`).trigger('mousemove', 'right');
+                cy.get(`#cvat_canvas_shape_${id}`).trigger('mousemove', 'center');
                 cy.get(`#cvat_canvas_shape_${id}`).should('have.class', 'cvat_canvas_shape_activated');
                 cy.get(`#cvat_canvas_shape_${id}`).rightclick({ force: true });
                 cy.get('.cvat-canvas-context-menu').should('be.visible');
@@ -170,7 +170,7 @@ context('Object make a copy.', () => {
             },
         );
 
-        it('Copy a shape to an another frame.', { scrollBehavior: false }, () => {
+        it('Copy a shape to an another frame.', () => {
             cy.get('#cvat_canvas_shape_1').trigger('mousemove');
             cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
             cy.get('body').type('{ctrl}c');
@@ -180,7 +180,7 @@ context('Object make a copy.', () => {
             cy.get('.cvat-player-previous-button').click();
         });
 
-        it('Copy a shape to an another frame after press "Ctrl+V" on the first frame.', { scrollBehavior: false }, () => {
+        it('Copy a shape to an another frame after press "Ctrl+V" on the first frame.', () => {
             cy.get('#cvat_canvas_shape_1').trigger('mousemove');
             cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
             cy.get('body').type('{ctrl}c');
@@ -192,7 +192,7 @@ context('Object make a copy.', () => {
             });
         });
 
-        it('Copy a shape with holding "Ctrl".', { scrollBehavior: false }, () => {
+        it('Copy a shape with holding "Ctrl".', () => {
             const keyCodeC = 67;
             const keyCodeV = 86;
             cy.get('.cvat_canvas_shape').first().trigger('mousemove');

--- a/tests/cypress/e2e/actions_objects/case_37_object_make_copy.js
+++ b/tests/cypress/e2e/actions_objects/case_37_object_make_copy.js
@@ -134,7 +134,7 @@ context('Object make a copy.', () => {
 
         // Disabled part of the test for the Firefox browser due to possible problems
         // positioning the element and completing the trigger() construct for moving the mouse cursor over the element.
-        it('Make a copy via object context menu.', { browser: '!firefox' }, () => {
+        it('Make a copy via object context menu.', { browser: '!firefox', scrollBehavior: false }, () => {
             let coordX = 100;
             const coordY = 400;
             for (let id = 1; id < countObject; id++) {
@@ -170,7 +170,7 @@ context('Object make a copy.', () => {
             },
         );
 
-        it('Copy a shape to an another frame.', () => {
+        it('Copy a shape to an another frame.', { scrollBehavior: false }, () => {
             cy.get('#cvat_canvas_shape_1').trigger('mousemove');
             cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
             cy.get('body').type('{ctrl}c');
@@ -180,7 +180,7 @@ context('Object make a copy.', () => {
             cy.get('.cvat-player-previous-button').click();
         });
 
-        it('Copy a shape to an another frame after press "Ctrl+V" on the first frame.', () => {
+        it('Copy a shape to an another frame after press "Ctrl+V" on the first frame.', { scrollBehavior: false }, () => {
             cy.get('#cvat_canvas_shape_1').trigger('mousemove');
             cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
             cy.get('body').type('{ctrl}c');
@@ -192,7 +192,7 @@ context('Object make a copy.', () => {
             });
         });
 
-        it('Copy a shape with holding "Ctrl".', () => {
+        it('Copy a shape with holding "Ctrl".', { scrollBehavior: false }, () => {
             const keyCodeC = 67;
             const keyCodeV = 86;
             cy.get('.cvat_canvas_shape').first().trigger('mousemove');

--- a/tests/cypress/e2e/actions_objects/case_37_object_make_copy.js
+++ b/tests/cypress/e2e/actions_objects/case_37_object_make_copy.js
@@ -139,7 +139,7 @@ context('Object make a copy.', () => {
             const coordY = 400;
             for (let id = 1; id < countObject; id++) {
                 // Point doesn't have a context menu
-                cy.get(`#cvat_canvas_shape_${id}`).trigger('mousemove', 'center');
+                cy.get(`#cvat-objects-sidebar-state-item-${id}`).trigger('mouseover');
                 cy.get(`#cvat_canvas_shape_${id}`).should('have.class', 'cvat_canvas_shape_activated');
                 cy.get(`#cvat_canvas_shape_${id}`).rightclick({ force: true });
                 cy.get('.cvat-canvas-context-menu').should('be.visible');

--- a/tests/cypress/support/commands_review_pipeline.js
+++ b/tests/cypress/support/commands_review_pipeline.js
@@ -13,8 +13,9 @@ Cypress.Commands.add('assignTaskToUser', (user) => {
             cy.get('.cvat-user-search-field').find('input').clear();
             cy.get('.cvat-user-search-field').find('input').type('{Enter}');
         }
-        cy.get('.cvat-spinner').should('not.exist');
     });
+
+    cy.get('.cvat-spinner').should('not.exist');
 });
 
 Cypress.Commands.add('assignJobToUser', (jobID, user) => {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced test reliability by updating scroll behavior settings in object copy tests.
  - Improved the `assignTaskToUser` command for better assertion handling of loading spinner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->