### PR TITLE
Minor fix in layout when running automatic annotations

### DIFF
--- a/changelog.d/20240624_145717_boris.md
+++ b/changelog.d/20240624_145717_boris.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Slightly broken layout when running attributed face detection model
+  (<https://github.com/cvat-ai/cvat/pull/8072>)

--- a/cvat-ui/src/components/model-runner-modal/object-mapper.tsx
+++ b/cvat-ui/src/components/model-runner-modal/object-mapper.tsx
@@ -78,13 +78,13 @@ function ObjectMapperComponent(props: Props): JSX.Element {
                 return (
                     <React.Fragment key={`${leftName}:${rightName}`}>
                         <Row className={rowClassName} key={`${leftName}:${rightName}`}>
-                            <Col span={10}>
+                            <Col span={9}>
                                 <Tag style={{ color: textColor }} color={color} key={leftName}>{leftName}</Tag>
                             </Col>
-                            <Col span={10} offset={1}>
+                            <Col span={9} offset={1}>
                                 <Tag style={{ color: textColor }} color={color} key={rightName}>{rightName}</Tag>
                             </Col>
-                            <Col span={1} offset={1}>
+                            <Col span={2} offset={1}>
                                 <CVATTooltip title={deleteMappingLabel}>
                                     <DeleteOutlined
                                         className='cvat-danger-circle-icon'
@@ -103,7 +103,7 @@ function ObjectMapperComponent(props: Props): JSX.Element {
 
             { (leftValue === null || rightValue === null) && !!notMappedLeft.length && (
                 <Row className={rowClassName}>
-                    <Col span={10}>
+                    <Col span={9}>
                         <Select
                             virtual
                             showSearch
@@ -124,7 +124,7 @@ function ObjectMapperComponent(props: Props): JSX.Element {
                             ))}
                         </Select>
                     </Col>
-                    <Col span={10} offset={1}>
+                    <Col span={9} offset={1}>
                         <Select
                             virtual
                             showSearch
@@ -145,7 +145,7 @@ function ObjectMapperComponent(props: Props): JSX.Element {
                             ))}
                         </Select>
                     </Col>
-                    <Col span={1} offset={1}>
+                    <Col span={2} offset={1}>
                         { (leftValue === null && rightValue === null) ? (
                             <Col span={1} offset={1}>
                                 <CVATTooltip title={infoMappingLabel}>

--- a/cvat-ui/src/components/model-runner-modal/styles.scss
+++ b/cvat-ui/src/components/model-runner-modal/styles.scss
@@ -19,14 +19,13 @@
 
     &:has(.cvat-runner-label-mapper) {
         max-height: $grid-unit-size * 64;
-        overflow-y: auto;
+        overflow: hidden auto;
     }
 
     > .cvat-runner-label-mapper {
         margin-top: $grid-unit-size * 2;
         margin-bottom: $grid-unit-size * 2;
-        padding-left: $grid-unit-size * 4;
-        padding-right: $grid-unit-size * 4;
+        margin-left: $grid-unit-size * 2;
     }
 
     .cvat-runner-attribute-mapper {
@@ -42,8 +41,7 @@
         width: 100%;
         margin-top: $grid-unit-size * 2;
         margin-bottom: $grid-unit-size * 2;
-        padding-left: $grid-unit-size * 4;
-        padding-right: $grid-unit-size * 4;
+        margin-left: $grid-unit-size * 2;
     }
 }
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Before:
![image](https://github.com/cvat-ai/cvat/assets/40690378/af5ac930-6ea0-479f-9dd9-ccf9130505df)

After:
![image](https://github.com/cvat-ai/cvat/assets/40690378/606b77c8-d139-4c96-8a88-84dabc86be5c)



### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the column spans and layout in the Object Mapper modal for improved presentation.
  - Modified padding and margins in the Model Runner modal styles for better element spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->