### PR TITLE
Fix quality computation for tasks with skeletons and normal labels

### DIFF
--- a/changelog.d/20240628_183747_mzhiltso_fix_quality_for_skeletons.md
+++ b/changelog.d/20240628_183747_mzhiltso_fix_quality_for_skeletons.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Quality computation for tasks with skeletons and normal labels
+  (<https://github.com/cvat-ai/cvat/pull/8100>)

--- a/changelog.d/20240628_183747_mzhiltso_fix_quality_for_skeletons.md
+++ b/changelog.d/20240628_183747_mzhiltso_fix_quality_for_skeletons.md
@@ -1,4 +1,4 @@
 ### Fixed
 
-- Quality computation for tasks with skeletons and normal labels
+- A possible crash in quality computation for tasks with skeletons and normal labels
   (<https://github.com/cvat-ai/cvat/pull/8100>)

--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -1930,9 +1930,7 @@ class DatasetComparator:
         invalid_labels_count = len(mismatches)
         total_labels_count = valid_labels_count + invalid_labels_count
 
-        confusion_matrix_labels, confusion_matrix, label_id_mapper = (
-            self._make_zero_confusion_matrix()
-        )
+        confusion_matrix_labels, confusion_matrix, label_id_map = self._make_zero_confusion_matrix()
         for gt_ann, ds_ann in itertools.chain(
             # fully matched annotations - shape, label, attributes
             matches,
@@ -1940,8 +1938,8 @@ class DatasetComparator:
             zip(itertools.repeat(None), ds_unmatched),
             zip(gt_unmatched, itertools.repeat(None)),
         ):
-            ds_label_idx = label_id_mapper(ds_ann.label) if ds_ann else self._UNMATCHED_IDX
-            gt_label_idx = label_id_mapper(gt_ann.label) if gt_ann else self._UNMATCHED_IDX
+            ds_label_idx = label_id_map[ds_ann.label] if ds_ann else self._UNMATCHED_IDX
+            gt_label_idx = label_id_map[gt_ann.label] if gt_ann else self._UNMATCHED_IDX
             confusion_matrix[ds_label_idx, gt_label_idx] += 1
 
         self._frame_results[frame_id] = ComparisonReportFrameSummary(
@@ -1972,24 +1970,24 @@ class DatasetComparator:
     # row/column index in the confusion matrix corresponding to unmatched annotations
     _UNMATCHED_IDX = -1
 
-    def _make_zero_confusion_matrix(self) -> Tuple[List[str], np.ndarray]:
-        label_id_name_map = {
-            label_id: label.name
-            for label_id, label in enumerate(self._gt_dataset.categories()[dm.AnnotationType.label])
-            if not label.parent
-        }
-        label_id_name_map[len(label_id_name_map)] = "unmatched"
+    def _make_zero_confusion_matrix(self) -> Tuple[List[str], np.ndarray, Dict[int, int]]:
+        label_id_idx_map = {}
+        label_names = []
+        max_label_id = -1
+        for label_id, label in enumerate(self._gt_dataset.categories()[dm.AnnotationType.label]):
+            if not label.parent:
+                label_id_idx_map[label_id] = len(label_names)
+                label_names.append(label.name)
 
-        label_names = list(label_id_name_map.values())
-        label_id_idx_map = {
-            label_id: label_idx for label_idx, label_id in enumerate(label_id_name_map)
-        }
-        label_id_mapper = label_id_idx_map.__getitem__
+            max_label_id = label_id
+
+        label_id_idx_map[max_label_id + 1] = len(label_names)
+        label_names.append("unmatched")
 
         num_labels = len(label_names)
         confusion_matrix = np.zeros((num_labels, num_labels), dtype=int)
 
-        return label_names, confusion_matrix, label_id_mapper
+        return label_names, confusion_matrix, label_id_idx_map
 
     @classmethod
     def _generate_annotations_summary(

--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -1973,15 +1973,11 @@ class DatasetComparator:
     def _make_zero_confusion_matrix(self) -> Tuple[List[str], np.ndarray, Dict[int, int]]:
         label_id_idx_map = {}
         label_names = []
-        max_label_id = -1
         for label_id, label in enumerate(self._gt_dataset.categories()[dm.AnnotationType.label]):
             if not label.parent:
                 label_id_idx_map[label_id] = len(label_names)
                 label_names.append(label.name)
 
-            max_label_id = label_id
-
-        label_id_idx_map[max_label_id + 1] = len(label_names)
         label_names.append("unmatched")
 
         num_labels = len(label_names)

--- a/tests/python/rest_api/test_quality_control.py
+++ b/tests/python/rest_api/test_quality_control.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) 2024 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -1244,3 +1244,38 @@ class TestQualityReportMetrics(_PermissionTestBase):
             )
 
         assert task_confusion_matrix == [[2, 0, 1], [0, 0, 0], [1, 0, 0]]
+
+    @pytest.mark.parametrize("task_id", [8])
+    def test_can_compute_quality_if_non_skeleton_label_follows_skeleton_label(
+        self, admin_user, labels, task_id
+    ):
+        new_label_name = "non_skeleton"
+        with make_api_client(admin_user) as api_client:
+            task_labels = [label for label in labels if label.get("task_id") == task_id]
+            task_labels += [{"name": new_label_name, "type": "any"}]
+            api_client.tasks_api.partial_update(
+                task_id,
+                patched_task_write_request=models.PatchedTaskWriteRequest(labels=task_labels),
+            )
+            new_label_obj, _ = api_client.labels_api.list(task_id=task_id, name=new_label_name)
+            new_label_id = new_label_obj.results[0].id
+            api_client.tasks_api.update_annotations(
+                task_id,
+                task_annotations_update_request={
+                    "shapes": [
+                        models.LabeledShapeRequest(
+                            type="rectangle",
+                            frame=0,
+                            label_id=new_label_id,
+                            points=[0, 0, 1, 1],
+                        )
+                    ]
+                },
+            )
+
+        self.create_gt_job(admin_user, task_id)
+
+        report = self.create_quality_report(admin_user, task_id)
+        with make_api_client(admin_user) as api_client:
+            (_, response) = api_client.quality_api.retrieve_report_data(report["id"])
+            assert response.status == HTTPStatus.OK

--- a/tests/python/rest_api/test_quality_control.py
+++ b/tests/python/rest_api/test_quality_control.py
@@ -1252,11 +1252,13 @@ class TestQualityReportMetrics(_PermissionTestBase):
         new_label_name = "non_skeleton"
         with make_api_client(admin_user) as api_client:
             task_labels = [label for label in labels if label.get("task_id") == task_id]
+            assert any(label["type"] == "skeleton" for label in task_labels)
             task_labels += [{"name": new_label_name, "type": "any"}]
             api_client.tasks_api.partial_update(
                 task_id,
                 patched_task_write_request=models.PatchedTaskWriteRequest(labels=task_labels),
             )
+
             new_label_obj, _ = api_client.labels_api.list(task_id=task_id, name=new_label_name)
             new_label_id = new_label_obj.results[0].id
             api_client.tasks_api.update_annotations(


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

- Fixed quality report computation in tasks with non-skeleton labels after skeleton labels

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Unit tests

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved quality computation for tasks with both skeletons and normal labels in the Computer Vision Annotation Tool (CVAT).

- **Tests**
  - Added a new test to ensure quality can be computed correctly when a non-skeleton label follows a skeleton label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->