### PR TITLE
Checking copy/paste of a skeleton point

### DIFF
--- a/tests/cypress/e2e/features/skeletons_pipeline.js
+++ b/tests/cypress/e2e/features/skeletons_pipeline.js
@@ -223,5 +223,18 @@ context('Manipulations with skeletons', { scrollBehavior: false }, () => {
 
             cy.removeAnnotations();
         });
+
+        it('Copy/paste a skeleton shape', () => {
+            cy.on('window:console:error', (error) => {
+                throw new Error(`Console error detected: ${error}`);
+            });
+
+            createSkeletonObject('shape');
+            cy.interactAnnotationObjectMenu('#cvat-objects-sidebar-state-item-1', 'Make a copy');
+            cy.get('.cvat-canvas-container').click();
+            cy.get('#cvat_canvas_shape_5').should('exist').and('be.visible');
+
+            cy.removeAnnotations();
+        });
     });
 });

--- a/tests/cypress/e2e/features/skeletons_pipeline.js
+++ b/tests/cypress/e2e/features/skeletons_pipeline.js
@@ -225,14 +225,14 @@ context('Manipulations with skeletons', { scrollBehavior: false }, () => {
         });
 
         it('Copy/paste a skeleton shape', () => {
-            cy.on('window:console:error', (error) => {
-                throw new Error(`Console error detected: ${error}`);
-            });
-
             createSkeletonObject('shape');
-            cy.interactAnnotationObjectMenu('#cvat-objects-sidebar-state-item-1', 'Make a copy');
+            cy.get('#cvat_canvas_shape_2').click();
+            cy.get('#cvat_canvas_shape_2').trigger('mouseover');
+            cy.get('body').type('{ctrl}c');
+            cy.get('body').type('{ctrl}v');
             cy.get('.cvat-canvas-container').click();
-            cy.get('#cvat_canvas_shape_5').should('exist').and('be.visible');
+
+            cy.get('#cvat_canvas_shape_7').should('exist').and('be.visible');
 
             cy.removeAnnotations();
         });


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Test for https://github.com/cvat-ai/cvat/pull/7843
### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added a new end-to-end test case for copying and pasting a skeleton shape, ensuring reliable functionality in shape manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->