### PR TITLE
Fixed unexpected deletion of log files of other processes that led to OSError: [Errno 116] Stale file handle error on NFS volumes

### DIFF
--- a/supervisord/server.conf
+++ b/supervisord/server.conf
@@ -15,7 +15,7 @@ logfile_maxbytes=50MB       ; maximum size of logfile before rotation
 logfile_backups=10          ; number of backed up logfiles
 loglevel=debug              ; info, debug, warn, trace
 pidfile=/tmp/supervisord/supervisord.pid ; pidfile location
-childlogdir=%(ENV_HOME)s/logs/            ; where child log files will live
+childlogdir=%(ENV_HOME)s/logs/ ; where child log files will live
 
 [program:clamav_update]
 startsecs=0
@@ -41,6 +41,8 @@ autorestart=true
 environment=CVAT_EVENTS_LOCAL_DB_FILENAME="events_%(process_num)03d.db",CVAT_POSTGRES_APPLICATION_NAME="cvat:server"
 numprocs=%(ENV_NUMPROCS)s
 process_name=%(program_name)s-%(process_num)d
+stdout_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stdout.log
+stderr_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stderr.log
 
 [program:smokescreen]
 command=smokescreen --listen-ip=127.0.0.1 %(ENV_SMOKESCREEN_OPTS)s

--- a/supervisord/utils.conf
+++ b/supervisord/utils.conf
@@ -15,7 +15,7 @@ logfile_maxbytes=50MB       ; maximum size of logfile before rotation
 logfile_backups=10          ; number of backed up logfiles
 loglevel=debug              ; info, debug, warn, trace
 pidfile=/tmp/supervisord/supervisord.pid ; pidfile location
-childlogdir=%(ENV_HOME)s/logs/            ; where child log files will live
+childlogdir=%(ENV_HOME)s/logs/ ; where child log files will live
 
 [program:rqscheduler]
 command=%(ENV_HOME)s/wait_for_deps.sh
@@ -25,6 +25,8 @@ command=%(ENV_HOME)s/wait_for_deps.sh
         -i 30 --path %(ENV_HOME)s
 environment=VECTOR_EVENT_HANDLER="SynchronousLogstashHandler"
 numprocs=1
+stdout_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stdout.log
+stderr_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stderr.log
 
 [program:rqworker-notifications]
 command=%(ENV_HOME)s/wait_for_deps.sh
@@ -32,6 +34,9 @@ command=%(ENV_HOME)s/wait_for_deps.sh
         --worker-class cvat.rqworker.DefaultWorker
 environment=VECTOR_EVENT_HANDLER="SynchronousLogstashHandler",CVAT_POSTGRES_APPLICATION_NAME="cvat:worker:notifications"
 numprocs=1
+stdout_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stdout.log
+stderr_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stderr.log
+autorestart=true
 
 [program:rqworker-cleaning]
 command=%(ENV_HOME)s/wait_for_deps.sh
@@ -41,3 +46,5 @@ environment=VECTOR_EVENT_HANDLER="SynchronousLogstashHandler",CVAT_POSTGRES_APPL
 numprocs=%(ENV_NUMPROCS)s
 process_name=%(program_name)s-%(process_num)d
 autorestart=true
+stdout_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stdout.log
+stderr_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stderr.log

--- a/supervisord/worker.analytics_reports.conf
+++ b/supervisord/worker.analytics_reports.conf
@@ -15,7 +15,7 @@ logfile_maxbytes=50MB       ; maximum size of logfile before rotation
 logfile_backups=10          ; number of backed up logfiles
 loglevel=debug              ; info, debug, warn, trace
 pidfile=/tmp/supervisord/supervisord.pid ; pidfile location
-childlogdir=%(ENV_HOME)s/logs/            ; where child log files will live
+childlogdir=%(ENV_HOME)s/logs/ ; where child log files will live
 
 [program:rqworker-analytics-reports]
 command=%(ENV_HOME)s/wait_for_deps.sh
@@ -25,3 +25,5 @@ environment=VECTOR_EVENT_HANDLER="SynchronousLogstashHandler",CVAT_POSTGRES_APPL
 numprocs=%(ENV_NUMPROCS)s
 process_name=%(program_name)s-%(process_num)d
 autorestart=true
+stdout_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stdout.log
+stderr_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stderr.log

--- a/supervisord/worker.annotation.conf
+++ b/supervisord/worker.annotation.conf
@@ -15,7 +15,7 @@ logfile_maxbytes=50MB       ; maximum size of logfile before rotation
 logfile_backups=10          ; number of backed up logfiles
 loglevel=debug              ; info, debug, warn, trace
 pidfile=/tmp/supervisord/supervisord.pid ; pidfile location
-childlogdir=%(ENV_HOME)s/logs/            ; where child log files will live
+childlogdir=%(ENV_HOME)s/logs/ ; where child log files will live
 
 [program:rqworker-annotation]
 command=%(ENV_HOME)s/wait_for_deps.sh
@@ -25,3 +25,5 @@ environment=VECTOR_EVENT_HANDLER="SynchronousLogstashHandler",CVAT_POSTGRES_APPL
 numprocs=%(ENV_NUMPROCS)s
 process_name=%(program_name)s-%(process_num)d
 autorestart=true
+stdout_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stdout.log
+stderr_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stderr.log

--- a/supervisord/worker.export.conf
+++ b/supervisord/worker.export.conf
@@ -15,7 +15,7 @@ logfile_maxbytes=50MB       ; maximum size of logfile before rotation
 logfile_backups=10          ; number of backed up logfiles
 loglevel=debug              ; info, debug, warn, trace
 pidfile=/tmp/supervisord/supervisord.pid ; pidfile location
-childlogdir=%(ENV_HOME)s/logs/            ; where child log files will live
+childlogdir=%(ENV_HOME)s/logs/ ; where child log files will live
 
 [program:rqworker-export]
 command=%(ENV_HOME)s/wait_for_deps.sh
@@ -25,6 +25,8 @@ environment=VECTOR_EVENT_HANDLER="SynchronousLogstashHandler",CVAT_POSTGRES_APPL
 numprocs=%(ENV_NUMPROCS)s
 process_name=%(program_name)s-%(process_num)d
 autorestart=true
+stdout_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stdout.log
+stderr_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stderr.log
 
 [program:smokescreen]
 command=smokescreen --listen-ip=127.0.0.1 %(ENV_SMOKESCREEN_OPTS)s

--- a/supervisord/worker.import.conf
+++ b/supervisord/worker.import.conf
@@ -15,7 +15,7 @@ logfile_maxbytes=50MB       ; maximum size of logfile before rotation
 logfile_backups=10          ; number of backed up logfiles
 loglevel=debug              ; info, debug, warn, trace
 pidfile=/tmp/supervisord/supervisord.pid ; pidfile location
-childlogdir=%(ENV_HOME)s/logs/            ; where child log files will live
+childlogdir=%(ENV_HOME)s/logs/ ; where child log files will live
 
 [program:rqworker-import]
 command=%(ENV_HOME)s/wait_for_deps.sh
@@ -25,7 +25,8 @@ environment=VECTOR_EVENT_HANDLER="SynchronousLogstashHandler",CVAT_POSTGRES_APPL
 numprocs=%(ENV_NUMPROCS)s
 process_name=%(program_name)s-%(process_num)d
 autorestart=true
-
+stdout_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stdout.log
+stderr_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stderr.log
 
 [program:clamav-update]
 command=bash -c "if [ \"${CLAM_AV}\" = 'yes' ]; then /usr/bin/freshclam -d \

--- a/supervisord/worker.quality_reports.conf
+++ b/supervisord/worker.quality_reports.conf
@@ -15,7 +15,7 @@ logfile_maxbytes=50MB       ; maximum size of logfile before rotation
 logfile_backups=10          ; number of backed up logfiles
 loglevel=debug              ; info, debug, warn, trace
 pidfile=/tmp/supervisord/supervisord.pid ; pidfile location
-childlogdir=%(ENV_HOME)s/logs/            ; where child log files will live
+childlogdir=%(ENV_HOME)s/logs/ ; where child log files will live
 
 [program:rqworker-quality-reports]
 command=%(ENV_HOME)s/wait_for_deps.sh
@@ -25,3 +25,5 @@ environment=VECTOR_EVENT_HANDLER="SynchronousLogstashHandler",CVAT_POSTGRES_APPL
 numprocs=%(ENV_NUMPROCS)s
 process_name=%(program_name)s-%(process_num)d
 autorestart=true
+stdout_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stdout.log
+stderr_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stderr.log

--- a/supervisord/worker.webhooks.conf
+++ b/supervisord/worker.webhooks.conf
@@ -15,7 +15,7 @@ logfile_maxbytes=50MB       ; maximum size of logfile before rotation
 logfile_backups=10          ; number of backed up logfiles
 loglevel=debug              ; info, debug, warn, trace
 pidfile=/tmp/supervisord/supervisord.pid ; pidfile location
-childlogdir=%(ENV_HOME)s/logs/            ; where child log files will live
+childlogdir=%(ENV_HOME)s/logs/ ; where child log files will live
 
 [program:rqworker-webhooks]
 command=%(ENV_HOME)s/wait_for_deps.sh
@@ -24,6 +24,8 @@ command=%(ENV_HOME)s/wait_for_deps.sh
 environment=VECTOR_EVENT_HANDLER="SynchronousLogstashHandler",CVAT_POSTGRES_APPLICATION_NAME="cvat:worker:webhooks"
 numprocs=%(ENV_NUMPROCS)s
 process_name=%(program_name)s-%(process_num)d
+stdout_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stdout.log
+stderr_logfile=%(ENV_HOME)s/logs/%(program_name)s-%(host_node_name)s-%(process_num)d-stderr.log
 
 [program:smokescreen]
 command=smokescreen --listen-ip=127.0.0.1 %(ENV_SMOKESCREEN_OPTS)s


### PR DESCRIPTION
Due the nocleanup option defaults to false and we use AUTO-generated names for backend process log files, this causes NFS4ERR_STALE to appear on NFS-mounted volumes
```python
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/supervisor/loggers.py", line 109, in emit
    self.flush()
  File "/usr/lib/python3/dist-packages/supervisor/loggers.py", line 68, in flush
    self.stream.flush()
OSError: [Errno 116] Stale file handle
```
http://supervisord.org/configuration.html#:~:text=Introduced%3A%203.0-,nocleanup,-Prevent%20supervisord%20from
https://stackoverflow.com/questions/40262823/stale-file-handle-error-when-process-trying-read-the-file-that-other-process

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
