### PR TITLE
Update docs to match currently used nuclio version

### DIFF
--- a/site/content/en/docs/administration/advanced/installation_automatic_annotation.md
+++ b/site/content/en/docs/administration/advanced/installation_automatic_annotation.md
@@ -29,7 +29,7 @@ description: 'Information about the installation of components needed for semi-a
   ```
 
 - You have to install `nuctl` command line tool to build and deploy serverless
-  functions. Download [version 1.11.24](https://github.com/nuclio/nuclio/releases/tag/1.11.24).
+  functions. Download [version 1.13.0](https://github.com/nuclio/nuclio/releases/tag/1.13.0).
   It is important that the version you download matches the version in
   [docker-compose.serverless.yml](https://github.com/cvat-ai/cvat/blob/develop/components/serverless/docker-compose.serverless.yml).
   For example, using wget.


### PR DESCRIPTION
Updated the docs to point to the currently-used version of nuclio.

### Motivation and context
In #7787, the version of nuclio was upgraded to patch some security vulnerabilities. However, the docs pointed to the old version of nuclio. This PR updates the docs to match.

### How has this been tested?
Docs-only change. Can verify by checking version against the version used in [docker-compose.serverless.yml](https://github.com/cvat-ai/cvat/blob/develop/components/serverless/docker-compose.serverless.yml)

Not sure if we need a changelog fragment for a change this small, but happy to create one if the maintainers would prefer.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
~~- [ ] I have added tests to cover my changes~~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
~~- [ ] I have increased versions of npm packages if it is necessary~~
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the version number for downloading the `nuctl` command line tool from `1.11.24` to `1.13.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->