### PR TITLE
Fixed ValueError: operands could not be broadcast together with shapes (X, ) (Y, )

### DIFF
--- a/changelog.d/20240717_125734_boris_fixed_export_skeletons.md
+++ b/changelog.d/20240717_125734_boris_fixed_export_skeletons.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Exporting a skeleton track in a format defined for shapes raises error 
+`operands could not be broadcast together with shapes (X, ) (Y, )`
+  (<https://github.com/cvat-ai/cvat/pull/8179>)

--- a/cvat-core/src/annotations-objects.ts
+++ b/cvat-core/src/annotations-objects.ts
@@ -2999,6 +2999,12 @@ export class SkeletonTrack extends Track {
     // Method is used to export data to the server
     public toJSON(): SerializedTrack {
         const result: SerializedTrack = Track.prototype.toJSON.call(this);
+
+        result.shapes = result.shapes.map((shape) => ({
+            ...shape,
+            points: [],
+        }));
+
         result.elements = this.elements.map((el) => ({
             ...el.toJSON(),
             source: this.source,

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -563,6 +563,8 @@ class JobAnnotation:
         for db_shape in db_shapes:
             self._extend_attributes(db_shape.attributes,
                 self.db_attributes[db_shape.label_id]["all"].values())
+            if db_shape['type'] == str(models.ShapeType.SKELETON):
+                db_shape['points'] = []
 
             if db_shape.parent is None:
                 db_shape.elements = []
@@ -649,9 +651,11 @@ class JobAnnotation:
             default_attribute_values = self.db_attributes[db_track.label_id]["mutable"].values()
             for db_shape in db_track["shapes"]:
                 db_shape["attributes"] = list(set(db_shape["attributes"]))
-                # in case of trackedshapes need to interpolate attriute values and extend it
+                # in case of trackedshapes need to interpolate attribute values and extend it
                 # by previous shape attribute values (not default values)
                 self._extend_attributes(db_shape["attributes"], default_attribute_values)
+                if db_shape['type'] == str(models.ShapeType.SKELETON):
+                    db_shape['points'] = []
                 default_attribute_values = db_shape["attributes"]
 
             if db_track.parent is None:

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -564,6 +564,8 @@ class JobAnnotation:
             self._extend_attributes(db_shape.attributes,
                 self.db_attributes[db_shape.label_id]["all"].values())
             if db_shape['type'] == str(models.ShapeType.SKELETON):
+                # skeletons themselves should not have points as they consist of other elements
+                # here we ensure that it was initialized correctly
                 db_shape['points'] = []
 
             if db_shape.parent is None:
@@ -655,6 +657,8 @@ class JobAnnotation:
                 # by previous shape attribute values (not default values)
                 self._extend_attributes(db_shape["attributes"], default_attribute_values)
                 if db_shape['type'] == str(models.ShapeType.SKELETON):
+                    # skeletons themselves should not have points as they consist of other elements
+                    # here we ensure that it was initialized correctly
                     db_shape['points'] = []
                 default_attribute_values = db_shape["attributes"]
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
1. Draw a skeleton track, go 10 frames forward, set a keyframe (press K shortcut)
2. Save, export in `CVAT for Images`
3. Get exception because one skeleton shape has N points and another one does not have points. 

![image](https://github.com/user-attachments/assets/d6ab4a16-f70e-4f23-8b27-c1a090f50b51)

Stacktrace:

```
Traceback (most recent call last):
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/views.py", line 108, in export
    export_fn(db_instance.id, temp_file, dst_format,
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/task.py", line 888, in export_job
    job.export(f, exporter, host=server_url, save_images=save_images)
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/task.py", line 694, in export
    exporter(dst_file, temp_dir, job_data, **options)
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/formats/registry.py", line 36, in __call__
    f_or_cls(*args, **kwargs)
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/formats/cvat.py", line 1433, in _export_images
    _export_task_or_job(dst_file, temp_dir, instance_data,
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/formats/cvat.py", line 1396, in _export_task_or_job
    dump_task_or_job_anno(f, instance_data, anno_callback)
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/formats/cvat.py", line 1364, in dump_task_or_job_anno
    callback(dumper, instance_data)
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/formats/cvat.py", line 719, in dump_as_cvat_annotation
    for frame_annotation in annotations.group_by_frame(include_empty=True):
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/bindings.py", line 435, in group_by_frame
    anno_manager.to_shapes(self.stop, self._annotation_ir.dimension,
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/annotation.py", line 185, in to_shapes
    return shapes + tracks.to_shapes(end_frame,
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/annotation.py", line 442, in to_shapes
    for shape in TrackManager.get_interpolated_shapes(
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/annotation.py", line 926, in get_interpolated_shapes
    shapes.extend(interpolate(prev_shape, shape))
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/annotation.py", line 874, in interpolate
    shapes = simple_interpolation(shape0, shape1)
  File "/home/bsekachev/app.cvat.ai/cvat_enterprise/cvat/cvat/apps/dataset_manager/annotation.py", line 592, in simple_interpolation
    diff = np.subtract(shape1["points"], shape0["points"])
```

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved initialization and handling of `SKELETON` type shapes to prevent errors by setting their points to an empty list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->