### PR TITLE
Fixed importing skeletons in a specific scenario

### DIFF
--- a/cvat/apps/dataset_manager/annotation.py
+++ b/cvat/apps/dataset_manager/annotation.py
@@ -72,14 +72,22 @@ class AnnotationIR:
             # a <= b
             return 0 <= min(b, stop) - max(a, start)
 
+        elements = track.get('elements', [])
+        if elements:
+            # skeletons usually have only one shape defined on initial frame
+            # anyway, for them we decided if they are inside range based on child elements
+            return any(AnnotationIR._is_track_inside(t, start, stop) for t in elements)
+
         prev_shape = None
         for shape in track['shapes']:
             if prev_shape and not prev_shape['outside'] and \
                     has_overlap(prev_shape['frame'], shape['frame']):
                 return True
-            prev_shape = shape
 
-        if not prev_shape['outside'] and prev_shape['frame'] <= stop:
+            if shape['frame'] >= start:
+                prev_shape = shape
+
+        if prev_shape and not prev_shape['outside'] and prev_shape['frame'] <= stop:
             return True
 
         return False
@@ -88,6 +96,8 @@ class AnnotationIR:
     def _slice_track(cls, track_, start, stop, dimension):
         def filter_track_shapes(shapes):
             shapes = [s for s in shapes if cls._is_shape_inside(s, start, stop)]
+
+            # remove leading outside shapes as they are not necessary
             drop_count = 0
             for s in shapes:
                 if s['outside']:
@@ -111,7 +121,7 @@ class AnnotationIR:
             scoped_shapes = filter_track_shapes(interpolated_shapes)
 
             if scoped_shapes:
-                last_key = sorted(track['shapes'], key=lambda s: s['frame'])[-1]['frame']
+                last_key = max(shape['frame'] for shape in track['shapes'])
                 if not scoped_shapes[0]['keyframe']:
                     segment_shapes.insert(0, scoped_shapes[0])
                 if last_key >= stop and scoped_shapes[-1]['points'] != segment_shapes[-1]['points']:

--- a/cvat/apps/dataset_manager/annotation.py
+++ b/cvat/apps/dataset_manager/annotation.py
@@ -86,7 +86,7 @@ class AnnotationIR:
                 continue
 
             if prev_shape and not prev_shape['outside'] and \
-                   has_overlap(prev_shape['frame'], shape['frame']):
+                    has_overlap(prev_shape['frame'], shape['frame']):
                 return True
 
             prev_shape = shape

--- a/cvat/apps/dataset_manager/annotation.py
+++ b/cvat/apps/dataset_manager/annotation.py
@@ -118,13 +118,6 @@ class AnnotationIR:
             cls._slice_track(element, start, stop, dimension)
             for element in track.get('elements', [])
         ]
-        if track["elements"]:
-            if all(len(t["shapes"]) == 0 for t in track["elements"]):
-                # when all skeleton elements do not have shapes
-                # the skeleton must not have any shapes likewise
-                # thus, the skeleton is incorrect and will not be appended to the collection
-                track["shapes"] = []
-                return track
 
         if len(segment_shapes) < len(track['shapes']):
             interpolated_shapes = TrackManager.get_interpolated_shapes(


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
1. Create a minor task, with one segment, let's say 4 frames.
1. Create a skeleton shape on the first frame, propagate it until the latest frame, save, close, export task annotations as CVAT for Videos. 
1. Create the same task, but with two segments (segment size is 2), thus you will have two segments. Upload annotations. You will not be able to open the second task anymore. 

In the second task:
the second segment will have two skeletons from the first segment. But elements of this skeletons will not have shapes.

That happens because skeleton dumped as two shapes into format:

```
<track>
    <skeleton frame=1>
         <points outside=0>
    </skeleton>
    <skeleton frame=2>
         <points outside=1>
     </skeleton>
</track>
```

When imported, skeleton does not have "outside" flags and for skeleton two shapes are defined:
```
{"type": "skeleton", "frame": 1, "outside": False }
{"type": "skeleton", "frame": 2, "outside": False } # I believe this is also error, but this pull request does not fix that
```

Based on this information, method `_is_track_inside` consider such skeletons to exist in the second segment, however any child elements does not exist in the second segment.  

The second corner case related to skeletons:

`skeleton` will have one `element` with two `shape` in the same scenario 
```
{"type": "points", "frame": 1, "outside": False }
{"type": "points", "frame": 2, "outside": True }
```

And current implementation of `_is_track_inside` will return true for this point (and for skeleton consequently) [in the second segment where start frame is 2 and stop frame is 3]. 
However that is not exactly correct as this segment only has outside frame.  

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of shapes in a track, addressing corner cases and ensuring correct overlap checks.
  - Enhanced logic for filtering and slicing track shapes, including better handling of leading outside shapes and removing unnecessary ones.
  - Added checks for skeleton elements without shapes to ensure correct processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->