### PR TITLE
Fixed UI crash on project page when task is creating in the project

### DIFF
--- a/changelog.d/20240718_085228_boris_fixed_undefined_value.md
+++ b/changelog.d/20240718_085228_boris_fixed_undefined_value.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- User interface crashed if there are active creating task requests on a project page
+  (<https://github.com/cvat-ai/cvat/pull/8187>)

--- a/cvat-ui/src/components/project-page/project-page.tsx
+++ b/cvat-ui/src/components/project-page/project-page.tsx
@@ -116,12 +116,12 @@ export default function ProjectPageComponent(): JSX.Element {
     }, [tasksQuery]);
 
     useEffect(() => {
-        if (projectInstance && id in deletes && deletes[id]) {
+        if (deletes[id]) {
             history.push('/projects');
         }
     }, [deletes]);
 
-    if (fechingProject) {
+    if (fechingProject || id in deletes) {
         return <Spin size='large' className='cvat-spinner' />;
     }
 

--- a/cvat-ui/src/components/project-page/project-page.tsx
+++ b/cvat-ui/src/components/project-page/project-page.tsx
@@ -23,9 +23,8 @@ import notification from 'antd/lib/notification';
 import { getCore, Project, Task } from 'cvat-core-wrapper';
 import { CombinedState, Indexable } from 'reducers';
 import { getProjectTasksAsync } from 'actions/projects-actions';
-import { cancelInferenceAsync } from 'actions/models-actions';
 import CVATLoadingSpinner from 'components/common/loading-spinner';
-import TaskItem from 'components/tasks-page/task-item';
+import TaskItem from 'containers/tasks-page/task-item';
 import MoveTaskModal from 'components/move-task-modal/move-task-modal';
 import ModelRunnerDialog from 'components/model-runner-modal/model-runner-dialog';
 import {
@@ -60,10 +59,7 @@ export default function ProjectPageComponent(): JSX.Element {
     const [updatingProject, setUpdatingProject] = useState(false);
     const mounted = useRef(false);
 
-    const ribbonPlugins = useSelector((state: CombinedState) => state.plugins.components.taskItem.ribbon);
     const deletes = useSelector((state: CombinedState) => state.projects.activities.deletes);
-    const taskDeletes = useSelector((state: CombinedState) => state.tasks.activities.deletes);
-    const tasksActiveInferences = useSelector((state: CombinedState) => state.models.inferences);
     const tasks = useSelector((state: CombinedState) => state.tasks.current);
     const tasksCount = useSelector((state: CombinedState) => state.tasks.count);
     const tasksQuery = useSelector((state: CombinedState) => state.projects.tasksGettingQuery);
@@ -153,14 +149,8 @@ export default function ProjectPageComponent(): JSX.Element {
                         .map((task: Task) => (
                             <TaskItem
                                 key={task.id}
-                                ribbonPlugins={ribbonPlugins}
-                                deleted={task.id in taskDeletes ? taskDeletes[task.id] : false}
-                                hidden={false}
-                                activeInference={tasksActiveInferences[task.id] || null}
-                                cancelAutoAnnotation={() => {
-                                    dispatch(cancelInferenceAsync(task.id));
-                                }}
-                                taskInstance={task}
+                                taskID={task.id}
+                                idx={tasks.indexOf(task)}
                             />
                         ))}
                 </React.Fragment>

--- a/cvat-ui/src/reducers/projects-reducer.ts
+++ b/cvat-ui/src/reducers/projects-reducer.ts
@@ -1,9 +1,10 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) 2022-2024 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 
 import { AnyAction } from 'redux';
+import { omit } from 'lodash';
 
 import { ProjectsActionTypes } from 'actions/projects-actions';
 import { BoundariesActionTypes } from 'actions/boundaries-actions';
@@ -117,49 +118,40 @@ export default (state: ProjectsState = defaultState, action: AnyAction): Project
         }
         case ProjectsActionTypes.DELETE_PROJECT: {
             const { projectId } = action.payload;
-            const { deletes } = state.activities;
-
-            deletes[projectId] = false;
 
             return {
                 ...state,
                 activities: {
                     ...state.activities,
                     deletes: {
-                        ...deletes,
+                        ...state.activities.deletes,
+                        [projectId]: false,
                     },
                 },
             };
         }
         case ProjectsActionTypes.DELETE_PROJECT_SUCCESS: {
             const { projectId } = action.payload;
-            const { deletes } = state.activities;
-
-            deletes[projectId] = true;
 
             return {
                 ...state,
                 activities: {
                     ...state.activities,
                     deletes: {
-                        ...deletes,
+                        ...state.activities.deletes,
+                        [projectId]: true,
                     },
                 },
             };
         }
         case ProjectsActionTypes.DELETE_PROJECT_FAILED: {
             const { projectId } = action.payload;
-            const { deletes } = state.activities;
-
-            delete deletes[projectId];
 
             return {
                 ...state,
                 activities: {
                     ...state.activities,
-                    deletes: {
-                        ...deletes,
-                    },
+                    deletes: omit(state.activities.deletes, projectId),
                 },
             };
         }


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
1. Start creating a task in a project
2. When the task is submitted to the queue, but not finished yet, open the project page
![image](https://github.com/user-attachments/assets/d0f9e984-3d6e-4ec0-94ad-dc2caa685193)


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the `TaskItem` component usage in the project page for improved maintainability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->