### PR TITLE
Added Object.hasOwn to the list of required features

### DIFF
--- a/cvat-ui/src/utils/platform-checker.ts
+++ b/cvat-ui/src/utils/platform-checker.ts
@@ -45,7 +45,7 @@ export default function showPlatformNotification(): boolean {
 }
 
 export function showUnsupportedNotification(): boolean {
-    const necessaryFeatures = [window.ResizeObserver, Object.fromEntries];
+    const necessaryFeatures = [window.ResizeObserver, Object.fromEntries, Object.hasOwn];
 
     const unsupportedFeatures = necessaryFeatures.some((feature) => typeof feature === 'undefined');
     return !featuresNotificationShown && unsupportedFeatures;


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
We sometimes have exceptions in analytics: "TypeError: Object.hasOwn is not a function

The feature was introduced in Chrome v93, but the user uses Chrome v90. 
Need to notify the user additionally about outdated browser.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved feature detection to better identify and notify users of unsupported features in their platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->