### PR TITLE
fix(ui): Default server error message

### DIFF
--- a/changelog.d/20240719_200840_jacky.lam_ui_error_message.md
+++ b/changelog.d/20240719_200840_jacky.lam_ui_error_message.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed the UI to show a default server error message instead of an HTML
+  (<https://github.com/cvat-ai/cvat/pull/8202>)

--- a/cvat-core/src/server-proxy.ts
+++ b/cvat-core/src/server-proxy.ts
@@ -193,6 +193,8 @@ function filterPythonTraceback(data: string): string {
 }
 
 function generateError(errorData: AxiosError): ServerError {
+    const DEFAULT_MESSAGE = 'An error occurred. Please try again later.';
+
     if (errorData.response) {
         if (errorData.response.status >= 500 && typeof errorData.response.data === 'string') {
             return new ServerError(
@@ -236,7 +238,11 @@ function generateError(errorData: AxiosError): ServerError {
 
             // errors with string data
             if (typeof errorData.response.data === 'string') {
-                return new ServerError(errorData.response.data, errorData.response.status);
+                let message = errorData.response.data;
+                if (message.toLowerCase().includes('<!doctype html>')) {
+                    message = DEFAULT_MESSAGE;
+                }
+                return new ServerError(message, errorData.response.status);
             }
         }
 
@@ -247,8 +253,8 @@ function generateError(errorData: AxiosError): ServerError {
         );
     }
 
-    // Server is unavailable (no any response)
-    const message = `${errorData.message}.`; // usually is "Error Network"
+    // Server is unavailable (no any response), it's usually "Error Network"
+    const message = errorData.message ? `${errorData.message}.` : DEFAULT_MESSAGE;
     return new ServerError(message, 0);
 }
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

Fixed the UI to show a default server error message instead of an HTML

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display of server error messages, replacing raw HTML content with a user-friendly default message.
  - Enhanced error handling to ensure consistent and clear feedback is provided, even when server responses are inadequate.

- **Documentation**
  - Added a changelog entry summarizing the updates related to error message handling and user experience improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->