### PR TITLE
Fixed default mapping when lambda function called

### DIFF
--- a/changelog.d/20240801_104929_boris_fixed_default_mapping.md
+++ b/changelog.d/20240801_104929_boris_fixed_default_mapping.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- API call to run automatic annotations fails on a model with attributes
+ when mapping not provided in the request (<https://github.com/cvat-ai/cvat/pull/8250>)

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -349,7 +349,10 @@ class LambdaFunction:
                         db_label.sublabels.all()
                     )
 
-        mapping = make_default_mapping(model_labels, task_labels)
+        if not mapping:
+            mapping = make_default_mapping(model_labels, task_labels)
+        else:
+            validate_labels_mapping(mapping, self.labels, task_labels)
 
         mapping = update_mapping(mapping, self.labels, task_labels)
 

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -271,9 +271,9 @@ class LambdaFunction:
                     if task_label.name == model_label['name'] and labels_compatible(model_label, task_label):
                         attributes_default_mapping = {}
                         for model_attr in model_label.get('attributes', {}):
-                            for db_attr in model_label.attributespec_set.all():
+                            for db_attr in task_label.attributespec_set.all():
                                 if db_attr.name == model_attr['name']:
-                                    attributes_default_mapping[model_attr] = db_attr.name
+                                    attributes_default_mapping[model_attr['name']] = db_attr.name
 
                         mapping_by_default[model_label['name']] = {
                             'name': task_label.name,
@@ -349,10 +349,7 @@ class LambdaFunction:
                         db_label.sublabels.all()
                     )
 
-        if not mapping:
-            mapping = make_default_mapping(model_labels, task_labels)
-        else:
-            validate_labels_mapping(mapping, self.labels, task_labels)
+        mapping = make_default_mapping(model_labels, task_labels)
 
         mapping = update_mapping(mapping, self.labels, task_labels)
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
`make_default_mapping` didn't work well for lambda functions with attributes

Related #8213


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved mapping functionality by generating default mappings based on task labels instead of model labels.
  
- **Bug Fixes**
	- Simplified the validation process for attribute mappings, ensuring consistent behavior when creating mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->