### PR TITLE
Stabilized cypress test features/ground_truth_jobs.js

### DIFF
--- a/cvat-ui/src/components/job-item/job-item.tsx
+++ b/cvat-ui/src/components/job-item/job-item.tsx
@@ -174,6 +174,7 @@ function JobItem(props: Props): JSX.Element {
                                         </Row>
                                         <Select
                                             className='cvat-job-item-stage'
+                                            popupClassName='cvat-job-item-stage-dropdown'
                                             value={stage}
                                             onChange={(newValue: JobStage) => {
                                                 onJobUpdate(job, { stage: newValue });
@@ -198,6 +199,7 @@ function JobItem(props: Props): JSX.Element {
                                         </Row>
                                         <Select
                                             className='cvat-job-item-state'
+                                            popupClassName='cvat-job-item-state-dropdown'
                                             value={job.state}
                                             onChange={(newValue: JobState) => {
                                                 onJobUpdate(job, { state: newValue });

--- a/cvat-ui/src/components/task-page/user-selector.tsx
+++ b/cvat-ui/src/components/task-page/user-selector.tsx
@@ -149,6 +149,7 @@ export default function UserSelector(props: Props): JSX.Element {
             onSelect={handleSelect}
             onBlur={onBlur}
             className={combinedClassName}
+            popupClassName='cvat-user-search-dropdown'
             options={users.map((user) => ({
                 value: user.id.toString(),
                 label: user.username,

--- a/tests/cypress/e2e/actions_users/issue_2440_value_must_be_a_user_instance.js
+++ b/tests/cypress/e2e/actions_users/issue_2440_value_must_be_a_user_instance.js
@@ -19,7 +19,7 @@ context('Value must be a user instance.', () => {
             cy.get('.cvat-task-details-user-block').within(() => {
                 cy.get('.cvat-user-search-field').click();
             });
-            cy.get('.ant-select-dropdown')
+            cy.get('.cvat-user-search-dropdown')
                 .not('.ant-select-dropdown-hidden')
                 .within(() => {
                     cy.get(`.ant-select-item-option[title="${Cypress.env('user')}"]`).click();
@@ -30,7 +30,7 @@ context('Value must be a user instance.', () => {
             cy.get('.cvat-task-details-user-block').within(() => {
                 cy.get('.cvat-user-search-field').click();
             });
-            cy.get('.ant-select-dropdown')
+            cy.get('.cvat-user-search-dropdown')
                 .not('.ant-select-dropdown-hidden')
                 .within(() => {
                     cy.get(`.ant-select-item-option[title="${Cypress.env('user')}"]`).click();

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1173,7 +1173,7 @@ Cypress.Commands.add('setJobState', (jobID, state) => {
         .contains('a', `Job #${jobID}`)
         .parents('.cvat-job-item')
         .find('.cvat-job-item-state').click();
-    cy.get('.ant-select-dropdown')
+    cy.get('.cvat-job-item-state-dropdown')
         .should('be.visible')
         .not('.ant-select-dropdown-hidden')
         .within(() => {
@@ -1187,7 +1187,7 @@ Cypress.Commands.add('setJobStage', (jobID, stage) => {
         .contains('a', `Job #${jobID}`)
         .parents('.cvat-job-item')
         .find('.cvat-job-item-stage').click();
-    cy.get('.ant-select-dropdown')
+    cy.get('.cvat-job-item-stage-dropdown')
         .should('be.visible')
         .not('.ant-select-dropdown-hidden')
         .within(() => {

--- a/tests/cypress/support/commands_projects.js
+++ b/tests/cypress/support/commands_projects.js
@@ -257,7 +257,7 @@ Cypress.Commands.add('assignProjectToUser', (user) => {
         cy.get('.cvat-user-search-field').click();
         cy.get('.cvat-user-search-field').type(user);
     });
-    cy.get('.ant-select-dropdown')
+    cy.get('.cvat-user-search-dropdown')
         .not('.ant-select-dropdown-hidden')
         .within(() => {
             cy.get(`.ant-select-item-option[title="${user}"]`).click();

--- a/tests/cypress/support/commands_review_pipeline.js
+++ b/tests/cypress/support/commands_review_pipeline.js
@@ -29,7 +29,7 @@ Cypress.Commands.add('assignJobToUser', (jobID, user) => {
         cy.intercept('GET', `/api/users?**search=${user}**`).as('searchUsers');
         cy.get(`.cvat-job-item[data-row-id="${jobID}"]`).find('.cvat-job-assignee-selector input').type(user);
         cy.wait('@searchUsers').its('response.statusCode').should('equal', 200);
-        cy.get('.ant-select-dropdown')
+        cy.get('.cvat-user-search-dropdown')
             .should('be.visible')
             .not('.ant-select-dropdown-hidden')
             .contains(new RegExp(`^${user}$`, 'g'))


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
     CypressError: `cy.within()` can only be called on a single element. Your subject contained 2 elements. Narrow down your subject to a single element (using `.first()`, for example) before calling `.within()`.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced styling for dropdowns in the JobItem component for better visual presentation of job stages and states.
	- Improved user interface for the UserSelector component with a new styling property for the dropdown.
  
- **Bug Fixes**
	- Updated selectors in Cypress commands to ensure more accurate interaction with job state and stage dropdowns, improving testing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->