### PR TITLE
Fixed server code 500 -> 400 when user input is not correct

### DIFF
--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -345,7 +345,7 @@ class LambdaFunction:
                 if md_label['type'] == 'skeleton' and db_label.type == 'skeleton':
                     if 'sublabels' not in mapping_item:
                         raise ValidationError(
-                            f'Sublabels mapping is missing for the skeleton "{model_label_name}" '
+                            f'Sublabels mapping is missing for skeleton "{model_label_name}" '
                         )
 
                     validate_labels_mapping(

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -343,6 +343,11 @@ class LambdaFunction:
                 )
 
                 if md_label['type'] == 'skeleton' and db_label.type == 'skeleton':
+                    if 'sublabels' not in mapping_item:
+                        raise ValidationError(
+                            f'Mapping for sublabels of skeleton "{model_label_name}" is missing'
+                        )
+
                     validate_labels_mapping(
                         mapping_item['sublabels'],
                         md_label['sublabels'],

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -345,7 +345,7 @@ class LambdaFunction:
                 if md_label['type'] == 'skeleton' and db_label.type == 'skeleton':
                     if 'sublabels' not in mapping_item:
                         raise ValidationError(
-                            f'Sublabels mapping is missing for skeleton "{model_label_name}" '
+                            f'Mapping for skeleton elements was not specified in label "{model_label_name}" '
                         )
 
                     validate_labels_mapping(

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -345,7 +345,7 @@ class LambdaFunction:
                 if md_label['type'] == 'skeleton' and db_label.type == 'skeleton':
                     if 'sublabels' not in mapping_item:
                         raise ValidationError(
-                            f'Mapping for skeleton elements was not specified in label "{model_label_name}" '
+                            f'Mapping for elements was not specified in skeleton "{model_label_name}" '
                         )
 
                     validate_labels_mapping(

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -345,7 +345,7 @@ class LambdaFunction:
                 if md_label['type'] == 'skeleton' and db_label.type == 'skeleton':
                     if 'sublabels' not in mapping_item:
                         raise ValidationError(
-                            f'Mapping for sublabels of skeleton "{model_label_name}" is missing'
+                            f'Sublabels mapping is missing for the skeleton "{model_label_name}" '
                         )
 
                     validate_labels_mapping(


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
How to reproduce: send automatic annotation request for a skeleton without specifying any sublabels, e.g:

![image](https://github.com/user-attachments/assets/88476dac-019f-4f69-bbd8-ba1322a6b381)

![image](https://github.com/user-attachments/assets/f724df89-c81c-4707-a650-eb33f25a9741)


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for skeleton type mappings, ensuring that sublabels are provided when needed.
  
- **Bug Fixes**
	- Introduced error handling to prevent further validation issues caused by missing sublabel mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->