### PR TITLE
Layer tus-js-client on top of Axios

### DIFF
--- a/cvat-core/package.json
+++ b/cvat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-core",
-  "version": "15.1.0",
+  "version": "15.1.1",
   "type": "module",
   "description": "Part of Computer Vision Tool which presents an interface for client-side integration",
   "main": "src/api.ts",

--- a/cvat-core/src/axios-tus.ts
+++ b/cvat-core/src/axios-tus.ts
@@ -1,0 +1,87 @@
+// Copyright (C) 2024 CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import Axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import * as tus from 'tus-js-client';
+
+class AxiosHttpResponse implements tus.HttpResponse {
+    readonly #axiosResponse: AxiosResponse;
+
+    constructor(axiosResponse: AxiosResponse) {
+        this.#axiosResponse = axiosResponse;
+    }
+
+    getStatus(): number {
+        return this.#axiosResponse.status;
+    }
+    getHeader(header: string): string | undefined {
+        return this.#axiosResponse.headers[header.toLowerCase()];
+    }
+    getBody(): string {
+        return this.#axiosResponse.data;
+    }
+    getUnderlyingObject(): AxiosResponse {
+        return this.#axiosResponse;
+    }
+}
+
+class AxiosHttpRequest implements tus.HttpRequest {
+    readonly #axiosConfig: AxiosRequestConfig;
+    readonly #abortController: AbortController;
+
+    constructor(method: string, url: string) {
+        this.#abortController = new AbortController();
+        this.#axiosConfig = {
+            method,
+            url,
+            headers: {},
+            signal: this.#abortController.signal,
+            validateStatus: () => true,
+        };
+    }
+
+    getMethod(): string {
+        return this.#axiosConfig.method;
+    }
+    getURL(): string {
+        return this.#axiosConfig.url;
+    }
+
+    setHeader(header: string, value: string): void {
+        this.#axiosConfig.headers[header.toLowerCase()] = value;
+    }
+    getHeader(header: string): string | undefined {
+        return this.#axiosConfig.headers[header.toLowerCase()];
+    }
+
+    setProgressHandler(handler: (bytesSent: number) => void): void {
+        this.#axiosConfig.onUploadProgress = (progressEvent) => {
+            handler(progressEvent.loaded);
+        };
+    }
+
+    async send(body: any): Promise<tus.HttpResponse> {
+        const axiosResponse = await Axios({ ...this.#axiosConfig, data: body });
+        return new AxiosHttpResponse(axiosResponse);
+    }
+
+    async abort(): Promise<void> {
+        this.#abortController.abort();
+    }
+
+    getUnderlyingObject(): AxiosRequestConfig {
+        return this.#axiosConfig;
+    }
+}
+
+class AxiosHttpStack implements tus.HttpStack {
+    createRequest(method: string, url: string): tus.HttpRequest {
+        return new AxiosHttpRequest(method, url);
+    }
+    getName(): string {
+        return 'AxiosHttpStack';
+    }
+}
+
+export const axiosTusHttpStack = new AxiosHttpStack();

--- a/cvat-core/src/server-proxy.ts
+++ b/cvat-core/src/server-proxy.ts
@@ -10,6 +10,7 @@ import * as tus from 'tus-js-client';
 import { ChunkQuality } from 'cvat-data';
 
 import './axios-config';
+import { axiosTusHttpStack } from './axios-tus';
 import {
     SerializedLabel, SerializedAnnotationFormats, ProjectsFilter,
     SerializedProject, SerializedTask, TasksFilter, SerializedUser, SerializedOrganization,
@@ -117,7 +118,6 @@ function fetchAll(url, filter = {}): Promise<any> {
 }
 
 async function chunkUpload(file: File, uploadConfig): Promise<{ uploadSentSize: number; filename: string }> {
-    const params = enableOrganization();
     const {
         endpoint, chunkSize, totalSize, onUpdate, metadata, totalSentSize,
     } = uploadConfig;
@@ -130,9 +130,7 @@ async function chunkUpload(file: File, uploadConfig): Promise<{ uploadSentSize: 
                 filetype: file.type,
                 ...metadata,
             },
-            headers: {
-                Authorization: Axios.defaults.headers.common.Authorization,
-            },
+            httpStack: axiosTusHttpStack,
             chunkSize,
             retryDelays: [2000, 4000, 8000, 16000, 32000, 64000],
             onShouldRetry(err: tus.DetailedError | Error): boolean {
@@ -150,12 +148,6 @@ async function chunkUpload(file: File, uploadConfig): Promise<{ uploadSentSize: 
             },
             onError(error) {
                 reject(error);
-            },
-            onBeforeRequest(req) {
-                const xhr = req.getUnderlyingObject();
-                const { org } = params;
-                req.setHeader('X-Organization', org);
-                xhr.withCredentials = true;
             },
             onProgress(bytesUploaded) {
                 if (onUpdate && Number.isInteger(totalSentSize) && Number.isInteger(totalSize)) {

--- a/cvat/apps/engine/mixins.py
+++ b/cvat/apps/engine/mixins.py
@@ -14,6 +14,7 @@ from tempfile import NamedTemporaryFile
 from unittest import mock
 from textwrap import dedent
 from typing import Optional, Callable, Dict, Any, Mapping
+from urllib.parse import urljoin
 
 import django_rq
 from attr.converters import to_bool
@@ -315,7 +316,7 @@ class UploadMixin:
 
             return self._tus_response(
                 status=status.HTTP_201_CREATED,
-                extra_headers={'Location': '{}{}'.format(location, tus_file.file_id),
+                extra_headers={'Location': urljoin(location, tus_file.file_id),
                                'Upload-Filename': tus_file.filename})
 
     def append_tus_chunk(self, request, file_id):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This ensures that requests coming from tus-js-client have the same defaults as the ones coming from the rest of the UI. In particular, this ensures that TUS requests include the `X-CSRFTOKEN` header.

Currently, this doesn't matter much, because TUS requests are authenticated using the token. However, I'd like to get rid of token authentication in the UI, after which `X-CSRFTOKEN` will become important.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new integration for resumable uploads using Axios and the tus protocol, enhancing upload reliability and control.
  
- **Bug Fixes**
  - Updated version from 15.1.0 to 15.1.1 for minor fixes and improvements.

- **Refactor**
  - Streamlined the `chunkUpload` function by removing organization-specific parameters and callbacks, refining the upload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->