### PR TITLE
Add test with colliding labels for skeletons

### DIFF
--- a/cvat/apps/dataset_manager/tests/assets/tasks.json
+++ b/cvat/apps/dataset_manager/tests/assets/tasks.json
@@ -435,6 +435,40 @@
             "type": "points"
           },
           {
+            "name": "22",
+            "color": "#479ffe",
+            "attributes": [],
+            "type": "points"
+          }
+        ],
+        "svg": "<line x1=\"38.92810821533203\" y1=\"53.31378173828125\" x2=\"80.23341369628906\" y2=\"18.36313819885254\" stroke=\"black\" data-type=\"edge\" data-node-from=\"2\" stroke-width=\"0.5\" data-node-to=\"3\"></line><line x1=\"30.399484634399414\" y1=\"32.74474334716797\" x2=\"38.92810821533203\" y2=\"53.31378173828125\" stroke=\"black\" data-type=\"edge\" data-node-from=\"1\" stroke-width=\"0.5\" data-node-to=\"2\"></line><circle r=\"1.5\" stroke=\"black\" fill=\"#b3b3b3\" cx=\"30.399484634399414\" cy=\"32.74474334716797\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"1\" data-node-id=\"1\" data-label-name=\"1\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#b3b3b3\" cx=\"38.92810821533203\" cy=\"53.31378173828125\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"2\" data-node-id=\"2\" data-label-name=\"2\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#b3b3b3\" cx=\"80.23341369628906\" cy=\"18.36313819885254\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"3\" data-node-id=\"3\" data-label-name=\"3\"></circle>"
+      },
+      {
+        "name": "skeleton2",
+        "color": "#2080c0",
+        "type": "skeleton",
+        "attributes": [
+          {
+            "name": "attr",
+            "mutable": false,
+            "input_type": "select",
+            "values": ["0", "1", "2"]
+          }
+        ],
+        "sublabels": [
+          {
+            "name": "1",
+            "color": "#d12345",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "2",
+            "color": "#350dea",
+            "attributes": [],
+            "type": "points"
+          },
+          {
             "name": "3",
             "color": "#479ffe",
             "attributes": [],

--- a/cvat/apps/dataset_manager/tests/assets/tasks.json
+++ b/cvat/apps/dataset_manager/tests/assets/tasks.json
@@ -435,13 +435,127 @@
             "type": "points"
           },
           {
-            "name": "22",
+            "name": "3",
             "color": "#479ffe",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "4",
+            "color": "#ff7f0e",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "5",
+            "color": "#2ca02c",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "6",
+            "color": "#9467bd",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "7",
+            "color": "#8c564b",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "8",
+            "color": "#e377c2",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "9",
+            "color": "#7f7f7f",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "10",
+            "color": "#bcbd22",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "11",
+            "color": "#17becf",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "12",
+            "color": "#1f77b4",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "13",
+            "color": "#ff9896",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "14",
+            "color": "#98df8a",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "15",
+            "color": "#c49c94",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "16",
+            "color": "#f7b6d2",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "17",
+            "color": "#c5b0d5",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "18",
+            "color": "#ffbb78",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "19",
+            "color": "#aec7e8",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "20",
+            "color": "#ffbb78",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "21",
+            "color": "#dbdb8d",
+            "attributes": [],
+            "type": "points"
+          },
+          {
+            "name": "22",
+            "color": "#9edae5",
             "attributes": [],
             "type": "points"
           }
         ],
-        "svg": "<line x1=\"38.92810821533203\" y1=\"53.31378173828125\" x2=\"80.23341369628906\" y2=\"18.36313819885254\" stroke=\"black\" data-type=\"edge\" data-node-from=\"2\" stroke-width=\"0.5\" data-node-to=\"3\"></line><line x1=\"30.399484634399414\" y1=\"32.74474334716797\" x2=\"38.92810821533203\" y2=\"53.31378173828125\" stroke=\"black\" data-type=\"edge\" data-node-from=\"1\" stroke-width=\"0.5\" data-node-to=\"2\"></line><circle r=\"1.5\" stroke=\"black\" fill=\"#b3b3b3\" cx=\"30.399484634399414\" cy=\"32.74474334716797\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"1\" data-node-id=\"1\" data-label-name=\"1\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#b3b3b3\" cx=\"38.92810821533203\" cy=\"53.31378173828125\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"2\" data-node-id=\"2\" data-label-name=\"2\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#b3b3b3\" cx=\"80.23341369628906\" cy=\"18.36313819885254\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"3\" data-node-id=\"3\" data-label-name=\"3\"></circle>"
+        "svg": "<line x1=\"38.92810821533203\" y1=\"53.31378173828125\" x2=\"80.23341369628906\" y2=\"18.36313819885254\" stroke=\"black\" data-type=\"edge\" data-node-from=\"2\" stroke-width=\"0.5\" data-node-to=\"3\"></line><line x1=\"30.399484634399414\" y1=\"32.74474334716797\" x2=\"38.92810821533203\" y2=\"53.31378173828125\" stroke=\"black\" data-type=\"edge\" data-node-from=\"1\" stroke-width=\"0.5\" data-node-to=\"2\"></line><circle r=\"1.5\" stroke=\"black\" fill=\"#b3b3b3\" cx=\"30.399484634399414\" cy=\"32.74474334716797\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"1\" data-node-id=\"1\" data-label-name=\"1\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#b3b3b3\" cx=\"38.92810821533203\" cy=\"53.31378173828125\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"2\" data-node-id=\"2\" data-label-name=\"2\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#b3b3b3\" cx=\"80.23341369628906\" cy=\"18.36313819885254\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"3\" data-node-id=\"3\" data-label-name=\"3\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#ff7f0e\" cx=\"45\" cy=\"60\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"4\" data-node-id=\"4\" data-label-name=\"4\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#2ca02c\" cx=\"50\" cy=\"65\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"5\" data-node-id=\"5\" data-label-name=\"5\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#9467bd\" cx=\"55\" cy=\"70\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"6\" data-node-id=\"6\" data-label-name=\"6\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#8c564b\" cx=\"60\" cy=\"75\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"7\" data-node-id=\"7\" data-label-name=\"7\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#e377c2\" cx=\"65\" cy=\"80\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"8\" data-node-id=\"8\" data-label-name=\"8\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#7f7f7f\" cx=\"70\" cy=\"85\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"9\" data-node-id=\"9\" data-label-name=\"9\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#bcbd22\" cx=\"75\" cy=\"90\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"10\" data-node-id=\"10\" data-label-name=\"10\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#17becf\" cx=\"80\" cy=\"95\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"11\" data-node-id=\"11\" data-label-name=\"11\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#1f77b4\" cx=\"85\" cy=\"100\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"12\" data-node-id=\"12\" data-label-name=\"12\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#ff9896\" cx=\"90\" cy=\"105\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"13\" data-node-id=\"13\" data-label-name=\"13\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#98df8a\" cx=\"95\" cy=\"110\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"14\" data-node-id=\"14\" data-label-name=\"14\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#c49c94\" cx=\"100\" cy=\"115\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"15\" data-node-id=\"15\" data-label-name=\"15\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#f7b6d2\" cx=\"105\" cy=\"120\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"16\" data-node-id=\"16\" data-label-name=\"16\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#c5b0d5\" cx=\"110\" cy=\"125\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"17\" data-node-id=\"17\" data-label-name=\"17\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#ffbb78\" cx=\"115\" cy=\"130\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"18\" data-node-id=\"18\" data-label-name=\"18\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#aec7e8\" cx=\"120\" cy=\"135\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"19\" data-node-id=\"19\" data-label-name=\"19\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#ffbb78\" cx=\"125\" cy=\"140\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"20\" data-node-id=\"20\" data-label-name=\"20\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#dbdb8d\" cx=\"130\" cy=\"145\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"21\" data-node-id=\"21\" data-label-name=\"21\"></circle><circle r=\"1.5\" stroke=\"black\" fill=\"#9edae5\" cx=\"135\" cy=\"150\" stroke-width=\"0.1\" data-type=\"element node\" data-element-id=\"22\" data-node-id=\"22\" data-label-name=\"22\"></circle>"
       },
       {
         "name": "skeleton2",


### PR DESCRIPTION
### Motivation and context
This PR is an addition to https://github.com/cvat-ai/cvat/pull/8262 and https://github.com/cvat-ai/datumaro/pull/51.

It modifies existing test data adding specific case where label names and their keypoints collide in a specific way (label = "name" and keypoint = "22", label = "name2" and keypoint = "2").

The file is used in `cvat.apps.dataset_manager.tests.test_rest_api_formats.ProjectDumpUpload.test_api_v2_export_import_dataset`.
Running this test with these changes and older version of datumaro (`datumaro @ git+https://github.com/cvat-ai/datumaro.git@2a4d9dbbd86f2e5fc5f8db2cfd2defdf464e9645`) will result in `AssertionError`.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new "sublabels" section to enhance data categorization with 22 entries, improving user interaction and annotation processes.
	- Expanded the "svg" attribute for better visual representation of dataset elements, facilitating clearer insights into their relationships.
	- Updated the existing skeleton entry to consistently include a "sublabels" section, reinforcing coherence in the dataset configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->