### PR TITLE
Prepare auto-annotation RQ jobs for migration to the general request API

### DIFF
--- a/cvat-core/src/request.ts
+++ b/cvat-core/src/request.ts
@@ -13,6 +13,7 @@ type Operation = {
     jobID: number | null;
     taskID: number | null;
     projectID: number | null;
+    functionID: string | null;
 };
 
 export class Request {
@@ -72,6 +73,7 @@ export class Request {
             jobID: this.#operation.job_id,
             taskID: this.#operation.task_id,
             projectID: this.#operation.project_id,
+            functionID: this.#operation.function_id,
         };
     }
 

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -1204,6 +1204,7 @@ class RequestStatus(TextChoices):
     FINISHED = "finished"
 
 class RequestAction(TextChoices):
+    AUTOANNOTATE = "autoannotate"
     CREATE = "create"
     IMPORT = "import"
     EXPORT = "export"

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -2208,6 +2208,7 @@ class RequestDataOperationSerializer(serializers.Serializer):
     task_id = serializers.IntegerField(required=False, allow_null=True)
     job_id = serializers.IntegerField(required=False, allow_null=True)
     format = serializers.CharField(required=False, allow_null=True)
+    function_id = serializers.CharField(required=False, allow_null=True)
 
     def to_representation(self, rq_job: RQJob) -> Dict[str, Any]:
         parsed_rq_id: RQId = rq_job.parsed_rq_id
@@ -2224,6 +2225,7 @@ class RequestDataOperationSerializer(serializers.Serializer):
             "task_id": rq_job.meta[RQJobMetaField.TASK_ID],
             "job_id": rq_job.meta[RQJobMetaField.JOB_ID],
             "format": parsed_rq_id.format,
+            "function_id": rq_job.meta.get(RQJobMetaField.FUNCTION_ID),
         }
 
 class RequestSerializer(serializers.Serializer):

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -33,7 +33,10 @@ from rest_framework.request import Request
 
 import cvat.apps.dataset_manager as dm
 from cvat.apps.engine.frame_provider import FrameProvider
-from cvat.apps.engine.models import Job, ShapeType, SourceType, Task, Label
+from cvat.apps.engine.models import (
+    Job, ShapeType, SourceType, Task, Label, RequestAction, RequestTarget,
+)
+from cvat.apps.engine.rq_job_handler import RQId, RQJobMetaField
 from cvat.apps.engine.serializers import LabeledDataSerializer
 from cvat.apps.lambda_manager.permissions import LambdaPermission
 from cvat.apps.lambda_manager.serializers import (
@@ -525,16 +528,31 @@ class LambdaQueue:
         *,
         job: Optional[int] = None
     ) -> LambdaJob:
-        jobs = self.get_jobs()
+        queue = self._get_queue()
+        rq_id = RQId(RequestAction.AUTOANNOTATE, RequestTarget.TASK, task).render()
+
         # It is still possible to run several concurrent jobs for the same task.
         # But the race isn't critical. The filtration is just a light-weight
         # protection.
-        if list(filter(lambda job: job.get_task() == task and not job.is_finished, jobs)):
+        rq_job = queue.fetch_job(rq_id)
+
+        have_conflict = rq_job and \
+            rq_job.get_status(refresh=False) not in {rq.job.JobStatus.FAILED, rq.job.JobStatus.FINISHED}
+
+        # There could be some jobs left over from before the current naming convention was adopted.
+        # TODO: remove this check after a few releases.
+        have_legacy_conflict = any(
+            job.get_task() == task and not (job.is_finished or job.is_failed)
+            for job in self.get_jobs()
+        )
+        if have_conflict or have_legacy_conflict:
             raise ValidationError(
                 "Only one running request is allowed for the same task #{}".format(task),
                 code=status.HTTP_409_CONFLICT)
 
-        queue = self._get_queue()
+        if rq_job:
+            rq_job.delete()
+
         # LambdaJob(None) is a workaround for python-rq. It has multiple issues
         # with invocation of non-trivial functions. For example, it cannot run
         # staticmethod, it cannot run a callable class. Thus I provide an object
@@ -543,6 +561,7 @@ class LambdaQueue:
 
         with get_rq_lock_by_user(queue, user_id):
             rq_job = queue.create_job(LambdaJob(None),
+                job_id=rq_id,
                 meta={
                     **get_rq_job_meta(
                         request,
@@ -550,6 +569,7 @@ class LambdaQueue:
                             Job.objects.get(pk=job) if job else Task.objects.get(pk=task)
                         ),
                     ),
+                    RQJobMetaField.FUNCTION_ID: lambda_func.id,
                     "lambda": True,
                 },
                 kwargs={

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -4529,6 +4529,7 @@ paths:
         schema:
           type: string
           enum:
+          - autoannotate
           - create
           - import
           - export
@@ -9928,6 +9929,9 @@ components:
           type: integer
           nullable: true
         format:
+          type: string
+          nullable: true
+        function_id:
           type: string
           nullable: true
       required:


### PR DESCRIPTION
* Define an RQ ID format for auto-annotation jobs, and make use of it.

* Add a `function_id` field to `RequestSerializer`, so that the general request API can expose the same information as the lambda request API. (In truth, the lambda request API also exposes the "threshold" field, but the UI doesn't use it, and I don't see the point in having it.)

Note that this doesn't actually _enable_ the general request API for auto-annotation requests. This is because a similar patch needs to first be applied to the Enterprise version, otherwise requests for Roboflow/Hugging Face jobs will be invisible.

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
We're trying to unify the API for managing long-running requests.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `functionID` property to enhance operation tracking.
	- Added `AUTOANNOTATE` action to expand request handling options.
	- New `function_id` field in serializers for better data representation.
	- Enhanced job handling logic to improve robustness and clarity.

- **Bug Fixes**
	- Improved job management to delete outdated jobs based on naming conventions.

- **Documentation**
	- Updated schema to include new `autoannotate` operation type and `function_id` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->