### PR TITLE
Fixed `undefined` active control

### DIFF
--- a/changelog.d/20240822_111601_sekachev.bs_fixed_minor_issue.md
+++ b/changelog.d/20240822_111601_sekachev.bs_fixed_minor_issue.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Sometimes it is not possible to switch workspace because active control broken after 
+trying to create a tag with a shortcut (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/changelog.d/20240822_111601_sekachev.bs_fixed_minor_issue.md
+++ b/changelog.d/20240822_111601_sekachev.bs_fixed_minor_issue.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - Sometimes it is not possible to switch workspace because active control broken after 
-trying to create a tag with a shortcut (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+trying to create a tag with a shortcut (<https://github.com/cvat-ai/cvat/pull/8334>)

--- a/cvat-ui/src/actions/annotation-actions.ts
+++ b/cvat-ui/src/actions/annotation-actions.ts
@@ -1412,7 +1412,9 @@ export function repeatDrawShapeAsync(): ThunkAction {
             return;
         }
 
-        activeControl = ShapeTypeToControl[activeShapeType];
+        if (activeObjectType !== ObjectType.TAG) {
+            activeControl = ShapeTypeToControl[activeShapeType];
+        }
 
         if (canvasInstance instanceof Canvas) {
             canvasInstance.cancel();


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with workspace switching that caused the active control to become unresponsive after creating a tag using a keyboard shortcut, improving user experience.
  
- **Enhancements**
	- Improved control flow by refining the assignment of the `activeControl` variable based on the active object type, enhancing the behavior of the tagging feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->