### PR TITLE
Don't check permissions for the target resource when canceling requests

### DIFF
--- a/changelog.d/20240828_053041_roman_rm_extra_checks.md
+++ b/changelog.d/20240828_053041_roman_rm_extra_checks.md
@@ -1,0 +1,5 @@
+### Changed
+
+- When cancelling a request, a user is no longer required to have
+  permissions to perform the original action
+  (<https://github.com/cvat-ai/cvat/pull/8369>)

--- a/cvat/apps/engine/permissions.py
+++ b/cvat/apps/engine/permissions.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union, cast
 from django.shortcuts import get_object_or_404
 from django.conf import settings
 
-from rest_framework.exceptions import ValidationError, PermissionDenied, NotFound
+from rest_framework.exceptions import ValidationError, PermissionDenied
 from rq.job import Job as RQJob
 
 from cvat.apps.engine.rq_job_handler import is_rq_job_owner
@@ -1219,42 +1219,6 @@ class RequestPermission(OpenPolicyAgentPermission):
         permissions = []
         if view.basename == 'request':
             for scope in cls.get_scopes(request, view, obj):
-                if scope == cls.Scopes.CANCEL:
-                    parsed_rq_id = obj.parsed_rq_id
-
-                    permission_class, resource_scope = {
-                        ('import', 'project', 'dataset'): (ProjectPermission, ProjectPermission.Scopes.IMPORT_DATASET),
-                        ('import', 'project', 'backup'): (ProjectPermission, ProjectPermission.Scopes.IMPORT_BACKUP),
-                        ('import', 'task', 'annotations'): (TaskPermission, TaskPermission.Scopes.IMPORT_ANNOTATIONS),
-                        ('import', 'task', 'backup'): (TaskPermission, TaskPermission.Scopes.IMPORT_BACKUP),
-                        ('import', 'job', 'annotations'): (JobPermission, JobPermission.Scopes.IMPORT_ANNOTATIONS),
-                        ('create', 'task', None): (TaskPermission, TaskPermission.Scopes.VIEW),
-                        ('export', 'project', 'annotations'): (ProjectPermission, ProjectPermission.Scopes.EXPORT_ANNOTATIONS),
-                        ('export', 'project', 'dataset'): (ProjectPermission, ProjectPermission.Scopes.EXPORT_DATASET),
-                        ('export', 'project', 'backup'): (ProjectPermission, ProjectPermission.Scopes.EXPORT_BACKUP),
-                        ('export', 'task', 'annotations'): (TaskPermission, TaskPermission.Scopes.EXPORT_ANNOTATIONS),
-                        ('export', 'task', 'dataset'): (TaskPermission, TaskPermission.Scopes.EXPORT_DATASET),
-                        ('export', 'task', 'backup'): (TaskPermission, TaskPermission.Scopes.EXPORT_BACKUP),
-                        ('export', 'job', 'annotations'): (JobPermission, JobPermission.Scopes.EXPORT_ANNOTATIONS),
-                        ('export', 'job', 'dataset'): (JobPermission, JobPermission.Scopes.EXPORT_DATASET),
-                    }[(parsed_rq_id.action, parsed_rq_id.target, parsed_rq_id.subresource)]
-
-
-                    resource = None
-                    if (resource_id := parsed_rq_id.identifier) and isinstance(resource_id, int):
-                        resource_model = {
-                            'project': Project,
-                            'task': Task,
-                            'job': Job,
-                        }[parsed_rq_id.target]
-
-                        try:
-                            resource = resource_model.objects.get(id=resource_id)
-                        except resource_model.DoesNotExist as ex:
-                            raise NotFound(f'The {parsed_rq_id.target!r} with specified id#{resource_id} does not exist') from ex
-
-                    permissions.append(permission_class.create_base_perm(request, view, scope=resource_scope, iam_context=iam_context, obj=resource))
-
                 if scope != cls.Scopes.LIST:
                     user_id = request.user.id
                     if not is_rq_job_owner(obj, user_id):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
IMO, these checks are not very useful. The permission logic for requests already checks that the request is being canceled by the same user that created it. Therefore, these additional checks can only fail if a user creates a request for some action, loses the permissions to do the same action again, and then tries to cancel the request. But cancelling a request does not do anything to the target resource (in fact, it _prevents_ some future actions from taking place), so I really don't see why this shouldn't be allowed.

In addition, these checks create some problems:

* If the creator of the request is no longer able to cancel it, we now have a request that _nobody_ is allowed to cancel. That seems wrong.

* To implement these checks, `RequestPermission` has to know which actions require which permissions. This creates code duplication between it and the other permission classes. It also causes a dependency on those classes, which could create problems if we want to use the request API for actions from the Enterprise version.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users can now cancel requests without needing specific permissions, enhancing flexibility and streamlining workflows.

- **Bug Fixes**
  - Simplified permission handling may improve overall user experience, though it raises concerns about permission validation robustness.

- **Chores**
  - Code simplification for permission handling has been implemented for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->