### PR TITLE
Memory optimisation

### DIFF
--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -45,7 +45,9 @@ from .formats.transformations import MaskConverter, EllipsesToMasks
 CVAT_INTERNAL_ATTRIBUTES = {'occluded', 'outside', 'keyframe', 'track_id', 'rotation'}
 
 class InstanceLabelData:
-    Attribute = NamedTuple('Attribute', [('name', str), ('value', Any)])
+    class Attribute(NamedTuple):
+        name: str
+        value: Any
 
     @classmethod
     def add_prefetch_info(cls, queryset: QuerySet):
@@ -190,20 +192,76 @@ class InstanceLabelData:
         return exported_attributes
 
 class CommonData(InstanceLabelData):
-    Shape = namedtuple("Shape", 'id, label_id')  # 3d
-    LabeledShape = namedtuple(
-        'LabeledShape', 'type, frame, label, points, occluded, attributes, source, rotation, group, z_order, elements, outside, id')
-    LabeledShape.__new__.__defaults__ = (0, 0, 0, [], False, None)
-    TrackedShape = namedtuple(
-        'TrackedShape', 'type, frame, points, occluded, outside, keyframe, attributes, rotation, source, group, z_order, label, track_id, elements, id')
-    TrackedShape.__new__.__defaults__ = (0, 'manual', 0, 0, None, 0, [], None)
-    Track = namedtuple('Track', 'label, group, source, shapes, elements, id')
-    Track.__new__.__defaults__ = ([], None)
-    Tag = namedtuple('Tag', 'frame, label, attributes, source, group, id')
-    Tag.__new__.__defaults__ = (0, None)
-    Frame = namedtuple(
-        'Frame', 'idx, id, frame, name, width, height, labeled_shapes, tags, shapes, labels, subset')
-    Label = namedtuple('Label', 'id, name, color, type')
+    class Shape(NamedTuple):
+        id: int
+        label_id: int
+
+    class LabeledShape(NamedTuple):
+        type: int = 0
+        frame: int = 0
+        label: int = 0
+        points: Sequence[int] = ()
+        occluded: bool = False
+        attributes: dict | None = None
+        source: str | None = None
+        rotation: float = 0.0
+        group: int = 0
+        z_order: int = 0
+        elements: Sequence[CommonData.LabeledShape] = ()
+        outside: bool = False
+        id: int | None = None
+
+    class TrackedShape(NamedTuple):
+        type: int = 0
+        frame: int = 0
+        points: Sequence[int] = ()
+        occluded: bool = False
+        outside: bool = False
+        keyframe: bool = False
+        attributes: Sequence[int] = ()
+        rotation: float | None = None
+        source: str = "manual"
+        group: int = 0
+        z_order: int = 0
+        label: str | None = None
+        track_id: int = 0
+        elements: Sequence[CommonData.TrackedShape] = ()
+        id: int | None = None
+
+    class Track(NamedTuple):
+        label: int
+        group: int
+        source: str
+        shapes: Sequence[CommonData.TrackedShape] = ()
+        elements: Sequence[int] = ()
+        id: int | None = None
+
+    class Tag(NamedTuple):
+        frame: int
+        label: int
+        attributes: Sequence[InstanceLabelData.Attribute] = ()
+        source: str | None = None
+        group: int | None = None
+        id: int | None = None
+
+    class Frame(NamedTuple):
+        idx: int
+        id: int
+        frame: int
+        name: str
+        width: int
+        height: int
+        labeled_shapes: Sequence[CommonData.LabeledShape]
+        tags: Sequence[CommonData.Tag]
+        shapes: Sequence[CommonData.Shape]
+        labels: Sequence[CommonData.Label]
+        subset: str
+
+    class Label(NamedTuple):
+        id: int
+        name: str
+        color: str | None = None
+        type: str | None = None
 
     def __init__(self,
         annotation_ir,

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import logging
 import os.path as osp
 import re
 import sys
@@ -40,6 +39,9 @@ from cvat.apps.engine.lazy_list import LazyList
 
 from .annotation import AnnotationIR, AnnotationManager, TrackManager
 from .formats.transformations import MaskConverter, EllipsesToMasks
+from ..engine.log import ServerLogManager
+
+slogger = ServerLogManager(__name__)
 
 CVAT_INTERNAL_ATTRIBUTES = {'occluded', 'outside', 'keyframe', 'track_id', 'rotation'}
 
@@ -641,11 +643,11 @@ class CommonData(InstanceLabelData):
 
         for point in points:
             if not isinstance(point, int | float):
-                logging.error(
+                slogger.glob.error(
                     f"Points must be type of "
                     f"`tuple[int | float] | list[int | float] | LazyList`, "
                     f"not `{points.__class__.__name__}[{point.__class__.__name__}]`"
-                    "Please, update import code to return the correct type"
+                    "Please, update import code to return the correct type."
                 )
                 shape["points"] = tuple(map(float, points))
                 return

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -9,7 +9,6 @@ import logging
 import os.path as osp
 import re
 import sys
-from collections import namedtuple
 from functools import reduce
 from operator import add
 from pathlib import Path

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -205,12 +205,12 @@ class CommonData(InstanceLabelData):
         occluded: bool
         attributes: Sequence[CommonData.Attribute]
         source: str | None
-        rotation: float
-        group: int
-        z_order: int
-        elements: Sequence[CommonData.LabeledShape]
-        outside: bool
-        id: int | None
+        rotation: float = 0
+        group: int = 0
+        z_order: int = 0
+        elements: Sequence[CommonData.LabeledShape] = ()
+        outside: bool = False
+        id: int | None = None
 
     class TrackedShape(NamedTuple):
         type: int
@@ -220,30 +220,30 @@ class CommonData(InstanceLabelData):
         outside: bool
         keyframe: bool
         attributes: Sequence[CommonData.Attribute]
-        rotation: float | None
-        source: str
-        group: int
-        z_order: int
-        label: str | None
-        track_id: int
-        elements: Sequence[CommonData.TrackedShape]
-        id: int | None
+        rotation: float = 0
+        source: str = "manual"
+        group: int = 0
+        z_order: int = 0
+        label: str | None = None
+        track_id: int = 0
+        elements: Sequence[CommonData.TrackedShape] = ()
+        id: int | None = None
 
     class Track(NamedTuple):
         label: int
         group: int
         source: str
         shapes: Sequence[CommonData.TrackedShape]
-        elements: Sequence[int]
-        id: int | None
+        elements: Sequence[int] = ()
+        id: int | None = None
 
     class Tag(NamedTuple):
         frame: int
         label: int
         attributes: Sequence[CommonData.Attribute]
         source: str | None
-        group: int | None
-        id: int | None
+        group: int | None = 0
+        id: int | None = None
 
     class Frame(NamedTuple):
         idx: int

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -196,52 +196,52 @@ class CommonData(InstanceLabelData):
         label_id: int
 
     class LabeledShape(NamedTuple):
-        type: int = 0
-        frame: int = 0
-        label: int = 0
-        points: Sequence[int] = ()
-        occluded: bool = False
-        attributes: dict | None = None
-        source: str | None = None
-        rotation: float = 0.0
-        group: int = 0
-        z_order: int = 0
-        elements: Sequence[CommonData.LabeledShape] = ()
-        outside: bool = False
-        id: int | None = None
+        type: int
+        frame: int
+        label: int
+        points: Sequence[int]
+        occluded: bool
+        attributes: Sequence[CommonData.Attribute]
+        source: str | None
+        rotation: float
+        group: int
+        z_order: int
+        elements: Sequence[CommonData.LabeledShape]
+        outside: bool
+        id: int | None
 
     class TrackedShape(NamedTuple):
-        type: int = 0
-        frame: int = 0
-        points: Sequence[int] = ()
-        occluded: bool = False
-        outside: bool = False
-        keyframe: bool = False
-        attributes: Sequence[int] = ()
-        rotation: float | None = None
-        source: str = "manual"
-        group: int = 0
-        z_order: int = 0
-        label: str | None = None
-        track_id: int = 0
-        elements: Sequence[CommonData.TrackedShape] = ()
-        id: int | None = None
+        type: int
+        frame: int
+        points: Sequence[int]
+        occluded: bool
+        outside: bool
+        keyframe: bool
+        attributes: Sequence[CommonData.Attribute]
+        rotation: float | None
+        source: str
+        group: int
+        z_order: int
+        label: str | None
+        track_id: int
+        elements: Sequence[CommonData.TrackedShape]
+        id: int | None
 
     class Track(NamedTuple):
         label: int
         group: int
         source: str
-        shapes: Sequence[CommonData.TrackedShape] = ()
-        elements: Sequence[int] = ()
-        id: int | None = None
+        shapes: Sequence[CommonData.TrackedShape]
+        elements: Sequence[int]
+        id: int | None
 
     class Tag(NamedTuple):
         frame: int
         label: int
-        attributes: Sequence[InstanceLabelData.Attribute] = ()
-        source: str | None = None
-        group: int | None = None
-        id: int | None = None
+        attributes: Sequence[CommonData.Attribute]
+        source: str | None
+        group: int | None
+        id: int | None
 
     class Frame(NamedTuple):
         idx: int
@@ -259,8 +259,8 @@ class CommonData(InstanceLabelData):
     class Label(NamedTuple):
         id: int
         name: str
-        color: str | None = None
-        type: str | None = None
+        color: str | None
+        type: str | None
 
     def __init__(self,
         annotation_ir,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
By using tuple as a container for points when dealing with import from datumaro, we can achieve 2 things:
- Reduce memory needed for copying shapes and tracks during import (running `deepcopy` on `tuple[int]` will return the same object, as opposed to `list[int]`)
- Guarantee type safety during later stages of data pipeline and skip additional conversion added in #1898

Same thing arguable should be done for CVAT format as well.

Benchmarks: [memray_reports.zip](https://github.com/user-attachments/files/16849509/memray_reports.zip)


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of shape points during the import process for enhanced data accuracy.
	- Centralized conversion of shape points to floats, optimizing memory usage and performance.

- **Refactor**
	- Enhanced code readability and maintainability by restructuring the point conversion logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->