### PR TITLE
lambda_manager: revamp function parsing error handling

### DIFF
--- a/changelog.d/20240905_201903_roman_lambda_error_handling.md
+++ b/changelog.d/20240905_201903_roman_lambda_error_handling.md
@@ -1,0 +1,15 @@
+### Changed
+
+- Lambda function endpoints now return 500 instead of 404
+  if a function's metadata is invalid
+  (<https://github.com/cvat-ai/cvat/pull/8406>)
+
+- An unknown lambda function type is now treated as invalid metadata
+  and the function is no longer included in the list endpoint output
+  (<https://github.com/cvat-ai/cvat/pull/8406>)
+
+### Fixed
+
+- One lambda function with invalid metadata will no longer
+  break function listing
+  (<https://github.com/cvat-ai/cvat/pull/8406>)

--- a/cvat/apps/lambda_manager/tests/assets/functions.json
+++ b/cvat/apps/lambda_manager/tests/assets/functions.json
@@ -90,6 +90,42 @@
         "httpPort": 49158
       }
     },
+    "test-model-has-state-building": {
+      "metadata": {
+        "name": "test-model-has-state-building",
+        "annotations": {
+          "framework": "openvino",
+          "name": "State is building",
+          "spec": "[\n  { \"id\": 0, \"name\": \"person\" },                              \n  { \"id\": 1, \"name\": \"bicycle\" },                              \n  { \"id\": 2, \"name\": \"car\" }                              \n]\n",
+          "type": "detector"
+        }
+      },
+      "spec": {
+        "description": "Test state building"
+      },
+      "status": {
+        "state": "building"
+      }
+    },
+    "test-model-has-state-error": {
+      "metadata": {
+        "name": "test-model-has-state-building",
+        "annotations": {
+          "framework": "openvino",
+          "name": "State is error",
+          "spec": "[\n  { \"id\": 0, \"name\": \"person\" },                              \n  { \"id\": 1, \"name\": \"bicycle\" },                              \n  { \"id\": 2, \"name\": \"car\" }                              \n]\n",
+          "type": "detector"
+        }
+      },
+      "spec": {
+        "description": "Test state error"
+      },
+      "status": {
+        "state": "error"
+      }
+    }
+  },
+  "negative": {
     "test-model-has-non-type": {
       "metadata": {
         "name": "test-model-has-non-type",
@@ -143,42 +179,6 @@
         "httpPort": 49162
       }
     },
-    "test-model-has-state-building": {
-      "metadata": {
-        "name": "test-model-has-state-building",
-        "annotations": {
-          "framework": "openvino",
-          "name": "State is building",
-          "spec": "[\n  { \"id\": 0, \"name\": \"person\" },                              \n  { \"id\": 1, \"name\": \"bicycle\" },                              \n  { \"id\": 2, \"name\": \"car\" }                              \n]\n",
-          "type": "detector"
-        }
-      },
-      "spec": {
-        "description": "Test state building"
-      },
-      "status": {
-        "state": "building"
-      }
-    },
-    "test-model-has-state-error": {
-      "metadata": {
-        "name": "test-model-has-state-building",
-        "annotations": {
-          "framework": "openvino",
-          "name": "State is error",
-          "spec": "[\n  { \"id\": 0, \"name\": \"person\" },                              \n  { \"id\": 1, \"name\": \"bicycle\" },                              \n  { \"id\": 2, \"name\": \"car\" }                              \n]\n",
-          "type": "detector"
-        }
-      },
-      "spec": {
-        "description": "Test state error"
-      },
-      "status": {
-        "state": "error"
-      }
-    }
-  },
-  "negative": {
     "test-model-has-non-unique-labels": {
       "metadata": {
         "name": "test-model-has-non-unique-labels",

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -76,7 +76,7 @@ class ForceLogin:
 
 class _LambdaTestCaseBase(APITestCase):
     def setUp(self):
-        self.client = APIClient()
+        self.client = APIClient(raise_request_exception=False)
 
         http_patcher = mock.patch('cvat.apps.lambda_manager.views.LambdaGateway._http', side_effect = self._get_data_from_lambda_manager_http)
         self.addCleanup(http_patcher.stop)
@@ -295,16 +295,21 @@ class LambdaTestCases(_LambdaTestCaseBase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
-    @mock.patch('cvat.apps.lambda_manager.views.LambdaGateway._http', return_value = functions["negative"])
-    def test_api_v2_lambda_functions_list_wrong(self, mock_http):
+    @mock.patch(
+        'cvat.apps.lambda_manager.views.LambdaGateway._http',
+        return_value={**functions["negative"], id_function_detector: functions["positive"][id_function_detector]}
+    )
+    def test_api_v2_lambda_functions_list_negative(self, mock_http):
         response = self._get_request(LAMBDA_FUNCTIONS_PATH, self.admin)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        # the positive function must remain visible
+        visible_ids = {f["id"] for f in response.data}
+        self.assertEqual(visible_ids, {id_function_detector})
 
     def test_api_v2_lambda_functions_read(self):
         ids_functions = [id_function_detector, id_function_interactor,\
-                         id_function_tracker, id_function_reid_with_response_data, \
-                         id_function_non_type, id_function_wrong_type, id_function_unknown_type]
+                         id_function_tracker, id_function_reid_with_response_data]
 
         for id_func in ids_functions:
             path = f'{LAMBDA_FUNCTIONS_PATH}/{id_func}'
@@ -333,10 +338,17 @@ class LambdaTestCases(_LambdaTestCaseBase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
-    @mock.patch('cvat.apps.lambda_manager.views.LambdaGateway._http', return_value = functions["negative"][id_function_non_unique_labels])
-    def test_api_v2_lambda_functions_read_non_unique_labels(self, mock_http):
-        response = self._get_request(f'{LAMBDA_FUNCTIONS_PATH}/{id_function_non_unique_labels}', self.admin)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+    def test_api_v2_lambda_functions_read_negative(self):
+        for id_func in [
+            id_function_non_type, id_function_wrong_type, id_function_unknown_type,
+            id_function_non_unique_labels,
+        ]:
+            with mock.patch(
+                'cvat.apps.lambda_manager.views.LambdaGateway._http',
+                return_value=functions["negative"][id_func]
+            ):
+                response = self._get_request(f'{LAMBDA_FUNCTIONS_PATH}/{id_func}', self.admin)
+                self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
     @skip("Fail: add mock")
@@ -446,8 +458,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
 
     def test_api_v2_lambda_requests_create(self):
         ids_functions = [id_function_detector, id_function_interactor, id_function_tracker, \
-                         id_function_reid_with_response_data, id_function_detector, id_function_reid_with_no_response_data, \
-                         id_function_non_type, id_function_wrong_type, id_function_unknown_type]
+                         id_function_reid_with_response_data, id_function_detector, id_function_reid_with_no_response_data]
 
         for id_func in ids_functions:
             data_main_task = {
@@ -492,19 +503,26 @@ class LambdaTestCases(_LambdaTestCaseBase):
             self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
-    @mock.patch('cvat.apps.lambda_manager.views.LambdaGateway._http', return_value = functions["negative"]["test-model-has-non-unique-labels"])
-    def test_api_v2_lambda_requests_create_non_unique_labels(self, mock_http):
-        data = {
-            "function": id_function_non_unique_labels,
-            "task": self.main_task["id"],
-            "cleanup": True,
-            "mapping": {
-                "car": { "name": "car" },
-            },
-        }
+    def test_api_v2_lambda_requests_create_negative(self):
+        for id_func in [
+            id_function_non_type, id_function_wrong_type, id_function_unknown_type,
+            id_function_non_unique_labels,
+        ]:
+            data = {
+                "function": id_func,
+                "task": self.main_task["id"],
+                "cleanup": True,
+                "mapping": {
+                    "car": { "name": "car" },
+                },
+            }
 
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+            with mock.patch(
+                'cvat.apps.lambda_manager.views.LambdaGateway._http',
+                return_value=functions["negative"][id_func],
+            ):
+                response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+                self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
     def test_api_v2_lambda_requests_create_empty_data(self):
@@ -808,7 +826,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
-    def test_api_v2_lambda_functions_create_non_type(self):
+    def test_api_v2_lambda_functions_create_negative(self):
         data = {
             "task": self.main_task["id"],
             "frame": 0,
@@ -818,51 +836,16 @@ class LambdaTestCases(_LambdaTestCaseBase):
             },
         }
 
-        response = self._post_request(f"{LAMBDA_FUNCTIONS_PATH}/{id_function_non_type}", self.admin, data)
-        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-
-    def test_api_v2_lambda_functions_create_wrong_type(self):
-        data = {
-            "task": self.main_task["id"],
-            "frame": 0,
-            "cleanup": True,
-            "mapping": {
-                "car": { "name": "car" },
-            },
-        }
-
-        response = self._post_request(f"{LAMBDA_FUNCTIONS_PATH}/{id_function_wrong_type}", self.admin, data)
-        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-
-    def test_api_v2_lambda_functions_create_unknown_type(self):
-        data = {
-            "task": self.main_task["id"],
-            "frame": 0,
-            "cleanup": True,
-            "mapping": {
-                "car": { "name": "car" },
-            },
-        }
-
-        response = self._post_request(f"{LAMBDA_FUNCTIONS_PATH}/{id_function_unknown_type}", self.admin, data)
-        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-
-    @mock.patch('cvat.apps.lambda_manager.views.LambdaGateway._http', return_value = functions["negative"]["test-model-has-non-unique-labels"])
-    def test_api_v2_lambda_functions_create_non_unique_labels(self, mock_http):
-        data = {
-            "task": self.main_task["id"],
-            "frame": 0,
-            "cleanup": True,
-            "mapping": {
-                "car": { "name": "car" },
-            },
-        }
-
-        response = self._post_request(f"{LAMBDA_FUNCTIONS_PATH}/{id_function_non_unique_labels}", self.admin, data)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        for id_func in [
+            id_function_non_type, id_function_wrong_type, id_function_unknown_type,
+            id_function_non_unique_labels,
+        ]:
+            with mock.patch(
+                'cvat.apps.lambda_manager.views.LambdaGateway._http',
+                return_value=functions["negative"][id_func]
+            ):
+                response = self._post_request(f"{LAMBDA_FUNCTIONS_PATH}/{id_func}", self.admin, data)
+                self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
     def test_api_v2_lambda_functions_create_quality(self):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This has several goals:

* Remove `LambdaType.UNKNOWN`. Functions with this non-type are useless and should not be presented to the user.

* Don't return 404 from the list endpoint if one function cannot be loaded. This prevents one bad function from essentially disabling the entire serverless function feature. Instead, log the error and ignore the function.

* Don't return 404 from other endpoints either when the problem is a bad function. This is not a client problem. Raise an exception and let Django log it and return a 500.

* Remove HTTP codes from `LambdaFunction`, to improve separation of concerns.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved error handling for lambda function endpoints, providing clearer feedback on invalid metadata.
	- Introduced validation for lambda function types, ensuring only valid functions are displayed in the output.

- **Bug Fixes**
	- Resolved an issue where a single lambda function with invalid metadata would disrupt the entire function listing process.

- **Documentation**
	- Updated changelog to reflect the changes in error handling and validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->