### PR TITLE
Display the ID for non-system models

### DIFF
--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.65.1",
+  "version": "1.65.2",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/models-page/deployed-model-item.tsx
+++ b/cvat-ui/src/components/models-page/deployed-model-item.tsx
@@ -87,7 +87,10 @@ export default function DeployedModelItem(props: Props): JSX.Element {
                 />
                 { modelTopBar }
                 <div className='cvat-model-info-container'>
-                    <Title level={3}>{model.name}</Title>
+                    <Title level={3}>
+                        {model.provider !== ModelProviders.CVAT && `#${model.id}: `}
+                        {model.name}
+                    </Title>
                     {modelDescription}
                 </div>
                 <Divider />
@@ -157,6 +160,7 @@ export default function DeployedModelItem(props: Props): JSX.Element {
                 <Meta
                     title={(
                         <Text ellipsis={{ tooltip: model.name }} onClick={onOpenModel} className='cvat-models-item-title' aria-hidden>
+                            {model.provider !== ModelProviders.CVAT && `#${model.id}: `}
                             {model.name}
                         </Text>
                     )}


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This is consistent with other user-controllable objects, and when you're triggering the API manually, makes it easier to determine which ID to use.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced display of model information by conditionally including model IDs based on the provider, improving clarity for users.
  
- **Bug Fixes**
	- Minor version update to address backward-compatible bug fixes or enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->