### PR TITLE
`*Permission.get_scopes`: don't tolerate unknown actions

### DIFF
--- a/cvat/apps/analytics_report/permissions.py
+++ b/cvat/apps/analytics_report/permissions.py
@@ -70,7 +70,7 @@ class AnalyticsReportPermission(OpenPolicyAgentPermission):
             {
                 "list": Scopes.LIST,
                 "create": Scopes.CREATE,
-            }.get(view.action, None)
+            }[view.action]
         ]
 
     def get_resource(self):

--- a/cvat/apps/engine/permissions.py
+++ b/cvat/apps/engine/permissions.py
@@ -65,7 +65,7 @@ class ServerPermission(OpenPolicyAgentPermission):
             ('about', 'GET'): Scopes.VIEW,
             ('plugins', 'GET'): Scopes.VIEW,
             ('share', 'GET'): Scopes.LIST_CONTENT,
-        }.get((view.action, request.method))]
+        }[(view.action, request.method)]]
 
     def get_resource(self):
         return None
@@ -100,7 +100,7 @@ class UserPermission(OpenPolicyAgentPermission):
             'retrieve': Scopes.VIEW,
             'partial_update': Scopes.UPDATE,
             'destroy': Scopes.DELETE,
-        }.get(view.action)]
+        }[view.action]]
 
     @classmethod
     def create_scope_view(cls, iam_context, user_id):
@@ -178,7 +178,7 @@ class CloudStoragePermission(OpenPolicyAgentPermission):
             'preview': Scopes.VIEW,
             'status': Scopes.VIEW,
             'actions': Scopes.VIEW,
-        }.get(view.action)]
+        }[view.action]]
 
     def get_resource(self):
         data = None
@@ -281,7 +281,7 @@ class ProjectPermission(OpenPolicyAgentPermission):
             ('append_backup_chunk', 'PATCH'): Scopes.IMPORT_BACKUP,
             ('append_backup_chunk', 'HEAD'): Scopes.IMPORT_BACKUP,
             ('preview', 'GET'): Scopes.VIEW,
-        }.get((view.action, request.method))
+        }[(view.action, request.method)]
 
         scopes = []
         if scope == Scopes.UPDATE:
@@ -498,7 +498,7 @@ class TaskPermission(OpenPolicyAgentPermission):
             ('export_backup', 'GET'): Scopes.EXPORT_BACKUP,
             ('export_backup_v2', 'POST'): Scopes.EXPORT_BACKUP,
             ('preview', 'GET'): Scopes.VIEW,
-        }.get((view.action, request.method))
+        }[(view.action, request.method)]
 
         scopes = []
         if scope == Scopes.CREATE:
@@ -542,13 +542,8 @@ class TaskPermission(OpenPolicyAgentPermission):
 
             scopes.append(scope)
 
-        elif scope is not None:
-            scopes.append(scope)
-
         else:
-            # TODO: think if we can protect from missing endpoints
-            # assert False, "Unknown scope"
-            pass
+            scopes.append(scope)
 
         return scopes
 
@@ -729,7 +724,7 @@ class JobPermission(OpenPolicyAgentPermission):
             ('dataset_export', 'GET'): Scopes.EXPORT_DATASET,
             ('export_dataset_v2', 'POST'): Scopes.EXPORT_DATASET if is_dataset_export(request) else Scopes.EXPORT_ANNOTATIONS,
             ('preview', 'GET'): Scopes.VIEW,
-        }.get((view.action, request.method))
+        }[(view.action, request.method)]
 
         scopes = []
         if scope == Scopes.UPDATE:
@@ -849,7 +844,7 @@ class CommentPermission(OpenPolicyAgentPermission):
             'destroy': Scopes.DELETE,
             'partial_update': Scopes.UPDATE,
             'retrieve': Scopes.VIEW,
-        }.get(view.action, None)]
+        }[view.action]]
 
     def get_resource(self):
         data = None
@@ -941,7 +936,7 @@ class IssuePermission(OpenPolicyAgentPermission):
             'partial_update': Scopes.UPDATE,
             'retrieve': Scopes.VIEW,
             'comments': Scopes.VIEW,
-        }.get(view.action, None)]
+        }[view.action]]
 
     def get_resource(self):
         data = None
@@ -1065,7 +1060,7 @@ class LabelPermission(OpenPolicyAgentPermission):
             'destroy': Scopes.DELETE,
             'partial_update': Scopes.UPDATE,
             'retrieve': Scopes.VIEW,
-        }.get(view.action, None)]
+        }[view.action]]
 
     def get_resource(self):
         data = None
@@ -1127,7 +1122,7 @@ class AnnotationGuidePermission(OpenPolicyAgentPermission):
             'destroy': Scopes.DELETE,
             'partial_update': Scopes.UPDATE,
             'retrieve': Scopes.VIEW,
-        }.get(view.action, None)]
+        }[view.action]]
 
     def get_resource(self):
         data = {}
@@ -1205,7 +1200,7 @@ class GuideAssetPermission(OpenPolicyAgentPermission):
             'create': Scopes.CREATE,
             'destroy': Scopes.DELETE,
             'retrieve': Scopes.VIEW,
-        }.get(view.action, None)]
+        }[view.action]]
 
 
 class RequestPermission(OpenPolicyAgentPermission):
@@ -1237,7 +1232,7 @@ class RequestPermission(OpenPolicyAgentPermission):
             ('list', 'GET'): Scopes.LIST,
             ('retrieve', 'GET'): Scopes.VIEW,
             ('cancel', 'POST'): Scopes.CANCEL,
-        }.get((view.action, request.method))]
+        }[(view.action, request.method)]]
 
 
     def get_resource(self):

--- a/cvat/apps/events/permissions.py
+++ b/cvat/apps/events/permissions.py
@@ -50,7 +50,7 @@ class EventsPermission(OpenPolicyAgentPermission):
         return [{
             ('create', 'POST'): Scopes.SEND_EVENTS,
             ('list', 'GET'): Scopes.DUMP_EVENTS,
-        }.get((view.action, request.method))]
+        }[(view.action, request.method)]]
 
     def get_resource(self):
         return None

--- a/cvat/apps/lambda_manager/permissions.py
+++ b/cvat/apps/lambda_manager/permissions.py
@@ -49,7 +49,7 @@ class LambdaPermission(OpenPolicyAgentPermission):
             ('lambda_request', 'list'): Scopes.LIST_OFFLINE,
             ('lambda_request', 'retrieve'): Scopes.CALL_OFFLINE,
             ('lambda_request', 'destroy'): Scopes.CALL_OFFLINE,
-        }.get((view.basename, view.action), None)]
+        }[(view.basename, view.action)]]
 
     def get_resource(self):
         return None

--- a/cvat/apps/log_viewer/permissions.py
+++ b/cvat/apps/log_viewer/permissions.py
@@ -30,7 +30,7 @@ class LogViewerPermission(OpenPolicyAgentPermission):
         Scopes = __class__.Scopes
         return [{
             'list': Scopes.VIEW,
-        }.get(view.action, None)]
+        }[view.action]]
 
     def get_resource(self):
         return {

--- a/cvat/apps/organizations/permissions.py
+++ b/cvat/apps/organizations/permissions.py
@@ -42,7 +42,7 @@ class OrganizationPermission(OpenPolicyAgentPermission):
             'destroy': Scopes.DELETE,
             'partial_update': Scopes.UPDATE,
             'retrieve': Scopes.VIEW,
-        }.get(view.action, None)]
+        }[view.action]]
 
     def get_resource(self):
         if self.obj:
@@ -109,7 +109,7 @@ class InvitationPermission(OpenPolicyAgentPermission):
             'accept': Scopes.ACCEPT,
             'decline': Scopes.DECLINE,
             'resend': Scopes.RESEND,
-        }.get(view.action)]
+        }[view.action]]
 
     def get_resource(self):
         data = None
@@ -172,12 +172,12 @@ class MembershipPermission(OpenPolicyAgentPermission):
             'partial_update': Scopes.UPDATE,
             'retrieve': Scopes.VIEW,
             'destroy': Scopes.DELETE,
-        }.get(view.action)
+        }[view.action]
 
         if scope == Scopes.UPDATE:
             if request.data.get('role') != cast(Membership, obj).role:
                 scopes.append(Scopes.UPDATE_ROLE)
-        elif scope:
+        else:
             scopes.append(scope)
 
         return scopes

--- a/cvat/apps/quality_control/permissions.py
+++ b/cvat/apps/quality_control/permissions.py
@@ -85,7 +85,7 @@ class QualityReportPermission(OpenPolicyAgentPermission):
                 "create": Scopes.CREATE,
                 "retrieve": Scopes.VIEW,
                 "data": Scopes.VIEW,
-            }.get(view.action, None)
+            }[view.action]
         ]
 
     def get_resource(self):
@@ -158,7 +158,7 @@ class AnnotationConflictPermission(OpenPolicyAgentPermission):
         return [
             {
                 "list": Scopes.LIST,
-            }.get(view.action, None)
+            }[view.action]
         ]
 
     def get_resource(self):
@@ -225,7 +225,7 @@ class QualitySettingPermission(OpenPolicyAgentPermission):
                 "list": Scopes.LIST,
                 "retrieve": Scopes.VIEW,
                 "partial_update": Scopes.UPDATE,
-            }.get(view.action, None)
+            }[view.action]
         ]
 
     def get_resource(self):

--- a/cvat/apps/webhooks/permissions.py
+++ b/cvat/apps/webhooks/permissions.py
@@ -62,7 +62,7 @@ class WebhookPermission(OpenPolicyAgentPermission):
             ('deliveries', 'GET'): Scopes.VIEW,
             ('retrieve_delivery', 'GET'): Scopes.VIEW,
             ('redelivery', 'POST'): Scopes.UPDATE,
-        }.get((view.action, request.method))
+        }[(view.action, request.method)]
 
         scopes = []
         if scope == Scopes.CREATE:
@@ -70,7 +70,7 @@ class WebhookPermission(OpenPolicyAgentPermission):
             if webhook_type in [m.value for m in WebhookTypeChoice]:
                 scope = Scopes(str(scope) + f'@{webhook_type}')
             scopes.append(scope)
-        elif scope in [Scopes.UPDATE, Scopes.DELETE, Scopes.LIST, Scopes.VIEW]:
+        else:
             scopes.append(scope)
 
         return scopes

--- a/cvat/apps/webhooks/views.py
+++ b/cvat/apps/webhooks/views.py
@@ -109,7 +109,9 @@ class WebhookViewSet(viewsets.ModelViewSet):
         ],
         responses={"200": OpenApiResponse(EventsSerializer)},
     )
-    @action(detail=False, methods=["GET"], serializer_class=EventsSerializer)
+    @action(detail=False, methods=["GET"], serializer_class=EventsSerializer,
+        permission_classes=[],
+    )
     def events(self, request):
         webhook_type = request.query_params.get("type", "all")
         events = None


### PR DESCRIPTION

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
With almost all of the `get_scopes` methods, an unknown (action, method) combination will result in an array like `[None]` being returned (sometimes with other elements as well). If that happens, the OPA input will then have `"scope": null`, and so the policy evaluation will fail, unless the user is an admin.

Because of this, it's really easy to accidentally make a view admin-only, by forgetting to add/update an entry in `get_scopes` when making changes.

`TaskPermission`, `MembershipPermission` and `WebhookPermission` are even worse, because they will just return an empty list of scopes, which will later translate to an empty list of permissions, which means that everyone will be permitted to perform the action. This can lead to vulnerabilities like CVE-2024-45393.

Fix this by replacing all `.get` calls with indexing, which will cause a crash if the (action, method) combo is unknown. This breaks one endpoint (`/api/webhooks/events`), which is supposed to be publicly accessible; fix that by disabling authorization for it.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
