### PR TITLE
Improve grammar in the email invitation

### DIFF
--- a/cvat/apps/organizations/templates/invitation/invitation_message.html
+++ b/cvat/apps/organizations/templates/invitation/invitation_message.html
@@ -155,7 +155,7 @@
           <tr>
             <td align="left" bgcolor="#ffffff" style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
               <h1 style="margin: 0; font-size: 32px; font-weight: 700; letter-spacing: -1px; line-height: 48px;">
-                You've been invited to organization
+                You've been invited to an organization
               </h1>
             </td>
           </tr>
@@ -184,10 +184,10 @@
             <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
               {% blocktrans %}
               <p>
-                You're receiving this email because you've been invited to join <strong>{{ organization_name }}</strong> organization in CVAT by <strong>{{ invitation_owner }}</strong> at {{ site_name }}.
+                You're receiving this email because you've been invited to join the <strong>{{ organization_name }}</strong> organization in CVAT by <strong>{{ invitation_owner }}</strong> at {{ site_name }}.
               </p>
               <p style="margin: 0;">
-                To join organization and start annotating, simply tap the button below and complete registration.
+                To join the organization and start annotating, simply tap the button below and complete the registration.
               </p>
               {% endblocktrans %}
             </td>

--- a/cvat/apps/organizations/templates/invitation/invitation_message.html
+++ b/cvat/apps/organizations/templates/invitation/invitation_message.html
@@ -184,7 +184,7 @@
             <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
               {% blocktrans %}
               <p>
-                You're receiving this email because you've been invited to join the <strong>{{ organization_name }}</strong> organization in CVAT by <strong>{{ invitation_owner }}</strong> at {{ site_name }}.
+                You're receiving this email because you've been invited by <strong>{{ invitation_owner }}</strong> to join the <strong>{{ organization_name }}</strong> organization in CVAT at {{ site_name }}.
               </p>
               <p style="margin: 0;">
                 To join the organization and start annotating, simply tap the button below and complete the registration.

--- a/cvat/apps/organizations/templates/invitation/invitation_subject.txt
+++ b/cvat/apps/organizations/templates/invitation/invitation_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}You're invited to join {{ organization_name }} organization in CVAT!{% endblocktrans %}
+{% blocktrans %}You're invited to join the {{ organization_name }} organization in CVAT!{% endblocktrans %}
 {% endautoescape %}


### PR DESCRIPTION
Improve grammar in the email invitation

### Motivation and context
The current email invitation is very nice and simple but the grammar is a bit odd in some places, I think this will improve the quality of the email invitation.

### How has this been tested?
I have sent invite emails using my SMTP server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved clarity and grammatical correctness in invitation messages and subjects.
	- Enhanced readability of invitation emails by adding necessary articles.
- **Bug Fixes**
	- Corrected minor grammatical errors in invitation templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->