### PR TITLE
Change borken link to logo in invitation email

### DIFF
--- a/cvat/apps/organizations/templates/invitation/invitation_message.html
+++ b/cvat/apps/organizations/templates/invitation/invitation_message.html
@@ -3,6 +3,7 @@
 {% load static %}
 
 <html>
+
 <head>
 
   <meta charset="utf-8">
@@ -10,102 +11,105 @@
   <title>Email Confirmation</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style type="text/css">
-  /**
+    /**
    * Google webfonts. Recommended to include the .woff version for cross-client compatibility.
    */
-  @media screen {
-    @font-face {
-      font-family: 'Source Sans Pro';
-      font-style: normal;
-      font-weight: 400;
-      src: local('Source Sans Pro Regular'), local('SourceSansPro-Regular'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/ODelI1aHBYDBqgeIAH2zlBM0YzuT7MdOe03otPbuUS0.woff) format('woff');
+    @media screen {
+      @font-face {
+        font-family: 'Source Sans Pro';
+        font-style: normal;
+        font-weight: 400;
+        src: local('Source Sans Pro Regular'), local('SourceSansPro-Regular'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/ODelI1aHBYDBqgeIAH2zlBM0YzuT7MdOe03otPbuUS0.woff) format('woff');
+      }
+
+      @font-face {
+        font-family: 'Source Sans Pro';
+        font-style: normal;
+        font-weight: 700;
+        src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/toadOcfmlt9b38dHJxOBGFkQc6VGVFSmCnC_l7QZG60.woff) format('woff');
+      }
     }
 
-    @font-face {
-      font-family: 'Source Sans Pro';
-      font-style: normal;
-      font-weight: 700;
-      src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/toadOcfmlt9b38dHJxOBGFkQc6VGVFSmCnC_l7QZG60.woff) format('woff');
-    }
-  }
-
-  /**
+    /**
    * Avoid browser level font resizing.
    * 1. Windows Mobile
    * 2. iOS / OSX
    */
-  body,
-  table,
-  td,
-  a {
-    -ms-text-size-adjust: 100%; /* 1 */
-    -webkit-text-size-adjust: 100%; /* 2 */
-  }
+    body,
+    table,
+    td,
+    a {
+      -ms-text-size-adjust: 100%;
+      /* 1 */
+      -webkit-text-size-adjust: 100%;
+      /* 2 */
+    }
 
-  /**
+    /**
    * Remove extra space added to tables and cells in Outlook.
    */
-  table,
-  td {
-    mso-table-rspace: 0pt;
-    mso-table-lspace: 0pt;
-  }
+    table,
+    td {
+      mso-table-rspace: 0pt;
+      mso-table-lspace: 0pt;
+    }
 
-  /**
+    /**
    * Better fluid images in Internet Explorer.
    */
-  img {
-    -ms-interpolation-mode: bicubic;
-  }
+    img {
+      -ms-interpolation-mode: bicubic;
+    }
 
-  /**
+    /**
    * Remove blue links for iOS devices.
    */
-  a[x-apple-data-detectors] {
-    font-family: inherit !important;
-    font-size: inherit !important;
-    font-weight: inherit !important;
-    line-height: inherit !important;
-    color: inherit !important;
-    text-decoration: none !important;
-  }
+    a[x-apple-data-detectors] {
+      font-family: inherit !important;
+      font-size: inherit !important;
+      font-weight: inherit !important;
+      line-height: inherit !important;
+      color: inherit !important;
+      text-decoration: none !important;
+    }
 
-  /**
+    /**
    * Fix centering issues in Android 4.4.
    */
-  div[style*="margin: 16px 0;"] {
-    margin: 0 !important;
-  }
+    div[style*="margin: 16px 0;"] {
+      margin: 0 !important;
+    }
 
-  body {
-    width: 100% !important;
-    height: 100% !important;
-    padding: 0 !important;
-    margin: 0 !important;
-  }
+    body {
+      width: 100% !important;
+      height: 100% !important;
+      padding: 0 !important;
+      margin: 0 !important;
+    }
 
-  /**
+    /**
    * Collapse table borders to avoid space between cells.
    */
-  table {
-    border-collapse: collapse !important;
-  }
+    table {
+      border-collapse: collapse !important;
+    }
 
-  a {
-    color: #ffffff;
-    text-decoration: none;
-  }
+    a {
+      color: #ffffff;
+      text-decoration: none;
+    }
 
-  img {
-    height: auto;
-    line-height: 100%;
-    text-decoration: none;
-    border: 0;
-    outline: none;
-  }
+    img {
+      height: auto;
+      line-height: 100%;
+      text-decoration: none;
+      border: 0;
+      outline: none;
+    }
   </style>
 
 </head>
+
 <body style="background-color: #e9ecef;">
 
   <!-- start body -->
@@ -122,14 +126,9 @@
         <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
           <tr>
             <td align="center" valign="bottom">
-              <a href="https://www.cvat.ai/" target="_blank" style="display: inline-block;">
-                <img
-                  src="https://github.com/cvat-ai/cvat/blob/develop/site/content/en/images/cvat_poster_with_name.png?raw=true"
-                  alt="Logo"
-                  border="0"
-                  width="100%"
-                  style="display: block; width: 100%;"
-                >
+              <a href="https://www.cvat.ai/" target="_blank">
+                <img src="https://raw.githubusercontent.com/cvat-ai/cvat/v2.18.0/cvat-ui/src/assets/cvat-logo.svg"
+                  alt="Logo" style="width: 25%; margin: 10px;">
               </a>
             </td>
           </tr>
@@ -153,7 +152,8 @@
         <![endif]-->
         <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
           <tr>
-            <td align="left" bgcolor="#ffffff" style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
+            <td align="left" bgcolor="#ffffff"
+              style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
               <h1 style="margin: 0; font-size: 32px; font-weight: 700; letter-spacing: -1px; line-height: 48px;">
                 You've been invited to an organization
               </h1>
@@ -181,7 +181,8 @@
 
           <!-- start copy -->
           <tr>
-            <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
+            <td align="left" bgcolor="#ffffff"
+              style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
               {% blocktrans %}
               <p>
                 You're receiving this email because you've been invited by <strong>{{ invitation_owner }}</strong> to join the <strong>{{ organization_name }}</strong> organization in CVAT at {{ site_name }}.
@@ -204,14 +205,10 @@
                       <tr>
                         <td align="center" bgcolor="#FCA836" style="border-radius: 6px;">
                           {% blocktrans %}
-                          <a
-                            href="{{ protocol }}://{{ domain }}/auth/login?email={{ email }}&invitation={{ invitation_key }}"
+                          <a href="{{ protocol }}://{{ domain }}/auth/login?email={{ email }}&invitation={{ invitation_key }}"
                             target="_blank"
-                            style="display: inline-block; padding: 16px 36px;"
-                                  "font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif;"
-                                  "font-size: 16px; color: #ffffff; text-decoration: none; border-radius: 6px;"
-                            rel="noopener noreferrer"
-                          >
+                            style="display: inline-block; padding: 16px 36px;" "font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif;" "font-size: 16px; color: #ffffff; text-decoration: none; border-radius: 6px;"
+                            rel="noopener noreferrer">
                             Setup your account
                           </a>
                           {% endblocktrans %}
@@ -227,7 +224,8 @@
 
           <!-- start copy -->
           <tr>
-            <td align="center" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px; border-bottom: 3px solid #d4dadf">
+            <td align="center" bgcolor="#ffffff"
+              style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px; border-bottom: 3px solid #d4dadf">
               <hr>
               {% blocktrans %}
               <p style="margin: 0;">
@@ -260,7 +258,8 @@
 
           <!-- start permission -->
           <tr>
-            <td align="center" bgcolor="#e9ecef" style="padding: 12px 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; color: #666;">
+            <td align="center" bgcolor="#e9ecef"
+              style="padding: 12px 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; color: #666;">
               <p style="margin: 0;">If you didn't request this, please ignore this email.</p>
             </td>
           </tr>
@@ -280,4 +279,5 @@
   <!-- end body -->
 
 </body>
+
 </html>

--- a/cvat/apps/organizations/templates/invitation/invitation_message.html
+++ b/cvat/apps/organizations/templates/invitation/invitation_message.html
@@ -3,7 +3,6 @@
 {% load static %}
 
 <html>
-
 <head>
 
   <meta charset="utf-8">
@@ -11,105 +10,102 @@
   <title>Email Confirmation</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style type="text/css">
-    /**
+  /**
    * Google webfonts. Recommended to include the .woff version for cross-client compatibility.
    */
-    @media screen {
-      @font-face {
-        font-family: 'Source Sans Pro';
-        font-style: normal;
-        font-weight: 400;
-        src: local('Source Sans Pro Regular'), local('SourceSansPro-Regular'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/ODelI1aHBYDBqgeIAH2zlBM0YzuT7MdOe03otPbuUS0.woff) format('woff');
-      }
-
-      @font-face {
-        font-family: 'Source Sans Pro';
-        font-style: normal;
-        font-weight: 700;
-        src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/toadOcfmlt9b38dHJxOBGFkQc6VGVFSmCnC_l7QZG60.woff) format('woff');
-      }
+  @media screen {
+    @font-face {
+      font-family: 'Source Sans Pro';
+      font-style: normal;
+      font-weight: 400;
+      src: local('Source Sans Pro Regular'), local('SourceSansPro-Regular'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/ODelI1aHBYDBqgeIAH2zlBM0YzuT7MdOe03otPbuUS0.woff) format('woff');
     }
 
-    /**
+    @font-face {
+      font-family: 'Source Sans Pro';
+      font-style: normal;
+      font-weight: 700;
+      src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/toadOcfmlt9b38dHJxOBGFkQc6VGVFSmCnC_l7QZG60.woff) format('woff');
+    }
+  }
+
+  /**
    * Avoid browser level font resizing.
    * 1. Windows Mobile
    * 2. iOS / OSX
    */
-    body,
-    table,
-    td,
-    a {
-      -ms-text-size-adjust: 100%;
-      /* 1 */
-      -webkit-text-size-adjust: 100%;
-      /* 2 */
-    }
+  body,
+  table,
+  td,
+  a {
+    -ms-text-size-adjust: 100%; /* 1 */
+    -webkit-text-size-adjust: 100%; /* 2 */
+  }
 
-    /**
+  /**
    * Remove extra space added to tables and cells in Outlook.
    */
-    table,
-    td {
-      mso-table-rspace: 0pt;
-      mso-table-lspace: 0pt;
-    }
+  table,
+  td {
+    mso-table-rspace: 0pt;
+    mso-table-lspace: 0pt;
+  }
 
-    /**
+  /**
    * Better fluid images in Internet Explorer.
    */
-    img {
-      -ms-interpolation-mode: bicubic;
-    }
+  img {
+    -ms-interpolation-mode: bicubic;
+  }
 
-    /**
+  /**
    * Remove blue links for iOS devices.
    */
-    a[x-apple-data-detectors] {
-      font-family: inherit !important;
-      font-size: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      color: inherit !important;
-      text-decoration: none !important;
-    }
+  a[x-apple-data-detectors] {
+    font-family: inherit !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+    color: inherit !important;
+    text-decoration: none !important;
+  }
 
-    /**
+  /**
    * Fix centering issues in Android 4.4.
    */
-    div[style*="margin: 16px 0;"] {
-      margin: 0 !important;
-    }
+  div[style*="margin: 16px 0;"] {
+    margin: 0 !important;
+  }
 
-    body {
-      width: 100% !important;
-      height: 100% !important;
-      padding: 0 !important;
-      margin: 0 !important;
-    }
+  body {
+    width: 100% !important;
+    height: 100% !important;
+    padding: 0 !important;
+    margin: 0 !important;
+  }
 
-    /**
+  /**
    * Collapse table borders to avoid space between cells.
    */
-    table {
-      border-collapse: collapse !important;
-    }
+  table {
+    border-collapse: collapse !important;
+  }
 
-    a {
-      color: #ffffff;
-      text-decoration: none;
-    }
+  a {
+    color: #ffffff;
+    text-decoration: none;
+  }
 
-    img {
-      height: auto;
-      line-height: 100%;
-      text-decoration: none;
-      border: 0;
-      outline: none;
-    }
+  img {
+    height: auto;
+    line-height: 100%;
+    text-decoration: none;
+    border: 0;
+    outline: none;
+  }
   </style>
 
 </head>
-
 <body style="background-color: #e9ecef;">
 
   <!-- start body -->
@@ -127,8 +123,8 @@
           <tr>
             <td align="center" valign="bottom">
               <a href="https://www.cvat.ai/" target="_blank">
-                <img src="https://raw.githubusercontent.com/cvat-ai/cvat/v2.18.0/cvat-ui/src/assets/cvat-logo.svg"
-                  alt="Logo" style="width: 25%; margin: 10px;">
+                <img src="https://raw.githubusercontent.com/cvat-ai/cvat/v2.18.0/cvat-ui/src/assets/cvat-logo.svg" alt="Logo"
+                  style="width: 25%; margin: 10px;">
               </a>
             </td>
           </tr>
@@ -152,8 +148,7 @@
         <![endif]-->
         <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
           <tr>
-            <td align="left" bgcolor="#ffffff"
-              style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
+            <td align="left" bgcolor="#ffffff" style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
               <h1 style="margin: 0; font-size: 32px; font-weight: 700; letter-spacing: -1px; line-height: 48px;">
                 You've been invited to an organization
               </h1>
@@ -181,8 +176,7 @@
 
           <!-- start copy -->
           <tr>
-            <td align="left" bgcolor="#ffffff"
-              style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
+            <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
               {% blocktrans %}
               <p>
                 You're receiving this email because you've been invited by <strong>{{ invitation_owner }}</strong> to join the <strong>{{ organization_name }}</strong> organization in CVAT at {{ site_name }}.
@@ -205,10 +199,14 @@
                       <tr>
                         <td align="center" bgcolor="#FCA836" style="border-radius: 6px;">
                           {% blocktrans %}
-                          <a href="{{ protocol }}://{{ domain }}/auth/login?email={{ email }}&invitation={{ invitation_key }}"
+                          <a
+                            href="{{ protocol }}://{{ domain }}/auth/login?email={{ email }}&invitation={{ invitation_key }}"
                             target="_blank"
-                            style="display: inline-block; padding: 16px 36px;" "font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif;" "font-size: 16px; color: #ffffff; text-decoration: none; border-radius: 6px;"
-                            rel="noopener noreferrer">
+                            style="display: inline-block; padding: 16px 36px;"
+                                  "font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif;"
+                                  "font-size: 16px; color: #ffffff; text-decoration: none; border-radius: 6px;"
+                            rel="noopener noreferrer"
+                          >
                             Setup your account
                           </a>
                           {% endblocktrans %}
@@ -224,8 +222,7 @@
 
           <!-- start copy -->
           <tr>
-            <td align="center" bgcolor="#ffffff"
-              style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px; border-bottom: 3px solid #d4dadf">
+            <td align="center" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px; border-bottom: 3px solid #d4dadf">
               <hr>
               {% blocktrans %}
               <p style="margin: 0;">
@@ -258,8 +255,7 @@
 
           <!-- start permission -->
           <tr>
-            <td align="center" bgcolor="#e9ecef"
-              style="padding: 12px 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; color: #666;">
+            <td align="center" bgcolor="#e9ecef" style="padding: 12px 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; color: #666;">
               <p style="margin: 0;">If you didn't request this, please ignore this email.</p>
             </td>
           </tr>
@@ -279,5 +275,4 @@
   <!-- end body -->
 
 </body>
-
 </html>


### PR DESCRIPTION
Current link to logo in the email is broken. I used the link from the CVAT.ai page to the logo SVG image, I think this link to the SVG is autogenerated so it might change in a later deployment of CVAT.ai but I couldn't find the source of that file such that I could refer to it. If you point me to it I will change an test it.

This is how the logo looks like now:

![image](https://github.com/user-attachments/assets/89f40e95-81b6-4e22-b066-3e753be4273b)

this is how it was looking before:

![image](https://github.com/user-attachments/assets/43427483-b60d-4e32-af8a-2dd2bcc17afe)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the invitation message with a new SVG logo for improved visual presentation.
	- Enhanced logo adaptability with responsive sizing and color inversion filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->