### PR TITLE
Stabilize E2E tests

### DIFF
--- a/tests/cypress/e2e/features/ground_truth_jobs.js
+++ b/tests/cypress/e2e/features/ground_truth_jobs.js
@@ -89,12 +89,12 @@ context('Ground truth jobs', () => {
     }
 
     function openManagementTab() {
-        cy.get('.cvat-task-page-actions-button').should('exist').and('be.visible');
         cy.clickInTaskMenu('Quality control', true);
         cy.get('.cvat-task-control-tabs')
             .within(() => {
                 cy.contains('Management').click();
             });
+        cy.get('.cvat-quality-control-management-tab').should('exist').and('be.visible');
     }
 
     before(() => {
@@ -225,9 +225,9 @@ context('Ground truth jobs', () => {
             )).then((jobResponse) => {
                 groundTruthJobID = jobResponse.jobID;
             }).then(() => {
-                cy.visit(`/tasks/${taskID}`);
-                cy.get('.cvat-task-details').should('exist').and('be.visible');
-                openManagementTab();
+                cy.visit(`/tasks/${taskID}/quality-control#management`);
+                cy.get('.cvat-quality-control-management-tab').should('exist').and('be.visible');
+                cy.get('.cvat-annotations-quality-allocation-table-summary').should('exist').and('be.visible');
             });
         });
 

--- a/tests/cypress/e2e/features/ground_truth_jobs.js
+++ b/tests/cypress/e2e/features/ground_truth_jobs.js
@@ -89,6 +89,7 @@ context('Ground truth jobs', () => {
     }
 
     function openManagementTab() {
+        cy.get('.cvat-task-page-actions-button').should('exist').and('be.visible');
         cy.clickInTaskMenu('Quality control', true);
         cy.get('.cvat-task-control-tabs')
             .within(() => {

--- a/tests/cypress/e2e/features/ground_truth_jobs.js
+++ b/tests/cypress/e2e/features/ground_truth_jobs.js
@@ -225,7 +225,7 @@ context('Ground truth jobs', () => {
             )).then((jobResponse) => {
                 groundTruthJobID = jobResponse.jobID;
             }).then(() => {
-                // comment to run ci
+                // comment to run ci 2
                 cy.visit(`/tasks/${taskID}/quality-control#management`);
                 cy.get('.cvat-quality-control-management-tab').should('exist').and('be.visible');
                 cy.get('.cvat-annotations-quality-allocation-table-summary').should('exist').and('be.visible');

--- a/tests/cypress/e2e/features/ground_truth_jobs.js
+++ b/tests/cypress/e2e/features/ground_truth_jobs.js
@@ -225,7 +225,6 @@ context('Ground truth jobs', () => {
             )).then((jobResponse) => {
                 groundTruthJobID = jobResponse.jobID;
             }).then(() => {
-                // comment to run ci 2
                 cy.visit(`/tasks/${taskID}/quality-control#management`);
                 cy.get('.cvat-quality-control-management-tab').should('exist').and('be.visible');
                 cy.get('.cvat-annotations-quality-allocation-table-summary').should('exist').and('be.visible');

--- a/tests/cypress/e2e/features/ground_truth_jobs.js
+++ b/tests/cypress/e2e/features/ground_truth_jobs.js
@@ -225,6 +225,7 @@ context('Ground truth jobs', () => {
             )).then((jobResponse) => {
                 groundTruthJobID = jobResponse.jobID;
             }).then(() => {
+                // comment to run ci
                 cy.visit(`/tasks/${taskID}/quality-control#management`);
                 cy.get('.cvat-quality-control-management-tab').should('exist').and('be.visible');
                 cy.get('.cvat-annotations-quality-allocation-table-summary').should('exist').and('be.visible');

--- a/tests/cypress/e2e/features/requests_page.js
+++ b/tests/cypress/e2e/features/requests_page.js
@@ -323,7 +323,8 @@ context('Requests page', () => {
             cy.getJobIDFromIdx(0).then((jobID) => {
                 const closeExportNotification = () => {
                     cy.contains('Export is finished').should('be.visible');
-                    cy.closeNotification('.ant-notification-notice-info');
+                    cy.contains('Export is finished').parents('.ant-notification-notice')
+                        .find('span[aria-label="close"]').click();
                 };
 
                 const exportParams = {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
requests page tests:
The is a potential issue in regression test. As we test 2 exports one by one, there can be 2 pop-up notifications about successful operation. But our command cy.closeNotification expects only one. So changed logic a bit in test so it doesnt crush even if there is several notifications

quality_management tests:
sometimes actions button is not clicked

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->~~
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the method for closing the export completion notification on the requests page for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->