### PR TITLE
Remove `task_subsets` from `ProjectWriteSerializer`

### DIFF
--- a/changelog.d/20241001_131450_roman.md
+++ b/changelog.d/20241001_131450_roman.md
@@ -1,0 +1,5 @@
+### Removed
+
+- Removed the non-functional `task_subsets` parameter from the project create
+  and update endpoints
+  (<https://github.com/cvat-ai/cvat/pull/8492>)

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1371,7 +1371,6 @@ class ProjectWriteSerializer(serializers.ModelSerializer):
     labels = LabelSerializer(write_only=True, many=True, source='label_set', partial=True, default=[])
     owner_id = serializers.IntegerField(write_only=True, allow_null=True, required=False)
     assignee_id = serializers.IntegerField(write_only=True, allow_null=True, required=False)
-    task_subsets = serializers.ListField(write_only=True, child=serializers.CharField(), required=False)
 
     target_storage = StorageSerializer(write_only=True, required=False)
     source_storage = StorageSerializer(write_only=True, required=False)
@@ -1379,7 +1378,7 @@ class ProjectWriteSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Project
         fields = ('name', 'labels', 'owner_id', 'assignee_id', 'bug_tracker',
-            'target_storage', 'source_storage', 'task_subsets',
+            'target_storage', 'source_storage',
         )
 
     def to_representation(self, instance):

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -9332,12 +9332,6 @@ components:
           allOf:
           - $ref: '#/components/schemas/StorageRequest'
           writeOnly: true
-        task_subsets:
-          type: array
-          items:
-            type: string
-            minLength: 1
-          writeOnly: true
     PatchedQualitySettingsRequest:
       type: object
       properties:
@@ -9657,12 +9651,6 @@ components:
         source_storage:
           allOf:
           - $ref: '#/components/schemas/StorageRequest'
-          writeOnly: true
-        task_subsets:
-          type: array
-          items:
-            type: string
-            minLength: 1
           writeOnly: true
       required:
       - name


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This is a generated field, so it makes no sense to write it. In practice, attempting to do so when creating a project causes a crash in `ProjectWriteSerializer.create`, while doing it when updating a project has no effect.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new API endpoints for managing cloud storages, comments, issues, jobs, tasks, and webhooks.
	- Enhanced reporting capabilities with updated schemas for Analytics and Quality metrics.
  
- **Bug Fixes**
	- Removed the non-functional `task_subsets` parameter from project creation and update endpoints to streamline the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->