### PR TITLE
Harden access control in several PATCH endpoints

### DIFF
--- a/changelog.d/20241001_142106_roman_patch_scopes_hardening.md
+++ b/changelog.d/20241001_142106_roman_patch_scopes_hardening.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Made the `PATCH` endpoints for projects, tasks, jobs and memberships check
+  the input more strictly
+  (<https://github.com/cvat-ai/cvat/pull/8493>):
+
+  - unknown fields are rejected;
+  - updating a field now requires the same level of permissions regardless of
+    whether the new value is the same as the old value.

--- a/cvat/apps/engine/permissions.py
+++ b/cvat/apps/engine/permissions.py
@@ -286,26 +286,16 @@ class ProjectPermission(OpenPolicyAgentPermission):
 
         scopes = []
         if scope == Scopes.UPDATE:
-            # user should have permissions to view a project
-            scopes.append(Scopes.VIEW)
-
-            if any(k in request.data for k in ('owner_id', 'owner')):
-                owner_id = request.data.get('owner_id') or request.data.get('owner')
-                if owner_id != getattr(obj.owner, 'id', None):
-                    scopes.append(Scopes.UPDATE_OWNER)
-            if any(k in request.data for k in ('assignee_id', 'assignee')):
-                assignee_id = request.data.get('assignee_id') or request.data.get('assignee')
-                if assignee_id != getattr(obj.assignee, 'id', None):
-                    scopes.append(Scopes.UPDATE_ASSIGNEE)
-            for field in ('name', 'labels', 'bug_tracker'):
-                if field in request.data:
-                    scopes.append(Scopes.UPDATE_DESC)
-                    break
-            if 'organization' in request.data:
-                scopes.append(Scopes.UPDATE_ORG)
-
-            if {'source_storage', 'target_storage'} & request.data.keys():
-                scopes.append(Scopes.UPDATE_ASSOCIATED_STORAGE)
+            scopes.extend(__class__.get_per_field_update_scopes(request, {
+                'owner_id': Scopes.UPDATE_OWNER,
+                'assignee_id': Scopes.UPDATE_ASSIGNEE,
+                'name': Scopes.UPDATE_DESC,
+                'labels': Scopes.UPDATE_DESC,
+                'bug_tracker': Scopes.UPDATE_DESC,
+                'organization': Scopes.UPDATE_ORG,
+                'source_storage': Scopes.UPDATE_ASSOCIATED_STORAGE,
+                'target_storage': Scopes.UPDATE_ASSOCIATED_STORAGE,
+            }))
         else:
             scopes.append(scope)
 
@@ -517,31 +507,18 @@ class TaskPermission(OpenPolicyAgentPermission):
             scopes.append(scope)
 
         elif scope == Scopes.UPDATE:
-            # user should have permissions to view a task
-            scopes.append(Scopes.VIEW)
-            if any(k in request.data for k in ('owner_id', 'owner')):
-                owner_id = request.data.get('owner_id') or request.data.get('owner')
-                if owner_id != getattr(obj.owner, 'id', None):
-                    scopes.append(Scopes.UPDATE_OWNER)
-
-            if any(k in request.data for k in ('assignee_id', 'assignee')):
-                assignee_id = request.data.get('assignee_id') or request.data.get('assignee')
-                if assignee_id != getattr(obj.assignee, 'id', None):
-                    scopes.append(Scopes.UPDATE_ASSIGNEE)
-
-            if any(k in request.data for k in ('project_id', 'project')):
-                project_id = request.data.get('project_id') or request.data.get('project')
-                if project_id != getattr(obj.project, 'id', None):
-                    scopes.append(Scopes.UPDATE_PROJECT)
-
-            if any(k in request.data for k in ('name', 'labels', 'bug_tracker', 'subset')):
-                scopes.append(Scopes.UPDATE_DESC)
-
-            if request.data.get('organization'):
-                scopes.append(Scopes.UPDATE_ORGANIZATION)
-
-            if {'source_storage', 'target_storage'} & request.data.keys():
-                scopes.append(Scopes.UPDATE_ASSOCIATED_STORAGE)
+            scopes.extend(__class__.get_per_field_update_scopes(request, {
+                'owner_id': Scopes.UPDATE_OWNER,
+                'assignee_id': Scopes.UPDATE_ASSIGNEE,
+                'project_id': Scopes.UPDATE_PROJECT,
+                'name': Scopes.UPDATE_DESC,
+                'labels': Scopes.UPDATE_DESC,
+                'bug_tracker': Scopes.UPDATE_DESC,
+                'subset': Scopes.UPDATE_DESC,
+                'organization': Scopes.UPDATE_ORGANIZATION,
+                'source_storage': Scopes.UPDATE_ASSOCIATED_STORAGE,
+                'target_storage': Scopes.UPDATE_ASSOCIATED_STORAGE,
+            }))
 
         elif scope == Scopes.VIEW_ANNOTATIONS:
             if 'format' in request.query_params:
@@ -738,19 +715,11 @@ class JobPermission(OpenPolicyAgentPermission):
 
         scopes = []
         if scope == Scopes.UPDATE:
-            # user should have permissions to view a job
-            scopes.append(Scopes.VIEW)
-
-            if any(k in request.data for k in ('assignee_id', 'assignee')):
-                assignee_id = request.data.get('assignee_id') or request.data.get('assignee')
-                if assignee_id != getattr(obj.assignee, 'id', None):
-                    scopes.append(Scopes.UPDATE_ASSIGNEE)
-
-            if 'stage' in request.data:
-                scopes.append(Scopes.UPDATE_STAGE)
-            if 'state' in request.data:
-                scopes.append(Scopes.UPDATE_STATE)
-
+            scopes.extend(__class__.get_per_field_update_scopes(request, {
+                'assignee': Scopes.UPDATE_ASSIGNEE,
+                'stage': Scopes.UPDATE_STAGE,
+                'state': Scopes.UPDATE_STATE,
+            }))
         elif scope == Scopes.VIEW_ANNOTATIONS:
             if 'format' in request.query_params:
                 scope = Scopes.EXPORT_ANNOTATIONS

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -382,6 +382,11 @@ class JobPartialUpdateAPITestCase(ApiTestBase):
         response = self._run_api_v2_jobs_id(self.job.id, self.admin, data)
         self._check_request(response, data)
 
+    def test_api_v2_jobs_id_unknown_field(self):
+        data = {"foo": "bar"}
+        response = self._run_api_v2_jobs_id(self.job.id, self.admin, data)
+        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN, response)
+
 class JobUpdateAPITestCase(ApiTestBase):
     def setUp(self):
         super().setUp()
@@ -1127,6 +1132,11 @@ class ProjectPartialUpdateAPITestCase(ApiTestBase):
             "name": "new name for the project",
         }
         self._check_api_v2_projects_id(None, data)
+
+    def test_api_v2_projects_id_unknown_field(self):
+        data = {"foo": "bar"}
+        response = self._run_api_v2_projects_id(self.projects[0].id, self.admin, data)
+        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN, response)
 
 class UpdateLabelsAPITestCase(ApiTestBase):
     def assertLabelsEqual(self, label1, label2):
@@ -2224,6 +2234,11 @@ class TaskPartialUpdateAPITestCase(ApiTestBase):
             }]
         }
         self._check_api_v2_tasks_id(None, data)
+
+    def test_api_v2_tasks_id_unknown_field(self):
+        data = {"foo": "bar"}
+        response = self._run_api_v2_tasks_id(self.tasks[0].id, self.admin, data)
+        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN, response)
 
 class TaskDataMetaPartialUpdateAPITestCase(ApiTestBase):
     @classmethod

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -378,8 +378,8 @@ class JobPartialUpdateAPITestCase(ApiTestBase):
         self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN, response)
 
     def test_api_v2_jobs_id_admin_partial(self):
-        data = {"assignee_id": self.user.id}
-        response = self._run_api_v2_jobs_id(self.job.id, self.owner, data)
+        data = {"assignee": self.user.id}
+        response = self._run_api_v2_jobs_id(self.job.id, self.admin, data)
         self._check_request(response, data)
 
 class JobUpdateAPITestCase(ApiTestBase):

--- a/cvat/apps/organizations/permissions.py
+++ b/cvat/apps/organizations/permissions.py
@@ -173,11 +173,9 @@ class MembershipPermission(OpenPolicyAgentPermission):
         }[view.action]
 
         if scope == Scopes.UPDATE:
-            # user should have permissions to view a membership
-            scopes.append(Scopes.VIEW)
-
-            if 'role' in request.data.keys():
-                scopes.append(Scopes.UPDATE_ROLE)
+            scopes.extend(__class__.get_per_field_update_scopes(request, {
+                'role': Scopes.UPDATE_ROLE,
+            }))
         else:
             scopes.append(scope)
 

--- a/tests/python/rest_api/test_memberships.py
+++ b/tests/python/rest_api/test_memberships.py
@@ -147,6 +147,15 @@ class TestPatchMemberships:
             with pytest.raises(ForbiddenException):
                 api_client.memberships_api.partial_update(membership["id"])
 
+    def test_user_cannot_update_unknown_field(self, admin_user, memberships):
+        membership = next(iter(memberships))
+
+        response = patch_method(
+            admin_user, f"memberships/{membership['id']}", {"foo": "bar"}, org_id=self._ORG
+        )
+
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
 
 @pytest.mark.usefixtures("restore_db_per_function")
 class TestDeleteMemberships:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Currently several permission classes dynamically determine scopes for `PATCH` endpoints, depending on request body fields. This is error-prone for a couple of reasons:

* If you forget to add a default scope like `Scopes.VIEW`, then anyone can view the resource by submitting a `PATCH` request with an empty body.

* If you add a field to a resource, but forget to define which scope it should be associated with, then anyone can modify this field on any instance of this resource.

Both of these have happened previously; see <[GHSA-gxhm-hg65-5gh2](https://github.com/cvat-ai/cvat/security/advisories/GHSA-gxhm-hg65-5gh2)>.

Attempt to harden the scope determination logic for such endpoints, so that such errors could not occur. Specifically:

* Factor out the common logic (including the default scope) into a function.

* Instead of checking for each known field in the request body, check every field in the body against a map of known fields, and abort if the field does not map to any scopes.

A side effect of this change is that request bodies that set certain fields (such as `owner_id`) to the values they already have did not previously require the appropriate `UPDATE_*` scope, but now they do. This is for simplicity of implementation. I see no need to preserve the current behavior, since a user who does not have the requisite permission can simply omit the field from the request.

Another side effect is that request bodies with unknown fields are now rejected, whereas previously such fields would be ignored. I think that's probably a good thing, since we can't properly fulfill such a request anyway - can't set a field that doesn't exist.

This change detected a broken test in the unit test suite, so fix that.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Unit tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for `PATCH` requests, ensuring stricter input checks.
	- Standardized permission requirements for updating fields across projects, tasks, jobs, and memberships.
	- Improved handling of annotation features with new formats and adjustments.

- **Bug Fixes**
	- Robustness improvements in annotation handling tests to cover various user roles and scenarios.

- **Documentation**
	- Updates to the changelog reflecting the new validation and permission handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->