### PR TITLE
Fixed quality reports and immediate feedback on jobs with start frame and step

### DIFF
--- a/changelog.d/20241016_180804_sekachev.bs.md
+++ b/changelog.d/20241016_180804_sekachev.bs.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Incorrect quality reports and immediate feedback with non default start frame or frame step
+  (<https://github.com/cvat-ai/cvat/pull/8551>)

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -812,7 +812,8 @@ class JobData(CommonData):
                 self._excluded_frames.update(self.db_data.validation_layout.disabled_frames)
 
         if self._required_frames:
-            self._required_frames = set(frame for frame in self._required_frames if frame in self.rel_range)
+            rel_range = self.rel_range
+            self._required_frames = set(frame for frame in self._required_frames if frame in rel_range)
 
     def __len__(self):
         segment = self._db_job.segment

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -812,11 +812,7 @@ class JobData(CommonData):
                 self._excluded_frames.update(self.db_data.validation_layout.disabled_frames)
 
         if self._required_frames:
-            abs_range = self.abs_range
-            self._required_frames = set(
-                self.abs_frame_id(frame) for frame in self._required_frames
-                if frame in abs_range
-            )
+            self._required_frames = set(frame for frame in self._required_frames if frame in self.rel_range)
 
     def __len__(self):
         segment = self._db_job.segment

--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -2317,7 +2317,7 @@ class QualityReportUpdateManager:
                 job.id: JobDataProvider(
                     job.id,
                     queryset=job_queryset,
-                    included_frames=set(job.segment.frame_set) & active_validation_frames,
+                    included_frames=active_validation_frames,
                 )
                 for job in jobs
             }

--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -2303,13 +2303,13 @@ class QualityReportUpdateManager:
             if validation_layout.mode == ValidationMode.GT_POOL:
                 task_frame_provider = TaskFrameProvider(task)
                 active_validation_frames = set(
-                    task_frame_provider.get_rel_frame_number(frame)
-                    for frame, real_frame in (
+                    task_frame_provider.get_rel_frame_number(abs_frame)
+                    for abs_frame, abs_real_frame in (
                         Image.objects.filter(data=task.data, is_placeholder=True)
                         .values_list("frame", "real_frame")
                         .iterator(chunk_size=10000)
                     )
-                    if real_frame in active_validation_frames
+                    if task_frame_provider.get_rel_frame_number(abs_real_frame) in active_validation_frames
                 )
 
             jobs: List[Job] = [j for j in job_queryset if j.type == JobType.ANNOTATION]

--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -2309,7 +2309,8 @@ class QualityReportUpdateManager:
                         .values_list("frame", "real_frame")
                         .iterator(chunk_size=10000)
                     )
-                    if task_frame_provider.get_rel_frame_number(abs_real_frame) in active_validation_frames
+                    if task_frame_provider.get_rel_frame_number(abs_real_frame)
+                    in active_validation_frames
                 )
 
             jobs: List[Job] = [j for j in job_queryset if j.type == JobType.ANNOTATION]


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
To address the identified issue, we likely need to store relative frame numbers in self._required_frames.

Explanation:
The only place where self._required_frames is used is in the method:

```
def _is_frame_required(self, frame):
    return self._required_frames is None or frame in self._required_frames
```

This method is called in:

```
def get_included_frames(self):
    return set(
        i for i in self.rel_range
        if not self._is_frame_deleted(i)
        and not self._is_frame_excluded(i)
        and self._is_frame_required(i)
    )

```
Currently, the implementation tries to check whether a relative frame number exists in a set that contains absolute frame numbers, which doesn't work if start_frame or frame_step is defined when the task is created. This causes failures in both quality reports and immediate feedback, as well as possibly other functionalities that rely on get_included_frames.


Another issue with the current code is a logical inconsistency:

```
abs_range = self.abs_range
self._required_frames = set(
     self.abs_frame_id(frame) for frame in self._required_frames
     if frame in abs_range
)
```

Here, abs_frame_id expects a relative frame number and converts it to an absolute frame number, but we first check if the relative frame number from self._required_frames is already in the absolute range, which is incorrect.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for managing required frames within job data.
	- Added properties for absolute and relative frame ranges.
	- Implemented a method to return the number of frames in a job.

- **Bug Fixes**
	- Improved frame matching logic for better accuracy.

- **Refactor**
	- Cleaned up code for better readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->