### PR TITLE
Workaround for av context closing issue when using AUTO thread_type

### DIFF
--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -552,6 +552,8 @@ class _AvVideoReading:
             for stream in container.streams:
                 context = stream.codec_context
                 if context and context.is_open:
+                    # Currently, context closing may get stuck on some videos for an unknown reason,
+                    # so the thread_type == 'AUTO' setting is disabled for future investigation
                     context.close()
 
             if container.open_files:
@@ -583,7 +585,7 @@ class VideoReader(IMediaReader):
         stop: Optional[int] = None,
         dimension: DimensionType = DimensionType.DIM_2D,
         *,
-        allow_threading: bool = True,
+        allow_threading: bool = False,
     ):
         super().__init__(
             source_path=source_path,
@@ -635,6 +637,8 @@ class VideoReader(IMediaReader):
 
                 if self.allow_threading:
                     video_stream.thread_type = 'AUTO'
+                else:
+                    video_stream.thread_type = 'NONE'
 
             frame_counter = itertools.count()
             with closing(self._decode_stream(container, video_stream)) as stream_decoder:
@@ -795,6 +799,8 @@ class VideoReaderWithManifest:
             video_stream = container.streams.video[0]
             if self.allow_threading:
                 video_stream.thread_type = 'AUTO'
+            else:
+                video_stream.thread_type = 'NONE'
 
             container.seek(offset=start_decode_timestamp, stream=video_stream)
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
