### PR TITLE
Fix a bug where retrying an export RQ job may break scheduling

### DIFF
--- a/changelog.d/20241022_191618_roman_fix_integer_dependencies.md
+++ b/changelog.d/20241022_191618_roman_fix_integer_dependencies.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Fixed a bug where an export RQ job being retried may break scheduling
+  of new jobs
+  (<https://github.com/cvat-ai/cvat/pull/8584>)

--- a/cvat/apps/dataset_manager/views.py
+++ b/cvat/apps/dataset_manager/views.py
@@ -85,7 +85,6 @@ def _retry_current_rq_job(time_delta: timedelta) -> rq.job.Job:
                 **current_rq_job.kwargs,
                 job_id=current_rq_job.id,
                 meta=current_rq_job.meta,
-                depends_on=current_rq_job.dependency_ids,
                 job_ttl=current_rq_job.ttl,
                 job_result_ttl=current_rq_job.result_ttl,
                 job_description=current_rq_job.description,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
`_patched_retry` tries to schedule a copy of the current job. In particular, it copies the dependencies of the old job using
`current_rq_job.dependency_ids`.

Unfortunately, `dependency_ids` does not return IDs of dependency jobs, as one might expect. It actually returns the Redis _keys_ corresponding to those jobs, as bytestrings. The RQ job creation code does not support bytestrings as dependency specifiers, so it unintentionally treats them as sequences, saving the individual bytes (as integers) as the dependency job IDs. But since IDs have to be strings, the scheduler quickly crashes when it tries to use those integer "IDs" to construct Redis keys.

Thankfully, we don't actually need to get the dependency IDs. `_patched_retry` is only used inside running jobs, and if a job is running, it means that all its dependencies are already completed. Thus, the newly scheduled job doesn't need to have any dependencies at all.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where retrying export jobs disrupted the scheduling of new jobs, ensuring proper job queue integrity.

- **Improvements**
	- Enhanced error handling for export jobs, including better logging and retry mechanisms.
	- Updated cache management to check for the existence of cache files before removal.

- **Documentation**
	- Improved clarity in logging related to the export process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->