### PR TITLE
Update the Docker image handling code in `schedule.yml`

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -5,9 +5,8 @@ on:
   workflow_dispatch:
 
 env:
-  SERVER_IMAGE_TEST_REPO: cvat_server
-  UI_IMAGE_TEST_REPO: instrumentation_cvat_ui
   CYPRESS_VERIFY_TIMEOUT: 180000 # https://docs.cypress.io/guides/guides/command-line#cypress-verify
+  CVAT_VERSION: "local"
 
 jobs:
   check_updates:
@@ -48,12 +47,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_CI_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_CI_TOKEN }}
-
       - name: CVAT server. Getting cache from the default branch
         uses: actions/cache@v4
         with:
@@ -66,24 +59,14 @@ jobs:
           path: /tmp/cvat_cache_ui
           key: ${{ runner.os }}-build-ui-${{ needs.search_cache.outputs.sha }}
 
-      - name: CVAT server. Extract metadata (tags, labels) for Docker
-        id: meta-server
-        uses: docker/metadata-action@master
-        with:
-          images: ${{ secrets.DOCKERHUB_CI_WORKSPACE }}/${{ env.SERVER_IMAGE_TEST_REPO }}
-          tags:
-            type=raw,value=nightly
-
-      - name: CVAT UI. Extract metadata (tags, labels) for Docker
-        id: meta-ui
-        uses: docker/metadata-action@master
-        with:
-          images: ${{ secrets.DOCKERHUB_CI_WORKSPACE }}/${{ env.UI_IMAGE_TEST_REPO }}
-          tags:
-            type=raw,value=nightly
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Create artifact directories
+        run: |
+          mkdir /tmp/cvat_server
+          mkdir /tmp/cvat_ui
+          mkdir /tmp/cvat_sdk
 
       - name: CVAT server. Build and push
         uses: docker/build-push-action@v6
@@ -91,9 +74,8 @@ jobs:
           cache-from: type=local,src=/tmp/cvat_cache_server
           context: .
           file: Dockerfile
-          push: true
-          tags: ${{ steps.meta-server.outputs.tags }}
-          labels: ${{ steps.meta-server.outputs.labels }}
+          tags: cvat/server:${{ env.CVAT_VERSION }}
+          outputs: type=docker,dest=/tmp/cvat_server/image.tar
 
       - name: CVAT UI. Build and push
         uses: docker/build-push-action@v6
@@ -101,9 +83,20 @@ jobs:
           cache-from: type=local,src=/tmp/cvat_cache_ui
           context: .
           file: Dockerfile.ui
-          push: true
-          tags: ${{ steps.meta-ui.outputs.tags }}
-          labels: ${{ steps.meta-ui.outputs.labels }}
+          tags: cvat/ui:${{ env.CVAT_VERSION }}
+          outputs: type=docker,dest=/tmp/cvat_ui/image.tar
+
+      - name: Upload CVAT server artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cvat_server
+          path: /tmp/cvat_server/image.tar
+
+      - name: Upload CVAT UI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cvat_ui
+          path: /tmp/cvat_ui/image.tar
 
   unit_testing:
     needs: build
@@ -115,41 +108,23 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Getting CVAT UI cache from the default branch
-        uses: actions/cache@v4
+      - name: Download CVAT server image
+        uses: actions/download-artifact@v4
         with:
-          path: /tmp/cvat_cache_ui
-          key: ${{ runner.os }}-build-ui-${{ needs.search_cache.outputs.sha }}
+          name: cvat_server
+          path: /tmp/cvat_server/
 
-      - name: Building CVAT UI image
-        uses: docker/build-push-action@v6
+      - name: Download CVAT UI images
+        uses: actions/download-artifact@v4
         with:
-          context: .
-          file: ./Dockerfile.ui
-          cache-from: type=local,src=/tmp/cvat_cache_ui
-          tags: cvat/ui:latest
-          load: true
+          name: cvat_ui
+          path: /tmp/cvat_ui/
 
-      - name: CVAT server. Extract metadata (tags, labels) for Docker
-        id: meta-server
-        uses: docker/metadata-action@master
-        with:
-          images: ${{ secrets.DOCKERHUB_CI_WORKSPACE }}/${{ env.SERVER_IMAGE_TEST_REPO }}
-          tags:
-            type=raw,value=nightly
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_CI_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_CI_TOKEN }}
-
-      - name: Pull CVAT server image
+      - name: Load Docker images
         run: |
-          docker pull ${{ steps.meta-server.outputs.tags }}
-          docker tag ${{ steps.meta-server.outputs.tags }} cvat/server:local
-          docker tag ${{ steps.meta-server.outputs.tags }} cvat/server:latest
-          docker tag cvat/ui:latest cvat/ui:local
+          docker load --input /tmp/cvat_server/image.tar
+          docker load --input /tmp/cvat_ui/image.tar
+          docker image ls -a
 
       - name: OPA tests
         run: |
@@ -210,35 +185,23 @@ jobs:
         with:
             node-version: '16.x'
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+      - name: Download CVAT server image
+        uses: actions/download-artifact@v4
         with:
-          username: ${{ secrets.DOCKERHUB_CI_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_CI_TOKEN }}
+          name: cvat_server
+          path: /tmp/cvat_server/
 
-      - name: CVAT server. Extract metadata (tags, labels) for Docker
-        id: meta-server
-        uses: docker/metadata-action@master
+      - name: Download CVAT UI image
+        uses: actions/download-artifact@v4
         with:
-          images: ${{ secrets.DOCKERHUB_CI_WORKSPACE }}/${{ env.SERVER_IMAGE_TEST_REPO }}
-          tags:
-            type=raw,value=nightly
+          name: cvat_ui
+          path: /tmp/cvat_ui/
 
-      - name: CVAT UI. Extract metadata (tags, labels) for Docker
-        id: meta-ui
-        uses: docker/metadata-action@master
-        with:
-          images: ${{ secrets.DOCKERHUB_CI_USERNAME }}/${{ env.UI_IMAGE_TEST_REPO }}
-          tags:
-            type=raw,value=nightly
-
-      - name: Pull CVAT UI image
+      - name: Load Docker images
         run: |
-          docker pull ${{ steps.meta-server.outputs.tags }}
-          docker tag ${{ steps.meta-server.outputs.tags }} cvat/server:dev
-
-          docker pull ${{ steps.meta-ui.outputs.tags }}
-          docker tag ${{ steps.meta-ui.outputs.tags }} cvat/ui:dev
+          docker load --input /tmp/cvat_server/image.tar
+          docker load --input /tmp/cvat_ui/image.tar
+          docker image ls -a
 
       - name: Run CVAT instance
         run: |


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
It currently uses an auxiliary Docker Hub account to temporarily store the images, but all other workflows have long ago switched to using workflow artifacts. Switch this workflow too, by replacing all image-handling code with the equivalents from `main.yml`.

The main reason to do this is to fix a bug in the workflow: the `unit_testing` job tags the `cvat/*` images as `:latest`, but the Compose file wants the `:dev` tag. So the images end up being redownloaded from Docker Hub.

There are also a few other reasons why the new version is better:

* It avoids unnecessary complexity, viz. the usage of Docker Hub, an external service.

* It's consistent with the other pipelines, which should make future changes easier.

* It's much less code.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Test run: <https://github.com/cvat-ai/cvat/actions/runs/11504222821>. You can see that at no point it pulls the `cvat/server` or `cvat/ui` images from GitHub.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration to streamline artifact management for image builds.
	- Removed Docker Hub interactions for building and testing images.
	- Introduced a new environment variable `CVAT_VERSION` for tagging images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->