### PR TITLE
Fix return type annotations for functions used with @contextmanager

### DIFF
--- a/cvat-sdk/cvat_sdk/core/client.py
+++ b/cvat-sdk/cvat_sdk/core/client.py
@@ -10,7 +10,7 @@ import urllib.parse
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from time import sleep
-from typing import Any, Dict, Iterator, Optional, Sequence, Tuple, TypeVar
+from typing import Any, Dict, Generator, Optional, Sequence, Tuple, TypeVar
 
 import attrs
 import packaging.specifiers as specifiers
@@ -121,7 +121,7 @@ class Client:
             self.api_client.default_headers[self._ORG_SLUG_HEADER] = org_slug
 
     @contextmanager
-    def organization_context(self, slug: str) -> Iterator[None]:
+    def organization_context(self, slug: str) -> Generator[None, None, None]:
         prev_slug = self.organization_slug
         self.organization_slug = slug
         try:

--- a/cvat-sdk/cvat_sdk/core/progress.py
+++ b/cvat-sdk/cvat_sdk/core/progress.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import contextlib
-from typing import ContextManager, Iterable, Optional, TypeVar
+from typing import Generator, Iterable, Optional, TypeVar
 
 T = TypeVar("T")
 
@@ -26,7 +26,7 @@ class ProgressReporter:
     """
 
     @contextlib.contextmanager
-    def task(self, **kwargs) -> ContextManager[None]:
+    def task(self, **kwargs) -> Generator[None, None, None]:
         """
         Returns a context manager that represents a long-running task
         for which progress can be reported.

--- a/cvat-sdk/cvat_sdk/core/utils.py
+++ b/cvat-sdk/cvat_sdk/core/utils.py
@@ -13,7 +13,7 @@ from typing import (
     BinaryIO,
     ContextManager,
     Dict,
-    Iterator,
+    Generator,
     Literal,
     Sequence,
     TextIO,
@@ -43,7 +43,7 @@ def atomic_writer(
 @contextlib.contextmanager
 def atomic_writer(
     path: Union[os.PathLike, str], mode: Literal["w", "wb"], encoding: str = "UTF-8"
-) -> Iterator[IO]:
+) -> Generator[IO, None, None]:
     """
     Returns a context manager that, when entered, returns a handle to a temporary
     file opened with the specified `mode` and `encoding`. If the context manager

--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -539,7 +539,9 @@ class ZipReader(ImageListReader):
 
 class _AvVideoReading:
     @contextmanager
-    def read_av_container(self, source: Union[str, io.BytesIO]) -> av.container.InputContainer:
+    def read_av_container(
+        self, source: Union[str, io.BytesIO]
+    ) -> Generator[av.container.InputContainer, None, None]:
         if isinstance(source, io.BytesIO):
             source.seek(0) # required for re-reading
 

--- a/tests/python/cli/util.py
+++ b/tests/python/cli/util.py
@@ -9,7 +9,7 @@ import ssl
 import threading
 import unittest
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Union
+from typing import Any, Dict, Generator, List, Union
 
 import requests
 
@@ -39,7 +39,7 @@ def generate_images(dst_dir: Path, count: int) -> List[Path]:
 
 
 @contextlib.contextmanager
-def https_reverse_proxy() -> Iterator[str]:
+def https_reverse_proxy() -> Generator[str, None, None]:
     ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
     cert_dir = Path(__file__).parent


### PR DESCRIPTION

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Some of them are annotated with an `Iterator` return type. However...

It just occurred to me that `@contextmanager` cannot work with a function that returns a plain iterator, since it relies on the generator class's `throw` method. `contextmanager` is defined in typeshed as accepting an iterator-returning function, but that appears to be a bug: <https://github.com/python/typeshed/issues/2772>.

Change all such annotations to a `Generator` type instead.

Some annotations are also broken in other ways; fix them too.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type hinting across multiple methods to clarify their return types as generators, improving code readability and maintainability.
  
- **Bug Fixes**
	- Added comments in the `_AvVideoReading` class to address potential memory corruption issues with the `av` library, providing guidance for developers.

- **Documentation**
	- Updated method signatures in documentation to reflect changes in return types, ensuring accurate representation of functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->