### PR TITLE
tests: remove imports that were deprecated in Python 3.9

### DIFF
--- a/tests/python/cli/example_function.py
+++ b/tests/python/cli/example_function.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-from typing import List
-
 import cvat_sdk.auto_annotation as cvataa
 import cvat_sdk.models as models
 import PIL.Image
@@ -17,7 +15,7 @@ spec = cvataa.DetectionFunctionSpec(
 
 def detect(
     context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
-) -> List[models.LabeledShapeRequest]:
+) -> list[models.LabeledShapeRequest]:
     return [
         cvataa.rectangle(0, [1, 2, 3, 4]),
     ]

--- a/tests/python/cli/example_parameterized_function.py
+++ b/tests/python/cli/example_parameterized_function.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 from types import SimpleNamespace as namespace
-from typing import List
 
 import cvat_sdk.auto_annotation as cvataa
 import cvat_sdk.models as models
@@ -24,7 +23,7 @@ def create(s: str, i: int, f: float, b: bool) -> cvataa.DetectionFunction:
 
     def detect(
         context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
-    ) -> List[models.LabeledShapeRequest]:
+    ) -> list[models.LabeledShapeRequest]:
         return [
             cvataa.rectangle(0, [1, 2, 3, 4]),
         ]

--- a/tests/python/cli/util.py
+++ b/tests/python/cli/util.py
@@ -8,8 +8,9 @@ import http.server
 import ssl
 import threading
 import unittest
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Union
+from typing import Any, Union
 
 import requests
 
@@ -28,7 +29,7 @@ def run_cli(test: Union[unittest.TestCase, Any], *args: str, expected_code: int 
         assert expected_code == main(args)
 
 
-def generate_images(dst_dir: Path, count: int) -> List[Path]:
+def generate_images(dst_dir: Path, count: int) -> list[Path]:
     filenames = []
     dst_dir.mkdir(parents=True, exist_ok=True)
     for i in range(count):
@@ -70,7 +71,7 @@ class _ProxyHttpRequestHandler(http.server.BaseHTTPRequestHandler):
         response = requests.post(data=self.rfile.read(body_length), **self._shared_request_args())
         self._translate_response(response)
 
-    def _shared_request_args(self) -> Dict[str, Any]:
+    def _shared_request_args(self) -> dict[str, Any]:
         headers = {k.lower(): v for k, v in self.headers.items()}
         del headers["host"]
 

--- a/tests/python/rest_api/test_analytics_reports.py
+++ b/tests/python/rest_api/test_analytics_reports.py
@@ -4,7 +4,7 @@
 
 import json
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import pytest
 from cvat_sdk.api_client import models
@@ -67,7 +67,7 @@ class TestGetAnalyticsReports(_PermissionTestBase):
         job_id: Optional[int] = None,
         task_id: Optional[int] = None,
         project_id: Optional[int] = None,
-        expected_data: Optional[Dict[str, Any]] = None,
+        expected_data: Optional[dict[str, Any]] = None,
         **kwargs,
     ):
         params = self._get_query_params(job_id=job_id, task_id=task_id, project_id=project_id)

--- a/tests/python/rest_api/test_issues.py
+++ b/tests/python/rest_api/test_issues.py
@@ -6,7 +6,7 @@
 import json
 from copy import deepcopy
 from http import HTTPStatus
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import pytest
 from cvat_sdk import models
@@ -367,7 +367,7 @@ class TestCommentsListFilters(CollectionSimpleFilterTestBase):
     def _get_endpoint(self, api_client: ApiClient) -> Endpoint:
         return api_client.comments_api.list_endpoint
 
-    def _get_field_samples(self, field: str) -> Tuple[Any, List[Dict[str, Any]]]:
+    def _get_field_samples(self, field: str) -> tuple[Any, list[dict[str, Any]]]:
         if field == "job_id":
             issue_id, issue_comments = super()._get_field_samples("issue_id")
             issue = next((s for s in self.sample_issues if s["id"] == issue_id))

--- a/tests/python/rest_api/test_jobs.py
+++ b/tests/python/rest_api/test_jobs.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from http import HTTPStatus
 from io import BytesIO
 from itertools import groupby, product
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import pytest
@@ -71,7 +71,7 @@ def filter_jobs(jobs, tasks, org):
 
 @pytest.mark.usefixtures("restore_db_per_function")
 class TestPostJobs:
-    def _test_create_job_ok(self, user: str, data: Dict[str, Any], **kwargs):
+    def _test_create_job_ok(self, user: str, data: dict[str, Any], **kwargs):
         with make_api_client(user) as api_client:
             (_, response) = api_client.jobs_api.create(
                 models.JobWriteRequest(**deepcopy(data)), **kwargs
@@ -80,7 +80,7 @@ class TestPostJobs:
         return response
 
     def _test_create_job_fails(
-        self, user: str, data: Dict[str, Any], *, expected_status: int, **kwargs
+        self, user: str, data: dict[str, Any], *, expected_status: int, **kwargs
     ):
         with make_api_client(user) as api_client:
             (_, response) = api_client.jobs_api.create(
@@ -110,7 +110,7 @@ class TestPostJobs:
         tasks,
         task_mode: str,
         frame_selection_method: str,
-        method_params: Set[str],
+        method_params: set[str],
     ):
         required_task_size = 15
 
@@ -544,7 +544,7 @@ class TestDeleteJobs:
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestGetJobs:
     def _test_get_job_200(
-        self, user, jid, *, expected_data: Optional[Dict[str, Any]] = None, **kwargs
+        self, user, jid, *, expected_data: Optional[dict[str, Any]] = None, **kwargs
     ):
         with make_api_client(user) as client:
             (_, response) = client.jobs_api.retrieve(jid, **kwargs)
@@ -1442,7 +1442,7 @@ class TestJobDataset:
         username: str,
         jid: int,
         *,
-        api_version: Union[int, Tuple[int]],
+        api_version: Union[int, tuple[int]],
         local_download: bool = True,
         **kwargs,
     ) -> Optional[bytes]:
@@ -1473,9 +1473,9 @@ class TestJobDataset:
     def test_can_export_dataset_locally_and_to_cloud_with_both_api_versions(
         self,
         admin_user: str,
-        jobs_with_shapes: List,
+        jobs_with_shapes: list,
         filter_tasks,
-        api_version: Tuple[int],
+        api_version: tuple[int],
         local_download: bool,
     ):
         filter_ = "target_storage__location"

--- a/tests/python/rest_api/test_labels.py
+++ b/tests/python/rest_api/test_labels.py
@@ -7,7 +7,7 @@ import json
 from copy import deepcopy
 from http import HTTPStatus
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import pytest
 from cvat_sdk import exceptions, models
@@ -60,7 +60,7 @@ class _TestLabelsPermissionsBase:
         """
 
     @staticmethod
-    def _labels_by_source(labels: List[Dict], *, source_key: str) -> Dict[int, List[Dict]]:
+    def _labels_by_source(labels: list[dict], *, source_key: str) -> dict[int, list[dict]]:
         labels_by_source = {}
         for label in labels:
             label_source = label.get(source_key)
@@ -216,7 +216,7 @@ class TestLabelsListFilters(CollectionSimpleFilterTestBase):
     def _get_endpoint(self, api_client: ApiClient) -> Endpoint:
         return api_client.labels_api.list_endpoint
 
-    def _get_field_samples(self, field: str) -> Tuple[Any, List[Dict[str, Any]]]:
+    def _get_field_samples(self, field: str) -> tuple[Any, list[dict[str, Any]]]:
         if field == "parent":
             parent_id, gt_objects = self._get_field_samples("parent_id")
             parent_name = self._get_field(
@@ -584,8 +584,8 @@ class TestPatchLabels(_TestLabelsPermissionsBase):
         return response
 
     def _get_patch_data(
-        self, original_data: Dict[str, Any], **overrides
-    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        self, original_data: dict[str, Any], **overrides
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         result = deepcopy(original_data)
         result.update(overrides)
 

--- a/tests/python/rest_api/test_memberships.py
+++ b/tests/python/rest_api/test_memberships.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 from http import HTTPStatus
-from typing import ClassVar, List
+from typing import ClassVar
 
 import pytest
 from cvat_sdk.api_client.api_client import ApiClient, Endpoint
@@ -80,7 +80,7 @@ class TestMembershipsListFilters(CollectionSimpleFilterTestBase):
 @pytest.mark.usefixtures("restore_db_per_function")
 class TestPatchMemberships:
     _ORG: ClassVar[int] = 1
-    ROLES: ClassVar[List[str]] = ["worker", "supervisor", "maintainer", "owner"]
+    ROLES: ClassVar[list[str]] = ["worker", "supervisor", "maintainer", "owner"]
 
     def _test_can_change_membership(self, user, membership_id, new_role):
         response = patch_method(

--- a/tests/python/rest_api/test_projects.py
+++ b/tests/python/rest_api/test_projects.py
@@ -16,7 +16,7 @@ from io import BytesIO
 from itertools import product
 from operator import itemgetter
 from time import sleep
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import pytest
 from cvat_sdk.api_client import ApiClient, Configuration, models
@@ -504,7 +504,7 @@ class TestPostProjects:
         return json.loads(response.data)
 
     @classmethod
-    def _create_org(cls, api_client: ApiClient, members: Optional[Dict[str, str]] = None) -> str:
+    def _create_org(cls, api_client: ApiClient, members: Optional[dict[str, str]] = None) -> str:
         with api_client:
             (_, response) = api_client.organizations_api.create(
                 models.OrganizationWriteRequest(slug="test_org_roles"), _parse_response=False
@@ -629,7 +629,7 @@ class TestImportExportDatasetProject:
         username: str,
         pid: int,
         *,
-        api_version: Union[int, Tuple[int]],
+        api_version: Union[int, tuple[int]],
         local_download: bool = True,
         **kwargs,
     ) -> Optional[bytes]:
@@ -778,7 +778,7 @@ class TestImportExportDatasetProject:
         "local_download", (True, pytest.param(False, marks=pytest.mark.with_external_services))
     )
     def test_can_export_dataset_locally_and_to_cloud_with_both_api_versions(
-        self, admin_user: str, filter_projects, api_version: Tuple[int], local_download: bool
+        self, admin_user: str, filter_projects, api_version: tuple[int], local_download: bool
     ):
         filter_ = "target_storage__location"
         if local_download:
@@ -1103,7 +1103,7 @@ class TestImportExportDatasetProject:
 
 @pytest.mark.usefixtures("restore_db_per_function")
 class TestPatchProjectLabel:
-    def _get_project_labels(self, pid, user, **kwargs) -> List[models.Label]:
+    def _get_project_labels(self, pid, user, **kwargs) -> list[models.Label]:
         kwargs.setdefault("return_json", True)
         with make_api_client(user) as api_client:
             return get_paginated_collection(

--- a/tests/python/rest_api/test_quality_control.py
+++ b/tests/python/rest_api/test_quality_control.py
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: MIT
 
 import json
+from collections.abc import Iterable
 from copy import deepcopy
 from functools import partial
 from http import HTTPStatus
 from itertools import groupby
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Optional
 
 import pytest
 from cvat_sdk.api_client import exceptions, models
@@ -84,7 +85,7 @@ class _PermissionTestBase:
     def find_sandbox_task(self, tasks, jobs, users, is_task_staff):
         def _find(
             is_staff: bool, *, has_gt_jobs: Optional[bool] = None
-        ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        ) -> tuple[dict[str, Any], dict[str, Any]]:
             task = next(
                 t
                 for t in tasks
@@ -116,7 +117,7 @@ class _PermissionTestBase:
     def find_org_task(self, tasks, jobs, users, is_org_member, is_task_staff):
         def _find(
             is_staff: bool, user_org_role: str, *, has_gt_jobs: Optional[bool] = None
-        ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        ) -> tuple[dict[str, Any], dict[str, Any]]:
             for user in users:
                 if user["is_superuser"]:
                     continue
@@ -249,7 +250,7 @@ class TestListQualityReports(_PermissionTestBase):
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestGetQualityReports(_PermissionTestBase):
     def _test_get_report_200(
-        self, user: str, obj_id: int, *, expected_data: Optional[Dict[str, Any]] = None, **kwargs
+        self, user: str, obj_id: int, *, expected_data: Optional[dict[str, Any]] = None, **kwargs
     ):
         with make_api_client(user) as api_client:
             (_, response) = api_client.quality_api.retrieve_report(obj_id, **kwargs)
@@ -308,7 +309,7 @@ class TestGetQualityReports(_PermissionTestBase):
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestGetQualityReportData(_PermissionTestBase):
     def _test_get_report_data_200(
-        self, user: str, obj_id: int, *, expected_data: Optional[Dict[str, Any]] = None, **kwargs
+        self, user: str, obj_id: int, *, expected_data: Optional[dict[str, Any]] = None, **kwargs
     ):
         with make_api_client(user) as api_client:
             (_, response) = api_client.quality_api.retrieve_report_data(obj_id, **kwargs)
@@ -603,7 +604,7 @@ class TestPostQualityReports(_PermissionTestBase):
 
     def test_non_rq_job_owner_cannot_check_status_of_report_creation_in_sandbox(
         self,
-        find_sandbox_task_without_gt: Callable[[bool], Tuple[Dict[str, Any], Dict[str, Any]]],
+        find_sandbox_task_without_gt: Callable[[bool], tuple[dict[str, Any], dict[str, Any]]],
         admin_user: str,
         users: Iterable,
     ):
@@ -630,8 +631,8 @@ class TestPostQualityReports(_PermissionTestBase):
         self,
         role: str,
         admin_user: str,
-        find_org_task_without_gt: Callable[[bool, str], Tuple[Dict[str, Any], Dict[str, Any]]],
-        find_users: Callable[..., List[Dict[str, Any]]],
+        find_org_task_without_gt: Callable[[bool, str], tuple[dict[str, Any], dict[str, Any]]],
+        find_users: Callable[..., list[dict[str, Any]]],
     ):
         task, task_staff = find_org_task_without_gt(is_staff=True, user_org_role="supervisor")
 
@@ -657,8 +658,8 @@ class TestPostQualityReports(_PermissionTestBase):
         is_sandbox: bool,
         users: Iterable,
         admin_user: str,
-        find_org_task_without_gt: Callable[[bool, str], Tuple[Dict[str, Any], Dict[str, Any]]],
-        find_sandbox_task_without_gt: Callable[[bool], Tuple[Dict[str, Any], Dict[str, Any]]],
+        find_org_task_without_gt: Callable[[bool, str], tuple[dict[str, Any], dict[str, Any]]],
+        find_sandbox_task_without_gt: Callable[[bool], tuple[dict[str, Any], dict[str, Any]]],
     ):
         if is_sandbox:
             task, task_staff = find_sandbox_task_without_gt(is_staff=True)
@@ -696,7 +697,7 @@ class TestSimpleQualityReportsFilters(CollectionSimpleFilterTestBase):
     def _get_endpoint(self, api_client: ApiClient) -> Endpoint:
         return api_client.quality_api.list_reports_endpoint
 
-    def _get_field_samples(self, field: str) -> Tuple[Any, List[Dict[str, Any]]]:
+    def _get_field_samples(self, field: str) -> tuple[Any, list[dict[str, Any]]]:
         if field == "task_id":
             # This filter includes both the task and nested job reports
             task_id, task_reports = super()._get_field_samples(field)
@@ -819,7 +820,7 @@ class TestSimpleQualityConflictsFilters(CollectionSimpleFilterTestBase):
     def _get_endpoint(self, api_client: ApiClient) -> Endpoint:
         return api_client.quality_api.list_conflicts_endpoint
 
-    def _get_field_samples(self, field: str) -> Tuple[Any, List[Dict[str, Any]]]:
+    def _get_field_samples(self, field: str) -> tuple[Any, list[dict[str, Any]]]:
         if field == "job_id":
             # This field is not included in the response
             job_id = self._find_valid_field_value(self.report_samples, field_path=["job_id"])
@@ -889,7 +890,7 @@ class TestSimpleQualitySettingsFilters(CollectionSimpleFilterTestBase):
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestListSettings(_PermissionTestBase):
     def _test_list_settings_200(
-        self, user: str, task_id: int, *, expected_data: Optional[Dict[str, Any]] = None, **kwargs
+        self, user: str, task_id: int, *, expected_data: Optional[dict[str, Any]] = None, **kwargs
     ):
         with make_api_client(user) as api_client:
             actual = get_paginated_collection(
@@ -951,7 +952,7 @@ class TestListSettings(_PermissionTestBase):
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestGetSettings(_PermissionTestBase):
     def _test_get_settings_200(
-        self, user: str, obj_id: int, *, expected_data: Optional[Dict[str, Any]] = None, **kwargs
+        self, user: str, obj_id: int, *, expected_data: Optional[dict[str, Any]] = None, **kwargs
     ):
         with make_api_client(user) as api_client:
             (_, response) = api_client.quality_api.retrieve_settings(obj_id, **kwargs)
@@ -1016,9 +1017,9 @@ class TestPatchSettings(_PermissionTestBase):
         self,
         user: str,
         obj_id: int,
-        data: Dict[str, Any],
+        data: dict[str, Any],
         *,
-        expected_data: Optional[Dict[str, Any]] = None,
+        expected_data: Optional[dict[str, Any]] = None,
         **kwargs,
     ):
         with make_api_client(user) as api_client:
@@ -1032,7 +1033,7 @@ class TestPatchSettings(_PermissionTestBase):
 
         return response
 
-    def _test_patch_settings_403(self, user: str, obj_id: int, data: Dict[str, Any], **kwargs):
+    def _test_patch_settings_403(self, user: str, obj_id: int, data: dict[str, Any], **kwargs):
         with make_api_client(user) as api_client:
             (_, response) = api_client.quality_api.partial_update_settings(
                 obj_id,
@@ -1045,7 +1046,7 @@ class TestPatchSettings(_PermissionTestBase):
 
         return response
 
-    def _get_request_data(self, data: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    def _get_request_data(self, data: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
         patched_data = deepcopy(data)
 
         for field, value in data.items():

--- a/tests/python/rest_api/test_remote_url.py
+++ b/tests/python/rest_api/test_remote_url.py
@@ -5,7 +5,7 @@
 
 from http import HTTPStatus
 from time import sleep
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -21,7 +21,7 @@ def _post_task_remote_data(username, task_id, resources):
     return post_method(username, f"tasks/{task_id}/data", data)
 
 
-def _wait_until_task_is_created(username: str, rq_id: str) -> Dict[str, Any]:
+def _wait_until_task_is_created(username: str, rq_id: str) -> dict[str, Any]:
     url = f"requests/{rq_id}"
 
     for _ in range(100):

--- a/tests/python/rest_api/test_requests.py
+++ b/tests/python/rest_api/test_requests.py
@@ -4,7 +4,6 @@
 
 import io
 from http import HTTPStatus
-from typing import List
 from urllib.parse import urlparse
 
 import pytest
@@ -88,7 +87,7 @@ class TestRequestsListFilters(CollectionSimpleFilterTestBase):
         fxt_make_export_job_requests,
         fxt_download_file,
     ):
-        def _make_requests(project_ids: List[int], task_ids: List[int], job_ids: List[int]):
+        def _make_requests(project_ids: list[int], task_ids: list[int], job_ids: list[int]):
             # make requests to export projects|tasks|jobs annotations|datasets|backups
             fxt_make_export_project_requests(project_ids[1:])
             fxt_make_export_task_requests(task_ids[1:])
@@ -162,7 +161,7 @@ class TestRequestsListFilters(CollectionSimpleFilterTestBase):
 
     @pytest.fixture
     def fxt_make_export_project_requests(self):
-        def make_requests(project_ids: List[int]):
+        def make_requests(project_ids: list[int]):
             for project_id in project_ids:
                 export_project_backup(
                     self.user, api_version=2, id=project_id, download_result=False
@@ -182,7 +181,7 @@ class TestRequestsListFilters(CollectionSimpleFilterTestBase):
 
     @pytest.fixture
     def fxt_make_export_task_requests(self):
-        def make_requests(task_ids: List[int]):
+        def make_requests(task_ids: list[int]):
             for task_id in task_ids:
                 export_task_backup(self.user, api_version=2, id=task_id, download_result=False)
                 export_task_dataset(
@@ -196,7 +195,7 @@ class TestRequestsListFilters(CollectionSimpleFilterTestBase):
 
     @pytest.fixture
     def fxt_make_export_job_requests(self):
-        def make_requests(job_ids: List[int]):
+        def make_requests(job_ids: list[int]):
             for job_id in job_ids:
                 export_job_dataset(
                     self.user,
@@ -231,7 +230,7 @@ class TestRequestsListFilters(CollectionSimpleFilterTestBase):
         ],
     )
     def test_can_use_simple_filter_for_object_list(
-        self, simple_filter: str, values: List, fxt_resources_ids, fxt_make_requests
+        self, simple_filter: str, values: list, fxt_resources_ids, fxt_make_requests
     ):
         project_ids, task_ids, job_ids = fxt_resources_ids
         fxt_make_requests(project_ids, task_ids, job_ids)

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -14,6 +14,7 @@ import re
 import zipfile
 from abc import ABCMeta, abstractmethod
 from collections import Counter
+from collections.abc import Generator, Iterable, Sequence
 from contextlib import closing
 from copy import deepcopy
 from datetime import datetime
@@ -26,20 +27,7 @@ from operator import itemgetter
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from time import sleep, time
-from typing import (
-    Any,
-    Callable,
-    ClassVar,
-    Dict,
-    Generator,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, ClassVar, Optional, Union
 
 import attrs
 import numpy as np
@@ -742,7 +730,7 @@ class TestGetTaskDataset:
         username: str,
         task_id: int,
         *,
-        api_version: Union[int, Tuple[int]],
+        api_version: Union[int, tuple[int]],
         local_download: bool = True,
         **kwargs,
     ) -> Optional[bytes]:
@@ -764,7 +752,7 @@ class TestGetTaskDataset:
         admin_user,
         tasks_with_shapes,
         filter_tasks,
-        api_version: Tuple[int],
+        api_version: tuple[int],
         local_download: bool,
     ):
         filter_ = "target_storage__location"
@@ -1523,17 +1511,17 @@ class TestPostTaskData:
         request,
         cloud_storage: Any,
         use_manifest: bool,
-        server_files: List[str],
+        server_files: list[str],
         use_cache: bool = True,
         sorting_method: str = "lexicographical",
         data_type: str = "image",
         video_frame_count: int = 10,
-        server_files_exclude: Optional[List[str]] = None,
+        server_files_exclude: Optional[list[str]] = None,
         org: str = "",
-        filenames: Optional[List[str]] = None,
-        task_spec_kwargs: Optional[Dict[str, Any]] = None,
-        data_spec_kwargs: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[int, Any]:
+        filenames: Optional[list[str]] = None,
+        task_spec_kwargs: Optional[dict[str, Any]] = None,
+        data_spec_kwargs: Optional[dict[str, Any]] = None,
+    ) -> tuple[int, Any]:
         s3_client = s3.make_client(bucket=cloud_storage["resource"])
         if data_type == "video":
             video = generate_video_file(video_frame_count)
@@ -1639,8 +1627,8 @@ class TestPostTaskData:
         cloud_storage_id: int,
         use_cache: bool,
         use_manifest: bool,
-        server_files: List[str],
-        server_files_exclude: Optional[List[str]],
+        server_files: list[str],
+        server_files_exclude: Optional[list[str]],
         task_size: int,
         org: str,
         cloud_storages,
@@ -1686,8 +1674,8 @@ class TestPostTaskData:
         self,
         cloud_storage_id: int,
         use_manifest: bool,
-        server_files: List[str],
-        expected_result: List[str],
+        server_files: list[str],
+        expected_result: list[str],
         org: str,
         cloud_storages,
         request,
@@ -1929,7 +1917,7 @@ class TestPostTaskData:
     )
     def test_create_task_with_cloud_storage_and_check_data_sorting(
         self,
-        filenames: List[str],
+        filenames: list[str],
         sorting_method: str,
         cloud_storage_id: int,
         org: str,
@@ -2020,7 +2008,7 @@ class TestPostTaskData:
         )
 
         with make_api_client(self._USERNAME) as api_client:
-            jobs: List[models.JobRead] = get_paginated_collection(
+            jobs: list[models.JobRead] = get_paginated_collection(
                 api_client.jobs_api.list_endpoint, task_id=task_id, sort="id"
             )
             (task_meta, _) = api_client.tasks_api.retrieve_data_meta(id=task_id)
@@ -2084,7 +2072,7 @@ class TestPostTaskData:
         self,
         cloud_storage_id: int,
         use_manifest: bool,
-        server_files: List[str],
+        server_files: list[str],
         default_prefix: str,
         expected_task_size: int,
         org: str,
@@ -2128,7 +2116,7 @@ class TestPostTaskData:
         self,
         fxt_test_name,
         frame_selection_method: str,
-        method_params: Set[str],
+        method_params: set[str],
         per_job_count_param: str,
     ):
         base_segment_size = 4
@@ -2312,7 +2300,7 @@ class TestPostTaskData:
         self,
         request: pytest.FixtureRequest,
         frame_selection_method: str,
-        method_params: Set[str],
+        method_params: set[str],
     ):
         segment_size = 4
         total_frame_count = 15
@@ -2445,7 +2433,7 @@ class TestPostTaskData:
         self,
         request: pytest.FixtureRequest,
         frame_selection_method: str,
-        method_params: Set[str],
+        method_params: set[str],
     ):
         segment_size = 4
         total_frame_count = 15
@@ -2646,8 +2634,8 @@ class _TaskSpec(models.ITaskWriteRequest, models.IDataRequest, metaclass=ABCMeta
 
 @attrs.define
 class _TaskSpecBase(_TaskSpec):
-    _params: Union[Dict, models.TaskWriteRequest]
-    _data_params: Union[Dict, models.DataRequest]
+    _params: Union[dict, models.TaskWriteRequest]
+    _data_params: Union[dict, models.DataRequest]
     size: int = attrs.field(kw_only=True)
 
     @property
@@ -2711,7 +2699,7 @@ class TestTaskData:
         step: Optional[int] = None,
         segment_size: Optional[int] = None,
         **data_kwargs,
-    ) -> Generator[Tuple[_ImagesTaskSpec, int], None, None]:
+    ) -> Generator[tuple[_ImagesTaskSpec, int], None, None]:
         task_params = {
             "name": f"{request.node.name}[{request.fixturename}]",
             "labels": [{"name": "a"}],
@@ -2764,13 +2752,13 @@ class TestTaskData:
     @pytest.fixture(scope="class")
     def fxt_uploaded_images_task(
         self, request: pytest.FixtureRequest
-    ) -> Generator[Tuple[_TaskSpec, int], None, None]:
+    ) -> Generator[tuple[_TaskSpec, int], None, None]:
         yield from self._uploaded_images_task_fxt_base(request=request)
 
     @pytest.fixture(scope="class")
     def fxt_uploaded_images_task_with_segments(
         self, request: pytest.FixtureRequest
-    ) -> Generator[Tuple[_TaskSpec, int], None, None]:
+    ) -> Generator[tuple[_TaskSpec, int], None, None]:
         yield from self._uploaded_images_task_fxt_base(request=request, segment_size=4)
 
     @fixture(scope="class")
@@ -2779,7 +2767,7 @@ class TestTaskData:
     @parametrize("start_frame", [3, 7])
     def fxt_uploaded_images_task_with_segments_start_stop_step(
         self, request: pytest.FixtureRequest, start_frame: int, stop_frame: Optional[int], step: int
-    ) -> Generator[Tuple[_TaskSpec, int], None, None]:
+    ) -> Generator[tuple[_TaskSpec, int], None, None]:
         yield from self._uploaded_images_task_fxt_base(
             request=request,
             frame_count=30,
@@ -2796,7 +2784,7 @@ class TestTaskData:
         start_frame: Optional[int] = None,
         step: Optional[int] = None,
         random_seed: int = 42,
-    ) -> Generator[Tuple[_TaskSpec, int], None, None]:
+    ) -> Generator[tuple[_TaskSpec, int], None, None]:
         validation_params = models.DataRequestValidationParams._from_openapi_data(
             mode="gt_pool",
             frame_selection_method="random_uniform",
@@ -2858,14 +2846,14 @@ class TestTaskData:
     @fixture(scope="class")
     def fxt_uploaded_images_task_with_honeypots_and_segments(
         self, request: pytest.FixtureRequest
-    ) -> Generator[Tuple[_TaskSpec, int], None, None]:
+    ) -> Generator[tuple[_TaskSpec, int], None, None]:
         yield from self._uploaded_images_task_with_honeypots_and_segments_base(request)
 
     @fixture(scope="class")
     @parametrize("start_frame, step", [(2, 3)])
     def fxt_uploaded_images_task_with_honeypots_and_segments_start_step(
         self, request: pytest.FixtureRequest, start_frame: Optional[int], step: Optional[int]
-    ) -> Generator[Tuple[_TaskSpec, int], None, None]:
+    ) -> Generator[tuple[_TaskSpec, int], None, None]:
         yield from self._uploaded_images_task_with_honeypots_and_segments_base(
             request, start_frame=start_frame, step=step
         )
@@ -2874,7 +2862,7 @@ class TestTaskData:
     @parametrize("random_seed", [1, 2, 5])
     def fxt_uploaded_images_task_with_honeypots_and_changed_real_frames(
         self, request: pytest.FixtureRequest, random_seed: int
-    ) -> Generator[Tuple[_TaskSpec, int], None, None]:
+    ) -> Generator[tuple[_TaskSpec, int], None, None]:
         with closing(
             self._uploaded_images_task_with_honeypots_and_segments_base(
                 request, start_frame=2, step=3, random_seed=random_seed
@@ -2915,7 +2903,7 @@ class TestTaskData:
         start_frame: Optional[int] = None,
         step: Optional[int] = None,
         frame_selection_method: str = "random_uniform",
-    ) -> Generator[Tuple[_TaskSpec, int], None, None]:
+    ) -> Generator[tuple[_TaskSpec, int], None, None]:
         used_frames_count = 16
         total_frame_count = (start_frame or 0) + used_frames_count * (step or 1)
         segment_size = 5
@@ -2975,7 +2963,7 @@ class TestTaskData:
         start_frame: Optional[int],
         step: Optional[int],
         frame_selection_method: str,
-    ) -> Generator[Tuple[_TaskSpec, int], None, None]:
+    ) -> Generator[tuple[_TaskSpec, int], None, None]:
         yield from self._uploaded_images_task_with_gt_and_segments_base(
             request,
             start_frame=start_frame,
@@ -2992,7 +2980,7 @@ class TestTaskData:
         start_frame: Optional[int] = None,
         stop_frame: Optional[int] = None,
         step: Optional[int] = None,
-    ) -> Generator[Tuple[_VideoTaskSpec, int], None, None]:
+    ) -> Generator[tuple[_VideoTaskSpec, int], None, None]:
         task_params = {
             "name": f"{request.node.name}[{request.fixturename}]",
             "labels": [{"name": "a"}],
@@ -3036,13 +3024,13 @@ class TestTaskData:
     def fxt_uploaded_video_task(
         self,
         request: pytest.FixtureRequest,
-    ) -> Generator[Tuple[_TaskSpec, int], None, None]:
+    ) -> Generator[tuple[_TaskSpec, int], None, None]:
         yield from self._uploaded_video_task_fxt_base(request=request)
 
     @pytest.fixture(scope="class")
     def fxt_uploaded_video_task_with_segments(
         self, request: pytest.FixtureRequest
-    ) -> Generator[Tuple[_TaskSpec, int], None, None]:
+    ) -> Generator[tuple[_TaskSpec, int], None, None]:
         yield from self._uploaded_video_task_fxt_base(request=request, segment_size=4)
 
     @fixture(scope="class")
@@ -3051,7 +3039,7 @@ class TestTaskData:
     @parametrize("start_frame", [3, 7])
     def fxt_uploaded_video_task_with_segments_start_stop_step(
         self, request: pytest.FixtureRequest, start_frame: int, stop_frame: Optional[int], step: int
-    ) -> Generator[Tuple[_TaskSpec, int], None, None]:
+    ) -> Generator[tuple[_TaskSpec, int], None, None]:
         yield from self._uploaded_video_task_fxt_base(
             request=request,
             frame_count=30,
@@ -3061,7 +3049,7 @@ class TestTaskData:
             step=step,
         )
 
-    def _compute_annotation_segment_params(self, task_spec: _TaskSpec) -> List[Tuple[int, int]]:
+    def _compute_annotation_segment_params(self, task_spec: _TaskSpec) -> list[tuple[int, int]]:
         segment_params = []
         frame_step = task_spec.frame_step
         segment_size = getattr(task_spec, "segment_size", 0) or task_spec.size * frame_step
@@ -3585,7 +3573,7 @@ class TestTaskData:
 
 @pytest.mark.usefixtures("restore_db_per_function")
 class TestPatchTaskLabel:
-    def _get_task_labels(self, pid, user, **kwargs) -> List[models.Label]:
+    def _get_task_labels(self, pid, user, **kwargs) -> list[models.Label]:
         kwargs.setdefault("return_json", True)
         with make_api_client(user) as api_client:
             return get_paginated_collection(
@@ -3859,7 +3847,7 @@ class TestTaskBackups:
         "local_download", (True, pytest.param(False, marks=pytest.mark.with_external_services))
     )
     def test_can_export_backup_with_both_api_versions(
-        self, filter_tasks, api_version: Tuple[int], local_download: bool
+        self, filter_tasks, api_version: tuple[int], local_download: bool
     ):
         task = filter_tasks(
             **{("exclude_" if local_download else "") + "target_storage__location": "cloud_storage"}
@@ -4042,7 +4030,7 @@ class TestWorkWithSimpleGtJobTasks:
     @fixture
     def fxt_task_with_gt_job(
         self, tasks, jobs, job_has_annotations
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         gt_job = next(
             j
             for j in jobs
@@ -4164,7 +4152,7 @@ class TestWorkWithHoneypotTasks:
     @fixture
     def fxt_task_with_honeypots(
         self, tasks, jobs, job_has_annotations
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         gt_job = next(
             j
             for j in jobs
@@ -5247,7 +5235,7 @@ class TestImportWithComplexFilenames:
         cls._init_tasks()
 
     @classmethod
-    def _create_task_with_annotations(cls, filenames: List[str]):
+    def _create_task_with_annotations(cls, filenames: list[str]):
         images = generate_image_files(len(filenames), filenames=filenames)
 
         source_archive_path = cls.tmp_dir / "source_data.zip"

--- a/tests/python/rest_api/utils.py
+++ b/tests/python/rest_api/utils.py
@@ -4,10 +4,11 @@
 
 import json
 from abc import ABCMeta, abstractmethod
+from collections.abc import Iterator, Sequence
 from copy import deepcopy
 from http import HTTPStatus
 from time import sleep
-from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Optional, Union
 
 import requests
 from cvat_sdk.api_client import apis, models
@@ -191,7 +192,7 @@ def export_v2(
 def export_dataset(
     api: Union[ProjectsApi, TasksApi, JobsApi],
     api_version: Union[
-        int, Tuple[int]
+        int, tuple[int]
     ],  # make this parameter required to be sure that all tests was updated and both API versions are used
     *,
     save_images: bool,
@@ -251,21 +252,21 @@ def export_dataset(
 
 # FUTURE-TODO: support username: optional, api_client: optional
 def export_project_dataset(
-    username: str, api_version: Union[int, Tuple[int]], *args, **kwargs
+    username: str, api_version: Union[int, tuple[int]], *args, **kwargs
 ) -> Optional[bytes]:
     with make_api_client(username) as api_client:
         return export_dataset(api_client.projects_api, api_version, *args, **kwargs)
 
 
 def export_task_dataset(
-    username: str, api_version: Union[int, Tuple[int]], *args, **kwargs
+    username: str, api_version: Union[int, tuple[int]], *args, **kwargs
 ) -> Optional[bytes]:
     with make_api_client(username) as api_client:
         return export_dataset(api_client.tasks_api, api_version, *args, **kwargs)
 
 
 def export_job_dataset(
-    username: str, api_version: Union[int, Tuple[int]], *args, **kwargs
+    username: str, api_version: Union[int, tuple[int]], *args, **kwargs
 ) -> Optional[bytes]:
     with make_api_client(username) as api_client:
         return export_dataset(api_client.jobs_api, api_version, *args, **kwargs)
@@ -274,7 +275,7 @@ def export_job_dataset(
 def export_backup(
     api: Union[ProjectsApi, TasksApi],
     api_version: Union[
-        int, Tuple[int]
+        int, tuple[int]
     ],  # make this parameter required to be sure that all tests was updated and both API versions are used
     *,
     max_retries: int = 30,
@@ -309,14 +310,14 @@ def export_backup(
 
 
 def export_project_backup(
-    username: str, api_version: Union[int, Tuple[int]], *args, **kwargs
+    username: str, api_version: Union[int, tuple[int]], *args, **kwargs
 ) -> Optional[bytes]:
     with make_api_client(username) as api_client:
         return export_backup(api_client.projects_api, api_version, *args, **kwargs)
 
 
 def export_task_backup(
-    username: str, api_version: Union[int, Tuple[int]], *args, **kwargs
+    username: str, api_version: Union[int, tuple[int]], *args, **kwargs
 ) -> Optional[bytes]:
     with make_api_client(username) as api_client:
         return export_backup(api_client.tasks_api, api_version, *args, **kwargs)
@@ -379,12 +380,12 @@ def import_backup(
     return import_resource(endpoint, max_retries=max_retries, interval=interval, **kwargs)
 
 
-def import_project_backup(username: str, data: Dict, **kwargs) -> None:
+def import_project_backup(username: str, data: dict, **kwargs) -> None:
     with make_api_client(username) as api_client:
         return import_backup(api_client.projects_api, project_file_request=deepcopy(data), **kwargs)
 
 
-def import_task_backup(username: str, data: Dict, **kwargs) -> None:
+def import_task_backup(username: str, data: dict, **kwargs) -> None:
     with make_api_client(username) as api_client:
         return import_backup(api_client.tasks_api, task_file_request=deepcopy(data), **kwargs)
 
@@ -395,20 +396,20 @@ FieldPath = Sequence[Union[str, Callable]]
 class CollectionSimpleFilterTestBase(metaclass=ABCMeta):
     # These fields need to be defined in the subclass
     user: str
-    samples: List[Dict[str, Any]]
-    field_lookups: Dict[str, FieldPath] = None
-    cmp_ignore_keys: List[str] = ["updated_date"]
+    samples: list[dict[str, Any]]
+    field_lookups: dict[str, FieldPath] = None
+    cmp_ignore_keys: list[str] = ["updated_date"]
 
     @abstractmethod
     def _get_endpoint(self, api_client: ApiClient) -> Endpoint: ...
 
-    def _retrieve_collection(self, **kwargs) -> List:
+    def _retrieve_collection(self, **kwargs) -> list:
         kwargs["return_json"] = True
         with make_api_client(self.user) as api_client:
             return get_paginated_collection(self._get_endpoint(api_client), **kwargs)
 
     @classmethod
-    def _get_field(cls, d: Dict[str, Any], path: Union[str, FieldPath]) -> Optional[Any]:
+    def _get_field(cls, d: dict[str, Any], path: Union[str, FieldPath]) -> Optional[Any]:
         assert path
         for key in path:
             if isinstance(d, dict):
@@ -428,7 +429,7 @@ class CollectionSimpleFilterTestBase(metaclass=ABCMeta):
 
     @classmethod
     def _find_valid_field_value(
-        cls, samples: Iterator[Dict[str, Any]], field_path: FieldPath
+        cls, samples: Iterator[dict[str, Any]], field_path: FieldPath
     ) -> Any:
         value = None
         for sample in samples:
@@ -439,7 +440,7 @@ class CollectionSimpleFilterTestBase(metaclass=ABCMeta):
         assert value, f"Failed to find a sample for the '{'.'.join(field_path)}' field"
         return value
 
-    def _get_field_samples(self, field: str) -> Tuple[Any, List[Dict[str, Any]]]:
+    def _get_field_samples(self, field: str) -> tuple[Any, list[dict[str, Any]]]:
         field_path = self._map_field(field)
         field_value = self._find_valid_field_value(self.samples, field_path)
 
@@ -463,7 +464,7 @@ class CollectionSimpleFilterTestBase(metaclass=ABCMeta):
         assert diff == {}, diff
 
     def _test_can_use_simple_filter_for_object_list(
-        self, field: str, field_values: Optional[List[Any]] = None
+        self, field: str, field_values: Optional[list[Any]] = None
     ):
         gt_objects = []
         field_path = self._map_field(field)
@@ -485,12 +486,12 @@ class CollectionSimpleFilterTestBase(metaclass=ABCMeta):
             self._compare_results(gt_objects, received_items)
 
 
-def get_attrs(obj: Any, attributes: Sequence[str]) -> Tuple[Any, ...]:
+def get_attrs(obj: Any, attributes: Sequence[str]) -> tuple[Any, ...]:
     """Returns 1 or more object attributes as a tuple"""
     return (getattr(obj, attr) for attr in attributes)
 
 
-def build_exclude_paths_expr(ignore_fields: Iterator[str]) -> List[str]:
+def build_exclude_paths_expr(ignore_fields: Iterator[str]) -> list[str]:
     exclude_expr_parts = []
     for key in ignore_fields:
         if "." in key:

--- a/tests/python/sdk/fixtures.py
+++ b/tests/python/sdk/fixtures.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path
-from typing import Tuple
 from zipfile import ZipFile
 
 import pytest
@@ -72,7 +71,7 @@ def fxt_coco_dataset(tmp_path: Path, fxt_image_file: Path, fxt_coco_file: Path):
 
 
 @pytest.fixture
-def fxt_new_task(fxt_image_file: Path, fxt_login: Tuple[Client, str]):
+def fxt_new_task(fxt_image_file: Path, fxt_login: tuple[Client, str]):
     client, _ = fxt_login
     task = client.tasks.create_from_data(
         spec={
@@ -87,7 +86,7 @@ def fxt_new_task(fxt_image_file: Path, fxt_login: Tuple[Client, str]):
 
 
 @pytest.fixture
-def fxt_new_task_with_target_storage(fxt_image_file: Path, fxt_login: Tuple[Client, str]):
+def fxt_new_task_with_target_storage(fxt_image_file: Path, fxt_login: tuple[Client, str]):
     client, _ = fxt_login
     task = client.tasks.create_from_data(
         spec={

--- a/tests/python/sdk/test_auto_annotation.py
+++ b/tests/python/sdk/test_auto_annotation.py
@@ -6,7 +6,6 @@ import io
 from logging import Logger
 from pathlib import Path
 from types import SimpleNamespace as namespace
-from typing import List, Tuple
 
 import cvat_sdk.auto_annotation as cvataa
 import PIL.Image
@@ -27,8 +26,8 @@ except ModuleNotFoundError:
 @pytest.fixture(autouse=True)
 def _common_setup(
     tmp_path: Path,
-    fxt_login: Tuple[Client, str],
-    fxt_logger: Tuple[Logger, io.StringIO],
+    fxt_login: tuple[Client, str],
+    fxt_logger: tuple[Logger, io.StringIO],
     restore_redis_ondisk_per_function,
 ):
     logger = fxt_logger[0]
@@ -46,7 +45,7 @@ class TestTaskAutoAnnotation:
     def setup(
         self,
         tmp_path: Path,
-        fxt_login: Tuple[Client, str],
+        fxt_login: tuple[Client, str],
     ):
         self.client = fxt_login[0]
         self.images = [
@@ -114,7 +113,7 @@ class TestTaskAutoAnnotation:
 
         def detect(
             context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
-        ) -> List[models.LabeledShapeRequest]:
+        ) -> list[models.LabeledShapeRequest]:
             assert context.frame_name in {"1.png", "2.png"}
             assert image.width == image.height == 333
             return [
@@ -168,7 +167,7 @@ class TestTaskAutoAnnotation:
             ],
         )
 
-        def detect(context, image: PIL.Image.Image) -> List[models.LabeledShapeRequest]:
+        def detect(context, image: PIL.Image.Image) -> list[models.LabeledShapeRequest]:
             assert image.width == image.height == 333
             return [
                 cvataa.skeleton(
@@ -241,7 +240,7 @@ class TestTaskAutoAnnotation:
             ],
         )
 
-        def detect(context, image: PIL.Image.Image) -> List[models.LabeledShapeRequest]:
+        def detect(context, image: PIL.Image.Image) -> list[models.LabeledShapeRequest]:
             return [
                 cvataa.rectangle(
                     123,  # car
@@ -570,7 +569,7 @@ if torchvision_models is not None:
             super().__init__()
             self._label_id = label_id
 
-        def forward(self, images: List[torch.Tensor]) -> List[dict]:
+        def forward(self, images: list[torch.Tensor]) -> list[dict]:
             assert isinstance(images, list)
             assert all(isinstance(t, torch.Tensor) for t in images)
 
@@ -589,12 +588,12 @@ if torchvision_models is not None:
         return FakeTorchvisionDetector(label_id=car_label_id)
 
     class FakeTorchvisionKeypointDetector(nn.Module):
-        def __init__(self, label_id: int, keypoint_names: List[str]) -> None:
+        def __init__(self, label_id: int, keypoint_names: list[str]) -> None:
             super().__init__()
             self._label_id = label_id
             self._keypoint_names = keypoint_names
 
-        def forward(self, images: List[torch.Tensor]) -> List[dict]:
+        def forward(self, images: list[torch.Tensor]) -> list[dict]:
             assert isinstance(images, list)
             assert all(isinstance(t, torch.Tensor) for t in images)
 
@@ -628,7 +627,7 @@ class TestAutoAnnotationFunctions:
     def setup(
         self,
         tmp_path: Path,
-        fxt_login: Tuple[Client, str],
+        fxt_login: tuple[Client, str],
     ):
         self.client = fxt_login[0]
         self.image = generate_image_file("1.png", size=(100, 100))

--- a/tests/python/sdk/test_client.py
+++ b/tests/python/sdk/test_client.py
@@ -5,7 +5,6 @@
 import io
 from contextlib import ExitStack
 from logging import Logger
-from typing import List, Tuple
 
 import packaging.version as pv
 import pytest
@@ -22,7 +21,7 @@ class TestClientUsecases:
     def setup(
         self,
         restore_db_per_function,  # force fixture call order to allow DB setup
-        fxt_logger: Tuple[Logger, io.StringIO],
+        fxt_logger: tuple[Logger, io.StringIO],
         fxt_client: Client,
         fxt_stdout: io.StringIO,
         admin_user: str,
@@ -95,7 +94,7 @@ def test_can_reject_invalid_server_schema():
 
 @pytest.mark.parametrize("raise_exception", (True, False))
 def test_can_warn_on_mismatching_server_version(
-    fxt_logger: Tuple[Logger, io.StringIO], monkeypatch, raise_exception: bool
+    fxt_logger: tuple[Logger, io.StringIO], monkeypatch, raise_exception: bool
 ):
     logger, logger_stream = fxt_logger
 
@@ -118,7 +117,7 @@ def test_can_warn_on_mismatching_server_version(
 
 @pytest.mark.parametrize("do_check", (True, False))
 def test_can_check_server_version_in_ctor(
-    fxt_logger: Tuple[Logger, io.StringIO], monkeypatch, do_check: bool
+    fxt_logger: tuple[Logger, io.StringIO], monkeypatch, do_check: bool
 ):
     logger, logger_stream = fxt_logger
 
@@ -141,7 +140,7 @@ def test_can_check_server_version_in_ctor(
     ) == do_check
 
 
-def test_can_check_server_version_in_method(fxt_logger: Tuple[Logger, io.StringIO], monkeypatch):
+def test_can_check_server_version_in_method(fxt_logger: tuple[Logger, io.StringIO], monkeypatch):
     logger, logger_stream = fxt_logger
 
     def mocked_version(_):
@@ -183,10 +182,10 @@ def test_can_check_server_version_in_method(fxt_logger: Tuple[Logger, io.StringI
     ],
 )
 def test_can_check_server_version_compatibility(
-    fxt_logger: Tuple[Logger, io.StringIO],
+    fxt_logger: tuple[Logger, io.StringIO],
     monkeypatch: pytest.MonkeyPatch,
     server_version: str,
-    supported_versions: List[str],
+    supported_versions: list[str],
     expect_supported: bool,
 ):
     logger, _ = fxt_logger

--- a/tests/python/sdk/test_datasets.py
+++ b/tests/python/sdk/test_datasets.py
@@ -5,7 +5,6 @@
 import io
 from logging import Logger
 from pathlib import Path
-from typing import Tuple
 
 import cvat_sdk.datasets as cvatds
 import PIL.Image
@@ -21,8 +20,8 @@ from .util import restrict_api_requests
 @pytest.fixture(autouse=True)
 def _common_setup(
     tmp_path: Path,
-    fxt_login: Tuple[Client, str],
-    fxt_logger: Tuple[Logger, io.StringIO],
+    fxt_login: tuple[Client, str],
+    fxt_logger: tuple[Logger, io.StringIO],
     restore_redis_ondisk_per_function,
 ):
     logger = fxt_logger[0]
@@ -40,7 +39,7 @@ class TestTaskDataset:
     def setup(
         self,
         tmp_path: Path,
-        fxt_login: Tuple[Client, str],
+        fxt_login: tuple[Client, str],
     ):
         self.client = fxt_login[0]
         self.images = generate_image_files(10)

--- a/tests/python/sdk/test_issues_comments.py
+++ b/tests/python/sdk/test_issues_comments.py
@@ -5,7 +5,6 @@
 import io
 from logging import Logger
 from pathlib import Path
-from typing import Tuple
 
 import pytest
 from cvat_sdk import Client
@@ -18,8 +17,8 @@ class TestIssuesUsecases:
     def setup(
         self,
         tmp_path: Path,
-        fxt_login: Tuple[Client, str],
-        fxt_logger: Tuple[Logger, io.StringIO],
+        fxt_login: tuple[Client, str],
+        fxt_logger: tuple[Logger, io.StringIO],
         fxt_stdout: io.StringIO,
     ):
         self.tmp_path = tmp_path
@@ -139,8 +138,8 @@ class TestCommentsUsecases:
     def setup(
         self,
         tmp_path: Path,
-        fxt_login: Tuple[Client, str],
-        fxt_logger: Tuple[Logger, io.StringIO],
+        fxt_login: tuple[Client, str],
+        fxt_logger: tuple[Logger, io.StringIO],
         fxt_stdout: io.StringIO,
     ):
         self.tmp_path = tmp_path

--- a/tests/python/sdk/test_jobs.py
+++ b/tests/python/sdk/test_jobs.py
@@ -5,7 +5,7 @@
 import io
 from logging import Logger
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 
 import pytest
 from cvat_sdk import Client
@@ -26,8 +26,8 @@ class TestJobUsecases(TestDatasetExport):
     def setup(
         self,
         tmp_path: Path,
-        fxt_login: Tuple[Client, str],
-        fxt_logger: Tuple[Logger, io.StringIO],
+        fxt_login: tuple[Client, str],
+        fxt_logger: tuple[Logger, io.StringIO],
         fxt_stdout: io.StringIO,
         restore_redis_ondisk_per_function,
     ):

--- a/tests/python/sdk/test_organizations.py
+++ b/tests/python/sdk/test_organizations.py
@@ -4,7 +4,6 @@
 
 import io
 from logging import Logger
-from typing import Tuple
 
 import pytest
 from cvat_sdk import Client, models
@@ -16,8 +15,8 @@ class TestOrganizationUsecases:
     @pytest.fixture(autouse=True)
     def setup(
         self,
-        fxt_login: Tuple[Client, str],
-        fxt_logger: Tuple[Logger, io.StringIO],
+        fxt_login: tuple[Client, str],
+        fxt_logger: tuple[Logger, io.StringIO],
         fxt_stdout: io.StringIO,
     ):
         logger, self.logger_stream = fxt_logger

--- a/tests/python/sdk/test_projects.py
+++ b/tests/python/sdk/test_projects.py
@@ -5,7 +5,7 @@
 import io
 from logging import Logger
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 
 import pytest
 from cvat_sdk import Client, models
@@ -29,8 +29,8 @@ class TestProjectUsecases(TestDatasetExport):
     def setup(
         self,
         tmp_path: Path,
-        fxt_login: Tuple[Client, str],
-        fxt_logger: Tuple[Logger, io.StringIO],
+        fxt_login: tuple[Client, str],
+        fxt_logger: tuple[Logger, io.StringIO],
         fxt_stdout: io.StringIO,
         restore_redis_ondisk_per_function,
     ):

--- a/tests/python/sdk/test_pytorch.py
+++ b/tests/python/sdk/test_pytorch.py
@@ -7,7 +7,6 @@ import itertools
 import os
 from logging import Logger
 from pathlib import Path
-from typing import Tuple
 
 import pytest
 from cvat_sdk import Client, models
@@ -34,8 +33,8 @@ from .util import restrict_api_requests
 @pytest.fixture(autouse=True)
 def _common_setup(
     tmp_path: Path,
-    fxt_login: Tuple[Client, str],
-    fxt_logger: Tuple[Logger, io.StringIO],
+    fxt_login: tuple[Client, str],
+    fxt_logger: tuple[Logger, io.StringIO],
     restore_redis_ondisk_per_function,
 ):
     logger = fxt_logger[0]
@@ -54,7 +53,7 @@ class TestTaskVisionDataset:
     def setup(
         self,
         tmp_path: Path,
-        fxt_login: Tuple[Client, str],
+        fxt_login: tuple[Client, str],
     ):
         self.client = fxt_login[0]
         self.images = generate_image_files(10)
@@ -298,7 +297,7 @@ class TestProjectVisionDataset:
     def setup(
         self,
         tmp_path: Path,
-        fxt_login: Tuple[Client, str],
+        fxt_login: tuple[Client, str],
     ):
         self.client = fxt_login[0]
 

--- a/tests/python/sdk/test_tasks.py
+++ b/tests/python/sdk/test_tasks.py
@@ -7,7 +7,7 @@ import os.path as osp
 import zipfile
 from logging import Logger
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 
 import pytest
 from cvat_sdk import Client, models
@@ -30,8 +30,8 @@ class TestTaskUsecases(TestDatasetExport):
     def setup(
         self,
         tmp_path: Path,
-        fxt_login: Tuple[Client, str],
-        fxt_logger: Tuple[Logger, io.StringIO],
+        fxt_login: tuple[Client, str],
+        fxt_logger: tuple[Logger, io.StringIO],
         fxt_stdout: io.StringIO,
         restore_redis_ondisk_per_function,
     ):

--- a/tests/python/sdk/test_users.py
+++ b/tests/python/sdk/test_users.py
@@ -5,7 +5,6 @@
 import io
 from logging import Logger
 from pathlib import Path
-from typing import Tuple
 
 import pytest
 from cvat_sdk import Client, models
@@ -17,8 +16,8 @@ class TestUserUsecases:
     def setup(
         self,
         tmp_path: Path,
-        fxt_login: Tuple[Client, str],
-        fxt_logger: Tuple[Logger, io.StringIO],
+        fxt_login: tuple[Client, str],
+        fxt_logger: tuple[Logger, io.StringIO],
         fxt_stdout: io.StringIO,
     ):
         self.tmp_path = tmp_path

--- a/tests/python/sdk/util.py
+++ b/tests/python/sdk/util.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 import textwrap
+from collections.abc import Container
 from pathlib import Path
-from typing import Container, Tuple
 from urllib.parse import urlparse
 
 import pytest
@@ -16,7 +16,7 @@ def make_pbar(file, **kwargs):
     return DeferredTqdmProgressReporter({"file": file, "mininterval": 0, **kwargs})
 
 
-def generate_coco_json(filename: Path, img_info: Tuple[Path, int, int]):
+def generate_coco_json(filename: Path, img_info: tuple[Path, int, int]):
     image_filename, image_width, image_height = img_info
 
     content = generate_coco_anno(

--- a/tests/python/shared/fixtures/data.py
+++ b/tests/python/shared/fixtures/data.py
@@ -5,8 +5,8 @@
 import json
 import operator
 from collections import defaultdict
+from collections.abc import Iterable
 from copy import deepcopy
-from typing import Iterable
 
 import pytest
 

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -10,7 +10,7 @@ from http import HTTPStatus
 from pathlib import Path
 from subprocess import PIPE, CalledProcessError, run
 from time import sleep
-from typing import List, Union
+from typing import Union
 
 import pytest
 import requests
@@ -158,13 +158,13 @@ def docker_exec(container, command, capture_output=True):
     return _run(f"docker exec -u root {PREFIX}_{container}_1 {command}", capture_output)
 
 
-def docker_exec_cvat(command: Union[List[str], str]):
+def docker_exec_cvat(command: Union[list[str], str]):
     base = f"docker exec {PREFIX}_cvat_server_1"
     _command = f"{base} {command}" if isinstance(command, str) else base.split() + command
     return _run(_command)
 
 
-def kube_exec_cvat(command: Union[List[str], str]):
+def kube_exec_cvat(command: Union[list[str], str]):
     pod_name = _kube_get_server_pod_name()
     base = f"kubectl exec {pod_name} --"
     _command = f"{base} {command}" if isinstance(command, str) else base.split() + command

--- a/tests/python/shared/utils/config.py
+++ b/tests/python/shared/utils/config.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator
 
 import requests
 from cvat_sdk.api_client import ApiClient, Configuration

--- a/tests/python/shared/utils/helpers.py
+++ b/tests/python/shared/utils/helpers.py
@@ -3,9 +3,10 @@
 # SPDX-License-Identifier: MIT
 
 import subprocess
+from collections.abc import Generator
 from contextlib import closing
 from io import BytesIO
-from typing import Generator, List, Optional, Tuple
+from typing import Optional
 
 import av
 import av.video.reformatter
@@ -27,10 +28,10 @@ def generate_image_file(filename="image.png", size=(100, 50), color=(0, 0, 0)):
 def generate_image_files(
     count: int,
     *,
-    prefixes: Optional[List[str]] = None,
-    filenames: Optional[List[str]] = None,
-    sizes: Optional[List[Tuple[int, int]]] = None,
-) -> List[BytesIO]:
+    prefixes: Optional[list[str]] = None,
+    filenames: Optional[list[str]] = None,
+    sizes: Optional[list[tuple[int, int]]] = None,
+) -> list[BytesIO]:
     assert not (prefixes and filenames), "prefixes cannot be used together with filenames"
     assert not prefixes or len(prefixes) == count
     assert not filenames or len(filenames) == count

--- a/tests/python/shared/utils/resource_import_export.py
+++ b/tests/python/shared/utils/resource_import_export.py
@@ -1,10 +1,10 @@
 import functools
 import json
-from abc import ABC, abstractstaticmethod
+from abc import ABC, abstractmethod
 from contextlib import ExitStack
 from http import HTTPStatus
 from time import sleep
-from typing import Any, Dict, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 
 import pytest
 
@@ -17,7 +17,7 @@ EXPORT_FORMAT = "CVAT for images 1.1"
 IMPORT_FORMAT = "CVAT 1.1"
 
 
-def _make_custom_resource_params(resource: str, obj: str, cloud_storage_id: int) -> Dict[str, Any]:
+def _make_custom_resource_params(resource: str, obj: str, cloud_storage_id: int) -> dict[str, Any]:
     return {
         "filename": FILENAME_TEMPLATE.format(obj, resource),
         "location": "cloud_storage",
@@ -25,7 +25,7 @@ def _make_custom_resource_params(resource: str, obj: str, cloud_storage_id: int)
     }
 
 
-def _make_default_resource_params(resource: str, obj: str) -> Dict[str, Any]:
+def _make_default_resource_params(resource: str, obj: str) -> dict[str, Any]:
     return {
         "filename": FILENAME_TEMPLATE.format(obj, resource),
     }
@@ -33,7 +33,7 @@ def _make_default_resource_params(resource: str, obj: str) -> Dict[str, Any]:
 
 def _make_export_resource_params(
     resource: str, is_default: bool = True, **kwargs
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     func = _make_default_resource_params if is_default else _make_custom_resource_params
     params = func(resource, **kwargs)
     if resource != "backup":
@@ -43,7 +43,7 @@ def _make_export_resource_params(
 
 def _make_import_resource_params(
     resource: str, is_default: bool = True, **kwargs
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     func = _make_default_resource_params if is_default else _make_custom_resource_params
     params = func(resource, **kwargs)
     if resource != "backup":
@@ -52,7 +52,8 @@ def _make_import_resource_params(
 
 
 class _CloudStorageResourceTest(ABC):
-    @abstractstaticmethod
+    @staticmethod
+    @abstractmethod
     def _make_client():
         pass
 
@@ -64,7 +65,7 @@ class _CloudStorageResourceTest(ABC):
         with self.exit_stack:
             yield
 
-    def _ensure_file_created(self, func: T, storage: Dict[str, Any]) -> T:
+    def _ensure_file_created(self, func: T, storage: dict[str, Any]) -> T:
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             filename = kwargs["filename"]
@@ -219,7 +220,7 @@ class _CloudStorageResourceTest(ABC):
             response = get_method(user, url, action="import_status", rq_id=rq_id)
             status = response.status_code
 
-    def _import_resource(self, cloud_storage: Dict[str, Any], resource_type: str, *args, **kwargs):
+    def _import_resource(self, cloud_storage: dict[str, Any], resource_type: str, *args, **kwargs):
         methods = {
             "annotations": self._import_annotations_from_cloud_storage,
             "dataset": self._import_dataset_from_cloud_storage,
@@ -234,7 +235,7 @@ class _CloudStorageResourceTest(ABC):
 
         return methods[resource_type](*args, **kwargs)
 
-    def _export_resource(self, cloud_storage: Dict[str, Any], *args, **kwargs):
+    def _export_resource(self, cloud_storage: dict[str, Any], *args, **kwargs):
         org_id = cloud_storage["organization"]
         if org_id:
             kwargs.setdefault("org_id", org_id)


### PR DESCRIPTION
And also `abstractstaticmethod`, which was deprecated in 3.3.

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This is a continuation of #8626.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated type annotations across multiple test files to use built-in types (`list`, `dict`, `tuple`) instead of their counterparts from the `typing` module.
	- Simplified method signatures for various functions to enhance readability and maintainability.
	- Adjusted import statements to reflect the use of `collections.abc` for certain types.

These changes streamline the codebase and ensure compliance with modern Python typing standards without altering existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->