### PR TITLE
Filter nuclio functions based on organization

### DIFF
--- a/cvat/apps/lambda_manager/tests/assets/functions.json
+++ b/cvat/apps/lambda_manager/tests/assets/functions.json
@@ -26,7 +26,8 @@
           "name": "Person reidentification",
           "spec": "",
           "type": "reid"
-        }
+        },
+        "labels": {}
       },
       "spec": {
         "description": "Person reidentification model for a general scenario"
@@ -44,6 +45,9 @@
           "name": "Person reidentification",
           "spec": "",
           "type": "reid"
+        },
+        "labels": {
+          "test-label": "test-label-value"
         }
       },
       "spec": {
@@ -62,6 +66,9 @@
           "name": "DEXTR",
           "spec": "",
           "type": "interactor"
+        },
+        "labels": {
+          "organization": "my-org"
         }
       },
       "spec": {
@@ -80,6 +87,10 @@
           "name": "SiamMask",
           "spec": "",
           "type": "tracker"
+        },
+        "labels": {
+          "test-label": "test-label-value",
+          "organization": "my-org"
         }
       },
       "spec": {
@@ -98,6 +109,10 @@
           "name": "State is building",
           "spec": "[\n  { \"id\": 0, \"name\": \"person\" },                              \n  { \"id\": 1, \"name\": \"bicycle\" },                              \n  { \"id\": 2, \"name\": \"car\" }                              \n]\n",
           "type": "detector"
+        },
+        "labels": {
+          "test-label": "test-label-value",
+          "organization": "my-other-org"
         }
       },
       "spec": {
@@ -115,6 +130,9 @@
           "name": "State is error",
           "spec": "[\n  { \"id\": 0, \"name\": \"person\" },                              \n  { \"id\": 1, \"name\": \"bicycle\" },                              \n  { \"id\": 2, \"name\": \"car\" }                              \n]\n",
           "type": "detector"
+        },
+        "labels": {
+          "organization": "my-other-org"
         }
       },
       "spec": {

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -38,6 +38,13 @@ id_function_state_error = "test-model-has-state-error"
 expected_keys_in_response_all_functions = ["id", "kind", "labels_v2", "description", "name"]
 expected_keys_in_response_function_interactor = expected_keys_in_response_all_functions + ["min_pos_points", "startswith_box"]
 expected_keys_in_response_requests = ["id", "function", "status", "progress", "enqueued", "started", "ended", "exc_info"]
+expected_function_ids_in_response = {
+    "test-openvino-omz-public-yolo-v3-tf",
+    "test-openvino-omz-intel-person-reidentification-retail-0300",
+    "test-openvino-omz-intel-person-reidentification-retail-1234",
+    "test-openvino-dextr",
+    "test-pth-foolwood-siammask"
+}
 
 path = os.path.join(os.path.dirname(__file__), 'assets', 'tasks.json')
 with open(path) as f:
@@ -259,6 +266,25 @@ class LambdaTestCases(_LambdaTestCaseBase):
             self._check_expected_keys_in_response_function(data)
 
         response = self._get_request(LAMBDA_FUNCTIONS_PATH, None)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_api_v2_lambda_functions_list_with_org(self):
+        org = "my-org"
+        response = self._get_request(LAMBDA_FUNCTIONS_PATH, self.admin, org_id=org)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for data in response.data:
+            self._check_expected_keys_in_response_function(data)
+        ids = {data.id for data in response.data}
+        self.assertEqual(ids, expected_function_ids_in_response)
+
+        response = self._get_request(LAMBDA_FUNCTIONS_PATH, self.user, org_id=org)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for data in response.data:
+            self._check_expected_keys_in_response_function(data)
+        ids = {data.id for data in response.data}
+        self.assertEqual(ids, expected_function_ids_in_response)
+
+        response = self._get_request(LAMBDA_FUNCTIONS_PATH, None, org_id=org)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -83,9 +83,12 @@ class LambdaGateway:
 
         return response
 
-    def list(self):
+    def list(self, org=None):
         data = self._http(url=self.NUCLIO_ROOT_URL)
         for item in data.values():
+            labels = item["metadata"].get("labels")
+            if org and labels and "organization" in labels and org != labels["organization"]:
+                continue
             try:
                 yield LambdaFunction(self, item)
             except InvalidFunctionMetadataError:
@@ -1037,7 +1040,8 @@ class FunctionViewSet(viewsets.ViewSet):
     @return_response()
     def list(self, request):
         gateway = LambdaGateway()
-        return [f.to_dict() for f in gateway.list()]
+        org = request.GET.get("org")
+        return [f.to_dict() for f in gateway.list(org)]
 
     @return_response()
     def retrieve(self, request, func_id):


### PR DESCRIPTION
Filter nuclio functions based on organization. This allows organizations to produce their models and making only available to their CVAT org. 
This is quite helpful when a company has different departments for data science and one of them is related to R&D for example and their models might not be allowed to be shared while in-development as they might expose secret projects that a team might be working on.

### How has this been tested?
I tested in my own local deployment of CVAT and a colleague also tested the changes. By deploying nuclio models with the respective labels as mocked in the tests.

Solves #8606 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional organization filter for listing lambda functions, enhancing the ability to view functions associated with specific organizations.
	- Added structured "labels" fields to various models for better categorization and identification.

- **Bug Fixes**
	- Improved API response validation for organization-specific requests, ensuring correct status codes and function ID matching.

- **Tests**
	- Added a new test case to verify the API behavior when listing lambda functions with an organization ID, enhancing test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->