### PR TITLE
Fix: Progress on Requets page is displayed as `0..1`

### DIFF
--- a/changelog.d/20241108_115707_klakhov_fix_requests_progress.md
+++ b/changelog.d/20241108_115707_klakhov_fix_requests_progress.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Incorrect progress representation on `Requests` page
+  (<https://github.com/cvat-ai/cvat/pull/8668>)

--- a/cvat-core/src/request.ts
+++ b/cvat-core/src/request.ts
@@ -55,6 +55,7 @@ export class Request {
         return this.#status.toLowerCase() as RQStatus;
     }
 
+    // The `progress` represents a value between 0 and 1
     get progress(): number | undefined {
         return this.#progress;
     }

--- a/cvat-ui/src/components/requests-page/request-card.tsx
+++ b/cvat-ui/src/components/requests-page/request-card.tsx
@@ -149,7 +149,7 @@ function RequestCard(props: Props): JSX.Element {
     const dispatch = useDispatch();
 
     const linkToEntity = constructLink(request);
-    const percent = request.status === RQStatus.FINISHED ? 100 : request.progress;
+    const percent = request.status === RQStatus.FINISHED ? 100 : (request.progress ?? 0) * 100;
     const timestamps = constructTimestamps(request);
 
     const name = constructName(operation);


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
By design the server returns a progress value in `0..1` format. But for users its better to be displayed as `0...100%` value.
Resolved #8489
### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced progress percentage calculation in the RequestCard component to handle null or undefined values.
	- Improved formatting of the displayed progress percentage based on request status.

- **Bug Fixes**
	- Fixed potential errors in progress calculation by ensuring a default value is assigned when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->