### PR TITLE
Remove the `quality` parameter from lambda function call endpoints

### DIFF
--- a/changelog.d/20241111_195229_roman_remove_lambda_quality.md
+++ b/changelog.d/20241111_195229_roman_remove_lambda_quality.md
@@ -1,0 +1,5 @@
+### Removed
+
+- It it no longer possible to run lambda functions on compressed images;
+  original images will always be used
+  (<https://github.com/cvat-ai/cvat/pull/8683>)

--- a/cvat/apps/lambda_manager/serializers.py
+++ b/cvat/apps/lambda_manager/serializers.py
@@ -24,9 +24,6 @@ class FunctionCallRequestSerializer(serializers.Serializer):
     function = serializers.CharField(help_text="The name of the function to execute")
     task = serializers.IntegerField(help_text="The id of the task to be annotated")
     job = serializers.IntegerField(required=False, help_text="The id of the job to be annotated")
-    quality = serializers.ChoiceField(choices=['compressed', 'original'], default="original",
-        help_text="The quality of the images to use in the model run"
-    )
     max_distance = serializers.IntegerField(required=False)
     threshold = serializers.FloatField(required=False)
     cleanup = serializers.BooleanField(help_text="Whether existing annotations should be removed", default=False)

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -368,7 +368,6 @@ class LambdaTestCases(_LambdaTestCaseBase):
             "task": self.main_task["id"],
             "cleanup": True,
             "threshold": 55,
-            "quality": "original",
             "mapping": {
                 "car": { "name": "car" },
             },
@@ -447,7 +446,6 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "task": self.main_task["id"],
                 "cleanup": True,
                 "threshold": 55,
-                "quality": "original",
                 "mapping": {
                     "car": { "name": "car" },
                 },
@@ -456,7 +454,6 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "function": id_func,
                 "task": self.assigneed_to_user_task["id"],
                 "cleanup": False,
-                "quality": "compressed",
                 "max_distance": 70,
                 "mapping": {
                     "car": { "name": "car" },
@@ -769,7 +766,6 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 OrderedDict([('attributes', []), ('frame', 1), ('group', None), ('id', 11260), ('label_id', 8), ('occluded', False), ('points', [1076.0, 199.0, 1218.0, 593.0]), ('source', 'auto'), ('type', 'rectangle'), ('z_order', 0)]),
                 OrderedDict([('attributes', []), ('frame', 1), ('group', None), ('id', 11261), ('label_id', 8), ('occluded', False), ('points', [924.0, 177.0, 1090.0, 615.0]), ('source', 'auto'), ('type', 'rectangle'), ('z_order', 0)]),
             ],
-            "quality": None,
             "threshold": 0.5,
             "max_distance": 55,
         }
@@ -785,7 +781,6 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 OrderedDict([('attributes', []), ('frame', 1), ('group', None), ('id', 11260), ('label_id', 8), ('occluded', False), ('points', [1076.0, 199.0, 1218.0, 593.0]), ('source', 'auto'), ('type', 'rectangle'), ('z_order', 0)]),
                 OrderedDict([('attributes', []), ('frame', 1), ('group', 0), ('id', 11398), ('label_id', 8), ('occluded', False), ('points', [184.3935546875, 211.5048828125, 331.64968722073354, 97.27792672028772, 445.87667560321825, 126.17873100983161, 454.13404825737416, 691.8087578194827, 180.26452189455085]), ('source', 'manual'), ('type', 'polygon'), ('z_order', 0)]),
             ],
-            "quality": None,
         }
 
         response = self._post_request(f"{LAMBDA_FUNCTIONS_PATH}/{id_function_reid_with_response_data}", self.admin, data_main_task)
@@ -829,42 +824,11 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
-    def test_api_v2_lambda_functions_create_quality(self):
-        qualities = [None, "original", "compressed"]
-
-        for quality in qualities:
-            data = {
-                "task": self.main_task["id"],
-                "frame": 0,
-                "cleanup": True,
-                "quality": quality,
-                "mapping": {
-                    "car": { "name": "car" },
-                },
-            }
-
-            response = self._post_request(f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data)
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        data = {
-            "task": self.main_task["id"],
-            "frame": 0,
-            "cleanup": True,
-            "quality": "test-error-quality",
-            "mapping": {
-                "car": { "name": "car" },
-            },
-        }
-
-        response = self._post_request(f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
     def test_api_v2_lambda_functions_convert_mask_to_rle(self):
         data_main_task = {
             "function": id_function_detector,
             "task": self.main_task["id"],
             "cleanup": True,
-            "quality": "original",
             "mapping": {
                 "car": { "name": "car" },
             },

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -32,7 +32,7 @@ from rest_framework.response import Response
 from rest_framework.request import Request
 
 import cvat.apps.dataset_manager as dm
-from cvat.apps.engine.frame_provider import FrameQuality, TaskFrameProvider
+from cvat.apps.engine.frame_provider import TaskFrameProvider
 from cvat.apps.engine.models import (
     Job, ShapeType, SourceType, Task, Label, RequestAction, RequestTarget
 )
@@ -257,7 +257,6 @@ class LambdaFunction:
         threshold = data.get("threshold")
         if threshold:
             payload.update({ "threshold": threshold })
-        quality = data.get("quality")
         mapping = data.get("mapping", {})
 
         model_labels = self.labels
@@ -387,19 +386,19 @@ class LambdaFunction:
 
         if self.kind == FunctionKind.DETECTOR:
             payload.update({
-                "image": self._get_image(db_task, mandatory_arg("frame"), quality)
+                "image": self._get_image(db_task, mandatory_arg("frame"))
             })
         elif self.kind == FunctionKind.INTERACTOR:
             payload.update({
-                "image": self._get_image(db_task, mandatory_arg("frame"), quality),
+                "image": self._get_image(db_task, mandatory_arg("frame")),
                 "pos_points": mandatory_arg("pos_points"),
                 "neg_points": mandatory_arg("neg_points"),
                 "obj_bbox": data.get("obj_bbox", None)
             })
         elif self.kind == FunctionKind.REID:
             payload.update({
-                "image0": self._get_image(db_task, mandatory_arg("frame0"), quality),
-                "image1": self._get_image(db_task, mandatory_arg("frame1"), quality),
+                "image0": self._get_image(db_task, mandatory_arg("frame0")),
+                "image1": self._get_image(db_task, mandatory_arg("frame1")),
                 "boxes0": mandatory_arg("boxes0"),
                 "boxes1": mandatory_arg("boxes1")
             })
@@ -410,7 +409,7 @@ class LambdaFunction:
                 })
         elif self.kind == FunctionKind.TRACKER:
             payload.update({
-                "image": self._get_image(db_task, mandatory_arg("frame"), quality),
+                "image": self._get_image(db_task, mandatory_arg("frame")),
                 "shapes": data.get("shapes", []),
                 "states": data.get("states", [])
             })
@@ -487,19 +486,9 @@ class LambdaFunction:
 
         return response
 
-    def _get_image(self, db_task, frame, quality):
-        if quality is None or quality == "original":
-            quality = FrameQuality.ORIGINAL
-        elif  quality == "compressed":
-            quality = FrameQuality.COMPRESSED
-        else:
-            raise ValidationError(
-                '`{}` lambda function was run '.format(self.id) +
-                'with wrong arguments (quality={})'.format(quality),
-                code=status.HTTP_400_BAD_REQUEST)
-
+    def _get_image(self, db_task, frame):
         frame_provider = TaskFrameProvider(db_task)
-        image = frame_provider.get_frame(frame, quality=quality)
+        image = frame_provider.get_frame(frame)
 
         return base64.b64encode(image.data.getvalue()).decode('utf-8')
 
@@ -523,7 +512,7 @@ class LambdaQueue:
         return [LambdaJob(job) for job in jobs if job and job.meta.get("lambda")]
 
     def enqueue(self,
-        lambda_func, threshold, task, quality, mapping, cleanup, conv_mask_to_poly, max_distance, request,
+        lambda_func, threshold, task, mapping, cleanup, conv_mask_to_poly, max_distance, request,
         *,
         job: Optional[int] = None
     ) -> LambdaJob:
@@ -576,7 +565,6 @@ class LambdaQueue:
                     "threshold": threshold,
                     "task": task,
                     "job": job,
-                    "quality": quality,
                     "cleanup": cleanup,
                     "conv_mask_to_poly": conv_mask_to_poly,
                     "mapping": mapping,
@@ -667,7 +655,6 @@ class LambdaJob:
         function: LambdaFunction,
         db_task: Task,
         labels: Dict[str, Dict[str, Any]],
-        quality: str,
         threshold: float,
         mapping: Optional[Dict[str, str]],
         conv_mask_to_poly: bool,
@@ -799,7 +786,7 @@ class LambdaJob:
                 continue
 
             annotations = function.invoke(db_task, db_job=db_job, data={
-                "frame": frame, "quality": quality, "mapping": mapping,
+                "frame": frame, "mapping": mapping,
                 "threshold": threshold
             })
 
@@ -854,7 +841,6 @@ class LambdaJob:
         cls,
         function: LambdaFunction,
         db_task: Task,
-        quality: str,
         threshold: float,
         max_distance: int,
         *,
@@ -887,7 +873,7 @@ class LambdaJob:
             boxes1 = boxes_by_frame[frame1]
             if boxes0 and boxes1:
                 matching = function.invoke(db_task, db_job=db_job, data={
-                    "frame0": frame0, "frame1": frame1, "quality": quality,
+                    "frame0": frame0, "frame1": frame1,
                     "boxes0": boxes0, "boxes1": boxes1, "threshold": threshold,
                     "max_distance": max_distance})
 
@@ -947,7 +933,7 @@ class LambdaJob:
                     dm.task.put_task_data(db_task.id, serializer.data)
 
     @classmethod
-    def __call__(cls, function, task: int, quality: str, cleanup: bool, **kwargs):
+    def __call__(cls, function, task: int, cleanup: bool, **kwargs):
         # TODO: need logging
         db_job = None
         if job := kwargs.get('job'):
@@ -977,11 +963,11 @@ class LambdaJob:
         labels = convert_labels(db_task.get_labels(prefetch=True))
 
         if function.kind == FunctionKind.DETECTOR:
-            cls._call_detector(function, db_task, labels, quality,
+            cls._call_detector(function, db_task, labels,
                 kwargs.get("threshold"), kwargs.get("mapping"), kwargs.get("conv_mask_to_poly"),
                 db_job=db_job)
         elif function.kind == FunctionKind.REID:
-            cls._call_reid(function, db_task, quality,
+            cls._call_reid(function, db_task,
                 kwargs.get("threshold"), kwargs.get("max_distance"), db_job=db_job)
 
 def return_response(success_code=status.HTTP_200_OK):
@@ -1176,7 +1162,6 @@ class RequestViewSet(viewsets.ViewSet):
             threshold = request_data.get('threshold')
             task = request_data['task']
             job = request_data.get('job', None)
-            quality = request_data.get("quality")
             cleanup = request_data.get('cleanup', False)
             conv_mask_to_poly = request_data.get('convMaskToPoly', False)
             mapping = request_data.get('mapping')
@@ -1190,7 +1175,7 @@ class RequestViewSet(viewsets.ViewSet):
         gateway = LambdaGateway()
         queue = LambdaQueue()
         lambda_func = gateway.get(function)
-        rq_job = queue.enqueue(lambda_func, threshold, task, quality,
+        rq_job = queue.enqueue(lambda_func, threshold, task,
             mapping, cleanup, conv_mask_to_poly, max_distance, request, job=job)
 
         handle_function_call(function, job or task, category="batch")

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -8049,15 +8049,6 @@ components:
         job:
           type: integer
           description: The id of the job to be annotated
-        quality:
-          allOf:
-          - $ref: '#/components/schemas/QualityEnum'
-          default: original
-          description: |-
-            The quality of the images to use in the model run
-
-            * `compressed` - compressed
-            * `original` - original
         max_distance:
           type: integer
         threshold:
@@ -10020,14 +10011,6 @@ components:
         * `AZURE_CONTAINER` - AZURE_CONTAINER
         * `GOOGLE_DRIVE` - GOOGLE_DRIVE
         * `GOOGLE_CLOUD_STORAGE` - GOOGLE_CLOUD_STORAGE
-    QualityEnum:
-      enum:
-      - compressed
-      - original
-      type: string
-      description: |-
-        * `compressed` - compressed
-        * `original` - original
     QualityReport:
       type: object
       properties:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
1. In practice, it is never used by the UI.

2. In theory, I don't think it should be provided either. I don't think it ever makes sense for a user to want to run a function on a reduced-quality image, unless it just doesn't work on the original one (e.g. if it is too big). And in this case, CVAT should just perform the recompression automatically instead of making the user do it.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The system now consistently uses original images for processing, eliminating the option for compressed images.

- **Bug Fixes**
	- Removed the `quality` parameter from various functionalities, streamlining image processing operations.

- **Tests**
	- Updated test cases to reflect the removal of the `quality` parameter, ensuring alignment with the new image handling process. Added tests for organizational permissions for invoking lambda functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->