### PR TITLE
SDK/CLI: Add ability to call auto-annotation functions with a custom threshold

### DIFF
--- a/changelog.d/20241112_201034_roman_aa_threshold.md
+++ b/changelog.d/20241112_201034_roman_aa_threshold.md
@@ -1,9 +1,12 @@
 ### Added
 
-- \[SDK, CLI\] Added a `threshold` parameter to `cvat_sdk.auto_annotation.annotate_task`,
-  which is passed as-is to the AA function object via the context. The CLI
-  equivalent is `auto-annotate --threshold`. This makes it easier to write
-  and use AA functions that support object filtering based on confidence
-  levels. Updated the builtin functions in `cvat_sdk.auto_annotation.functions`
-  to support filtering via this parameter
+- \[SDK, CLI\] Added a `conf_threshold` parameter to
+  `cvat_sdk.auto_annotation.annotate_task`, which is passed as-is to the AA
+  function object via the context. The CLI equivalent is `auto-annotate
+  --conf-threshold`. This makes it easier to write and use AA functions that
+  support object filtering based on confidence levels
+  (<https://github.com/cvat-ai/cvat/pull/8688>)
+
+- \[SDK\] Built-in auto-annotation functions now support object filtering by
+  confidence level
   (<https://github.com/cvat-ai/cvat/pull/8688>)

--- a/changelog.d/20241112_201034_roman_aa_threshold.md
+++ b/changelog.d/20241112_201034_roman_aa_threshold.md
@@ -1,0 +1,9 @@
+### Added
+
+- \[SDK, CLI\] Added a `threshold` parameter to `cvat_sdk.auto_annotation.annotate_task`,
+  which is passed as-is to the AA function object via the context. The CLI
+  equivalent is `auto-annotate --threshold`. This makes it easier to write
+  and use AA functions that support object filtering based on confidence
+  levels. Updated the builtin functions in `cvat_sdk.auto_annotation.functions`
+  to support filtering via this parameter
+  (<https://github.com/cvat-ai/cvat/pull/8688>)

--- a/cvat-cli/src/cvat_cli/_internal/commands.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands.py
@@ -20,7 +20,13 @@ from cvat_sdk.core.helpers import DeferredTqdmProgressReporter
 from cvat_sdk.core.proxies.tasks import ResourceType
 
 from .command_base import CommandGroup
-from .parsers import BuildDictAction, parse_function_parameter, parse_label_arg, parse_resource_type
+from .parsers import (
+    BuildDictAction,
+    parse_function_parameter,
+    parse_label_arg,
+    parse_resource_type,
+    parse_threshold,
+)
 
 COMMANDS = CommandGroup(description="Perform common operations related to CVAT tasks.")
 
@@ -463,6 +469,13 @@ class TaskAutoAnnotate:
             help="Allow the function to declare labels not configured in the task",
         )
 
+        parser.add_argument(
+            "--threshold",
+            type=parse_threshold,
+            help="Confidence threshold for filtering detections",
+            default=None,
+        )
+
     def execute(
         self,
         client: Client,
@@ -473,6 +486,7 @@ class TaskAutoAnnotate:
         function_parameters: dict[str, Any],
         clear_existing: bool = False,
         allow_unmatched_labels: bool = False,
+        threshold: Optional[float],
     ) -> None:
         if function_module is not None:
             function = importlib.import_module(function_module)
@@ -497,4 +511,5 @@ class TaskAutoAnnotate:
             pbar=DeferredTqdmProgressReporter(),
             clear_existing=clear_existing,
             allow_unmatched_labels=allow_unmatched_labels,
+            threshold=threshold,
         )

--- a/cvat-cli/src/cvat_cli/_internal/commands.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands.py
@@ -470,7 +470,7 @@ class TaskAutoAnnotate:
         )
 
         parser.add_argument(
-            "--threshold",
+            "--conf-threshold",
             type=parse_threshold,
             help="Confidence threshold for filtering detections",
             default=None,
@@ -486,7 +486,7 @@ class TaskAutoAnnotate:
         function_parameters: dict[str, Any],
         clear_existing: bool = False,
         allow_unmatched_labels: bool = False,
-        threshold: Optional[float],
+        conf_threshold: Optional[float],
     ) -> None:
         if function_module is not None:
             function = importlib.import_module(function_module)
@@ -511,5 +511,5 @@ class TaskAutoAnnotate:
             pbar=DeferredTqdmProgressReporter(),
             clear_existing=clear_existing,
             allow_unmatched_labels=allow_unmatched_labels,
-            threshold=threshold,
+            conf_threshold=conf_threshold,
         )

--- a/cvat-cli/src/cvat_cli/_internal/parsers.py
+++ b/cvat-cli/src/cvat_cli/_internal/parsers.py
@@ -53,6 +53,17 @@ def parse_function_parameter(s: str) -> tuple[str, Any]:
     return (key, value)
 
 
+def parse_threshold(s: str) -> float:
+    try:
+        value = float(s)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError("must be a number") from e
+
+    if not 0 <= value <= 1:
+        raise argparse.ArgumentTypeError("must be between 0 and 1")
+    return value
+
+
 class BuildDictAction(argparse.Action):
     def __init__(self, option_strings, dest, default=None, **kwargs):
         super().__init__(option_strings, dest, default=default or {}, **kwargs)

--- a/cvat-sdk/cvat_sdk/auto_annotation/driver.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/driver.py
@@ -220,9 +220,10 @@ class _AnnotationMapper:
         shapes[:] = new_shapes
 
 
-@attrs.frozen
+@attrs.frozen(kw_only=True)
 class _DetectionFunctionContextImpl(DetectionFunctionContext):
     frame_name: str
+    threshold: Optional[float] = None
 
 
 def annotate_task(
@@ -233,6 +234,7 @@ def annotate_task(
     pbar: Optional[ProgressReporter] = None,
     clear_existing: bool = False,
     allow_unmatched_labels: bool = False,
+    threshold: Optional[float] = None,
 ) -> None:
     """
     Downloads data for the task with the given ID, applies the given function to it
@@ -264,10 +266,16 @@ def annotate_task(
     function declares a label in its spec that has no corresponding label in the task.
     If it's set to true, then such labels are allowed, and any annotations returned by the
     function that refer to this label are ignored. Otherwise, BadFunctionError is raised.
+
+    The threshold parameter must be None or a number between 0 and 1. It will be passed
+    to the function as the threshold attribute of the context object.
     """
 
     if pbar is None:
         pbar = NullProgressReporter()
+
+    if threshold is not None and not 0 <= threshold <= 1:
+        raise ValueError("threshold must be None or a number between 0 and 1")
 
     dataset = TaskDataset(client, task_id, load_annotations=False)
 
@@ -285,7 +293,8 @@ def annotate_task(
     with pbar.task(total=len(dataset.samples), unit="samples"):
         for sample in pbar.iter(dataset.samples):
             frame_shapes = function.detect(
-                _DetectionFunctionContextImpl(sample.frame_name), sample.media.load_image()
+                _DetectionFunctionContextImpl(frame_name=sample.frame_name, threshold=threshold),
+                sample.media.load_image(),
             )
             mapper.validate_and_remap(frame_shapes, sample.frame_index)
             shapes.extend(frame_shapes)

--- a/cvat-sdk/cvat_sdk/auto_annotation/driver.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/driver.py
@@ -223,7 +223,7 @@ class _AnnotationMapper:
 @attrs.frozen(kw_only=True)
 class _DetectionFunctionContextImpl(DetectionFunctionContext):
     frame_name: str
-    threshold: Optional[float] = None
+    conf_threshold: Optional[float] = None
 
 
 def annotate_task(
@@ -234,7 +234,7 @@ def annotate_task(
     pbar: Optional[ProgressReporter] = None,
     clear_existing: bool = False,
     allow_unmatched_labels: bool = False,
-    threshold: Optional[float] = None,
+    conf_threshold: Optional[float] = None,
 ) -> None:
     """
     Downloads data for the task with the given ID, applies the given function to it
@@ -267,15 +267,15 @@ def annotate_task(
     If it's set to true, then such labels are allowed, and any annotations returned by the
     function that refer to this label are ignored. Otherwise, BadFunctionError is raised.
 
-    The threshold parameter must be None or a number between 0 and 1. It will be passed
-    to the function as the threshold attribute of the context object.
+    The conf_threshold parameter must be None or a number between 0 and 1. It will be passed
+    to the function as the conf_threshold attribute of the context object.
     """
 
     if pbar is None:
         pbar = NullProgressReporter()
 
-    if threshold is not None and not 0 <= threshold <= 1:
-        raise ValueError("threshold must be None or a number between 0 and 1")
+    if conf_threshold is not None and not 0 <= conf_threshold <= 1:
+        raise ValueError("conf_threshold must be None or a number between 0 and 1")
 
     dataset = TaskDataset(client, task_id, load_annotations=False)
 
@@ -293,7 +293,9 @@ def annotate_task(
     with pbar.task(total=len(dataset.samples), unit="samples"):
         for sample in pbar.iter(dataset.samples):
             frame_shapes = function.detect(
-                _DetectionFunctionContextImpl(frame_name=sample.frame_name, threshold=threshold),
+                _DetectionFunctionContextImpl(
+                    frame_name=sample.frame_name, conf_threshold=conf_threshold
+                ),
                 sample.media.load_image(),
             )
             mapper.validate_and_remap(frame_shapes, sample.frame_index)

--- a/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_detection.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_detection.py
@@ -27,13 +27,17 @@ class _TorchvisionDetectionFunction:
             ]
         )
 
-    def detect(self, context, image: PIL.Image.Image) -> list[models.LabeledShapeRequest]:
+    def detect(
+        self, context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
+    ) -> list[models.LabeledShapeRequest]:
+        threshold = context.threshold or 0
         results = self._model([self._transforms(image)])
 
         return [
             cvataa.rectangle(label.item(), [x.item() for x in box])
             for result in results
-            for box, label in zip(result["boxes"], result["labels"])
+            for box, label, score in zip(result["boxes"], result["labels"], result["scores"])
+            if score >= threshold
         ]
 
 

--- a/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_detection.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_detection.py
@@ -30,14 +30,14 @@ class _TorchvisionDetectionFunction:
     def detect(
         self, context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
     ) -> list[models.LabeledShapeRequest]:
-        threshold = context.threshold or 0
+        conf_threshold = context.conf_threshold or 0
         results = self._model([self._transforms(image)])
 
         return [
             cvataa.rectangle(label.item(), [x.item() for x in box])
             for result in results
             for box, label, score in zip(result["boxes"], result["labels"], result["scores"])
-            if score >= threshold
+            if score >= conf_threshold
         ]
 
 

--- a/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_keypoint_detection.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_keypoint_detection.py
@@ -38,7 +38,7 @@ class _TorchvisionKeypointDetectionFunction:
     def detect(
         self, context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
     ) -> list[models.LabeledShapeRequest]:
-        threshold = context.threshold or 0
+        conf_threshold = context.conf_threshold or 0
         results = self._model([self._transforms(image)])
 
         return [
@@ -57,7 +57,7 @@ class _TorchvisionKeypointDetectionFunction:
             for keypoints, label, score in zip(
                 result["keypoints"], result["labels"], result["scores"]
             )
-            if score >= threshold
+            if score >= conf_threshold
         ]
 
 

--- a/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_keypoint_detection.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_keypoint_detection.py
@@ -35,7 +35,10 @@ class _TorchvisionKeypointDetectionFunction:
             ]
         )
 
-    def detect(self, context, image: PIL.Image.Image) -> list[models.LabeledShapeRequest]:
+    def detect(
+        self, context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
+    ) -> list[models.LabeledShapeRequest]:
+        threshold = context.threshold or 0
         results = self._model([self._transforms(image)])
 
         return [
@@ -51,7 +54,10 @@ class _TorchvisionKeypointDetectionFunction:
                 ],
             )
             for result in results
-            for keypoints, label in zip(result["keypoints"], result["labels"])
+            for keypoints, label, score in zip(
+                result["keypoints"], result["labels"], result["scores"]
+            )
+            if score >= threshold
         ]
 
 

--- a/cvat-sdk/cvat_sdk/auto_annotation/interface.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/interface.py
@@ -53,7 +53,7 @@ class DetectionFunctionContext(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def threshold(self) -> Optional[float]:
+    def conf_threshold(self) -> Optional[float]:
         """
         The confidence threshold that the function should use for filtering
         detections.

--- a/cvat-sdk/cvat_sdk/auto_annotation/interface.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/interface.py
@@ -4,7 +4,7 @@
 
 import abc
 from collections.abc import Sequence
-from typing import Protocol
+from typing import Optional, Protocol
 
 import attrs
 import PIL.Image
@@ -50,7 +50,23 @@ class DetectionFunctionContext(metaclass=abc.ABCMeta):
         The file name of the frame that the current image corresponds to in
         the dataset.
         """
-        ...
+
+    @property
+    @abc.abstractmethod
+    def threshold(self) -> Optional[float]:
+        """
+        The confidence threshold that the function should use for filtering
+        detections.
+
+        If the function is able to estimate confidence levels, then:
+
+        * If this value is None, the function may apply a default threshold at its discretion.
+
+        * Otherwise, it will be a number between 0 and 1. The function must only return
+          objects with confidence levels greater than or equal to this value.
+
+        If the function is not able to estimate confidence levels, it can ignore this value.
+        """
 
 
 class DetectionFunction(Protocol):

--- a/site/content/en/docs/api_sdk/sdk/auto-annotation.md
+++ b/site/content/en/docs/api_sdk/sdk/auto-annotation.md
@@ -72,7 +72,7 @@ class TorchvisionDetectionFunction:
         self, context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
     ) -> list[models.LabeledShapeRequest]:
         # determine the threshold for filtering results
-        threshold = context.threshold or 0
+        conf_threshold = context.conf_threshold or 0
 
         # convert the input into a form the model can understand
         transformed_image = [self._transforms(image)]
@@ -85,7 +85,7 @@ class TorchvisionDetectionFunction:
             cvataa.rectangle(label.item(), [x.item() for x in box])
             for result in results
             for box, label, score in zip(result["boxes"], result["labels"], result["scores"])
-            if score >= threshold
+            if score >= conf_threshold
         ]
 
 # log into the CVAT server
@@ -122,7 +122,7 @@ that these objects must follow.
   The following fields are available:
 
   - `frame_name` (`str`). The file name of the frame on the CVAT server.
-  - `threshold` (`float | None`). The confidence threshold that the function
+  - `conf_threshold` (`float | None`). The confidence threshold that the function
     should use to filter objects. If `None`, the function may apply a default
     threshold at its discretion.
 
@@ -206,7 +206,7 @@ and any shapes referring to them will be dropped.
 Same logic applies to sub-label IDs.
 
 It's possible to pass a custom confidence threshold to the function via the
-`threshold` parameter.
+`conf_threshold` parameter.
 
 `annotate_task` will raise a `BadFunctionError` exception
 if it detects that the function violated the AA function protocol.

--- a/tests/python/cli/conf_threshold_function.py
+++ b/tests/python/cli/conf_threshold_function.py
@@ -17,5 +17,5 @@ def detect(
     context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
 ) -> list[models.LabeledShapeRequest]:
     return [
-        cvataa.rectangle(0, [context.threshold, 1, 1, 1]),
+        cvataa.rectangle(0, [context.conf_threshold, 1, 1, 1]),
     ]

--- a/tests/python/cli/test_cli.py
+++ b/tests/python/cli/test_cli.py
@@ -347,3 +347,17 @@ class TestCLI:
 
         annotations = fxt_new_task.get_annotations()
         assert annotations.shapes
+
+    def test_auto_annotate_with_threshold(self, fxt_new_task: Task):
+        annotations = fxt_new_task.get_annotations()
+        assert not annotations.shapes
+
+        self.run_cli(
+            "auto-annotate",
+            str(fxt_new_task.id),
+            f"--function-module={__package__}.threshold_function",
+            "--threshold=0.75",
+        )
+
+        annotations = fxt_new_task.get_annotations()
+        assert annotations.shapes[0].points[0] == 0.75

--- a/tests/python/cli/test_cli.py
+++ b/tests/python/cli/test_cli.py
@@ -355,8 +355,8 @@ class TestCLI:
         self.run_cli(
             "auto-annotate",
             str(fxt_new_task.id),
-            f"--function-module={__package__}.threshold_function",
-            "--threshold=0.75",
+            f"--function-module={__package__}.conf_threshold_function",
+            "--conf-threshold=0.75",
         )
 
         annotations = fxt_new_task.get_annotations()

--- a/tests/python/cli/threshold_function.py
+++ b/tests/python/cli/threshold_function.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2024 CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import cvat_sdk.auto_annotation as cvataa
+import cvat_sdk.models as models
+import PIL.Image
+
+spec = cvataa.DetectionFunctionSpec(
+    labels=[
+        cvataa.label_spec("car", 0),
+    ],
+)
+
+
+def detect(
+    context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
+) -> list[models.LabeledShapeRequest]:
+    return [
+        cvataa.rectangle(0, [context.threshold, 1, 1, 1]),
+    ]

--- a/tests/python/sdk/test_auto_annotation.py
+++ b/tests/python/sdk/test_auto_annotation.py
@@ -269,7 +269,7 @@ class TestTaskAutoAnnotation:
             assert shapes[i].points == [5, 6, 7, 8]
             assert shapes[i].rotation == 10
 
-    def test_threshold(self):
+    def test_conf_threshold(self):
         spec = cvataa.DetectionFunctionSpec(labels=[])
 
         received_threshold = None
@@ -278,14 +278,14 @@ class TestTaskAutoAnnotation:
             context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
         ) -> list[models.LabeledShapeRequest]:
             nonlocal received_threshold
-            received_threshold = context.threshold
+            received_threshold = context.conf_threshold
             return []
 
         cvataa.annotate_task(
             self.client,
             self.task.id,
             namespace(spec=spec, detect=detect),
-            threshold=0.75,
+            conf_threshold=0.75,
         )
 
         assert received_threshold == 0.75
@@ -304,7 +304,7 @@ class TestTaskAutoAnnotation:
                     self.client,
                     self.task.id,
                     namespace(spec=spec, detect=detect),
-                    threshold=bad_threshold,
+                    conf_threshold=bad_threshold,
                 )
 
     def _test_bad_function_spec(self, spec: cvataa.DetectionFunctionSpec, exc_match: str) -> None:
@@ -713,7 +713,7 @@ class TestAutoAnnotationFunctions:
             self.task.id,
             td.create("fasterrcnn_resnet50_fpn_v2", "COCO_V1", test_param="expected_value"),
             allow_unmatched_labels=True,
-            threshold=0.75,
+            conf_threshold=0.75,
         )
 
         annotations = self.task.get_annotations()
@@ -733,7 +733,7 @@ class TestAutoAnnotationFunctions:
             self.task.id,
             tkd.create("keypointrcnn_resnet50_fpn", "COCO_V1", test_param="expected_value"),
             allow_unmatched_labels=True,
-            threshold=0.75,
+            conf_threshold=0.75,
         )
 
         annotations = self.task.get_annotations()

--- a/tests/python/sdk/test_auto_annotation.py
+++ b/tests/python/sdk/test_auto_annotation.py
@@ -269,6 +269,44 @@ class TestTaskAutoAnnotation:
             assert shapes[i].points == [5, 6, 7, 8]
             assert shapes[i].rotation == 10
 
+    def test_threshold(self):
+        spec = cvataa.DetectionFunctionSpec(labels=[])
+
+        received_threshold = None
+
+        def detect(
+            context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
+        ) -> list[models.LabeledShapeRequest]:
+            nonlocal received_threshold
+            received_threshold = context.threshold
+            return []
+
+        cvataa.annotate_task(
+            self.client,
+            self.task.id,
+            namespace(spec=spec, detect=detect),
+            threshold=0.75,
+        )
+
+        assert received_threshold == 0.75
+
+        cvataa.annotate_task(
+            self.client,
+            self.task.id,
+            namespace(spec=spec, detect=detect),
+        )
+
+        assert received_threshold is None
+
+        for bad_threshold in [-0.1, 1.1]:
+            with pytest.raises(ValueError):
+                cvataa.annotate_task(
+                    self.client,
+                    self.task.id,
+                    namespace(spec=spec, detect=detect),
+                    threshold=bad_threshold,
+                )
+
     def _test_bad_function_spec(self, spec: cvataa.DetectionFunctionSpec, exc_match: str) -> None:
         def detect(context, image):
             assert False
@@ -575,8 +613,9 @@ if torchvision_models is not None:
 
             return [
                 {
-                    "boxes": torch.tensor([[1, 2, 3, 4]]),
-                    "labels": torch.tensor([self._label_id]),
+                    "boxes": torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]]),
+                    "labels": torch.tensor([self._label_id, self._label_id]),
+                    "scores": torch.tensor([0.75, 0.74]),
                 }
             ]
 
@@ -599,15 +638,17 @@ if torchvision_models is not None:
 
             return [
                 {
-                    "labels": torch.tensor([self._label_id]),
+                    "labels": torch.tensor([self._label_id, self._label_id]),
                     "keypoints": torch.tensor(
                         [
                             [
                                 [hash(name) % 100, 0, 1 if name.startswith("right_") else 0]
                                 for i, name in enumerate(self._keypoint_names)
-                            ]
+                            ],
+                            [[0, 0, 1] for i, name in enumerate(self._keypoint_names)],
                         ]
                     ),
+                    "scores": torch.tensor([0.75, 0.74]),
                 }
             ]
 
@@ -672,6 +713,7 @@ class TestAutoAnnotationFunctions:
             self.task.id,
             td.create("fasterrcnn_resnet50_fpn_v2", "COCO_V1", test_param="expected_value"),
             allow_unmatched_labels=True,
+            threshold=0.75,
         )
 
         annotations = self.task.get_annotations()
@@ -691,6 +733,7 @@ class TestAutoAnnotationFunctions:
             self.task.id,
             tkd.create("keypointrcnn_resnet50_fpn", "COCO_V1", test_param="expected_value"),
             allow_unmatched_labels=True,
+            threshold=0.75,
         )
 
         annotations = self.task.get_annotations()


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
My main motivation is to support a future feature, but I think this is a good thing in its own right.

While it's already possible to create an AA function that lets you customize the threshold (by adding a creation parameter), confidence scoring is very common in detection models, so it makes sense to make this easier to support, both for the implementer of the function, and for its user.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Unit tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a `threshold` parameter for automatic annotation, allowing users to filter object detections based on confidence levels.
	- Added command-line support for the new `--threshold` option in the auto-annotation command.

- **Bug Fixes**
	- Enhanced error handling for invalid threshold values, ensuring appropriate feedback for out-of-range inputs.

- **Tests**
	- Added new tests to verify the functionality of the threshold parameter in auto-annotation and ensure proper handling of detection scores.

- **Documentation**
	- Updated API documentation to reflect changes in the auto-annotation functionality and the new threshold parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->