### PR TITLE
Fix duplicate security headers

### DIFF
--- a/changelog.d/20241120_172837_roman.md
+++ b/changelog.d/20241120_172837_roman.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed security header duplication in HTTP responses from the backend
+  (<https://github.com/cvat-ai/cvat/pull/8726>)

--- a/cvat/nginx.conf
+++ b/cvat/nginx.conf
@@ -41,14 +41,27 @@ http {
   # CVAT Settings
   ##
 
+  # Only add security headers if the upstream server does not already provide them.
+  map $upstream_http_referrer_policy $hdr_referrer_policy {
+      '' "strict-origin-when-cross-origin";
+  }
+
+  map $upstream_http_x_content_type_options $hdr_x_content_type_options {
+      '' "nosniff";
+  }
+
+  map $upstream_http_x_frame_options $hdr_x_frame_options {
+      '' "deny";
+  }
+
   server {
     listen 8080;
     # previously used value
     client_max_body_size 1G;
 
-    add_header X-Frame-Options deny;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy $hdr_referrer_policy always;
+    add_header X-Content-Type-Options $hdr_x_content_type_options always;
+    add_header X-Frame-Options $hdr_x_frame_options always;
 
     server_name _;
 

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -574,6 +574,8 @@ TUS_DEFAULT_CHUNK_SIZE = 104857600  # 100 mb
 # How django uses X-Forwarded-Proto - https://docs.djangoproject.com/en/2.2/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+SECURE_REFERRER_POLICY = 'strict-origin-when-cross-origin'
+
 # Forwarded host - https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-USE_X_FORWARDED_HOST
 # Is used in TUS uploads to provide correct upload endpoint
 USE_X_FORWARDED_HOST = True


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Our NGINX configuration adds some headers to all responses, but Django already outputs these headers via `SecurityMiddleware` and `XFrameOptionsMiddleware`. So we end up with duplicate headers in the response, which has undefined semantics (and is just plain confusing).

I don't want to remove these headers from the Django configuration (because I want them to still be output when run via the development server) _or_ from the NGINX configuration (because they should still be added when serving static files). So instead, keep them in both places, but let NGINX add each header only if the upstream server has not already added one.

Also, update the referrer policy in Django to match the one we're using elsewhere.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security header management for improved web communication safety.
	- Introduced a new setting for secure referrer policy.
	- Added configuration for ClickHouse database connection.

- **Bug Fixes**
	- Resolved duplication of security headers in HTTP responses.

- **Chores**
	- Updated settings related to file uploads and asset management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->