### PR TITLE
Fix frame names in the allocation table for simple GT job

### DIFF
--- a/changelog.d/20241121_181517_mzhiltso_fix_allocation_table.md
+++ b/changelog.d/20241121_181517_mzhiltso_fix_allocation_table.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Incorrect display of validation frames on the task quality management page
+  (<https://github.com/cvat-ai/cvat/pull/8731>)

--- a/cvat-ui/src/components/quality-control/task-quality/allocation-table.tsx
+++ b/cvat-ui/src/components/quality-control/task-quality/allocation-table.tsx
@@ -19,6 +19,7 @@ import {
 } from 'cvat-core-wrapper';
 import CVATTooltip from 'components/common/cvat-tooltip';
 import { sorter } from 'utils/quality';
+import { ValidationMode } from 'components/create-task-page/quality-configuration-form';
 
 interface Props {
     task: Task;
@@ -52,7 +53,16 @@ function AllocationTable(props: Readonly<Props>): JSX.Element {
     const data = validationLayout.validationFrames.map((frame: number, index: number) => ({
         key: frame,
         frame,
-        name: gtJobMeta.frames[index]?.name ?? gtJobMeta.frames[0].name,
+        name: gtJobMeta.frames[
+            (validationLayout.mode === ValidationMode.GT) ? frame : index
+            // The generic formula was here:
+            // https://github.com/cvat-ai/cvat/blob/45e1b4be5f40667d254cb869395f4cfa7dafc3ad/cvat-ui/ ...
+            // ... /src/components/quality-control/task-quality/allocation-table.tsx#L43
+            //
+            // Shortly:
+            // - gt job meta starts from the 0 task frame;
+            // - honeypot gt job meta starts from the job start frame;
+        ]?.name ?? gtJobMeta.frames[0].name,
         active: !disabledFrames.includes(frame),
     }));
 

--- a/cvat-ui/src/components/quality-control/task-quality/allocation-table.tsx
+++ b/cvat-ui/src/components/quality-control/task-quality/allocation-table.tsx
@@ -54,14 +54,9 @@ function AllocationTable(props: Readonly<Props>): JSX.Element {
         key: frame,
         frame,
         name: gtJobMeta.frames[
-            (validationLayout.mode === ValidationMode.GT) ? frame : index
-            // The generic formula was here:
-            // https://github.com/cvat-ai/cvat/blob/45e1b4be5f40667d254cb869395f4cfa7dafc3ad/cvat-ui/ ...
-            // ... /src/components/quality-control/task-quality/allocation-table.tsx#L43
-            //
-            // Shortly:
             // - gt job meta starts from the 0 task frame;
             // - honeypot gt job meta starts from the job start frame;
+            (validationLayout.mode === ValidationMode.GT) ? frame : index
         ]?.name ?? gtJobMeta.frames[0].name,
         active: !disabledFrames.includes(frame),
     }));


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

- Fixed invalid display of frame names in quality management for tasks with a simple GT job

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `AllocationTable` component to display frame names based on the selected validation mode.
  
- **Bug Fixes**
	- Improved accuracy of frame name retrieval in the allocation table, ensuring correct display under different validation conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->