### PR TITLE
Rename `FunctionCallRequestSerializer.convMaskToPoly` to fit the naming convention

### DIFF
--- a/changelog.d/20241126_140417_roman_rename_conv_mask_to_poly.md
+++ b/changelog.d/20241126_140417_roman_rename_conv_mask_to_poly.md
@@ -1,0 +1,11 @@
+### Added
+
+- The `POST /api/lambda/requests` endpoint now has a `conv_mask_to_poly`
+  parameter with the same semantics as the old `convMaskToPoly` parameter
+  (<https://github.com/cvat-ai/cvat/pull/8743>)
+
+### Deprecated
+
+- The `convMaskToPoly` parameter of the `POST /api/lambda/requests` endpoint
+  is deprecated; use `conv_mask_to_poly` instead
+  (<https://github.com/cvat-ai/cvat/pull/8743>)

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
@@ -1254,8 +1254,8 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                     try {
                         this.setState({ mode: 'detection', fetching: true });
 
-                        // The function call endpoint doesn't support the cleanup and convMaskToPoly parameters.
-                        const { cleanup, convMaskToPoly, ...restOfBody } = body;
+                        // The function call endpoint doesn't support the cleanup and conv_mask_to_poly parameters.
+                        const { cleanup, conv_mask_to_poly: convMaskToPoly, ...restOfBody } = body;
 
                         const result = await core.lambda.call(jobInstance.taskId, model, {
                             ...restOfBody, frame, job: jobInstance.id,

--- a/cvat-ui/src/components/model-runner-modal/detector-runner.tsx
+++ b/cvat-ui/src/components/model-runner-modal/detector-runner.tsx
@@ -40,7 +40,7 @@ type ServerMapping = Record<string, {
 export interface DetectorRequestBody {
     mapping: ServerMapping;
     cleanup: boolean;
-    convMaskToPoly: boolean;
+    conv_mask_to_poly: boolean;
 }
 
 function convertMappingToServer(mapping: FullMapping): ServerMapping {
@@ -235,7 +235,7 @@ function DetectorRunner(props: Props): JSX.Element {
                                 runInference(model, {
                                     mapping: serverMapping,
                                     cleanup,
-                                    convMaskToPoly: convertMasksToPolygons,
+                                    conv_mask_to_poly: convertMasksToPolygons,
                                 });
                             } else if (model.kind === ModelKind.REID) {
                                 runInference(model, { threshold, max_distance: distance });

--- a/cvat/apps/lambda_manager/serializers.py
+++ b/cvat/apps/lambda_manager/serializers.py
@@ -27,7 +27,8 @@ class FunctionCallRequestSerializer(serializers.Serializer):
     max_distance = serializers.IntegerField(required=False)
     threshold = serializers.FloatField(required=False)
     cleanup = serializers.BooleanField(help_text="Whether existing annotations should be removed", default=False)
-    convMaskToPoly = serializers.BooleanField(default=False) # TODO: use lowercase naming
+    convMaskToPoly = serializers.BooleanField(required=False, source="conv_mask_to_poly", write_only=True, help_text="Deprecated; use conv_mask_to_poly instead")
+    conv_mask_to_poly = serializers.BooleanField(required=False, help_text="Convert mask shapes to polygons")
     mapping = serializers.DictField(child=LabelMappingEntrySerializer(), required=False,
         help_text="Label mapping from the model to the task labels"
     )

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -1163,7 +1163,7 @@ class RequestViewSet(viewsets.ViewSet):
             task = request_data['task']
             job = request_data.get('job', None)
             cleanup = request_data.get('cleanup', False)
-            conv_mask_to_poly = request_data.get('convMaskToPoly', False)
+            conv_mask_to_poly = request_data.get('conv_mask_to_poly', False)
             mapping = request_data.get('mapping')
             max_distance = request_data.get('max_distance')
         except KeyError as err:

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -8060,7 +8060,11 @@ components:
           description: Whether existing annotations should be removed
         convMaskToPoly:
           type: boolean
-          default: false
+          writeOnly: true
+          description: Deprecated; use conv_mask_to_poly instead
+        conv_mask_to_poly:
+          type: boolean
+          description: Convert mask shapes to polygons
         mapping:
           type: object
           additionalProperties:


### PR DESCRIPTION
Keep the old name as a compatibility alias for the time being.

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
It's been a TODO for a long time, and a feature I'm working on will be reusing this name, so I'd rather fix it now.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new parameter `conv_mask_to_poly` for the `POST /api/lambda/requests` endpoint, enhancing parameter naming consistency.
	- Updated API schema to include `conv_mask_to_poly` while marking `convMaskToPoly` as deprecated.

- **Bug Fixes**
	- Improved error handling for missing parameters in the `create` method of the `RequestViewSet` class.

- **Documentation**
	- Enhanced API documentation clarity with updated descriptions and organization across various schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->