### PR TITLE
Fixed color of 'Create object URL' on not saved object

### DIFF
--- a/changelog.d/20241128_131448_sekachev.bs_fixed_create_obj_url_color.md
+++ b/changelog.d/20241128_131448_sekachev.bs_fixed_create_obj_url_color.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Color of 'Create object URL' button for a not saved on the server object
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/cvat-ui/src/components/annotation-page/annotations-actions/annotations-actions-modal.tsx
+++ b/cvat-ui/src/components/annotation-page/annotations-actions/annotations-actions-modal.tsx
@@ -583,14 +583,15 @@ function AnnotationsActionsModalContent(props: Props): JSX.Element {
                                     if (!cancellationRef.current) {
                                         canvasInstance.setup(frameData, []);
                                         storage.dispatch(fetchAnnotationsAsync());
+                                        if (isMounted()) {
+                                            if (targetObjectState !== null) {
+                                                onClose();
+                                            }
+                                        }
                                     }
                                 }).finally(() => {
                                     if (isMounted()) {
-                                        if (targetObjectState !== null) {
-                                            onClose();
-                                        } else {
-                                            dispatch(reducerActions.resetAfterRun());
-                                        }
+                                        dispatch(reducerActions.resetAfterRun());
                                     }
                                 }).catch((error: unknown) => {
                                     if (error instanceof Error) {

--- a/cvat-ui/src/components/annotation-page/annotations-actions/annotations-actions-modal.tsx
+++ b/cvat-ui/src/components/annotation-page/annotations-actions/annotations-actions-modal.tsx
@@ -583,15 +583,14 @@ function AnnotationsActionsModalContent(props: Props): JSX.Element {
                                     if (!cancellationRef.current) {
                                         canvasInstance.setup(frameData, []);
                                         storage.dispatch(fetchAnnotationsAsync());
-                                        if (isMounted()) {
-                                            if (targetObjectState !== null) {
-                                                onClose();
-                                            }
-                                        }
                                     }
                                 }).finally(() => {
                                     if (isMounted()) {
-                                        dispatch(reducerActions.resetAfterRun());
+                                        if (targetObjectState !== null) {
+                                            onClose();
+                                        } else {
+                                            dispatch(reducerActions.resetAfterRun());
+                                        }
                                     }
                                 }).catch((error: unknown) => {
                                     if (error instanceof Error) {

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
@@ -402,7 +402,10 @@
     }
 
     button {
-        color: $text-color;
+        &:not(:disabled) {
+            color: $text-color;
+        }
+
         width: 100%;
         height: 100%;
         text-align: left;


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
This button should be gray if disabled:
Before:
![image](https://github.com/user-attachments/assets/545543aa-c12d-44d2-be4e-63e0d9e8ea0d)

After:
![image](https://github.com/user-attachments/assets/31e14266-a52c-497e-9b13-29f54c175f0d)



### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
