### PR TITLE
CLI: log to stderr instead of stdout

### DIFF
--- a/changelog.d/20241206_135902_roman_cli_logging.md
+++ b/changelog.d/20241206_135902_roman_cli_logging.md
@@ -1,0 +1,4 @@
+### Changed
+
+- \[CLI\] Log messages are now printed on stderr rather than stdout
+  (<https://github.com/cvat-ai/cvat/pull/8784>)

--- a/cvat-cli/src/cvat_cli/_internal/commands.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands.py
@@ -418,11 +418,12 @@ class TaskImport:
         )
 
     def execute(self, client: Client, *, filename: str, status_check_period: int) -> None:
-        client.tasks.create_from_backup(
+        task = client.tasks.create_from_backup(
             filename=filename,
             status_check_period=status_check_period,
             pbar=DeferredTqdmProgressReporter(),
         )
+        print(f"Created task ID", task.id)
 
 
 @COMMANDS.command_class("auto-annotate")

--- a/cvat-cli/src/cvat_cli/_internal/common.py
+++ b/cvat-cli/src/cvat_cli/_internal/common.py
@@ -74,7 +74,7 @@ def configure_logger(logger: logging.Logger, parsed_args: argparse.Namespace) ->
     formatter = logging.Formatter(
         "[%(asctime)s] %(levelname)s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S", style="%"
     )
-    handler = logging.StreamHandler(sys.stdout)
+    handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(level)


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Since the `ls` command produces machine-readable output, we need to ensure that any log messages produced do not corrupt that output.

Logging to stderr is also conventional; Python's `StreamHandler` even defaults to it.

This breaks the `import` command tests, because previously they were looking at the last log message. I don't think we should be testing log messages, so add a proper `print` to this command. This also makes it consistent with the `create` command.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Unit tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging behavior in the command-line interface, now directing log messages to standard error (stderr) for better user experience during CLI operations.
	- Improved feedback for the `TaskImport` command by displaying the created task ID after task creation.

- **Bug Fixes**
	- No bug fixes were made in this release. 

- **Documentation**
	- Updated changelog to reflect recent changes in logging behavior and task feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->