### PR TITLE
Make the CLI hierarchical

### DIFF
--- a/changelog.d/20241206_184906_roman_cli_hierarchy.md
+++ b/changelog.d/20241206_184906_roman_cli_hierarchy.md
@@ -1,0 +1,20 @@
+### Added
+
+- \[CLI\] Added new commands: `project create`, `project delete`, `project ls`
+  (<https://github.com/cvat-ai/cvat/pull/8787>)
+
+- \[SDK\] You can now use `client.projects.remove_by_ids` to remove multiple
+  projects
+  (<https://github.com/cvat-ai/cvat/pull/8787>)
+
+### Changed
+
+- \[CLI\] Switched to a new subcommand hierarchy; now CLI subcommands
+  have the form `cvat-cli <resource> <action>`
+  (<https://github.com/cvat-ai/cvat/pull/8787>)
+
+### Deprecated
+
+- \[CLI\] All existing CLI commands of the form `cvat-cli <action>`
+  are now deprecated. Use `cvat-cli task <action>` instead
+  (<https://github.com/cvat-ai/cvat/pull/8787>)

--- a/cvat-cli/README.md
+++ b/cvat-cli/README.md
@@ -6,6 +6,11 @@ comprehensive CVAT administration tool in the future.
 
 Overview of functionality:
 
+- Projects:
+  - Create a new project
+  - Delete projects
+  - List all projects
+
 - Tasks:
   - Create a new task
   - Create a task from a backup file

--- a/cvat-cli/README.md
+++ b/cvat-cli/README.md
@@ -1,19 +1,21 @@
 # Command-line client for CVAT
 
-A simple command line interface for working with CVAT tasks. At the moment it
+A simple command line interface for working with CVAT. At the moment it
 implements a basic feature set but may serve as the starting point for a more
 comprehensive CVAT administration tool in the future.
 
 Overview of functionality:
 
-- Create a new task (supports name, bug tracker, project, labels JSON, local/share/remote files)
-- Delete tasks (supports deleting a list of task IDs)
-- List all tasks (supports basic CSV or JSON output)
-- Download JPEG frames (supports a list of frame IDs)
-- Dump annotations (supports all formats via format string)
-- Upload annotations for a task in the specified format (e.g. 'YOLO 1.1')
-- Export and download a whole task
-- Import a task
+- Tasks:
+  - Create a new task
+  - Create a task from a backup file
+  - Delete tasks
+  - List all tasks
+  - Download frames from a task
+  - Export a task as a dataset
+  - Import annotations into a task from a dataset
+  - Back up a task
+  - Automatically annotate a task using a local function
 
 ## Installation
 
@@ -21,29 +23,25 @@ Overview of functionality:
 
 ## Usage
 
-```bash
-$ cvat-cli --help
+The general form of a CLI command is:
 
-usage: cvat-cli [-h] [--version] [--auth USER:[PASS]]
-  [--server-host SERVER_HOST] [--server-port SERVER_PORT] [--debug]
-  {create,delete,ls,frames,dump,upload,export,import} ...
+```console
+$ cvat-cli <common options> <resource> <action> <options>
+```
 
-Perform common operations related to CVAT tasks.
+where:
 
-positional arguments:
-  {create,delete,ls,frames,dump,upload,export,import}
+- `<common options>` are options shared between all subcommands;
+- `<resource>` is a CVAT resource, such as `task`;
+- `<action>` is the action to do with the resource, such as `create`;
+- `<options>` is any options specific to a particular resource and action.
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --version             show program's version number and exit
-  --auth USER:[PASS]    defaults to the current user and supports the PASS
-                        environment variable or password prompt
-                        (default: current user)
-  --server-host SERVER_HOST
-                        host (default: localhost)
-  --server-port SERVER_PORT
-                        port (default: 8080)
-  --debug               show debug output
+You can list available subcommands and options using the `--help` option:
+
+```
+$ cvat-cli --help # get help on available common options and resources
+$ cvat-cli <resource> --help # get help on actions for the given resource
+$ cvat-cli <resource> <action> --help # get help on action-specific options
 ```
 
 ## Examples
@@ -51,7 +49,7 @@ optional arguments:
 Create a task with local images:
 
 ```bash
-cvat-cli --auth user create
+cvat-cli --auth user task create
     --labels '[{"name": "car"}, {"name": "person"}]'
     "test_task"
     "local"
@@ -63,5 +61,5 @@ List tasks on a custom server with auth:
 ```bash
 cvat-cli --auth admin:password \
     --server-host cvat.my.server.com --server-port 30123 \
-    ls
+    task ls
 ```

--- a/cvat-cli/README.md
+++ b/cvat-cli/README.md
@@ -4,23 +4,23 @@ A simple command line interface for working with CVAT. At the moment it
 implements a basic feature set but may serve as the starting point for a more
 comprehensive CVAT administration tool in the future.
 
-Overview of functionality:
+The following subcommands are supported:
 
 - Projects:
-  - Create a new project
-  - Delete projects
-  - List all projects
+  - `create` - create a new project
+  - `delete` - delete projects
+  - `ls` - list all projects
 
 - Tasks:
-  - Create a new task
-  - Create a task from a backup file
-  - Delete tasks
-  - List all tasks
-  - Download frames from a task
-  - Export a task as a dataset
-  - Import annotations into a task from a dataset
-  - Back up a task
-  - Automatically annotate a task using a local function
+  - `create` - create a new task
+  - `create-from-backup` - create a task from a backup file
+  - `delete` - delete tasks
+  - `ls` - list all tasks
+  - `frames` - download frames from a task
+  - `export-dataset` - export a task as a dataset
+  - `import-dataset` - import annotations into a task from a dataset
+  - `backup` - back up a task
+  - `auto-annotate` - automatically annotate a task using a local function
 
 ## Installation
 

--- a/cvat-cli/src/cvat_cli/__main__.py
+++ b/cvat-cli/src/cvat_cli/__main__.py
@@ -10,7 +10,7 @@ import sys
 import urllib3.exceptions
 from cvat_sdk import exceptions
 
-from ._internal.commands import COMMANDS
+from ._internal.commands_all import COMMANDS
 from ._internal.common import build_client, configure_common_arguments, configure_logger
 from ._internal.utils import popattr
 

--- a/cvat-cli/src/cvat_cli/_internal/commands_all.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_all.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2024 CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+from .command_base import CommandGroup, DeprecatedAlias
+from .commands_tasks import COMMANDS as COMMANDS_TASKS
+
+COMMANDS = CommandGroup(description="Perform operations on CVAT resources.")
+
+COMMANDS.add_command("task", COMMANDS_TASKS)
+
+_legacy_mapping = {
+    "create": "create",
+    "ls": "ls",
+    "delete": "delete",
+    "frames": "frames",
+    "dump": "export-dataset",
+    "upload": "import-dataset",
+    "export": "backup",
+    "import": "create-from-backup",
+    "auto-annotate": "auto-annotate",
+}
+
+for _legacy, _new in _legacy_mapping.items():
+    COMMANDS.add_command(_legacy, DeprecatedAlias(COMMANDS_TASKS.commands[_new], f"task {_new}"))

--- a/cvat-cli/src/cvat_cli/_internal/commands_all.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_all.py
@@ -3,10 +3,12 @@
 # SPDX-License-Identifier: MIT
 
 from .command_base import CommandGroup, DeprecatedAlias
+from .commands_projects import COMMANDS as COMMANDS_PROJECTS
 from .commands_tasks import COMMANDS as COMMANDS_TASKS
 
 COMMANDS = CommandGroup(description="Perform operations on CVAT resources.")
 
+COMMANDS.add_command("project", COMMANDS_PROJECTS)
 COMMANDS.add_command("task", COMMANDS_TASKS)
 
 _legacy_mapping = {

--- a/cvat-cli/src/cvat_cli/_internal/commands_projects.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_projects.py
@@ -47,7 +47,7 @@ class ProjectCreate:
 
     def execute(self, client: Client, *, name: str, labels: dict, **kwargs) -> None:
         project = client.projects.create(
-            spec=models.ProjectWriteRequest(name=name, label=labels, **kwargs)
+            spec=models.ProjectWriteRequest(name=name, labels=labels, **kwargs)
         )
         print(f"Created project ID {project.id}")
 

--- a/cvat-cli/src/cvat_cli/_internal/commands_projects.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_projects.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2024 CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import argparse
+import textwrap
+
+from cvat_sdk import Client, models
+
+from .command_base import CommandGroup, GenericCommand, GenericDeleteCommand, GenericListCommand
+from .parsers import parse_label_arg
+
+COMMANDS = CommandGroup(description="Perform operations on CVAT projects.")
+
+
+class GenericProjectCommand(GenericCommand):
+    resource_type_str = "project"
+
+    def repo(self, client: Client):
+        return client.projects
+
+
+@COMMANDS.command_class("ls")
+class ProjectList(GenericListCommand, GenericProjectCommand):
+    pass
+
+
+@COMMANDS.command_class("create")
+class ProjectCreate:
+    description = textwrap.dedent(
+        """\
+        Create a new CVAT project.
+        """
+    )
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("name", type=str, help="name of the project")
+        parser.add_argument(
+            "--bug_tracker", "--bug", default=argparse.SUPPRESS, type=str, help="bug tracker URL"
+        )
+        parser.add_argument(
+            "--labels",
+            required=True,
+            type=parse_label_arg,
+            help="string or file containing JSON labels specification",
+        )
+
+    def execute(self, client: Client, *, name: str, labels: dict, **kwargs) -> None:
+        project = client.projects.create(
+            spec=models.ProjectWriteRequest(name=name, label=labels, **kwargs)
+        )
+        print(f"Created project ID {project.id}")
+
+
+@COMMANDS.command_class("delete")
+class ProjectDelete(GenericDeleteCommand, GenericProjectCommand):
+    pass

--- a/cvat-cli/src/cvat_cli/_internal/commands_projects.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_projects.py
@@ -40,7 +40,7 @@ class ProjectCreate:
         )
         parser.add_argument(
             "--labels",
-            required=True,
+            default=[],
             type=parse_label_arg,
             help="string or file containing JSON labels specification",
         )

--- a/cvat-cli/src/cvat_cli/_internal/commands_projects.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_projects.py
@@ -29,7 +29,7 @@ class ProjectList(GenericListCommand, GenericProjectCommand):
 class ProjectCreate:
     description = textwrap.dedent(
         """\
-        Create a new CVAT project.
+        Create a new CVAT project, optionally importing a dataset.
         """
     )
 
@@ -44,10 +44,42 @@ class ProjectCreate:
             type=parse_label_arg,
             help="string or file containing JSON labels specification",
         )
+        parser.add_argument(
+            "--dataset_path",
+            default="",
+            type=str,
+            help="path to the dataset file to import",
+        )
+        parser.add_argument(
+            "--dataset_format",
+            default="CVAT 1.1",
+            type=str,
+            help="format of the dataset file being uploaded, e.g. CVAT 1.1",
+        )
+        parser.add_argument(
+            "--completion_verification_period",
+            dest="status_check_period",
+            default=2,
+            type=float,
+            help="period between status checks (only applies when --dataset_path is specified)",
+        )
 
-    def execute(self, client: Client, *, name: str, labels: dict, **kwargs) -> None:
-        project = client.projects.create(
-            spec=models.ProjectWriteRequest(name=name, labels=labels, **kwargs)
+    def execute(
+        self,
+        client: Client,
+        *,
+        name: str,
+        labels: dict,
+        dataset_path: str,
+        dataset_format: str,
+        status_check_period: int,
+        **kwargs,
+    ) -> None:
+        project = client.projects.create_from_dataset(
+            spec=models.ProjectWriteRequest(name=name, labels=labels, **kwargs),
+            dataset_path=dataset_path,
+            dataset_format=dataset_format,
+            status_check_period=status_check_period,
         )
         print(f"Created project ID {project.id}")
 

--- a/cvat-cli/src/cvat_cli/_internal/commands_projects.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_projects.py
@@ -42,7 +42,7 @@ class ProjectCreate:
             "--labels",
             default=[],
             type=parse_label_arg,
-            help="string or file containing JSON labels specification",
+            help="string or file containing JSON labels specification (default: %(default)s)",
         )
         parser.add_argument(
             "--dataset_path",
@@ -54,14 +54,16 @@ class ProjectCreate:
             "--dataset_format",
             default="CVAT 1.1",
             type=str,
-            help="format of the dataset file being uploaded, e.g. CVAT 1.1",
+            help="format of the dataset file being uploaded"
+            " (only applies when --dataset_path is specified; default: %(default)s)",
         )
         parser.add_argument(
             "--completion_verification_period",
             dest="status_check_period",
             default=2,
             type=float,
-            help="period between status checks (only applies when --dataset_path is specified)",
+            help="period between status checks"
+            " (only applies when --dataset_path is specified; default: %(default)s)",
         )
 
     def execute(

--- a/cvat-cli/src/cvat_cli/_internal/commands_tasks.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_tasks.py
@@ -28,7 +28,7 @@ from .parsers import (
     parse_threshold,
 )
 
-COMMANDS = CommandGroup(description="Perform common operations related to CVAT tasks.")
+COMMANDS = CommandGroup(description="Perform operations on CVAT tasks.")
 
 
 @COMMANDS.command_class("ls")
@@ -291,11 +291,11 @@ class TaskFrames:
         )
 
 
-@COMMANDS.command_class("dump")
-class TaskDump:
+@COMMANDS.command_class("export-dataset")
+class TaskExportDataset:
     description = textwrap.dedent(
         """\
-        Download annotations for a task in the specified format (e.g. 'YOLO 1.1').
+        Export a task as a dataset in the specified format (e.g. 'YOLO 1.1').
         """
     )
 
@@ -343,11 +343,11 @@ class TaskDump:
         )
 
 
-@COMMANDS.command_class("upload")
-class TaskUpload:
+@COMMANDS.command_class("import-dataset")
+class TaskImportDataset:
     description = textwrap.dedent(
         """\
-        Upload annotations for a task in the specified format
+        Import annotations into a task from a dataset in the specified format
         (e.g. 'YOLO 1.1').
         """
     )
@@ -378,8 +378,8 @@ class TaskUpload:
         )
 
 
-@COMMANDS.command_class("export")
-class TaskExport:
+@COMMANDS.command_class("backup")
+class TaskBackup:
     description = """Download a task backup."""
 
     def configure_parser(self, parser: argparse.ArgumentParser) -> None:
@@ -403,9 +403,9 @@ class TaskExport:
         )
 
 
-@COMMANDS.command_class("import")
-class TaskImport:
-    description = """Import a task from a backup file."""
+@COMMANDS.command_class("create-from-backup")
+class TaskCreateFromBackup:
+    description = """Create a task from a backup file."""
 
     def configure_parser(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("filename", type=str, help="upload file")

--- a/cvat-sdk/cvat_sdk/core/proxies/projects.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/projects.py
@@ -15,6 +15,7 @@ from cvat_sdk.core.progress import ProgressReporter
 from cvat_sdk.core.proxies.model_proxy import (
     DownloadBackupMixin,
     ExportDatasetMixin,
+    ModelBatchDeleteMixin,
     ModelCreateMixin,
     ModelDeleteMixin,
     ModelListMixin,
@@ -97,6 +98,7 @@ class ProjectsRepo(
     ModelCreateMixin[Project, models.IProjectWriteRequest],
     ModelListMixin[Project],
     ModelRetrieveMixin[Project],
+    ModelBatchDeleteMixin,
 ):
     _entity_type = Project
 

--- a/cvat-sdk/cvat_sdk/core/proxies/tasks.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/tasks.py
@@ -24,6 +24,7 @@ from cvat_sdk.core.proxies.jobs import Job
 from cvat_sdk.core.proxies.model_proxy import (
     DownloadBackupMixin,
     ExportDatasetMixin,
+    ModelBatchDeleteMixin,
     ModelCreateMixin,
     ModelDeleteMixin,
     ModelListMixin,
@@ -286,6 +287,7 @@ class TasksRepo(
     ModelCreateMixin[Task, models.ITaskWriteRequest],
     ModelRetrieveMixin[Task],
     ModelListMixin[Task],
+    ModelBatchDeleteMixin,
 ):
     _entity_type = Task
 
@@ -333,23 +335,16 @@ class TasksRepo(
 
         return task
 
+    # This is a backwards compatibility wrapper to support calls which pass
+    # the task_ids parameter by keyword (the base class implementation is generic,
+    # so it doesn't support this).
+    # pylint: disable-next=arguments-differ
     def remove_by_ids(self, task_ids: Sequence[int]) -> None:
         """
         Delete a list of tasks, ignoring those which don't exist.
         """
 
-        for task_id in task_ids:
-            (_, response) = self.api.destroy(task_id, _check_status=False)
-
-            if 200 <= response.status <= 299:
-                self._client.logger.info(f"Task ID {task_id} deleted")
-            elif response.status == 404:
-                self._client.logger.info(f"Task ID {task_id} not found")
-            else:
-                self._client.logger.warning(
-                    f"Failed to delete task ID {task_id}: "
-                    f"{response.msg} (status {response.status})"
-                )
+        super().remove_by_ids(task_ids)
 
     def create_from_backup(
         self,

--- a/site/content/en/docs/api_sdk/cli/_index.md
+++ b/site/content/en/docs/api_sdk/cli/_index.md
@@ -13,6 +13,11 @@ comprehensive CVAT administration tool in the future.
 
 Overview of functionality:
 
+- Projects:
+  - Create a new project
+  - Delete projects
+  - List all projects
+
 - Tasks:
   - Create a new task
   - Create a task from a backup file
@@ -274,4 +279,36 @@ if it isn't there already.
   letting it import other modules from that directory.
   ```bash
   PYTHONPATH=path/to/my-project cvat-cli task auto-annotate 139 --function-module my_func
+  ```
+
+## Examples - projects
+
+### Create
+
+To create a project, you have to define its labels.
+The `project create` command accepts labels in the same format as the `task create` command;
+see that command's examples for more information.
+
+- Create a project named "new project" on the default server "localhost:8080",
+  with labels from the file "labels.json":
+  ```bash
+  cvat-cli project create "new project" --labels labels.json
+  ```
+
+### Delete
+
+- Delete projects with id "100", "101", "102":
+  ```bash
+  cvat-cli project delete 100 101 102
+  ```
+
+### List
+
+- List all projects:
+  ```bash
+  cvat-cli project ls
+  ```
+- Save list of all projects into file "list_of_projects.json":
+  ```bash
+  cvat-cli project ls --json > list_of_projects.json
   ```

--- a/site/content/en/docs/api_sdk/cli/_index.md
+++ b/site/content/en/docs/api_sdk/cli/_index.md
@@ -154,7 +154,7 @@ by using the {{< ilink "/docs/manual/basics/create_an_annotation_task#labels" "l
 
 ### Delete
 
-- Delete tasks with id "100", "101", "102" , the command will be executed from "user-1" having delete permissions:
+- Delete tasks with IDs "100", "101", "102" , the command will be executed from "user-1" having delete permissions:
   ```bash
   cvat-cli --auth user-1:password task delete 100 101 102
   ```
@@ -297,7 +297,7 @@ see that command's examples for more information.
 
 ### Delete
 
-- Delete projects with id "100", "101", "102":
+- Delete projects with IDs "100", "101", "102":
   ```bash
   cvat-cli project delete 100 101 102
   ```

--- a/site/content/en/docs/api_sdk/cli/_index.md
+++ b/site/content/en/docs/api_sdk/cli/_index.md
@@ -7,20 +7,22 @@ description: ''
 
 ## Overview
 
-A simple command line interface for working with CVAT tasks. At the moment it
+A simple command line interface for working with CVAT. At the moment it
 implements a basic feature set but may serve as the starting point for a more
 comprehensive CVAT administration tool in the future.
 
 Overview of functionality:
 
-- Create a new task (supports name, bug tracker, project, labels JSON, local/share/remote files)
-- Delete tasks (supports deleting a list of task IDs)
-- List all tasks (supports basic CSV or JSON output)
-- Download JPEG frames (supports a list of frame IDs)
-- Dump annotations (supports all formats via format string)
-- Upload annotations for a task in the specified format (e.g. 'YOLO 1.1')
-- Export and download a whole task
-- Import a task
+- Tasks:
+  - Create a new task
+  - Create a task from a backup file
+  - Delete tasks
+  - List all tasks
+  - Download frames from a task
+  - Export a task as a dataset
+  - Import annotations into a task from a dataset
+  - Back up a task
+  - Automatically annotate a task using a local function
 
 ## Installation
 
@@ -34,51 +36,33 @@ We support Python versions 3.9 and higher.
 
 ## Usage
 
-You can get help with `cvat-cli --help`.
+The general form of a CLI command is:
 
-```
-usage: cvat-cli [-h] [--version] [--insecure] [--auth USER:[PASS]] [--server-host SERVER_HOST]
-                [--server-port SERVER_PORT] [--organization SLUG] [--debug]
-                {create,delete,ls,frames,dump,upload,export,import,auto-annotate} ...
-
-Perform common operations related to CVAT tasks.
-
-positional arguments:
-  {create,delete,ls,frames,dump,upload,export,import,auto-annotate}
-
-options:
-  -h, --help            show this help message and exit
-  --version             show program's version number and exit
-  --insecure            Allows to disable SSL certificate check
-  --auth USER:[PASS]    defaults to the current user and supports the PASS environment variable or password
-                        prompt (default user: ...).
-  --server-host SERVER_HOST
-                        host (default: localhost)
-  --server-port SERVER_PORT
-                        port (default: 80 for http and 443 for https connections)
-  --organization SLUG, --org SLUG
-                        short name (slug) of the organization to use when listing or creating resources; set
-                        to blank string to use the personal workspace (default: list all accessible objects,
-                        create in personal workspace)
-  --debug               show debug output
+```console
+$ cvat-cli <common options> <resource> <action> <options>
 ```
 
-You can get help for each positional argument, e.g. `ls`:
+where:
 
-```bash
-cvat-cli ls -h
+- `<common options>` are options shared between all subcommands;
+- `<resource>` is a CVAT resource, such as `task`;
+- `<action>` is the action to do with the resource, such as `create`;
+- `<options>` is any options specific to a particular resource and action.
+
+You can list available subcommands and options using the `--help` option:
+
 ```
-```
-usage: cvat-cli ls [-h] [--json]
-
-List all CVAT tasks in simple or JSON format.
-
-optional arguments:
-  -h, --help  show this help message and exit
-  --json      output JSON data
+$ cvat-cli --help # get help on available common options and resources
+$ cvat-cli <resource> --help # get help on actions for the given resource
+$ cvat-cli <resource> <action> --help # get help on action-specific options
 ```
 
-## Examples
+The CLI implements alias subcommands for some task actions, so that,
+for example, `cvat-cli ls` works the same way as `cvat-cli task ls`. These
+aliases are provided for backwards compatibility and are deprecated.
+Use the `task <action>` form instead.
+
+## Examples - tasks
 
 ### Create
 
@@ -108,30 +92,30 @@ by using the {{< ilink "/docs/manual/basics/create_an_annotation_task#labels" "l
 - Create a task named "new task" on the default server "localhost:8080", labels from the file "labels.json"
   and local images "file1.jpg" and "file2.jpg", the task will be created as current user:
   ```bash
-  cvat-cli create "new task" --labels labels.json local file1.jpg file2.jpg
+  cvat-cli task create "new task" --labels labels.json local file1.jpg file2.jpg
   ```
 - Create a task named "task 1" on the server "example.com" labels from the file "labels.json"
   and local image "image1.jpg", the task will be created as user "user-1":
   ```bash
-  cvat-cli --server-host example.com --auth user-1 create "task 1" \
+  cvat-cli --server-host example.com --auth user-1 task create "task 1" \
   --labels labels.json local image1.jpg
   ```
 - Create a task named "task 1" on the default server, with labels from "labels.json"
   and local image "file1.jpg", as the current user, in organization "myorg":
   ```bash
-  cvat-cli --org myorg create "task 1" --labels labels.json local file1.jpg
+  cvat-cli --org myorg task create "task 1" --labels labels.json local file1.jpg
   ```
 - Create a task named "task 1", labels from the project with id 1 and with a remote video file,
   the task will be created as user "user-1":
   ```bash
-  cvat-cli --auth user-1:password create "task 1" --project_id 1 \
+  cvat-cli --auth user-1:password task create "task 1" --project_id 1 \
   remote https://github.com/opencv/opencv/blob/master/samples/data/vtest.avi?raw=true
   ```
 - Create a task named "task 1 sort random", with labels "cat" and "dog", with chunk size 8,
   with sorting-method random, frame step 10, copy the data on the CVAT server,
   with use zip chunks and the video file will be taken from the shared resource:
   ```bash
-  cvat-cli create "task 1 sort random" --labels '[{"name": "cat"},{"name": "dog"}]' --chunk_size 8 \
+  cvat-cli task create "task 1 sort random" --labels '[{"name": "cat"},{"name": "dog"}]' --chunk_size 8 \
   --sorting-method random --frame_step 10 --copy_data --use_zip_chunks share //share/dataset_1/video.avi
   ```
 - Create a task named "task from dataset_1", labels from the file "labels.json", with link to bug tracker,
@@ -139,27 +123,27 @@ by using the {{< ilink "/docs/manual/basics/create_an_annotation_task#labels" "l
   from the file "annotation.xml", the data will be loaded from "dataset_1/images/",
   the task will be created as user "user-2", and the password will need to be entered additionally:
   ```bash
-  cvat-cli --auth user-2 create "task from dataset_1" --labels labels.json \
+  cvat-cli --auth user-2 task create "task from dataset_1" --labels labels.json \
   --bug_tracker https://bug-tracker.com/0001 --image_quality 75 --annotation_path annotation.xml \
   --annotation_format "CVAT 1.1" local dataset_1/images/
   ```
 - Create a task named "segmented task 1", labels from the file "labels.json", with overlay size 5,
   segment size 100, with frames 5 through 705, using cache and with a remote video file:
   ```bash
-  cvat-cli create "segmented task 1" --labels labels.json --overlap 5 --segment_size 100 \
+  cvat-cli task create "segmented task 1" --labels labels.json --overlap 5 --segment_size 100 \
   --start_frame 5 --stop_frame 705 --use_cache \
   remote https://github.com/opencv/opencv/blob/master/samples/data/vtest.avi?raw=true
   ```
 - Create a task named "task with filtered cloud storage data", with filename_pattern `test_images/*.jpeg`
   and using the data from the cloud storage resource described in the manifest.jsonl:
   ```bash
-  cvat-cli create "task with filtered cloud storage data" --labels '[{"name": "car"}]'\
+  cvat-cli task create "task with filtered cloud storage data" --labels '[{"name": "car"}]'\
   --use_cache --cloud_storage_id 1 --filename_pattern "test_images/*.jpeg" share manifest.jsonl
   ```
 - Create a task named "task with filtered cloud storage data" using all data from the cloud storage resource
   described in the manifest.jsonl by specifying filename_pattern `*`:
   ```bash
-  cvat-cli create "task with filtered cloud storage data" --labels '[{"name": "car"}]'\
+  cvat-cli task create "task with filtered cloud storage data" --labels '[{"name": "car"}]'\
   --use_cache --cloud_storage_id 1 --filename_pattern "*" share manifest.jsonl
   ```
 
@@ -167,61 +151,61 @@ by using the {{< ilink "/docs/manual/basics/create_an_annotation_task#labels" "l
 
 - Delete tasks with id "100", "101", "102" , the command will be executed from "user-1" having delete permissions:
   ```bash
-  cvat-cli --auth user-1:password delete 100 101 102
+  cvat-cli --auth user-1:password task delete 100 101 102
   ```
 
 ### List
 
 - List all tasks:
   ```bash
-  cvat-cli ls
+  cvat-cli task ls
   ```
 - List all tasks in organization "myorg":
   ```bash
-  cvat-cli --org myorg ls
+  cvat-cli --org myorg task ls
   ```
 - Save list of all tasks into file "list_of_tasks.json":
   ```bash
-  cvat-cli ls --json > list_of_tasks.json
+  cvat-cli task ls --json > list_of_tasks.json
   ```
 
 ### Frames
 
 - Save frame 12, 15, 22 from task with id 119, into "images" folder with compressed quality:
   ```bash
-  cvat-cli frames --outdir images --quality compressed 119 12 15 22
+  cvat-cli task frames --outdir images --quality compressed 119 12 15 22
   ```
 
-### Dump annotation
+### Export as a dataset
 
-- Dump annotation task with id 103, in the format `CVAT for images 1.1` and save to the file "output.zip":
+- Export annotation task with id 103, in the format `CVAT for images 1.1` and save to the file "output.zip":
   ```bash
-  cvat-cli dump --format "CVAT for images 1.1" 103 output.zip
+  cvat-cli task export-dataset --format "CVAT for images 1.1" 103 output.zip
   ```
-- Dump annotation task with id 104, in the format `COCO 1.0` and save to the file "output.zip":
+- Export annotation task with id 104, in the format `COCO 1.0` and save to the file "output.zip":
   ```bash
-  cvat-cli dump --format "COCO 1.0" 104 output.zip
-  ```
-
-### Upload annotation
-
-- Upload annotation into task with id 105, in the format `CVAT 1.1` from the file "annotation.xml":
-  ```bash
-  cvat-cli upload --format "CVAT 1.1" 105 annotation.xml
+  cvat-cli task export-dataset --format "COCO 1.0" 104 output.zip
   ```
 
-### Export task
+### Import annotations from a dataset
 
-- Export task with id 136 to file "task_136.zip":
+- Import annotation into task with id 105, in the format `CVAT 1.1` from the file "annotation.xml":
   ```bash
-  cvat-cli export 136 task_136.zip
+  cvat-cli task import-dataset --format "CVAT 1.1" 105 annotation.xml
   ```
 
-### Import
+### Back up a task
 
-- Import task from file "task_backup.zip":
+- Back up task with id 136 to file "task_136.zip":
   ```bash
-  cvat-cli import task_backup.zip
+  cvat-cli task backup 136 task_136.zip
+  ```
+
+### Create from backup
+
+- Create a task from backup file "task_backup.zip":
+  ```bash
+  cvat-cli task create-from-backup task_backup.zip
   ```
 
 ### Auto-annotate
@@ -271,13 +255,13 @@ It can auto-annotate using AA functions implemented in one of the following ways
 - Annotate the task with id 137 with the predefined torchvision detection function,
   which is parameterized:
   ```bash
-  cvat-cli auto-annotate 137 --function-module cvat_sdk.auto_annotation.functions.torchvision_detection \
+  cvat-cli task auto-annotate 137 --function-module cvat_sdk.auto_annotation.functions.torchvision_detection \
       -p model_name=str:fasterrcnn_resnet50_fpn_v2 -p box_score_thresh=float:0.5
   ```
 
 - Annotate the task with id 138 with an AA function defined in `my_func.py`:
   ```bash
-  cvat-cli auto-annotate 138 --function-file path/to/my_func.py
+  cvat-cli task auto-annotate 138 --function-file path/to/my_func.py
   ```
 
 Note that this command does not modify the Python module search path.
@@ -289,5 +273,5 @@ if it isn't there already.
   located in the `my-project` directory,
   letting it import other modules from that directory.
   ```bash
-  PYTHONPATH=path/to/my-project cvat-cli auto-annotate 139 --function-module my_func
+  PYTHONPATH=path/to/my-project cvat-cli task auto-annotate 139 --function-module my_func
   ```

--- a/site/content/en/docs/api_sdk/cli/_index.md
+++ b/site/content/en/docs/api_sdk/cli/_index.md
@@ -285,7 +285,7 @@ if it isn't there already.
 
 ### Create
 
-To create a project, you have to define its labels.
+While creating a project, you may optionally define its labels.
 The `project create` command accepts labels in the same format as the `task create` command;
 see that command's examples for more information.
 

--- a/site/content/en/docs/api_sdk/cli/_index.md
+++ b/site/content/en/docs/api_sdk/cli/_index.md
@@ -11,23 +11,23 @@ A simple command line interface for working with CVAT. At the moment it
 implements a basic feature set but may serve as the starting point for a more
 comprehensive CVAT administration tool in the future.
 
-Overview of functionality:
+The following subcommands are supported:
 
 - Projects:
-  - Create a new project
-  - Delete projects
-  - List all projects
+  - `create` - create a new project
+  - `delete` - delete projects
+  - `ls` - list all projects
 
 - Tasks:
-  - Create a new task
-  - Create a task from a backup file
-  - Delete tasks
-  - List all tasks
-  - Download frames from a task
-  - Export a task as a dataset
-  - Import annotations into a task from a dataset
-  - Back up a task
-  - Automatically annotate a task using a local function
+  - `create` - create a new task
+  - `create-from-backup` - create a task from a backup file
+  - `delete` - delete tasks
+  - `ls` - list all tasks
+  - `frames` - download frames from a task
+  - `export-dataset` - export a task as a dataset
+  - `import-dataset` - import annotations into a task from a dataset
+  - `backup` - back up a task
+  - `auto-annotate` - automatically annotate a task using a local function
 
 ## Installation
 

--- a/site/content/en/docs/api_sdk/cli/_index.md
+++ b/site/content/en/docs/api_sdk/cli/_index.md
@@ -294,6 +294,10 @@ see that command's examples for more information.
   ```bash
   cvat-cli project create "new project" --labels labels.json
   ```
+- Create a project from a dataset in the COCO format:
+  ```bash
+  cvat-cli project create "new project" --dataset_file coco.zip --dataset_format "COCO 1.0"
+  ```
 
 ### Delete
 

--- a/tests/python/cli/conftest.py
+++ b/tests/python/cli/conftest.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-from sdk.fixtures import fxt_client  # pylint: disable=unused-import
+from sdk.fixtures import *  # pylint: disable=unused-import

--- a/tests/python/cli/test_cli_misc.py
+++ b/tests/python/cli/test_cli_misc.py
@@ -22,7 +22,7 @@ class TestCliMisc(TestCliBase):
         # We don't actually run a separate process in the tests here, so it works
         monkeypatch.setattr(Client, "get_server_version", mocked_version)
 
-        self.run_cli("ls")
+        self.run_cli("task", "ls")
 
         assert "Server version '0' is not compatible with SDK version" in caplog.text
 
@@ -39,6 +39,7 @@ class TestCliMisc(TestCliBase):
                 f"--auth={self.user}:{self.password}",
                 f"--server-host={proxy_url}",
                 *insecure_args,
+                "task",
                 "ls",
                 expected_code=1 if verify else 0,
             )
@@ -55,6 +56,7 @@ class TestCliMisc(TestCliBase):
         files = generate_images(self.tmp_path, 1)
 
         stdout = self.run_cli(
+            "task",
             "create",
             "personal_task",
             ResourceType.LOCAL.name,
@@ -67,6 +69,7 @@ class TestCliMisc(TestCliBase):
         personal_task_id = int(stdout.split()[-1])
 
         stdout = self.run_cli(
+            "task",
             "create",
             "org_task",
             ResourceType.LOCAL.name,
@@ -78,14 +81,14 @@ class TestCliMisc(TestCliBase):
 
         org_task_id = int(stdout.split()[-1])
 
-        personal_task_ids = list(map(int, self.run_cli("ls", organization="").split()))
+        personal_task_ids = list(map(int, self.run_cli("task", "ls", organization="").split()))
         assert personal_task_id in personal_task_ids
         assert org_task_id not in personal_task_ids
 
-        org_task_ids = list(map(int, self.run_cli("ls", organization=org).split()))
+        org_task_ids = list(map(int, self.run_cli("task", "ls", organization=org).split()))
         assert personal_task_id not in org_task_ids
         assert org_task_id in org_task_ids
 
-        all_task_ids = list(map(int, self.run_cli("ls").split()))
+        all_task_ids = list(map(int, self.run_cli("task", "ls").split()))
         assert personal_task_id in all_task_ids
         assert org_task_id in all_task_ids

--- a/tests/python/cli/test_cli_misc.py
+++ b/tests/python/cli/test_cli_misc.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2022-2023 CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import json
+import os
+
+import packaging.version as pv
+import pytest
+from cvat_sdk import Client
+from cvat_sdk.api_client import models
+from cvat_sdk.core.proxies.tasks import ResourceType
+
+from .util import TestCliBase, generate_images, https_reverse_proxy, run_cli
+
+
+class TestCliMisc(TestCliBase):
+    def test_can_warn_on_mismatching_server_version(self, monkeypatch, caplog):
+        def mocked_version(_):
+            return pv.Version("0")
+
+        # We don't actually run a separate process in the tests here, so it works
+        monkeypatch.setattr(Client, "get_server_version", mocked_version)
+
+        self.run_cli("ls")
+
+        assert "Server version '0' is not compatible with SDK version" in caplog.text
+
+    @pytest.mark.parametrize("verify", [True, False])
+    def test_can_control_ssl_verification_with_arg(self, verify: bool):
+        with https_reverse_proxy() as proxy_url:
+            if verify:
+                insecure_args = []
+            else:
+                insecure_args = ["--insecure"]
+
+            run_cli(
+                self,
+                f"--auth={self.user}:{self.password}",
+                f"--server-host={proxy_url}",
+                *insecure_args,
+                "ls",
+                expected_code=1 if verify else 0,
+            )
+            stdout = self.stdout.getvalue()
+
+        if not verify:
+            for line in stdout.splitlines():
+                int(line)
+
+    def test_can_control_organization_context(self):
+        org = "cli-test-org"
+        self.client.organizations.create(models.OrganizationWriteRequest(org))
+
+        files = generate_images(self.tmp_path, 1)
+
+        stdout = self.run_cli(
+            "create",
+            "personal_task",
+            ResourceType.LOCAL.name,
+            *map(os.fspath, files),
+            "--labels=" + json.dumps([{"name": "person"}]),
+            "--completion_verification_period=0.01",
+            organization="",
+        )
+
+        personal_task_id = int(stdout.split()[-1])
+
+        stdout = self.run_cli(
+            "create",
+            "org_task",
+            ResourceType.LOCAL.name,
+            *map(os.fspath, files),
+            "--labels=" + json.dumps([{"name": "person"}]),
+            "--completion_verification_period=0.01",
+            organization=org,
+        )
+
+        org_task_id = int(stdout.split()[-1])
+
+        personal_task_ids = list(map(int, self.run_cli("ls", organization="").split()))
+        assert personal_task_id in personal_task_ids
+        assert org_task_id not in personal_task_ids
+
+        org_task_ids = list(map(int, self.run_cli("ls", organization=org).split()))
+        assert personal_task_id not in org_task_ids
+        assert org_task_id in org_task_ids
+
+        all_task_ids = list(map(int, self.run_cli("ls").split()))
+        assert personal_task_id in all_task_ids
+        assert org_task_id in all_task_ids

--- a/tests/python/cli/test_cli_projects.py
+++ b/tests/python/cli/test_cli_projects.py
@@ -30,11 +30,14 @@ class TestCliProjects(TestCliBase):
             "new_project",
             "--labels",
             json.dumps([{"name": "car"}, {"name": "person"}]),
+            "--bug_tracker",
+            "https://bugs.example/",
         )
 
         project_id = int(stdout.split()[-1])
         created_project = self.client.projects.retrieve(project_id)
         assert created_project.name == "new_project"
+        assert created_project.bug_tracker == "https://bugs.example/"
         assert {label.name for label in created_project.get_labels()} == {"car", "person"}
 
     def test_can_list_projects_in_simple_format(self, fxt_new_project: Project):

--- a/tests/python/cli/test_cli_projects.py
+++ b/tests/python/cli/test_cli_projects.py
@@ -33,7 +33,9 @@ class TestCliProjects(TestCliBase):
         )
 
         project_id = int(stdout.split()[-1])
-        assert self.client.projects.retrieve(project_id).name == "new_project"
+        created_project = self.client.projects.retrieve(project_id)
+        assert created_project.name == "new_project"
+        assert {label.name for label in created_project.get_labels()} == {"car", "person"}
 
     def test_can_list_projects_in_simple_format(self, fxt_new_project: Project):
         output = self.run_cli("project", "ls")

--- a/tests/python/cli/test_cli_tasks.py
+++ b/tests/python/cli/test_cli_tasks.py
@@ -280,3 +280,11 @@ class TestCliTasks(TestCliBase):
 
         annotations = fxt_new_task.get_annotations()
         assert annotations.shapes[0].type.value == "polygon"
+
+    def test_legacy_alias(self, caplog):
+        # All legacy aliases are implemented the same way;
+        # no need to test every single one.
+        self.run_cli("ls")
+
+        assert "deprecated" in caplog.text
+        assert "task ls" in caplog.text

--- a/tests/python/cli/test_cli_tasks.py
+++ b/tests/python/cli/test_cli_tasks.py
@@ -2,49 +2,22 @@
 #
 # SPDX-License-Identifier: MIT
 
-import io
 import json
 import os
 from pathlib import Path
-from typing import Optional
 
-import packaging.version as pv
 import pytest
-from cvat_sdk import Client, make_client
-from cvat_sdk.api_client import exceptions, models
+from cvat_sdk.api_client import exceptions
 from cvat_sdk.core.proxies.tasks import ResourceType, Task
 from PIL import Image
 
 from sdk.util import generate_coco_json
-from shared.utils.config import BASE_URL, USER_PASS
 from shared.utils.helpers import generate_image_file
 
-from .util import generate_images, https_reverse_proxy, run_cli
+from .util import TestCliBase, generate_images
 
 
-class TestCLI:
-    @pytest.fixture(autouse=True)
-    def setup(
-        self,
-        restore_db_per_function,  # force fixture call order to allow DB setup
-        restore_redis_inmem_per_function,
-        restore_redis_ondisk_per_function,
-        fxt_stdout: io.StringIO,
-        tmp_path: Path,
-        admin_user: str,
-    ):
-        self.tmp_path = tmp_path
-        self.stdout = fxt_stdout
-        self.host, self.port = BASE_URL.rsplit(":", maxsplit=1)
-        self.user = admin_user
-        self.password = USER_PASS
-        self.client = make_client(
-            host=self.host, port=self.port, credentials=(self.user, self.password)
-        )
-        self.client.config.status_check_period = 0.01
-
-        yield
-
+class TestCliTasks(TestCliBase):
     @pytest.fixture
     def fxt_image_file(self):
         img_path = self.tmp_path / "img_0.png"
@@ -85,27 +58,6 @@ class TestCLI:
         )
 
         return task
-
-    def run_cli(
-        self, cmd: str, *args: str, expected_code: int = 0, organization: Optional[str] = None
-    ) -> str:
-        common_args = [
-            f"--auth={self.user}:{self.password}",
-            f"--server-host={self.host}",
-            f"--server-port={self.port}",
-        ]
-
-        if organization is not None:
-            common_args.append(f"--organization={organization}")
-
-        run_cli(
-            self,
-            *common_args,
-            cmd,
-            *args,
-            expected_code=expected_code,
-        )
-        return self.stdout.getvalue()
 
     def test_can_create_task_from_local_images(self):
         files = generate_images(self.tmp_path, 5)
@@ -231,81 +183,6 @@ class TestCLI:
         assert task_id
         assert task_id != fxt_new_task.id
         assert self.client.tasks.retrieve(task_id).size == fxt_new_task.size
-
-    def test_can_warn_on_mismatching_server_version(self, monkeypatch, caplog):
-        def mocked_version(_):
-            return pv.Version("0")
-
-        # We don't actually run a separate process in the tests here, so it works
-        monkeypatch.setattr(Client, "get_server_version", mocked_version)
-
-        self.run_cli("ls")
-
-        assert "Server version '0' is not compatible with SDK version" in caplog.text
-
-    @pytest.mark.parametrize("verify", [True, False])
-    def test_can_control_ssl_verification_with_arg(self, verify: bool):
-        with https_reverse_proxy() as proxy_url:
-            if verify:
-                insecure_args = []
-            else:
-                insecure_args = ["--insecure"]
-
-            run_cli(
-                self,
-                f"--auth={self.user}:{self.password}",
-                f"--server-host={proxy_url}",
-                *insecure_args,
-                "ls",
-                expected_code=1 if verify else 0,
-            )
-            stdout = self.stdout.getvalue()
-
-        if not verify:
-            for line in stdout.splitlines():
-                int(line)
-
-    def test_can_control_organization_context(self):
-        org = "cli-test-org"
-        self.client.organizations.create(models.OrganizationWriteRequest(org))
-
-        files = generate_images(self.tmp_path, 1)
-
-        stdout = self.run_cli(
-            "create",
-            "personal_task",
-            ResourceType.LOCAL.name,
-            *map(os.fspath, files),
-            "--labels=" + json.dumps([{"name": "person"}]),
-            "--completion_verification_period=0.01",
-            organization="",
-        )
-
-        personal_task_id = int(stdout.split()[-1])
-
-        stdout = self.run_cli(
-            "create",
-            "org_task",
-            ResourceType.LOCAL.name,
-            *map(os.fspath, files),
-            "--labels=" + json.dumps([{"name": "person"}]),
-            "--completion_verification_period=0.01",
-            organization=org,
-        )
-
-        org_task_id = int(stdout.split()[-1])
-
-        personal_task_ids = list(map(int, self.run_cli("ls", organization="").split()))
-        assert personal_task_id in personal_task_ids
-        assert org_task_id not in personal_task_ids
-
-        org_task_ids = list(map(int, self.run_cli("ls", organization=org).split()))
-        assert personal_task_id not in org_task_ids
-        assert org_task_id in org_task_ids
-
-        all_task_ids = list(map(int, self.run_cli("ls").split()))
-        assert personal_task_id in all_task_ids
-        assert org_task_id in all_task_ids
 
     def test_auto_annotate_with_module(self, fxt_new_task: Task):
         annotations = fxt_new_task.get_annotations()


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Currently, the CLI has one level of subcommands, and all subcommands work on tasks. This leaves no room for subcommands that work on other CVAT resources.

This change redesigns the CLI interface by adding another level of subcommand hierarchy. Instead of running `cvat-cli <action>`, the user will now run `cvat-cli <resource> <action>`. Previously available commands are left available as deprecated aliases.

As a proof of concept, this PR adds some basic project actions.

I have also used this opportunity to correct some of the task action names, specifically `export`, `import`, `dump` and `upload`. These names don't correspond to either SDK function names, API endpoints, or UI labels corresponding to these actions. In the new subcommand hierarchy, I renamed those commands to `backup`, `create-from-backup`, `export-dataset` and `import-dataset`, which are more consistent with how other CVAT components call these actions.

I rewrote the introduction and usage sections of the cli README and reference in order to reduce clutter and remove the need to resynchronize the help output after every interface change.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
CLI tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new CLI commands for project management: `project create`, `project delete`, `project ls`.
  - Enhanced SDK functionality to support batch deletion of projects and tasks.
  
- **Documentation**
  - Updated CLI documentation to reflect new command structure and added detailed sections for projects and tasks.
  
- **Bug Fixes**
  - Improved error handling and logging for CLI commands, ensuring better user feedback on command execution.

- **Tests**
  - Added comprehensive tests for new project and task CLI commands, ensuring functionality and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->