### PR TITLE
Fix image renaming collisions by appending UUID in mangle_image_name

### DIFF
--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os.path as osp
 import re
 import sys
+import uuid
 from collections import OrderedDict, defaultdict
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from functools import reduce
@@ -1897,8 +1898,9 @@ def mangle_image_name(name: str, subset: str, names: defaultdict[tuple[str, str]
             return osp.extsep.join([image_name, ext])
         else:
             i = 1
+            uid = uuid.uuid4().hex
             while i < sys.maxsize:
-                new_image_name = f"{image_name}_{i}"
+                new_image_name = f"{image_name}_{uid}"
                 if not names[(subset, new_image_name)]:
                     names[(subset, name)] += 1
                     return osp.extsep.join([new_image_name, ext])


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->
Instead of appending an incremental integer to the end of files with colliding names we append a unique identifier, uuid. 

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
https://github.com/cvat-ai/cvat/issues/8076
This change is required because currently, when you try to export a project that contains multiple tasks with the same image name, some can be overwritten on export.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced image naming system to ensure unique names using UUIDs.
  
- **Bug Fixes**
	- Improved error handling for image name generation conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->