### PR TITLE
Fix instructions for running tests

### DIFF
--- a/tests/python/README.md
+++ b/tests/python/README.md
@@ -20,14 +20,16 @@ the server calling REST API directly (as it done by users).
 ## How to run?
 **Initial steps**
 
-1. Follow [this guide](../../site/content/en/docs/api_sdk/sdk/developer-guide.md) to prepare
-   `cvat-sdk` and `cvat-cli` source code
-1. Install all necessary requirements before running REST API tests:
+1. On Debian/Ubuntu, make sure that your ```$USER``` is in ```docker``` group:
+   ```
+   sudo usermod -aG docker $USER
+   ```
+1. Install ```pytest``` and the required plugins:
    ```
    pip install -r ./tests/python/requirements.txt
-   pip install -e ./cvat-sdk
-   pip install -e ./cvat-cli
    ```
+1. Follow [this guide](../../site/content/en/docs/api_sdk/sdk/developer-guide.md) to prepare
+   `cvat-sdk` and `cvat-cli` source code
 1. Stop any other CVAT containers which you run previously. They keep ports
 which are used by containers for the testing system.
 

--- a/tests/python/README.md
+++ b/tests/python/README.md
@@ -20,16 +20,16 @@ the server calling REST API directly (as it done by users).
 ## How to run?
 **Initial steps**
 
-1. On Debian/Ubuntu, make sure that your ```$USER``` is in ```docker``` group:
-   ```
+1. On Debian/Ubuntu, make sure that your `$USER` is in `docker` group:
+   ```shell
    sudo usermod -aG docker $USER
-   ```
-1. Install ```pytest``` and the required plugins:
-   ```
-   pip install -r ./tests/python/requirements.txt
    ```
 1. Follow [this guide](../../site/content/en/docs/api_sdk/sdk/developer-guide.md) to prepare
    `cvat-sdk` and `cvat-cli` source code
+1. Install all necessary requirements before running REST API tests:
+   ```shell
+   pip install -r ./tests/python/requirements.txt
+   ```
 1. Stop any other CVAT containers which you run previously. They keep ports
 which are used by containers for the testing system.
 


### PR DESCRIPTION
Update instructions for running tests:

- for running docker without sudo, the user has to be in docker group (as per Docker's [Linux post-install](https://docs.docker.com/engine/install/linux-postinstall/))

- pytest and plugins should be installed before the referenced guide (failed otherwise)

- the referenced guide already has instructions for installing the local packages, no need to duplicate it here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated instructions for setting up and running the testing infrastructure for REST API v2.0.
	- Clarified requirements for user permissions on Debian/Ubuntu systems.
	- Restructured installation instructions for `pytest` and related plugins for better clarity.
	- Expanded section on running tests to highlight automatic Docker container management.
	- Enhanced readability of backup and restore instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->