### PR TITLE
Update pip install command for local packages

### DIFF
--- a/site/content/en/docs/api_sdk/sdk/developer-guide.md
+++ b/site/content/en/docs/api_sdk/sdk/developer-guide.md
@@ -39,8 +39,8 @@ the repository. To get the full package, one need to generate missing package fi
    If you want to edit package files, install them with `-e`:
 
    ```bash
-   pip install -e ./cvat-sdk/
-   pip install -e ./cvat-cli/
+   pip install -e ./cvat-sdk
+   pip install -e ./cvat-cli
    ```
 
 ## How to edit templates

--- a/site/content/en/docs/api_sdk/sdk/developer-guide.md
+++ b/site/content/en/docs/api_sdk/sdk/developer-guide.md
@@ -32,8 +32,8 @@ the repository. To get the full package, one need to generate missing package fi
 1. Install the packages:
 
    ```bash
-   pip install cvat-sdk/
-   pip install cvat-cli/
+   pip install ./cvat-sdk
+   pip install ./cvat-cli
    ```
 
    If you want to edit package files, install them with `-e`:

--- a/site/content/en/docs/api_sdk/sdk/developer-guide.md
+++ b/site/content/en/docs/api_sdk/sdk/developer-guide.md
@@ -39,8 +39,8 @@ the repository. To get the full package, one need to generate missing package fi
    If you want to edit package files, install them with `-e`:
 
    ```bash
-   pip install -e cvat-sdk/
-   pip install -e cvat-cli/
+   pip install -e ./cvat-sdk/
+   pip install -e ./cvat-cli/
    ```
 
 ## How to edit templates


### PR DESCRIPTION
```pip install cvat-sdk/``` command is error-prone, the user can easily forget the slash and start downloading from PyPI, which is not required. To avoid this, it's better to write explicitly with current directory in mind



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated installation instructions for enhanced clarity.
	- Introduced Python type annotations for improved type compatibility.
	- Restructured `ApiClient` for streamlined API usage.
	- Added cookie management and interface classes for models.
	- Enabled passing dictionaries into API methods for easier model parsing.

- **Bug Fixes**
	- Improved readability of operation IDs.
	- Clarified separation of input and output types for server operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->