### PR TITLE
Add option to SDK allowing upload of annotation as masks instead of polygon.

### DIFF
--- a/changelog.d/20241212_185016_knotekjaroslav_add_mask_poly_conv_param.md
+++ b/changelog.d/20241212_185016_knotekjaroslav_add_mask_poly_conv_param.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added parameter `conv_mask_to_poly` support for importing annotations in projects,tasks and jobs

--- a/changelog.d/20241212_185016_knotekjaroslav_add_mask_poly_conv_param.md
+++ b/changelog.d/20241212_185016_knotekjaroslav_add_mask_poly_conv_param.md
@@ -1,4 +1,8 @@
 ### Added <!-- pick one -->
 
-- Added parameter `conv_mask_to_poly` to SDK's `project.export_dataset` method to allow conversion upon adding annotations.
-  (<https://github.com/cvat-ai/cvat/pull/feature/add_mask_poly_conv_param>)
+Added parameter `conv_mask_to_poly` to the following SDK methods to control mask-to-polygon conversion:
+- `project.export_dataset`
+- `project.import_dataset`
+- `project.create_from_dataset`
+- `DatasetUploader.upload_file_and_wait`
+([#8823](https://github.com/cvat-ai/cvat/pull/8823))

--- a/changelog.d/20241212_185016_knotekjaroslav_add_mask_poly_conv_param.md
+++ b/changelog.d/20241212_185016_knotekjaroslav_add_mask_poly_conv_param.md
@@ -1,0 +1,4 @@
+### Added <!-- pick one -->
+
+- Added parameter `conv_mask_to_poly` to SDK's `project.export_dataset` method to allow conversion upon adding annotations.
+  (<https://github.com/cvat-ai/cvat/pull/feature/add_mask_poly_conv_param>)

--- a/changelog.d/20241212_185016_knotekjaroslav_add_mask_poly_conv_param.md
+++ b/changelog.d/20241212_185016_knotekjaroslav_add_mask_poly_conv_param.md
@@ -1,7 +1,6 @@
 ### Added <!-- pick one -->
 
 Added parameter `conv_mask_to_poly` to the following SDK methods to control mask-to-polygon conversion:
-- `project.export_dataset`
 - `project.import_dataset`
 - `project.create_from_dataset`
 - `DatasetUploader.upload_file_and_wait`

--- a/changelog.d/20241212_185016_knotekjaroslav_add_mask_poly_conv_param.md
+++ b/changelog.d/20241212_185016_knotekjaroslav_add_mask_poly_conv_param.md
@@ -1,7 +1,0 @@
-### Added <!-- pick one -->
-
-Added parameter `conv_mask_to_poly` to the following SDK methods to control mask-to-polygon conversion:
-- `project.import_dataset`
-- `project.create_from_dataset`
-- `DatasetUploader.upload_file_and_wait`
-([#8823](https://github.com/cvat-ai/cvat/pull/8823))

--- a/changelog.d/20241212_185016_knotekjaroslav_add_mask_poly_conv_param.md
+++ b/changelog.d/20241212_185016_knotekjaroslav_add_mask_poly_conv_param.md
@@ -1,3 +1,4 @@
 ### Added
 
 - Added parameter `conv_mask_to_poly` support for importing annotations in projects,tasks and jobs
+  (<https://github.com/cvat-ai/cvat/pull/8823>)

--- a/cvat-sdk/cvat_sdk/core/proxies/jobs.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/jobs.py
@@ -49,6 +49,7 @@ class Job(
         format_name: str,
         filename: StrPath,
         *,
+        conv_mask_to_poly: Optional[bool] = None,
         status_check_period: Optional[int] = None,
         pbar: Optional[ProgressReporter] = None,
     ):
@@ -62,6 +63,7 @@ class Job(
             self.api.create_annotations_endpoint,
             filename,
             format_name,
+            conv_mask_to_poly=conv_mask_to_poly,
             url_params={"id": self.id},
             pbar=pbar,
             status_check_period=status_check_period,

--- a/cvat-sdk/cvat_sdk/core/proxies/projects.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/projects.py
@@ -49,6 +49,7 @@ class Project(
         format_name: str,
         filename: StrPath,
         *,
+        conv_mask_to_poly: Optional[bool] = None,
         status_check_period: Optional[int] = None,
         pbar: Optional[ProgressReporter] = None,
     ):
@@ -63,6 +64,7 @@ class Project(
             filename,
             format_name,
             url_params={"id": self.id},
+            conv_mask_to_poly: Optional[bool] = None,
             pbar=pbar,
             status_check_period=status_check_period,
         )
@@ -110,6 +112,7 @@ class ProjectsRepo(
         dataset_format: str = "CVAT XML 1.1",
         status_check_period: int = None,
         pbar: Optional[ProgressReporter] = None,
+        conv_mask_to_poly: Optional[bool] = None,
     ) -> Project:
         """
         Create a new project with the given name and labels JSON and

--- a/cvat-sdk/cvat_sdk/core/proxies/projects.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/projects.py
@@ -129,6 +129,7 @@ class ProjectsRepo(
                 filename=dataset_path,
                 pbar=pbar,
                 status_check_period=status_check_period,
+                conv_mask_to_poly=conv_mask_to_poly,
             )
 
         project.fetch()

--- a/cvat-sdk/cvat_sdk/core/proxies/projects.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/projects.py
@@ -64,7 +64,7 @@ class Project(
             filename,
             format_name,
             url_params={"id": self.id},
-            conv_mask_to_poly: Optional[bool] = None,
+            conv_mask_to_poly=conv_mask_to_poly,
             pbar=pbar,
             status_check_period=status_check_period,
         )

--- a/cvat-sdk/cvat_sdk/core/proxies/tasks.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/tasks.py
@@ -165,6 +165,7 @@ class Task(
         format_name: str,
         filename: StrPath,
         *,
+        conv_mask_to_poly: Optional[bool] = None,
         status_check_period: Optional[int] = None,
         pbar: Optional[ProgressReporter] = None,
     ):
@@ -179,6 +180,7 @@ class Task(
             filename,
             format_name,
             url_params={"id": self.id},
+            conv_mask_to_poly=conv_mask_to_poly,
             pbar=pbar,
             status_check_period=status_check_period,
         )

--- a/cvat-sdk/cvat_sdk/core/uploading.py
+++ b/cvat-sdk/cvat_sdk/core/uploading.py
@@ -281,11 +281,17 @@ class DatasetUploader(Uploader):
         format_name: str,
         *,
         url_params: Optional[dict[str, Any]] = None,
+        conv_mask_to_poly: Optional[bool] = None,
         pbar: Optional[ProgressReporter] = None,
         status_check_period: Optional[int] = None,
     ):
         url = self._client.api_map.make_endpoint_url(upload_endpoint.path, kwsub=url_params)
         params = {"format": format_name, "filename": filename.name}
+
+        if conv_mask_top_poly is not None:
+            value = "true" if conv_mask_to_poly else "false"
+            params["conv_mask_to_poly"] = value
+
         response = self.upload_file(
             url, filename, pbar=pbar, query_params=params, meta={"filename": params["filename"]}
         )

--- a/cvat-sdk/cvat_sdk/core/uploading.py
+++ b/cvat-sdk/cvat_sdk/core/uploading.py
@@ -269,8 +269,7 @@ class AnnotationUploader(Uploader):
         )
 
         if conv_mask_to_poly is not None:
-            value = "true" if conv_mask_to_poly else "false"
-            params["conv_mask_to_poly"] = value
+            params["conv_mask_to_poly"] = "true" if conv_mask_to_poly else "false"
 
         rq_id = json.loads(response.data).get("rq_id")
         assert rq_id, "The rq_id was not found in the response"

--- a/cvat-sdk/cvat_sdk/core/uploading.py
+++ b/cvat-sdk/cvat_sdk/core/uploading.py
@@ -294,8 +294,7 @@ class DatasetUploader(Uploader):
         params = {"format": format_name, "filename": filename.name}
 
         if conv_mask_to_poly is not None:
-            value = "true" if conv_mask_to_poly else "false"
-            params["conv_mask_to_poly"] = value
+            params["conv_mask_to_poly"] = "true" if conv_mask_to_poly else "false"
 
         response = self.upload_file(
             url, filename, pbar=pbar, query_params=params, meta={"filename": params["filename"]}

--- a/cvat-sdk/cvat_sdk/core/uploading.py
+++ b/cvat-sdk/cvat_sdk/core/uploading.py
@@ -288,7 +288,7 @@ class DatasetUploader(Uploader):
         url = self._client.api_map.make_endpoint_url(upload_endpoint.path, kwsub=url_params)
         params = {"format": format_name, "filename": filename.name}
 
-        if conv_mask_top_poly is not None:
+        if conv_mask_to_poly is not None:
             value = "true" if conv_mask_to_poly else "false"
             params["conv_mask_to_poly"] = value
 

--- a/cvat-sdk/cvat_sdk/core/uploading.py
+++ b/cvat-sdk/cvat_sdk/core/uploading.py
@@ -257,6 +257,7 @@ class AnnotationUploader(Uploader):
         filename: Path,
         format_name: str,
         *,
+        conv_mask_to_poly: Optional[bool] = None,
         url_params: Optional[dict[str, Any]] = None,
         pbar: Optional[ProgressReporter] = None,
         status_check_period: Optional[int] = None,
@@ -266,6 +267,10 @@ class AnnotationUploader(Uploader):
         response = self.upload_file(
             url, filename, pbar=pbar, query_params=params, meta={"filename": params["filename"]}
         )
+
+        if conv_mask_to_poly is not None:
+            value = "true" if conv_mask_to_poly else "false"
+            params["conv_mask_to_poly"] = value
 
         rq_id = json.loads(response.data).get("rq_id")
         assert rq_id, "The rq_id was not found in the response"

--- a/cvat/apps/engine/cache.py
+++ b/cvat/apps/engine/cache.py
@@ -37,13 +37,13 @@ import django_rq
 import PIL.Image
 import PIL.ImageOps
 import rq
-from rq.job import JobStatus as RQJobStatus
 from django.conf import settings
 from django.core.cache import caches
 from django.db import models as django_models
 from django.utils import timezone as django_tz
 from redis.exceptions import LockError
 from rest_framework.exceptions import NotFound, ValidationError
+from rq.job import JobStatus as RQJobStatus
 
 from cvat.apps.engine import models
 from cvat.apps.engine.cloud_provider import (
@@ -91,7 +91,8 @@ def enqueue_create_chunk_job(
                 # Enqueue the job if the chunk was deleted but the RQ job still exists.
                 # This can happen in cases involving jobs with honeypots and
                 # if the job wasn't collected by the requesting process for any reason.
-                rq_job.get_status(refresh=False) in {RQJobStatus.FINISHED, RQJobStatus.FAILED, RQJobStatus.CANCELED}
+                rq_job.get_status(refresh=False)
+                in {RQJobStatus.FINISHED, RQJobStatus.FAILED, RQJobStatus.CANCELED}
             ):
                 rq_job = queue.enqueue(
                     create_callback,

--- a/tests/python/sdk/fixtures.py
+++ b/tests/python/sdk/fixtures.py
@@ -78,13 +78,13 @@ def fxt_camvid_dataset(tmp_path: Path):
 
     label_colors_path = tmp_path / "label_colors.txt"
     with open(label_colors_path, "w") as f:
-        f.write(f"{r} {g} {b} ROI\n")
+        f.write(f"{r} {g} {b} car\n")
 
     dataset_img_path = "default/img.png"
     dataset_annot_path = "default/annot.png"
     default_txt_path = tmp_path / "default.txt"
     with open(default_txt_path, "w") as f:
-        f.write(f"{dataset_img_path} {dataset_annot_path}")
+        f.write(f"/{dataset_img_path} {dataset_annot_path}")
 
     dataset_path = tmp_path / "camvid_dataset.zip"
     with ZipFile(dataset_path, "x") as f:

--- a/tests/python/sdk/fixtures.py
+++ b/tests/python/sdk/fixtures.py
@@ -61,6 +61,42 @@ def fxt_login(admin_user: str, restore_db_per_class):
 
 
 @pytest.fixture
+def fxt_camvid_dataset(tmp_path: Path):
+    img_path = tmp_path / "img.png"
+    with img_path.open("wb") as f:
+        f.write(generate_image_file(filename=str(img_path), size=(5, 10)).getvalue())
+
+    annot_path = tmp_path / "annot.png"
+    r,g,b = (127,0,0)
+    annot = generate_image_file(
+        filename=str(annot_path),
+        size=(5, 10),
+        color=(r, g, b),
+    ).getvalue()
+    with annot_path.open("wb") as f:
+        f.write(annot)
+
+    label_colors_path = tmp_path / "label_colors.txt"
+    with open(label_colors_path, "w") as f:
+        f.write(f"{r} {g} {b} ROI\n")
+
+    dataset_img_path = "default/img.png"
+    dataset_annot_path = "default/annot.png"
+    default_txt_path = tmp_path / "default.txt"
+    with open(default_txt_path, "w") as f:
+        f.write(f"{dataset_img_path} {dataset_annot_path}")
+
+    dataset_path = tmp_path / "camvid_dataset.zip"
+    with ZipFile(dataset_path, "x") as f:
+        f.write(img_path, arcname=dataset_img_path)
+        f.write(annot_path, arcname=dataset_annot_path)
+        f.write(default_txt_path, arcname="default.txt")
+        f.write(label_colors_path, arcname="label_colors.txt")
+
+    yield dataset_path
+
+
+@pytest.fixture
 def fxt_coco_dataset(tmp_path: Path, fxt_image_file: Path, fxt_coco_file: Path):
     dataset_path = tmp_path / "coco_dataset.zip"
     with ZipFile(dataset_path, "x") as f:

--- a/tests/python/sdk/fixtures.py
+++ b/tests/python/sdk/fixtures.py
@@ -67,7 +67,7 @@ def fxt_camvid_dataset(tmp_path: Path):
         f.write(generate_image_file(filename=str(img_path), size=(5, 10)).getvalue())
 
     annot_path = tmp_path / "annot.png"
-    r,g,b = (127,0,0)
+    r, g, b = (127, 0, 0)
     annot = generate_image_file(
         filename=str(annot_path),
         size=(5, 10),

--- a/tests/python/sdk/test_projects.py
+++ b/tests/python/sdk/test_projects.py
@@ -164,16 +164,16 @@ class TestProjectUsecases(TestDatasetExport):
 
     @pytest.mark.parametrize("convert", [True, False])
     def test_can_create_project_from_dataset_with_polygons_to_masks_param(
-            self, fxt_coco_dataset: Path, convert: bool
+            self, fxt_camvid_dataset: Path, convert: bool
         ):
         pbar_out = io.StringIO()
         pbar = make_pbar(file=pbar_out)
 
         project = self.client.projects.create_from_dataset(
             spec=models.ProjectWriteRequest(name="project with data"),
-            dataset_path=fxt_coco_dataset,
-            dataset_format="COCO 1.0",
-            conv_mask_to_poly=False,
+            dataset_path=fxt_camvid_dataset,
+            dataset_format="Camvid 1.0",
+            conv_mask_to_poly=convert,
             pbar=pbar,
         )
 

--- a/tests/python/sdk/test_projects.py
+++ b/tests/python/sdk/test_projects.py
@@ -164,8 +164,8 @@ class TestProjectUsecases(TestDatasetExport):
 
     @pytest.mark.parametrize("convert", [True, False])
     def test_can_create_project_from_dataset_with_polygons_to_masks_param(
-            self, fxt_camvid_dataset: Path, convert: bool
-        ):
+        self, fxt_camvid_dataset: Path, convert: bool
+    ):
         pbar_out = io.StringIO()
         pbar = make_pbar(file=pbar_out)
 
@@ -183,10 +183,9 @@ class TestProjectUsecases(TestDatasetExport):
 
         task = project.get_tasks()[0]
         imported_annotations = task.get_annotations()
-        assert all([
-            s.type.value == "polygon" if convert else "mask"
-            for s in imported_annotations.shapes
-        ])
+        assert all(
+            [s.type.value == "polygon" if convert else "mask" for s in imported_annotations.shapes]
+        )
 
     def test_can_retrieve_project(self, fxt_new_project: Project):
         project_id = fxt_new_project.id

--- a/tests/python/sdk/test_projects.py
+++ b/tests/python/sdk/test_projects.py
@@ -172,7 +172,7 @@ class TestProjectUsecases(TestDatasetExport):
         project = self.client.projects.create_from_dataset(
             spec=models.ProjectWriteRequest(name="project with data"),
             dataset_path=fxt_camvid_dataset,
-            dataset_format="Camvid 1.0",
+            dataset_format="CamVid 1.0",
             conv_mask_to_poly=convert,
             pbar=pbar,
         )

--- a/tests/python/sdk/test_projects.py
+++ b/tests/python/sdk/test_projects.py
@@ -162,7 +162,10 @@ class TestProjectUsecases(TestDatasetExport):
         assert "100%" in pbar_out.getvalue().strip("\r").split("\r")[-1]
         assert self.stdout.getvalue() == ""
 
-    def test_can_create_project_from_dataset_without_poly_masks(self, fxt_coco_dataset: Path):
+    @pytest.mark.parametrize("convert", [True, False])
+    def test_can_create_project_from_dataset_with_polygons_to_masks_param(
+            self, fxt_coco_dataset: Path, convert: bool
+        ):
         pbar_out = io.StringIO()
         pbar = make_pbar(file=pbar_out)
 
@@ -178,6 +181,12 @@ class TestProjectUsecases(TestDatasetExport):
         assert "100%" in pbar_out.getvalue().strip("\r").split("\r")[-1]
         assert self.stdout.getvalue() == ""
 
+        task = project.get_tasks()[0]
+        imported_annotations = task.get_annotations()
+        assert all([
+            s.type.value == "polygon" if convert else "mask"
+            for s in imported_annotations.shapes
+        ])
 
     def test_can_retrieve_project(self, fxt_new_project: Project):
         project_id = fxt_new_project.id

--- a/tests/python/sdk/test_projects.py
+++ b/tests/python/sdk/test_projects.py
@@ -168,7 +168,6 @@ class TestProjectUsecases(TestDatasetExport):
     ):
         pbar_out = io.StringIO()
         pbar = make_pbar(file=pbar_out)
-
         project = self.client.projects.create_from_dataset(
             spec=models.ProjectWriteRequest(name="project with data"),
             dataset_path=fxt_camvid_dataset,

--- a/tests/python/sdk/test_projects.py
+++ b/tests/python/sdk/test_projects.py
@@ -162,6 +162,23 @@ class TestProjectUsecases(TestDatasetExport):
         assert "100%" in pbar_out.getvalue().strip("\r").split("\r")[-1]
         assert self.stdout.getvalue() == ""
 
+    def test_can_create_project_from_dataset_without_poly_masks(self, fxt_coco_dataset: Path):
+        pbar_out = io.StringIO()
+        pbar = make_pbar(file=pbar_out)
+
+        project = self.client.projects.create_from_dataset(
+            spec=models.ProjectWriteRequest(name="project with data"),
+            dataset_path=fxt_coco_dataset,
+            dataset_format="COCO 1.0",
+            conv_mask_to_poly=False,
+            pbar=pbar,
+        )
+
+        assert project.get_tasks()[0].size == 1
+        assert "100%" in pbar_out.getvalue().strip("\r").split("\r")[-1]
+        assert self.stdout.getvalue() == ""
+
+
     def test_can_retrieve_project(self, fxt_new_project: Project):
         project_id = fxt_new_project.id
 

--- a/tests/python/sdk/test_tasks.py
+++ b/tests/python/sdk/test_tasks.py
@@ -397,15 +397,28 @@ class TestTaskUsecases(TestDatasetExport):
             assert len(chunk_zip.infolist()) == 1
         assert self.stdout.getvalue() == ""
 
-    def test_can_upload_annotations(self, fxt_new_task: Task, fxt_coco_file: Path):
+    @pytest.mark.parametrize("convert", [True, False])
+    def test_can_upload_annotations(
+        self, fxt_new_task: Task, fxt_camvid_dataset: Path, convert: bool
+    ):
         pbar_out = io.StringIO()
         pbar = make_pbar(file=pbar_out)
 
-        fxt_new_task.import_annotations(format_name="COCO 1.0", filename=fxt_coco_file, pbar=pbar)
+        fxt_new_task.import_annotations(
+            format_name="COCO 1.0",
+            filename=fxt_camvid_dataset,
+            conv_mask_to_poly=convert,
+            pbar=pbar,
+        )
 
         assert "uploaded" in self.logger_stream.getvalue()
         assert "100%" in pbar_out.getvalue().strip("\r").split("\r")[-1]
         assert self.stdout.getvalue() == ""
+
+        imported_annotations = fxt_new_task.get_jobs()[0].get_annotations()
+        assert all(
+            [s.type.value == "polygon" if convert else "mask" for s in imported_annotations.shapes]
+        )
 
     def _test_can_create_from_backup(self, fxt_new_task: Task, fxt_backup_file: Path):
         pbar_out = io.StringIO()

--- a/tests/python/sdk/test_tasks.py
+++ b/tests/python/sdk/test_tasks.py
@@ -405,7 +405,7 @@ class TestTaskUsecases(TestDatasetExport):
         pbar = make_pbar(file=pbar_out)
 
         fxt_new_task.import_annotations(
-            format_name="COCO 1.0",
+            format_name="CamVid 1.0",
             filename=fxt_camvid_dataset,
             conv_mask_to_poly=convert,
             pbar=pbar,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context

I am using SDK to create project with pre-annotations. Having data in Camvid 1.0 format, I create a project and upload annotations using the following code:

```
project_request = ProjectWriteRequest(
    name="Project",
    labels= [
        PatchedLabelRequest(
            name="FG",
            attributes=[],
            type="mask",
            color="#1dff1d",
        )
    ],
    target_storage=PatchedProjectWriteRequestTargetStorage(),
    source_storage=PatchedProjectWriteRequestTargetStorage(),
)
project_response = client.projects.create_from_dataset(
    project_request,
    dataset_path = dataset_path,
    dataset_format=annotations_format,
)
```

After that I noticed that the mask-type annotations are represented as polygons which is the problem I wanted to overcome by implementing `conv_mask_to_poly` parameter to `create_from_dataset` method above



<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

This change corresponds to the UI toggle **Convert Masks to Polygons**. Which does exactly the same.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Given the impact of this change, no extensive tests were done appart of running the code.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
~~- [ ] I have updated the documentation accordingly~~ I looked around the code and there were no docsstrings/comments to update
- [x] I have added tests to cover my changes
~~- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new parameter for converting masks to polygon format during dataset export and import.
	- Enhanced the uploading process to support mask conversion options.

- **Bug Fixes**
	- Corrected a reference error in the upload method related to mask conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->