### PR TITLE
CLI: make the output of `create` commands machine-readable

### DIFF
--- a/changelog.d/20241216_144316_roman_machine_readable_create.md
+++ b/changelog.d/20241216_144316_roman_machine_readable_create.md
@@ -1,0 +1,6 @@
+### Changed
+
+- \[CLI\] The output of the `task create`, `task create-from-backup` and
+  `project create` commands is now just the created resource ID,
+  making it machine-readable
+  (<https://github.com/cvat-ai/cvat/pull/8833>)

--- a/cvat-cli/src/cvat_cli/_internal/commands_projects.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_projects.py
@@ -83,7 +83,7 @@ class ProjectCreate:
             dataset_format=dataset_format,
             status_check_period=status_check_period,
         )
-        print(f"Created project ID {project.id}")
+        print(project.id)
 
 
 @COMMANDS.command_class("delete")

--- a/cvat-cli/src/cvat_cli/_internal/commands_tasks.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_tasks.py
@@ -226,7 +226,7 @@ class TaskCreate:
             status_check_period=status_check_period,
             pbar=DeferredTqdmProgressReporter(),
         )
-        print("Created task id", task.id)
+        print(task.id)
 
 
 @COMMANDS.command_class("delete")
@@ -406,7 +406,7 @@ class TaskCreateFromBackup:
             status_check_period=status_check_period,
             pbar=DeferredTqdmProgressReporter(),
         )
-        print(f"Created task ID", task.id)
+        print(task.id)
 
 
 @COMMANDS.command_class("auto-annotate")

--- a/tests/python/cli/test_cli_projects.py
+++ b/tests/python/cli/test_cli_projects.py
@@ -35,7 +35,7 @@ class TestCliProjects(TestCliBase):
             "https://bugs.example/",
         )
 
-        project_id = int(stdout.split()[-1])
+        project_id = int(stdout.rstrip("\n"))
         created_project = self.client.projects.retrieve(project_id)
         assert created_project.name == "new_project"
         assert created_project.bug_tracker == "https://bugs.example/"
@@ -52,7 +52,7 @@ class TestCliProjects(TestCliBase):
             "COCO 1.0",
         )
 
-        project_id = int(stdout.split()[-1])
+        project_id = int(stdout.rstrip("\n"))
         created_project = self.client.projects.retrieve(project_id)
         assert created_project.name == "new_project"
         assert {label.name for label in created_project.get_labels()} == {"car", "person"}

--- a/tests/python/cli/test_cli_tasks.py
+++ b/tests/python/cli/test_cli_tasks.py
@@ -74,7 +74,7 @@ class TestCliTasks(TestCliBase):
             "0.01",
         )
 
-        task_id = int(stdout.split()[-1])
+        task_id = int(stdout.rstrip("\n"))
         assert self.client.tasks.retrieve(task_id).size == 5
 
     def test_can_create_task_from_local_images_with_parameters(self):
@@ -102,7 +102,7 @@ class TestCliTasks(TestCliBase):
             "http://localhost/bug",
         )
 
-        task_id = int(stdout.split()[-1])
+        task_id = int(stdout.rstrip("\n"))
         task = self.client.tasks.retrieve(task_id)
         frames = task.get_frames_info()
         assert [f.name for f in frames] == [
@@ -191,7 +191,7 @@ class TestCliTasks(TestCliBase):
     def test_can_create_from_backup(self, fxt_new_task: Task, fxt_backup_file: Path):
         stdout = self.run_cli("task", "create-from-backup", str(fxt_backup_file))
 
-        task_id = int(stdout.split()[-1])
+        task_id = int(stdout.rstrip("\n"))
         assert task_id
         assert task_id != fxt_new_task.id
         assert self.client.tasks.retrieve(task_id).size == fxt_new_task.size


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The underlying SDK functions already emit human-friendly log messages with the ID of the created resource. Instead of printing largely the same message twice, we can just print the ID. That way, the CLI can be more easily integrated into other software.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
CLI tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined command-line output for project and task creation commands, now displaying only the resource ID.
  
- **Bug Fixes**
	- Improved robustness in extracting project and task IDs from command-line output by addressing trailing whitespace issues.

- **Tests**
	- Updated test methods to enhance ID extraction reliability, ensuring consistent handling of output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->