### PR TITLE
ignore deleted frames when converting tracks to shapes

### DIFF
--- a/changelog.d/20241216_211239_dmitrii.lavrukhin_deleted_track_keyframe.md
+++ b/changelog.d/20241216_211239_dmitrii.lavrukhin_deleted_track_keyframe.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed handling of tracks keyframes from deleted frames on export
+  (<https://github.com/cvat-ai/cvat/pull/8834>)

--- a/cvat/apps/dataset_manager/annotation.py
+++ b/cvat/apps/dataset_manager/annotation.py
@@ -7,7 +7,7 @@ from copy import copy, deepcopy
 
 import math
 from collections.abc import Container, Sequence
-from typing import Optional
+from typing import Collection, Optional
 import numpy as np
 from itertools import chain
 from scipy.optimize import linear_sum_assignment
@@ -199,12 +199,14 @@ class AnnotationManager:
             # Tracks are not expected in the cases this function is supposed to be used
             raise AssertionError("Partial annotation cleanup is not supported for tracks")
 
-    def to_shapes(self,
+    def to_shapes(
+        self,
         end_frame: int,
         *,
         included_frames: Optional[Sequence[int]] = None,
         include_outside: bool = False,
-        use_server_track_ids: bool = False
+        use_server_track_ids: bool = False,
+        deleted_frames: Optional[Collection[int]] = None,
     ) -> list:
         shapes = self.data.shapes
         tracks = TrackManager(self.data.tracks, dimension=self.dimension)
@@ -212,9 +214,12 @@ class AnnotationManager:
         if included_frames is not None:
             shapes = [s for s in shapes if s["frame"] in included_frames]
 
-        return shapes + tracks.to_shapes(end_frame,
-            included_frames=included_frames, include_outside=include_outside,
-            use_server_track_ids=use_server_track_ids
+        return shapes + tracks.to_shapes(
+            end_frame,
+            included_frames=included_frames,
+            include_outside=include_outside,
+            use_server_track_ids=use_server_track_ids,
+            deleted_frames=deleted_frames,
         )
 
     def to_tracks(self):
@@ -460,14 +465,21 @@ class ShapeManager(ObjectManager):
     def _modify_unmatched_object(self, obj, end_frame):
         pass
 
+
 class TrackManager(ObjectManager):
-    def to_shapes(self, end_frame: int, *,
+    def to_shapes(
+        self,
+        end_frame: int,
+        *,
         included_frames: Optional[Sequence[int]] = None,
         include_outside: bool = False,
-        use_server_track_ids: bool = False
+        use_server_track_ids: bool = False,
+        deleted_frames: Optional[Collection[int]] = None,
     ) -> list:
         shapes = []
         for idx, track in enumerate(self.objects):
+            if deleted_frames is not None:
+                track = dict(track, shapes=list(filter(lambda sh: sh['frame'] not in deleted_frames, track['shapes'])))
             track_id = track["id"] if use_server_track_ids else idx
             track_shapes = {}
 
@@ -497,10 +509,12 @@ class TrackManager(ObjectManager):
                 element_included_frames = set(track_shapes.keys())
                 if included_frames is not None:
                     element_included_frames = element_included_frames.intersection(included_frames)
-                element_shapes = track_elements.to_shapes(end_frame,
+                element_shapes = track_elements.to_shapes(
+                    end_frame,
                     included_frames=element_included_frames,
                     include_outside=True, # elements are controlled by the parent shape
-                    use_server_track_ids=use_server_track_ids
+                    use_server_track_ids=use_server_track_ids,
+                    deleted_frames=deleted_frames,
                 )
 
                 for shape in element_shapes:

--- a/cvat/apps/dataset_manager/annotation.py
+++ b/cvat/apps/dataset_manager/annotation.py
@@ -469,8 +469,6 @@ class TrackManager(ObjectManager):
     ) -> list:
         shapes = []
         for idx, track in enumerate(self.objects):
-            if included_frames is not None:
-                track = dict(track, shapes=list(filter(lambda sh: sh['frame'] in included_frames, track['shapes'])))
             track_id = track["id"] if use_server_track_ids else idx
             track_shapes = {}
 
@@ -932,6 +930,8 @@ class TrackManager(ObjectManager):
         prev_shape = None
         for shape in sorted(track["shapes"], key=lambda shape: shape["frame"]):
             curr_frame = shape["frame"]
+            if included_frames is not None and curr_frame not in included_frames:
+                continue
             if prev_shape and end_frame <= curr_frame:
                 # If we exceed the end_frame and there was a previous shape,
                 # we still need to interpolate up to the next keyframe,

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -320,7 +320,7 @@ class CommonData(InstanceLabelData):
         return d
 
     def _init_frame_info(self):
-        self._deleted_frames = { k for k in self._db_data.deleted_frames }
+        self._deleted_frames = { k: True for k in self._db_data.deleted_frames }
 
         self._excluded_frames = set()
 
@@ -499,8 +499,7 @@ class CommonData(InstanceLabelData):
                 # Skip outside, deleted and excluded frames
                 included_frames=included_frames,
                 include_outside=False,
-                use_server_track_ids=self._use_server_track_ids,
-                deleted_frames=self.deleted_frames,
+                use_server_track_ids=self._use_server_track_ids
             ),
             key=lambda shape: shape.get("z_order", 0)
         ):
@@ -696,7 +695,7 @@ class CommonData(InstanceLabelData):
         return self._frame_info
 
     @property
-    def deleted_frames(self) -> set[int]:
+    def deleted_frames(self):
         return self._deleted_frames
 
     @property
@@ -1299,8 +1298,7 @@ class ProjectData(InstanceLabelData):
                     task.data.size,
                     included_frames=task_included_frames,
                     include_outside=False,
-                    use_server_track_ids=self._use_server_track_ids,
-                    deleted_frames=task_data.deleted_frames,
+                    use_server_track_ids=self._use_server_track_ids
                 ),
                 key=lambda shape: shape.get("z_order", 0)
             ):

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -320,7 +320,7 @@ class CommonData(InstanceLabelData):
         return d
 
     def _init_frame_info(self):
-        self._deleted_frames = { k: True for k in self._db_data.deleted_frames }
+        self._deleted_frames = { k for k in self._db_data.deleted_frames }
 
         self._excluded_frames = set()
 
@@ -499,7 +499,8 @@ class CommonData(InstanceLabelData):
                 # Skip outside, deleted and excluded frames
                 included_frames=included_frames,
                 include_outside=False,
-                use_server_track_ids=self._use_server_track_ids
+                use_server_track_ids=self._use_server_track_ids,
+                deleted_frames=self.deleted_frames,
             ),
             key=lambda shape: shape.get("z_order", 0)
         ):
@@ -695,7 +696,7 @@ class CommonData(InstanceLabelData):
         return self._frame_info
 
     @property
-    def deleted_frames(self):
+    def deleted_frames(self) -> set[int]:
         return self._deleted_frames
 
     @property
@@ -1298,7 +1299,8 @@ class ProjectData(InstanceLabelData):
                     task.data.size,
                     included_frames=task_included_frames,
                     include_outside=False,
-                    use_server_track_ids=self._use_server_track_ids
+                    use_server_track_ids=self._use_server_track_ids,
+                    deleted_frames=task_data.deleted_frames,
                 ),
                 key=lambda shape: shape.get("z_order", 0)
             ):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
When a frame which contains a keyframe of a track is deleted, the keyframe continues to exist. When a dataset is exported (in all formats except CVAT for video), tracks are interpolated and keyframe from deleted frame is not ignored.
Fixing it.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced shape management by allowing exclusion of shapes based on deleted frames in both `AnnotationManager` and `TrackManager`.
	- Introduced a method for deleting specified frames from job data and verifying the integrity of subsequent annotations in tests.

- **Bug Fixes**
	- Improved handling of deleted frames by transitioning from a dictionary to a set for better performance and clarity.

- **Tests**
	- Added tests to ensure frame deletion functionality works as intended without affecting subsequent annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->