### PR TITLE
Make test_export_with_non_default_frame_step compatible with Python 3.11+

### DIFF
--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -2681,7 +2681,7 @@ class TestPostTaskData:
                         assert (img.shape[0], img.shape[1]) == (img_meta.height, img_meta.width)
 
 
-class _SourceDataType(str, Enum):
+class _SourceDataType(Enum):
     images = "images"
     video = "video"
 
@@ -6490,7 +6490,7 @@ class TestPatchExportFrames(TestTaskData):
         with make_sdk_client(self._USERNAME) as client:
             task = client.tasks.retrieve(task_id)
 
-            yield (spec, task, f"CVAT for {media_type} 1.1")
+            yield (spec, task, f"CVAT for {media_type.value} 1.1")
 
     @pytest.mark.usefixtures("restore_redis_ondisk_per_function")
     @parametrize("spec, task, format_name", [fixture_ref(fxt_uploaded_media_task)])


### PR DESCRIPTION

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
In Python 3.11, `Enum.__format__` was changed to be the same as `Enum.__str__`, so the yielded format name ends up being `CVAT for _SourceDataType.images 1.1`. Use the string value explicitly.

Also, remove the `str` base class from `_SourceDataType`, since it appears to be actively misleading (as well as unnecessary).

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I ran the test with Python 3.12.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the `_SourceDataType` class to use standard Enum implementation
	- Modified fixture to use correct enum value representation in test generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->