### PR TITLE
Fix lambda function logic when all detections are filtered out

### DIFF
--- a/changelog.d/20250113_122208_roman_filter_out_all_detections.md
+++ b/changelog.d/20250113_122208_roman_filter_out_all_detections.md
@@ -1,5 +1,5 @@
 ### Fixed
 
 - Fixed incorrect results being returned from lambda functions when all
-  detected shapes have labels that aren't mapped.
+  detected shapes have labels that aren't mapped
   (<https://github.com/cvat-ai/cvat/pull/8931>)

--- a/changelog.d/20250113_122208_roman_filter_out_all_detections.md
+++ b/changelog.d/20250113_122208_roman_filter_out_all_detections.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Fixed incorrect results being returned from lambda functions when all
+  detected shapes have labels that aren't mapped.
+  (<https://github.com/cvat-ai/cvat/pull/8931>)

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -1101,6 +1101,18 @@ class LambdaTestCases(_LambdaTestCaseBase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_api_v2_lambda_functions_create_detector_all_shapes_unmapped(self):
+        data = {
+            "task": self.main_task["id"],
+            "frame": 0,
+            "mapping": {"person": {"name": "person"}},
+        }
+        response = self._post_request(
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), [])
+
     def test_api_v2_lambda_functions_create_detector_without_task(self):
         data = {
             "frame": 0,

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -479,8 +479,6 @@ class LambdaFunction:
 
         response = self.gateway.invoke(self, payload)
 
-        response_filtered = []
-
         def check_attr_value(value, db_attr):
             if db_attr is None:
                 return False
@@ -509,6 +507,8 @@ class LambdaFunction:
             return attributes
 
         if self.kind == FunctionKind.DETECTOR:
+            response_filtered = []
+
             for item in response:
                 item_label = item["label"]
                 if item_label not in mapping:
@@ -534,7 +534,8 @@ class LambdaFunction:
                             db_label.attributespec_set.values(),
                         )
                 response_filtered.append(item)
-                response = response_filtered
+
+            response = response_filtered
 
         return response
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Currently, if all detected shapes have labels that aren't mapped, then the mapping is not applied at all.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved lambda function response handling to correctly filter out detections with unmapped labels.

- **Tests**
	- Added a new test case to validate handling of unmapped shapes in detector functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->