### PR TITLE
Peg the UI version to the server version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,11 +26,6 @@ If you're unsure about any of these, don't hesitate to ask. We're here to help! 
 - [ ] I have added tests to cover my changes
 - [ ] I have linked related issues (see [GitHub docs](
   https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
-- [ ] I have increased versions of npm packages if it is necessary
-  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
-  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
-  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
-  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))
 
 ### License
 

--- a/changelog.d/20250115_190017_roman_rm_ui_versions.md
+++ b/changelog.d/20250115_190017_roman_rm_ui_versions.md
@@ -1,0 +1,5 @@
+### Changed
+
+- The UI only displays one version for the whole client component,
+  which is now aligned with the server version
+  (<https://github.com/cvat-ai/cvat/pull/8948>)

--- a/cvat-canvas/README.md
+++ b/cvat-canvas/README.md
@@ -5,14 +5,6 @@
 The CVAT module written in TypeScript language.
 It presents a canvas to viewing, drawing and editing of annotations.
 
-## Versioning
-
-If you make changes in this package, please do following:
-
-- After not important changes (typos, backward compatible bug fixes, refactoring) do: `yarn version --patch`
-- After changing API (backward compatible new features) do: `yarn version --minor`
-- After changing API (changes that break backward compatibility) do: `yarn version --major`
-
 ## Commands
 
 - Building of the module from sources in the `dist` directory:

--- a/cvat-canvas/src/typescript/canvas.ts
+++ b/cvat-canvas/src/typescript/canvas.ts
@@ -18,9 +18,6 @@ import { CanvasController, CanvasControllerImpl } from './canvasController';
 import { CanvasView, CanvasViewImpl } from './canvasView';
 
 import '../scss/canvas.scss';
-import pjson from '../../package.json';
-
-const CanvasVersion = pjson.version;
 
 interface Canvas {
     html(): HTMLDivElement;
@@ -197,5 +194,5 @@ export type InteractionResult = _InteractionResult;
 export type HighlightSeverity = _HighlightSeverity;
 
 export {
-    CanvasImpl as Canvas, CanvasVersion, RectDrawingMethod, CuboidDrawingMethod, Mode as CanvasMode,
+    CanvasImpl as Canvas, RectDrawingMethod, CuboidDrawingMethod, Mode as CanvasMode,
 };

--- a/cvat-canvas3d/README.md
+++ b/cvat-canvas3d/README.md
@@ -5,14 +5,6 @@
 The CVAT module written in TypeScript language.
 It presents a canvas to viewing, drawing and editing of 3D annotations.
 
-## Versioning
-
-If you make changes in this package, please do following:
-
-- After not important changes (typos, backward compatible bug fixes, refactoring) do: `yarn version --patch`
-- After changing API (backward compatible new features) do: `yarn version --minor`
-- After changing API (changes that break backward compatibility) do: `yarn version --major`
-
 ## Commands
 
 - Building of the module from sources in the `dist` directory:

--- a/cvat-canvas3d/src/typescript/canvas3d.ts
+++ b/cvat-canvas3d/src/typescript/canvas3d.ts
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-import pjson from '../../package.json';
 import { Canvas3dController, Canvas3dControllerImpl } from './canvas3dController';
 import {
     Canvas3dModel,
@@ -21,8 +20,6 @@ import {
     Canvas3dView, Canvas3dViewImpl, ViewsDOM, CameraAction,
 } from './canvas3dView';
 import { Master } from './master';
-
-const Canvas3dVersion = pjson.version;
 
 interface Canvas3d {
     html(): ViewsDOM;
@@ -125,7 +122,7 @@ class Canvas3dImpl implements Canvas3d {
 }
 
 export {
-    Canvas3dImpl as Canvas3d, Canvas3dVersion, ViewType, MouseInteraction, CameraAction, Mode as CanvasMode,
+    Canvas3dImpl as Canvas3d, ViewType, MouseInteraction, CameraAction, Mode as CanvasMode,
 };
 
 export type { ViewsDOM };

--- a/cvat-core/README.md
+++ b/cvat-core/README.md
@@ -5,14 +5,6 @@
 This CVAT module is a client-side JavaScript library for management of objects, frames, logs, etc.
 It contains the core logic of the Computer Vision Annotation Tool.
 
-## Versioning
-
-If you make changes in this package, please do following:
-
-- After not important changes (typos, backward compatible bug fixes, refactoring) do: `yarn version --patch`
-- After changing API (backward compatible new features) do: `yarn version --minor`
-- After changing API (changes that break backward compatibility) do: `yarn version --major`
-
 ### Commands
 
 - Dependencies installation

--- a/cvat-core/src/api.ts
+++ b/cvat-core/src/api.ts
@@ -39,7 +39,6 @@ import {
 
 import { mask2Rle, rle2Mask, propagateShapes } from './object-utils';
 import User from './user';
-import pjson from '../package.json';
 import config from './config';
 
 import implementAPI from './api-implementation';
@@ -327,9 +326,6 @@ function build(): CVATCore {
                 config.jobMetaDataReloadPeriod = value;
             },
         },
-        client: {
-            version: `${pjson.version}`,
-        },
         enums,
         exceptions: {
             Exception,
@@ -481,7 +477,6 @@ function build(): CVATCore {
     cvat.lambda = Object.freeze(cvat.lambda);
     // logger: todo: logger storage implemented other way
     cvat.config = Object.freeze(cvat.config);
-    cvat.client = Object.freeze(cvat.client);
     cvat.enums = Object.freeze(cvat.enums);
     cvat.exceptions = Object.freeze(cvat.exceptions);
     cvat.cloudStorages = Object.freeze(cvat.cloudStorages);

--- a/cvat-core/src/index.ts
+++ b/cvat-core/src/index.ts
@@ -189,9 +189,6 @@ export default interface CVATCore {
         requestsStatusDelay: typeof config.requestsStatusDelay;
         jobMetaDataReloadPeriod: typeof config.jobMetaDataReloadPeriod;
     },
-    client: {
-        version: string;
-    };
     enums,
     exceptions: {
         Exception: typeof Exception,

--- a/cvat-data/README.md
+++ b/cvat-data/README.md
@@ -5,11 +5,3 @@ yarn run build  # build with minification
 yarn run build --mode=development     # build without minification
 yarn run server # run debug server
 ```
-
-## Versioning
-
-If you make changes in this package, please do following:
-
-- After not important changes (typos, backward compatible bug fixes, refactoring) do: `yarn version --patch`
-- After changing API (backward compatible new features) do: `yarn version --minor`
-- After changing API (changes that break backward compatibility) do: `yarn version --major`

--- a/cvat-ui/README.md
+++ b/cvat-ui/README.md
@@ -4,17 +4,6 @@
 
 This is a client UI for Computer Vision Annotation Tool based on React, Redux and Antd
 
-## Versioning
-
-If you make changes in this package, please do following:
-
-- After not important changes (typos, bug fixes, refactoring) do: `yarn version --patch`
-- After adding new features do: `yarn version --minor`
-- After significant UI redesign do: `yarn version --major`
-
-Important: If you have changed versions for `cvat-core`, `cvat-canvas`, `cvat-data`,
-you also need to do `yarn install` to update `package-lock.json`
-
 ## Commands
 
 - Installing dependencies:

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.67.0",
+  "version": "2.25.1",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/global-error-boundary/global-error-boundary.tsx
+++ b/cvat-ui/src/components/global-error-boundary/global-error-boundary.tsx
@@ -27,8 +27,6 @@ interface OwnProps {
 interface StateToProps {
     job: any | null;
     serverVersion: string;
-    coreVersion: string;
-    canvasVersion: string;
     uiVersion: string;
 }
 
@@ -53,8 +51,6 @@ function mapStateToProps(state: CombinedState): StateToProps {
     return {
         job,
         serverVersion: server.version as string,
-        coreVersion: packageVersion.core,
-        canvasVersion: packageVersion.canvas,
         uiVersion: packageVersion.ui,
     };
 }
@@ -109,7 +105,7 @@ class GlobalErrorBoundary extends React.PureComponent<Props, State> {
 
     public render(): React.ReactNode {
         const {
-            restore, job, serverVersion, coreVersion, canvasVersion, uiVersion,
+            restore, job, serverVersion, uiVersion,
         } = this.props;
 
         const { hasError, error } = this.state;
@@ -172,14 +168,6 @@ class GlobalErrorBoundary extends React.PureComponent<Props, State> {
                                             <li>
                                                 <Text strong>Server: </Text>
                                                 {serverVersion}
-                                            </li>
-                                            <li>
-                                                <Text strong>Core: </Text>
-                                                {coreVersion}
-                                            </li>
-                                            <li>
-                                                <Text strong>Canvas: </Text>
-                                                {canvasVersion}
                                             </li>
                                             <li>
                                                 <Text strong>UI: </Text>

--- a/cvat-ui/src/components/header/header.tsx
+++ b/cvat-ui/src/components/header/header.tsx
@@ -260,14 +260,6 @@ function HeaderComponent(props: Props): JSX.Element {
                         <Text type='secondary'>{` ${about.server.version}`}</Text>
                     </p>
                     <p>
-                        <Text strong>Core version:</Text>
-                        <Text type='secondary'>{` ${about.packageVersion.core}`}</Text>
-                    </p>
-                    <p>
-                        <Text strong>Canvas version:</Text>
-                        <Text type='secondary'>{` ${about.packageVersion.canvas}`}</Text>
-                    </p>
-                    <p>
                         <Text strong>UI version:</Text>
                         <Text type='secondary'>{` ${about.packageVersion.ui}`}</Text>
                     </p>

--- a/cvat-ui/src/cvat-canvas-wrapper.ts
+++ b/cvat-ui/src/cvat-canvas-wrapper.ts
@@ -5,7 +5,6 @@
 import {
     Canvas,
     CanvasMode,
-    CanvasVersion,
     RectDrawingMethod,
     CuboidDrawingMethod,
     CanvasHint as _CanvasHint,
@@ -36,5 +35,5 @@ export type HighlightSeverity = _HighlightSeverity;
 export type CanvasHint = _CanvasHint;
 
 export {
-    Canvas, CanvasMode, CanvasVersion, RectDrawingMethod, CuboidDrawingMethod,
+    Canvas, CanvasMode, RectDrawingMethod, CuboidDrawingMethod,
 };

--- a/cvat-ui/src/cvat-canvas3d-wrapper.ts
+++ b/cvat-ui/src/cvat-canvas3d-wrapper.ts
@@ -5,7 +5,6 @@
 
 import {
     Canvas3d,
-    Canvas3dVersion,
     MouseInteraction,
     ViewType,
     CameraAction,
@@ -14,7 +13,7 @@ import {
 } from 'cvat-canvas3d/src/typescript/canvas3d';
 
 export {
-    Canvas3d, Canvas3dVersion, MouseInteraction, ViewType, CameraAction, CanvasMode,
+    Canvas3d, MouseInteraction, ViewType, CameraAction, CanvasMode,
 };
 
 export type { ViewsDOM };

--- a/cvat-ui/src/reducers/about-reducer.ts
+++ b/cvat-ui/src/reducers/about-reducer.ts
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { getCore } from 'cvat-core-wrapper';
-import { CanvasVersion } from 'cvat-canvas-wrapper';
 import { BoundariesActions, BoundariesActionTypes } from 'actions/boundaries-actions';
 import { AboutActions, AboutActionTypes } from 'actions/about-actions';
 import { AuthActions, AuthActionTypes } from 'actions/auth-actions';
@@ -13,8 +11,6 @@ import pjson from '../../package.json';
 const defaultState: AboutState = {
     server: {},
     packageVersion: {
-        core: getCore().client.version,
-        canvas: CanvasVersion,
         ui: pjson.version,
     },
     fetching: false,

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -338,8 +338,6 @@ export interface PluginsState {
 export interface AboutState {
     server: any;
     packageVersion: {
-        core: string;
-        canvas: string;
         ui: string;
     };
     fetching: boolean;

--- a/dev/update_version.py
+++ b/dev/update_version.py
@@ -162,6 +162,11 @@ REPLACEMENT_RULES = [
         re.compile(r"^cvat-sdk==[\d.]+$", re.M),
         lambda v, m: f"cvat-sdk=={v.major}.{v.minor}.{v.patch}",
     ),
+    ReplacementRule(
+        "cvat-ui/package.json",
+        re.compile(r'^  "version": "[\d.]+",$', re.M),
+        lambda v, m: f'  "version": "{v.major}.{v.minor}.{v.patch}",',
+    ),
 ]
 
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The only reason to display separate UI and server version (IMO) is that sometimes they can diverge due to deployment issues, and the information can help with diagnostics. So it seems much more useful to use the same version numbering as for the server, since:

* This makes it much easier to see whether a divergence exists.

* We can automate updates to it, eliminating annoying busywork for developers.

* We don't need to show multiple versions for different UI components, simplifying the code and the UI.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- [x] I have increased versions of npm packages if it is necessary 😉
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
