### PR TITLE
Running CVAT in HTTP behind a HTTPS nginx proxy

### DIFF
--- a/cvat/apps/engine/mixins.py
+++ b/cvat/apps/engine/mixins.py
@@ -301,7 +301,12 @@ class UploadMixin:
             location = request.build_absolute_uri()
             if 'HTTP_X_FORWARDED_HOST' not in request.META:
                 location = request.META.get('HTTP_ORIGIN') + request.META.get('PATH_INFO')
-
+            
+            # Use X-Forwarded-Proto in nginx conf thats uses to determine if the original request was HTTP or HTTPS
+            # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto  
+            if settings.EXTERNAL_PROXY or request.META.get('HTTP_X_FORWARDED_PROTO', ''):
+                location = location.replace('http://', 'https://', 1) 
+            
             if import_type in ('backup', 'annotations', 'datasets'):
                 scheduler = django_rq.get_scheduler(settings.CVAT_QUEUES.CLEANING.value)
                 path = Path(self.get_upload_dir()) / tus_file.filename

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -320,7 +320,7 @@ RQ_QUEUES = {
     },
     CVAT_QUEUES.CLEANING.value: {
         **shared_queue_settings,
-        'DEFAULT_TIMEOUT': '2h',
+        'DEFAULT_TIMEOUT': '1h',
     },
     CVAT_QUEUES.CHUNKS.value: {
         **shared_queue_settings,
@@ -353,20 +353,6 @@ PERIODIC_RQ_JOBS = [
         'func': 'cvat.apps.iam.utils.clean_up_sessions',
         'cron_string': '0 0 * * *',
     },
-    {
-        'queue': CVAT_QUEUES.CLEANING.value,
-        'id': 'cron_export_cache_directory_cleanup',
-        'func': 'cvat.apps.dataset_manager.cron.cleanup_export_cache_directory',
-        # Run twice a day (at midnight and at noon)
-        'cron_string': '0 0,12 * * *',
-    },
-    {
-        'queue': CVAT_QUEUES.CLEANING.value,
-        'id': 'cron_tmp_directory_cleanup',
-        'func': 'cvat.apps.dataset_manager.cron.cleanup_tmp_directory',
-        # Run once a day
-        'cron_string': '0 18 * * *',
-    }
 ]
 
 # JavaScript and CSS compression
@@ -426,9 +412,6 @@ os.makedirs(MEDIA_DATA_ROOT, exist_ok=True)
 
 CACHE_ROOT = os.path.join(DATA_ROOT, 'cache')
 os.makedirs(CACHE_ROOT, exist_ok=True)
-
-EXPORT_CACHE_ROOT = os.path.join(CACHE_ROOT, 'export')
-os.makedirs(EXPORT_CACHE_ROOT, exist_ok=True)
 
 EVENTS_LOCAL_DB_ROOT = os.path.join(CACHE_ROOT, 'events')
 os.makedirs(EVENTS_LOCAL_DB_ROOT, exist_ok=True)
@@ -756,12 +739,13 @@ ONE_RUNNING_JOB_IN_QUEUE_PER_USER = to_bool(os.getenv('ONE_RUNNING_JOB_IN_QUEUE_
 # How many chunks can be prepared simultaneously during task creation in case the cache is not used
 CVAT_CONCURRENT_CHUNK_PROCESSING = int(os.getenv('CVAT_CONCURRENT_CHUNK_PROCESSING', 1))
 
+# if CVAT is deployed under a proxy https://github.com/cvat-ai/cvat/issues/7288
+# Not recommend to use it better to use https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto in nginx
+EXTERNAL_PROXY = os.getenv('USED_EXTERNAL_PROXY', False)
+
 from cvat.rq_patching import update_started_job_registry_cleanup
 
 update_started_job_registry_cleanup()
 
 CLOUD_DATA_DOWNLOADING_MAX_THREADS_NUMBER = 4
 CLOUD_DATA_DOWNLOADING_NUMBER_OF_FILES_PER_THREAD = 1000
-
-# Indicates the maximum number of days a file or directory is retained in the temporary directory
-TMP_FILE_OR_DIR_RETENTION_DAYS = 3

--- a/site/content/en/docs/administration/basics/installation.md
+++ b/site/content/en/docs/administration/basics/installation.md
@@ -546,6 +546,15 @@ docker compose -f docker-compose.yml -f docker-compose.https.yml up -d
 
 Then, the CVAT instance will be available at your domain on ports 443 (HTTPS) and 80 (HTTP, redirects to 443).
 
+## External proxy
+Sometimes, in production deployments, administrative structures have their own web server that provides access to a variety of sources.  
+The correct solution would be to use header with explicitly proxy protocol (like [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto) in Nginx). 
+
+If it is not possible to influence the nginx configuration
+```shell
+export USED_EXTERNAL_PROXY=True
+```
+
 ### Deploy CVAT with an external database
 
 By default, `docker compose up` will start a PostgreSQL database server,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->
https://github.com/cvat-ai/cvat/issues/7288
<!-- Provide a general summary of your changes in the Title above -->
Running CVAT in HTTP behind a HTTPS nginx proxy
### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Sometimes the conditions of application deployment do not allow you to keep full control. For example, when you have a large company where individual people are responsible for security, who use proxies to provide access to resources. Therefore, it turns out that you need to deploy the HTTP version of the service behind HTTPS proxy. In this case, build_absolute_uri does not work correctly. 

All the problems are described in more detail in ishew, but in fact it is not possible to restore data from backup with this configuration.

<img width="707" alt="Снимок экрана 2025-01-17 в 01 57 37" src="https://github.com/user-attachments/assets/965f07a4-562a-4e9a-83b2-70098157cfa5" />

P.S
Solution looks a bit ugly, because the [usual approach](https://stackoverflow.com/a/65934202) doesn't quite solve the problem. However, it can be improved.


### How has this been tested?
This was tested on a case with uploading data from a backup. Our environment is exactly as described.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
