### PR TITLE
Drop years from license headers associated to CVAT.ai Corporation

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2018-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2018-2022 Intel Corporation
-Copyright (c) 2022-2025 CVAT.ai Corporation
+Copyright (C) 2018-2022 Intel Corporation
+Copyright (C) 2022-2025 CVAT.ai Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cvat-canvas/.eslintrc.cjs
+++ b/cvat-canvas/.eslintrc.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/scss/canvas.scss
+++ b/cvat-canvas/src/scss/canvas.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/canvas.ts
+++ b/cvat-canvas/src/typescript/canvas.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/canvasController.ts
+++ b/cvat-canvas/src/typescript/canvasController.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/drawHandler.ts
+++ b/cvat-canvas/src/typescript/drawHandler.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/editHandler.ts
+++ b/cvat-canvas/src/typescript/editHandler.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/groupHandler.ts
+++ b/cvat-canvas/src/typescript/groupHandler.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/interactionHandler.ts
+++ b/cvat-canvas/src/typescript/interactionHandler.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/masksHandler.ts
+++ b/cvat-canvas/src/typescript/masksHandler.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/mergeHandler.ts
+++ b/cvat-canvas/src/typescript/mergeHandler.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/objectSelector.ts
+++ b/cvat-canvas/src/typescript/objectSelector.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/regionSelector.ts
+++ b/cvat-canvas/src/typescript/regionSelector.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/shared.ts
+++ b/cvat-canvas/src/typescript/shared.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/sliceHandler.ts
+++ b/cvat-canvas/src/typescript/sliceHandler.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/splitHandler.ts
+++ b/cvat-canvas/src/typescript/splitHandler.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/zoomHandler.ts
+++ b/cvat-canvas/src/typescript/zoomHandler.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/webpack.config.cjs
+++ b/cvat-canvas/webpack.config.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas3d/.eslintrc.cjs
+++ b/cvat-canvas3d/.eslintrc.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas3d/src/typescript/canvas3d.ts
+++ b/cvat-canvas3d/src/typescript/canvas3d.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas3d/src/typescript/canvas3dController.ts
+++ b/cvat-canvas3d/src/typescript/canvas3dController.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas3d/src/typescript/canvas3dModel.ts
+++ b/cvat-canvas3d/src/typescript/canvas3dModel.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas3d/src/typescript/canvas3dView.ts
+++ b/cvat-canvas3d/src/typescript/canvas3dView.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas3d/src/typescript/consts.ts
+++ b/cvat-canvas3d/src/typescript/consts.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas3d/src/typescript/cuboid.ts
+++ b/cvat-canvas3d/src/typescript/cuboid.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas3d/src/typescript/index.ts
+++ b/cvat-canvas3d/src/typescript/index.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas3d/webpack.config.cjs
+++ b/cvat-canvas3d/webpack.config.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-cli/src/cvat_cli/__main__.py
+++ b/cvat-cli/src/cvat_cli/__main__.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-cli/src/cvat_cli/_internal/agent.py
+++ b/cvat-cli/src/cvat_cli/_internal/agent.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-cli/src/cvat_cli/_internal/command_base.py
+++ b/cvat-cli/src/cvat_cli/_internal/command_base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-cli/src/cvat_cli/_internal/commands_all.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_all.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-cli/src/cvat_cli/_internal/commands_functions.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_functions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-cli/src/cvat_cli/_internal/commands_projects.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_projects.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-cli/src/cvat_cli/_internal/commands_tasks.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_tasks.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-cli/src/cvat_cli/_internal/common.py
+++ b/cvat-cli/src/cvat_cli/_internal/common.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-cli/src/cvat_cli/_internal/parsers.py
+++ b/cvat-cli/src/cvat_cli/_internal/parsers.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-cli/src/cvat_cli/_internal/utils.py
+++ b/cvat-cli/src/cvat_cli/_internal/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-core/.eslintrc.cjs
+++ b/cvat-core/.eslintrc.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2018-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) 2024 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/.eslintrc.cjs
+++ b/cvat-core/.eslintrc.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2018-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/jest.config.cjs
+++ b/cvat-core/jest.config.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/analytics-report.ts
+++ b/cvat-core/src/analytics-report.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotation-formats.ts
+++ b/cvat-core/src/annotation-formats.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotations-actions/annotations-actions.ts
+++ b/cvat-core/src/annotations-actions/annotations-actions.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotations-actions/base-action.ts
+++ b/cvat-core/src/annotations-actions/base-action.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotations-actions/base-collection-action.ts
+++ b/cvat-core/src/annotations-actions/base-collection-action.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotations-actions/base-shapes-action.ts
+++ b/cvat-core/src/annotations-actions/base-shapes-action.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotations-actions/propagate-shapes.ts
+++ b/cvat-core/src/annotations-actions/propagate-shapes.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotations-actions/remove-filtered-shapes.ts
+++ b/cvat-core/src/annotations-actions/remove-filtered-shapes.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotations-collection.ts
+++ b/cvat-core/src/annotations-collection.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotations-filter.ts
+++ b/cvat-core/src/annotations-filter.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotations-history.ts
+++ b/cvat-core/src/annotations-history.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotations-objects.ts
+++ b/cvat-core/src/annotations-objects.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotations-saver.ts
+++ b/cvat-core/src/annotations-saver.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/annotations.ts
+++ b/cvat-core/src/annotations.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/api-implementation.ts
+++ b/cvat-core/src/api-implementation.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/api.ts
+++ b/cvat-core/src/api.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/axios-config.ts
+++ b/cvat-core/src/axios-config.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/axios-tus.ts
+++ b/cvat-core/src/axios-tus.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/cloud-storage.ts
+++ b/cvat-core/src/cloud-storage.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/comment.ts
+++ b/cvat-core/src/comment.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/common.ts
+++ b/cvat-core/src/common.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/config.ts
+++ b/cvat-core/src/config.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/core-types.ts
+++ b/cvat-core/src/core-types.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/download.worker.ts
+++ b/cvat-core/src/download.worker.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/enums.ts
+++ b/cvat-core/src/enums.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier = MIT
 

--- a/cvat-core/src/event.ts
+++ b/cvat-core/src/event.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/exceptions.ts
+++ b/cvat-core/src/exceptions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/frames.ts
+++ b/cvat-core/src/frames.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/guide.ts
+++ b/cvat-core/src/guide.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/index.ts
+++ b/cvat-core/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/issue.ts
+++ b/cvat-core/src/issue.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/labels.ts
+++ b/cvat-core/src/labels.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/lambda-manager.ts
+++ b/cvat-core/src/lambda-manager.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/logger.ts
+++ b/cvat-core/src/logger.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/ml-model.ts
+++ b/cvat-core/src/ml-model.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/object-state.ts
+++ b/cvat-core/src/object-state.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/object-utils.ts
+++ b/cvat-core/src/object-utils.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/organization.ts
+++ b/cvat-core/src/organization.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/plugins.ts
+++ b/cvat-core/src/plugins.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/project-implementation.ts
+++ b/cvat-core/src/project-implementation.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/project.ts
+++ b/cvat-core/src/project.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/quality-conflict.ts
+++ b/cvat-core/src/quality-conflict.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/quality-report.ts
+++ b/cvat-core/src/quality-report.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/quality-settings.ts
+++ b/cvat-core/src/quality-settings.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/request.ts
+++ b/cvat-core/src/request.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/requests-manager.ts
+++ b/cvat-core/src/requests-manager.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/server-proxy.ts
+++ b/cvat-core/src/server-proxy.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/server-response-types.ts
+++ b/cvat-core/src/server-response-types.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/server-schema.ts
+++ b/cvat-core/src/server-schema.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/session-implementation.ts
+++ b/cvat-core/src/session-implementation.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/session.ts
+++ b/cvat-core/src/session.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/statistics.ts
+++ b/cvat-core/src/statistics.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/storage.ts
+++ b/cvat-core/src/storage.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/type-utils.ts
+++ b/cvat-core/src/type-utils.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/user.ts
+++ b/cvat-core/src/user.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/validation-layout.ts
+++ b/cvat-core/src/validation-layout.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/src/webhook.ts
+++ b/cvat-core/src/webhook.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/tests/api/annotations.cjs
+++ b/cvat-core/tests/api/annotations.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/tests/api/cloud-storages.cjs
+++ b/cvat-core/tests/api/cloud-storages.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/tests/api/frames.cjs
+++ b/cvat-core/tests/api/frames.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/tests/api/jobs.cjs
+++ b/cvat-core/tests/api/jobs.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/tests/api/object-state.cjs
+++ b/cvat-core/tests/api/object-state.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/tests/api/projects.cjs
+++ b/cvat-core/tests/api/projects.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/tests/api/server.cjs
+++ b/cvat-core/tests/api/server.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/tests/api/tasks.cjs
+++ b/cvat-core/tests/api/tasks.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/tests/api/user.cjs
+++ b/cvat-core/tests/api/user.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/tests/api/webhooks.cjs
+++ b/cvat-core/tests/api/webhooks.cjs
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/tests/mocks/server-proxy.mock.cjs
+++ b/cvat-core/tests/mocks/server-proxy.mock.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-core/webpack.config.cjs
+++ b/cvat-core/webpack.config.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-data/.eslintrc.cjs
+++ b/cvat-data/.eslintrc.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-data/src/ts/cvat-data.ts
+++ b/cvat-data/src/ts/cvat-data.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-data/src/ts/unzip_imgs.worker.ts
+++ b/cvat-data/src/ts/unzip_imgs.worker.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-data/webpack.config.cjs
+++ b/cvat-data/webpack.config.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/__init__.py
+++ b/cvat-sdk/cvat_sdk/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/auto_annotation/__init__.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/auto_annotation/driver.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/driver.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/auto_annotation/functions/_torchvision.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/functions/_torchvision.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_detection.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_detection.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_instance_segmentation.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_instance_segmentation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_keypoint_detection.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_keypoint_detection.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/auto_annotation/interface.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/interface.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/__init__.py
+++ b/cvat-sdk/cvat_sdk/core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/client.py
+++ b/cvat-sdk/cvat_sdk/core/client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/downloading.py
+++ b/cvat-sdk/cvat_sdk/core/downloading.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/exceptions.py
+++ b/cvat-sdk/cvat_sdk/core/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/helpers.py
+++ b/cvat-sdk/cvat_sdk/core/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/progress.py
+++ b/cvat-sdk/cvat_sdk/core/progress.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/proxies/annotations.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/annotations.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/proxies/issues.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/issues.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/proxies/jobs.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/jobs.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/proxies/model_proxy.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/model_proxy.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/proxies/organizations.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/organizations.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/proxies/projects.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/projects.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/proxies/tasks.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/tasks.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/proxies/types.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/types.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/proxies/users.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/users.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/uploading.py
+++ b/cvat-sdk/cvat_sdk/core/uploading.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/core/utils.py
+++ b/cvat-sdk/cvat_sdk/core/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/datasets/__init__.py
+++ b/cvat-sdk/cvat_sdk/datasets/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/datasets/caching.py
+++ b/cvat-sdk/cvat_sdk/datasets/caching.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/datasets/common.py
+++ b/cvat-sdk/cvat_sdk/datasets/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/datasets/task_dataset.py
+++ b/cvat-sdk/cvat_sdk/datasets/task_dataset.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/exceptions.py
+++ b/cvat-sdk/cvat_sdk/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/masks.py
+++ b/cvat-sdk/cvat_sdk/masks.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/models.py
+++ b/cvat-sdk/cvat_sdk/models.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/pytorch/__init__.py
+++ b/cvat-sdk/cvat_sdk/pytorch/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/pytorch/common.py
+++ b/cvat-sdk/cvat_sdk/pytorch/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/pytorch/project_dataset.py
+++ b/cvat-sdk/cvat_sdk/pytorch/project_dataset.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/pytorch/task_dataset.py
+++ b/cvat-sdk/cvat_sdk/pytorch/task_dataset.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/cvat_sdk/pytorch/transforms.py
+++ b/cvat-sdk/cvat_sdk/pytorch/transforms.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/gen/generate.sh
+++ b/cvat-sdk/gen/generate.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-sdk/gen/postprocess.py
+++ b/cvat-sdk/gen/postprocess.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat-ui/.eslintrc.cjs
+++ b/cvat-ui/.eslintrc.cjs
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/index.d.ts
+++ b/cvat-ui/index.d.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/plugins/sam/src/ts/index.tsx
+++ b/cvat-ui/plugins/sam/src/ts/index.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/plugins/sam/src/ts/inference.worker.ts
+++ b/cvat-ui/plugins/sam/src/ts/inference.worker.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/annotation-actions.ts
+++ b/cvat-ui/src/actions/annotation-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/auth-actions.ts
+++ b/cvat-ui/src/actions/auth-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/boundaries-actions.ts
+++ b/cvat-ui/src/actions/boundaries-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/cloud-storage-actions.ts
+++ b/cvat-ui/src/actions/cloud-storage-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/export-actions.ts
+++ b/cvat-ui/src/actions/export-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/import-actions.ts
+++ b/cvat-ui/src/actions/import-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/invitations-actions.ts
+++ b/cvat-ui/src/actions/invitations-actions.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/jobs-actions.ts
+++ b/cvat-ui/src/actions/jobs-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/models-actions.ts
+++ b/cvat-ui/src/actions/models-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/navigation-actions.ts
+++ b/cvat-ui/src/actions/navigation-actions.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/organization-actions.ts
+++ b/cvat-ui/src/actions/organization-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/plugins-actions.ts
+++ b/cvat-ui/src/actions/plugins-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/projects-actions.ts
+++ b/cvat-ui/src/actions/projects-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/requests-actions.ts
+++ b/cvat-ui/src/actions/requests-actions.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/requests-async-actions.ts
+++ b/cvat-ui/src/actions/requests-async-actions.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/review-actions.ts
+++ b/cvat-ui/src/actions/review-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/server-actions.ts
+++ b/cvat-ui/src/actions/server-actions.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/settings-actions.ts
+++ b/cvat-ui/src/actions/settings-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/shortcuts-actions.ts
+++ b/cvat-ui/src/actions/shortcuts-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/tasks-actions.ts
+++ b/cvat-ui/src/actions/tasks-actions.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/webhooks-actions.ts
+++ b/cvat-ui/src/actions/webhooks-actions.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/assets/filter-icon.svg
+++ b/cvat-ui/src/assets/filter-icon.svg
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2023 CVAT.ai Corporation
+    Copyright (C) CVAT.ai Corporation
     SPDX-License-Identifier: MIT
 -->
 <svg width="1em" height="1em" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/cvat-ui/src/assets/fullscreen-icon.svg
+++ b/cvat-ui/src/assets/fullscreen-icon.svg
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2023 CVAT.ai Corporation
+    Copyright (C) CVAT.ai Corporation
     SPDX-License-Identifier: MIT
 -->
 <svg width="1em" height="1em" viewBox="0 0 19 18" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/cvat-ui/src/assets/guide-icon.svg
+++ b/cvat-ui/src/assets/guide-icon.svg
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2023 CVAT.ai Corporation
+    Copyright (C) CVAT.ai Corporation
     SPDX-License-Identifier: MIT
 -->
 <svg width="1em" height="1em" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/cvat-ui/src/assets/index.d.ts
+++ b/cvat-ui/src/assets/index.d.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/base.scss
+++ b/cvat-ui/src/base.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/actions-menu/actions-menu.tsx
+++ b/cvat-ui/src/components/actions-menu/actions-menu.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/actions-menu/styles.scss
+++ b/cvat-ui/src/components/actions-menu/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/analytics-page/analytics-page.tsx
+++ b/cvat-ui/src/components/analytics-page/analytics-page.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/analytics-page/analytics-performance.tsx
+++ b/cvat-ui/src/components/analytics-page/analytics-performance.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/analytics-page/styles.scss
+++ b/cvat-ui/src/components/analytics-page/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/analytics-page/views/analytics-card.tsx
+++ b/cvat-ui/src/components/analytics-page/views/analytics-card.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/analytics-page/views/histogram-view.tsx
+++ b/cvat-ui/src/components/analytics-page/views/histogram-view.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/annotation-page.tsx
+++ b/cvat-ui/src/components/annotation-page/annotation-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/annotations-actions/annotations-actions-modal.tsx
+++ b/cvat-ui/src/components/annotation-page/annotations-actions/annotations-actions-modal.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/annotations-actions/styles.scss
+++ b/cvat-ui/src/components/annotation-page/annotations-actions/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/appearance-block.tsx
+++ b/cvat-ui/src/components/annotation-page/appearance-block.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-sidebar/attribute-annotation-sidebar.tsx
+++ b/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-sidebar/attribute-annotation-sidebar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-sidebar/attribute-editor.tsx
+++ b/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-sidebar/attribute-editor.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-sidebar/object-basics-edtior.tsx
+++ b/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-sidebar/object-basics-edtior.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-workspace.tsx
+++ b/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-workspace.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/styles.scss
+++ b/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/grid-layout/canvas-layout.conf.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/grid-layout/canvas-layout.conf.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/grid-layout/canvas-layout.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/grid-layout/canvas-layout.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/grid-layout/styles.scss
+++ b/cvat-ui/src/components/annotation-page/canvas/grid-layout/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/brush-toolbox-styles.scss
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/brush-toolbox-styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/brush-tools.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/brush-tools.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-context-menu.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-context-menu.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-hints.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-hints.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/draggable-hoc.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/draggable-hoc.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/gamma-filter.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/gamma-filter.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/image-setups-content.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/image-setups-content.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/styles.scss
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas3d/canvas-wrapper3D.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas3d/canvas-wrapper3D.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas3d/styles.scss
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas3d/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/context-image/context-image-selector.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/context-image/context-image-selector.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/context-image/context-image.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/context-image/context-image.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/context-image/styles.scss
+++ b/cvat-ui/src/components/annotation-page/canvas/views/context-image/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/review-workspace/controls-side-bar/controls-side-bar.tsx
+++ b/cvat-ui/src/components/annotation-page/review-workspace/controls-side-bar/controls-side-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/review-workspace/controls-side-bar/issue-control.tsx
+++ b/cvat-ui/src/components/annotation-page/review-workspace/controls-side-bar/issue-control.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/review-workspace/review-workspace.tsx
+++ b/cvat-ui/src/components/annotation-page/review-workspace/review-workspace.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/review-workspace/styles.scss
+++ b/cvat-ui/src/components/annotation-page/review-workspace/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/review/conflict-label.tsx
+++ b/cvat-ui/src/components/annotation-page/review/conflict-label.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/review/create-issue-dialog.tsx
+++ b/cvat-ui/src/components/annotation-page/review/create-issue-dialog.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/review/hidden-issue-label.tsx
+++ b/cvat-ui/src/components/annotation-page/review/hidden-issue-label.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/review/issue-dialog.tsx
+++ b/cvat-ui/src/components/annotation-page/review/issue-dialog.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/review/issues-aggregator.tsx
+++ b/cvat-ui/src/components/annotation-page/review/issues-aggregator.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/review/styles.scss
+++ b/cvat-ui/src/components/annotation-page/review/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/single-shape-workspace/single-shape-sidebar/single-shape-sidebar.tsx
+++ b/cvat-ui/src/components/annotation-page/single-shape-workspace/single-shape-sidebar/single-shape-sidebar.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/single-shape-workspace/single-shape-workspace.tsx
+++ b/cvat-ui/src/components/annotation-page/single-shape-workspace/single-shape-workspace.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/single-shape-workspace/styles.scss
+++ b/cvat-ui/src/components/annotation-page/single-shape-workspace/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/approximation-accuracy.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/approximation-accuracy.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/control-visibility-observer.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/control-visibility-observer.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/controls-side-bar.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/controls-side-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/cursor-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/cursor-control.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-mask-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-mask-control.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/group-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/group-control.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/handle-popover-visibility.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/handle-popover-visibility.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/join-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/join-control.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/merge-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/merge-control.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/opencv-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/opencv-control.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/rotate-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/rotate-control.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/slice-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/slice-control.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/split-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/split-control.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/color-picker.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/color-picker.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 import React, { useState } from 'react';

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/issues-list.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/issues-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/label-item.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/label-item.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/labels-list.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/labels-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-basics.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-basics.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-buttons.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-buttons.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-details.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-details.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-menu.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-menu.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/objects-list-header.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/objects-list-header.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/objects-list.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/objects-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/objects-side-bar.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/objects-side-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/states-ordering-selector.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/states-ordering-selector.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/propagate-confirm.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/propagate-confirm.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/remove-confirm.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/remove-confirm.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/standard-workspace.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/standard-workspace.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/styles.scss
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard3D-workspace/controls-side-bar/controls-side-bar.tsx
+++ b/cvat-ui/src/components/annotation-page/standard3D-workspace/controls-side-bar/controls-side-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/standard3D-workspace/standard3D-workspace.tsx
+++ b/cvat-ui/src/components/annotation-page/standard3D-workspace/standard3D-workspace.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/styles.scss
+++ b/cvat-ui/src/components/annotation-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/tag-annotation-workspace/frame-tags.tsx
+++ b/cvat-ui/src/components/annotation-page/tag-annotation-workspace/frame-tags.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/tag-annotation-workspace/styles.scss
+++ b/cvat-ui/src/components/annotation-page/tag-annotation-workspace/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/tag-annotation-workspace/tag-annotation-sidebar/shortcuts-select.tsx
+++ b/cvat-ui/src/components/annotation-page/tag-annotation-workspace/tag-annotation-sidebar/shortcuts-select.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/tag-annotation-workspace/tag-annotation-sidebar/tag-annotation-sidebar.tsx
+++ b/cvat-ui/src/components/annotation-page/tag-annotation-workspace/tag-annotation-sidebar/tag-annotation-sidebar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/tag-annotation-workspace/tag-annotation-workspace.tsx
+++ b/cvat-ui/src/components/annotation-page/tag-annotation-workspace/tag-annotation-workspace.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/top-bar/annotation-menu.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/annotation-menu.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/top-bar/filters-modal.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/filters-modal.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/top-bar/left-group.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/left-group.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/top-bar/player-navigation.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/player-navigation.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/top-bar/right-group.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/right-group.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/top-bar/save-annotations-button.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/save-annotations-button.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/top-bar/statistics-modal.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/statistics-modal.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/top-bar/top-bar.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/top-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/change-password-modal/change-password-modal.tsx
+++ b/cvat-ui/src/components/change-password-modal/change-password-modal.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/cloud-storages-page/cloud-storage-item.tsx
+++ b/cvat-ui/src/components/cloud-storages-page/cloud-storage-item.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/cloud-storages-page/cloud-storages-filter-configuration.ts
+++ b/cvat-ui/src/components/cloud-storages-page/cloud-storages-filter-configuration.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/cloud-storages-page/cloud-storages-list.tsx
+++ b/cvat-ui/src/components/cloud-storages-page/cloud-storages-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/cloud-storages-page/cloud-storages-page.tsx
+++ b/cvat-ui/src/components/cloud-storages-page/cloud-storages-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/cloud-storages-page/empty-list.tsx
+++ b/cvat-ui/src/components/cloud-storages-page/empty-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/cloud-storages-page/styles.scss
+++ b/cvat-ui/src/components/cloud-storages-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/cloud-storages-page/top-bar.tsx
+++ b/cvat-ui/src/components/cloud-storages-page/top-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/common/cvat-dropdown-menu-paper/index.scss
+++ b/cvat-ui/src/components/common/cvat-dropdown-menu-paper/index.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/common/cvat-markdown.tsx
+++ b/cvat-ui/src/components/common/cvat-markdown.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/common/cvat-tooltip.tsx
+++ b/cvat-ui/src/components/common/cvat-tooltip.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/common/go-back-button.tsx
+++ b/cvat-ui/src/components/common/go-back-button.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/common/not-found.tsx
+++ b/cvat-ui/src/components/common/not-found.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/common/preview.tsx
+++ b/cvat-ui/src/components/common/preview.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/common/styles.scss
+++ b/cvat-ui/src/components/common/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/common/upload-file-status-modal.tsx
+++ b/cvat-ui/src/components/common/upload-file-status-modal.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-cloud-storage-page/cloud-storage-form.tsx
+++ b/cvat-ui/src/components/create-cloud-storage-page/cloud-storage-form.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-cloud-storage-page/gcs-locatiion.tsx
+++ b/cvat-ui/src/components/create-cloud-storage-page/gcs-locatiion.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-cloud-storage-page/manifests-manager.tsx
+++ b/cvat-ui/src/components/create-cloud-storage-page/manifests-manager.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-cloud-storage-page/s3-region.tsx
+++ b/cvat-ui/src/components/create-cloud-storage-page/s3-region.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-cloud-storage-page/styles.scss
+++ b/cvat-ui/src/components/create-cloud-storage-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-job-page/create-job-page.tsx
+++ b/cvat-ui/src/components/create-job-page/create-job-page.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-job-page/job-form.tsx
+++ b/cvat-ui/src/components/create-job-page/job-form.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-job-page/styles.scss
+++ b/cvat-ui/src/components/create-job-page/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-organization-page/styles.scss
+++ b/cvat-ui/src/components/create-organization-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-project-page/create-project-content.tsx
+++ b/cvat-ui/src/components/create-project-page/create-project-content.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-project-page/styles.scss
+++ b/cvat-ui/src/components/create-project-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-task-page/advanced-configuration-form.tsx
+++ b/cvat-ui/src/components/create-task-page/advanced-configuration-form.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-task-page/basic-configuration-form.tsx
+++ b/cvat-ui/src/components/create-task-page/basic-configuration-form.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-task-page/create-task-content.tsx
+++ b/cvat-ui/src/components/create-task-page/create-task-content.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-task-page/create-task-page.tsx
+++ b/cvat-ui/src/components/create-task-page/create-task-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-task-page/multi-task-progress.tsx
+++ b/cvat-ui/src/components/create-task-page/multi-task-progress.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-task-page/project-search-field.tsx
+++ b/cvat-ui/src/components/create-task-page/project-search-field.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-task-page/quality-configuration-form.tsx
+++ b/cvat-ui/src/components/create-task-page/quality-configuration-form.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/create-task-page/styles.scss
+++ b/cvat-ui/src/components/create-task-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/cvat-app.tsx
+++ b/cvat-ui/src/components/cvat-app.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/dropdown-menu.tsx
+++ b/cvat-ui/src/components/dropdown-menu.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/email-confirmation-pages/email-confirmed.tsx
+++ b/cvat-ui/src/components/email-confirmation-pages/email-confirmed.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/email-confirmation-pages/email-verification-sent.tsx
+++ b/cvat-ui/src/components/email-confirmation-pages/email-verification-sent.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/email-confirmation-pages/incorrect-email-confirmation.tsx
+++ b/cvat-ui/src/components/email-confirmation-pages/incorrect-email-confirmation.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/export-backup/export-backup-modal.tsx
+++ b/cvat-ui/src/components/export-backup/export-backup-modal.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/export-backup/export-backup-modal.tsx
+++ b/cvat-ui/src/components/export-backup/export-backup-modal.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 CVAT.ai Corporation
+// Copyright (C) 2022-2024 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/export-backup/styles.scss
+++ b/cvat-ui/src/components/export-backup/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/export-dataset/export-dataset-modal.tsx
+++ b/cvat-ui/src/components/export-dataset/export-dataset-modal.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/file-manager/cloud-storages-tab.tsx
+++ b/cvat-ui/src/components/file-manager/cloud-storages-tab.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/file-manager/file-manager.tsx
+++ b/cvat-ui/src/components/file-manager/file-manager.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/file-manager/local-files.tsx
+++ b/cvat-ui/src/components/file-manager/local-files.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/file-manager/remote-browser.tsx
+++ b/cvat-ui/src/components/file-manager/remote-browser.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/file-manager/styles.scss
+++ b/cvat-ui/src/components/file-manager/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/global-error-boundary/global-error-boundary.tsx
+++ b/cvat-ui/src/components/global-error-boundary/global-error-boundary.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/header/header.tsx
+++ b/cvat-ui/src/components/header/header.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/header/organizations-search.tsx
+++ b/cvat-ui/src/components/header/organizations-search.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/header/settings-modal/multiple-shortcuts-display.tsx
+++ b/cvat-ui/src/components/header/settings-modal/multiple-shortcuts-display.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/header/settings-modal/player-settings.tsx
+++ b/cvat-ui/src/components/header/settings-modal/player-settings.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/header/settings-modal/settings-modal.tsx
+++ b/cvat-ui/src/components/header/settings-modal/settings-modal.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/header/settings-modal/shortcut-settings.tsx
+++ b/cvat-ui/src/components/header/settings-modal/shortcut-settings.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/header/settings-modal/styles.scss
+++ b/cvat-ui/src/components/header/settings-modal/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/header/styles.scss
+++ b/cvat-ui/src/components/header/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/import-backup/import-backup-modal.tsx
+++ b/cvat-ui/src/components/import-backup/import-backup-modal.tsx
@@ -1,5 +1,5 @@
-// Copyright (C) 2022 CVAT.ai Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/import-dataset/import-dataset-modal.tsx
+++ b/cvat-ui/src/components/import-dataset/import-dataset-modal.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/import-dataset/styles.scss
+++ b/cvat-ui/src/components/import-dataset/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/invitation-watcher/invitation-watcher.tsx
+++ b/cvat-ui/src/components/invitation-watcher/invitation-watcher.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/invitations-page/empty-list.tsx
+++ b/cvat-ui/src/components/invitations-page/empty-list.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/invitations-page/invitation-item.tsx
+++ b/cvat-ui/src/components/invitations-page/invitation-item.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/invitations-page/invitations-list.tsx
+++ b/cvat-ui/src/components/invitations-page/invitations-list.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/invitations-page/invitations-page.tsx
+++ b/cvat-ui/src/components/invitations-page/invitations-page.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/invitations-page/styles.scss
+++ b/cvat-ui/src/components/invitations-page/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/job-item/job-actions-menu.tsx
+++ b/cvat-ui/src/components/job-item/job-actions-menu.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/job-item/job-item.tsx
+++ b/cvat-ui/src/components/job-item/job-item.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/job-item/styles.scss
+++ b/cvat-ui/src/components/job-item/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/jobs-page/empty-list.tsx
+++ b/cvat-ui/src/components/jobs-page/empty-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/jobs-page/job-card.tsx
+++ b/cvat-ui/src/components/jobs-page/job-card.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/jobs-page/jobs-content.tsx
+++ b/cvat-ui/src/components/jobs-page/jobs-content.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/jobs-page/jobs-filter-configuration.ts
+++ b/cvat-ui/src/components/jobs-page/jobs-filter-configuration.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/jobs-page/jobs-page.tsx
+++ b/cvat-ui/src/components/jobs-page/jobs-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/jobs-page/styles.scss
+++ b/cvat-ui/src/components/jobs-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/labels-editor/common.ts
+++ b/cvat-ui/src/components/labels-editor/common.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/labels-editor/constructor-creator.tsx
+++ b/cvat-ui/src/components/labels-editor/constructor-creator.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/labels-editor/constructor-viewer-item.tsx
+++ b/cvat-ui/src/components/labels-editor/constructor-viewer-item.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/labels-editor/constructor-viewer.tsx
+++ b/cvat-ui/src/components/labels-editor/constructor-viewer.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/labels-editor/label-form.tsx
+++ b/cvat-ui/src/components/labels-editor/label-form.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/labels-editor/labels-editor.tsx
+++ b/cvat-ui/src/components/labels-editor/labels-editor.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/labels-editor/pick-from-model.tsx
+++ b/cvat-ui/src/components/labels-editor/pick-from-model.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/labels-editor/raw-viewer.tsx
+++ b/cvat-ui/src/components/labels-editor/raw-viewer.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/labels-editor/skeleton-configurator.tsx
+++ b/cvat-ui/src/components/labels-editor/skeleton-configurator.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/labels-editor/skeleton-element-context-menu.tsx
+++ b/cvat-ui/src/components/labels-editor/skeleton-element-context-menu.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/labels-editor/styles.scss
+++ b/cvat-ui/src/components/labels-editor/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/layout-grid/styles.scss
+++ b/cvat-ui/src/components/layout-grid/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/login-page/login-form.tsx
+++ b/cvat-ui/src/components/login-page/login-form.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/login-page/login-page.tsx
+++ b/cvat-ui/src/components/login-page/login-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/logout-component.tsx
+++ b/cvat-ui/src/components/logout-component.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/md-guide/annotation-guide-page.tsx
+++ b/cvat-ui/src/components/md-guide/annotation-guide-page.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/md-guide/md-guide-control.tsx
+++ b/cvat-ui/src/components/md-guide/md-guide-control.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/md-guide/styles.scss
+++ b/cvat-ui/src/components/md-guide/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/model-runner-modal/detector-runner.tsx
+++ b/cvat-ui/src/components/model-runner-modal/detector-runner.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/model-runner-modal/labels-mapper.tsx
+++ b/cvat-ui/src/components/model-runner-modal/labels-mapper.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/model-runner-modal/model-runner-dialog.tsx
+++ b/cvat-ui/src/components/model-runner-modal/model-runner-dialog.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/model-runner-modal/object-mapper.tsx
+++ b/cvat-ui/src/components/model-runner-modal/object-mapper.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/model-runner-modal/styles.scss
+++ b/cvat-ui/src/components/model-runner-modal/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/models-page/deployed-model-item.tsx
+++ b/cvat-ui/src/components/models-page/deployed-model-item.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/models-page/deployed-models-list.tsx
+++ b/cvat-ui/src/components/models-page/deployed-models-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/models-page/empty-list.tsx
+++ b/cvat-ui/src/components/models-page/empty-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/models-page/models-filter-configuration.tsx
+++ b/cvat-ui/src/components/models-page/models-filter-configuration.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/models-page/models-page.tsx
+++ b/cvat-ui/src/components/models-page/models-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/models-page/styles.scss
+++ b/cvat-ui/src/components/models-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/models-page/top-bar.tsx
+++ b/cvat-ui/src/components/models-page/top-bar.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/move-task-modal/move-task-modal.tsx
+++ b/cvat-ui/src/components/move-task-modal/move-task-modal.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/move-task-modal/styles.scss
+++ b/cvat-ui/src/components/move-task-modal/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/organization-page/member-item.tsx
+++ b/cvat-ui/src/components/organization-page/member-item.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/organization-page/members-list.tsx
+++ b/cvat-ui/src/components/organization-page/members-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/organization-page/styles.scss
+++ b/cvat-ui/src/components/organization-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/organization-page/top-bar.tsx
+++ b/cvat-ui/src/components/organization-page/top-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/paid-feature-placeholder/paid-feature-placeholder.tsx
+++ b/cvat-ui/src/components/paid-feature-placeholder/paid-feature-placeholder.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/paid-feature-placeholder/styles.scss
+++ b/cvat-ui/src/components/paid-feature-placeholder/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/plugins-entrypoint.tsx
+++ b/cvat-ui/src/components/plugins-entrypoint.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/project-page/details.tsx
+++ b/cvat-ui/src/components/project-page/details.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/project-page/project-page.tsx
+++ b/cvat-ui/src/components/project-page/project-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/project-page/project-tasks-filter-configuration.ts
+++ b/cvat-ui/src/components/project-page/project-tasks-filter-configuration.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/project-page/styles.scss
+++ b/cvat-ui/src/components/project-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/project-page/top-bar.tsx
+++ b/cvat-ui/src/components/project-page/top-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/projects-page/actions-menu.tsx
+++ b/cvat-ui/src/components/projects-page/actions-menu.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/projects-page/empty-list.tsx
+++ b/cvat-ui/src/components/projects-page/empty-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/projects-page/project-item.tsx
+++ b/cvat-ui/src/components/projects-page/project-item.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/projects-page/project-list.tsx
+++ b/cvat-ui/src/components/projects-page/project-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/projects-page/projects-filter-configuration.ts
+++ b/cvat-ui/src/components/projects-page/projects-filter-configuration.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/projects-page/projects-page.tsx
+++ b/cvat-ui/src/components/projects-page/projects-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/projects-page/styles.scss
+++ b/cvat-ui/src/components/projects-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/projects-page/top-bar.tsx
+++ b/cvat-ui/src/components/projects-page/top-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/quality-control/quality-control-page.tsx
+++ b/cvat-ui/src/components/quality-control/quality-control-page.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/quality-control/quality-settings-tab.tsx
+++ b/cvat-ui/src/components/quality-control/quality-settings-tab.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/quality-control/styles.scss
+++ b/cvat-ui/src/components/quality-control/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/quality-control/task-quality/allocation-table.tsx
+++ b/cvat-ui/src/components/quality-control/task-quality/allocation-table.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/quality-control/task-quality/quality-magement-tab.tsx
+++ b/cvat-ui/src/components/quality-control/task-quality/quality-magement-tab.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/quality-control/task-quality/quality-overview-tab.tsx
+++ b/cvat-ui/src/components/quality-control/task-quality/quality-overview-tab.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/quality-control/task-quality/quality-settings-form.tsx
+++ b/cvat-ui/src/components/quality-control/task-quality/quality-settings-form.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/quality-control/task-quality/quality-table-header.tsx
+++ b/cvat-ui/src/components/quality-control/task-quality/quality-table-header.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/register-page/register-form.tsx
+++ b/cvat-ui/src/components/register-page/register-form.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/register-page/register-page.tsx
+++ b/cvat-ui/src/components/register-page/register-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/register-page/register-page.tsx
+++ b/cvat-ui/src/components/register-page/register-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corp
+// Copyright (C) 2022 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/requests-page/empty-list.tsx
+++ b/cvat-ui/src/components/requests-page/empty-list.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/requests-page/request-card.tsx
+++ b/cvat-ui/src/components/requests-page/request-card.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/requests-page/request-status.tsx
+++ b/cvat-ui/src/components/requests-page/request-status.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/requests-page/requests-list.tsx
+++ b/cvat-ui/src/components/requests-page/requests-list.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/requests-page/requests-page.tsx
+++ b/cvat-ui/src/components/requests-page/requests-page.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/requests-page/styles.scss
+++ b/cvat-ui/src/components/requests-page/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/reset-password-confirm-page/reset-password-confirm-page.tsx
+++ b/cvat-ui/src/components/reset-password-confirm-page/reset-password-confirm-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/reset-password-confirm-page/reset-password-confirm-page.tsx
+++ b/cvat-ui/src/components/reset-password-confirm-page/reset-password-confirm-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corp
+// Copyright (C) 2022 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/reset-password-page/reset-password-form.tsx
+++ b/cvat-ui/src/components/reset-password-page/reset-password-form.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/reset-password-page/reset-password-form.tsx
+++ b/cvat-ui/src/components/reset-password-page/reset-password-form.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corp
+// Copyright (C) 2022 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/reset-password-page/reset-password-page.tsx
+++ b/cvat-ui/src/components/reset-password-page/reset-password-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/reset-password-page/reset-password-page.tsx
+++ b/cvat-ui/src/components/reset-password-page/reset-password-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corp
+// Copyright (C) 2022 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/resource-sorting-filtering/request-users.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/request-users.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/resource-sorting-filtering/sorting.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/sorting.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/resource-sorting-filtering/styles.scss
+++ b/cvat-ui/src/components/resource-sorting-filtering/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/select-cloud-storage/select-cloud-storage.tsx
+++ b/cvat-ui/src/components/select-cloud-storage/select-cloud-storage.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/setup-webhook-pages/create-webhook-page.tsx
+++ b/cvat-ui/src/components/setup-webhook-pages/create-webhook-page.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/setup-webhook-pages/setup-webhook-content.tsx
+++ b/cvat-ui/src/components/setup-webhook-pages/setup-webhook-content.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/setup-webhook-pages/styles.scss
+++ b/cvat-ui/src/components/setup-webhook-pages/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/setup-webhook-pages/update-webhook-page.tsx
+++ b/cvat-ui/src/components/setup-webhook-pages/update-webhook-page.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/shortcuts-dialog/shortcuts-dialog.tsx
+++ b/cvat-ui/src/components/shortcuts-dialog/shortcuts-dialog.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/signing-common/cvat-signing-input.tsx
+++ b/cvat-ui/src/components/signing-common/cvat-signing-input.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 import React, { useEffect, useState } from 'react';

--- a/cvat-ui/src/components/signing-common/signing-layout.tsx
+++ b/cvat-ui/src/components/signing-common/signing-layout.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/signing-common/styles.scss
+++ b/cvat-ui/src/components/signing-common/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/storage/source-storage-field.tsx
+++ b/cvat-ui/src/components/storage/source-storage-field.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/storage/storage-field.tsx
+++ b/cvat-ui/src/components/storage/storage-field.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/storage/storage-with-switch-field.tsx
+++ b/cvat-ui/src/components/storage/storage-with-switch-field.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/storage/styles.scss
+++ b/cvat-ui/src/components/storage/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/storage/target-storage-field.tsx
+++ b/cvat-ui/src/components/storage/target-storage-field.tsx
@@ -1,4 +1,4 @@
-// (Copyright (C) 2022 CVAT.ai Corporation
+// (Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/task-page/bug-tracker-editor.tsx
+++ b/cvat-ui/src/components/task-page/bug-tracker-editor.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/task-page/details.tsx
+++ b/cvat-ui/src/components/task-page/details.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/task-page/job-list.tsx
+++ b/cvat-ui/src/components/task-page/job-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/task-page/jobs-filter-configuration.ts
+++ b/cvat-ui/src/components/task-page/jobs-filter-configuration.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/task-page/styles.scss
+++ b/cvat-ui/src/components/task-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/task-page/task-page.tsx
+++ b/cvat-ui/src/components/task-page/task-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/task-page/top-bar.tsx
+++ b/cvat-ui/src/components/task-page/top-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/task-page/user-selector.tsx
+++ b/cvat-ui/src/components/task-page/user-selector.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/tasks-page/automatic-annotation-progress.tsx
+++ b/cvat-ui/src/components/tasks-page/automatic-annotation-progress.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/tasks-page/empty-list.tsx
+++ b/cvat-ui/src/components/tasks-page/empty-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/tasks-page/styles.scss
+++ b/cvat-ui/src/components/tasks-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/tasks-page/task-item.tsx
+++ b/cvat-ui/src/components/tasks-page/task-item.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/tasks-page/tasks-filter-configuration.ts
+++ b/cvat-ui/src/components/tasks-page/tasks-filter-configuration.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/tasks-page/tasks-page.tsx
+++ b/cvat-ui/src/components/tasks-page/tasks-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/tasks-page/top-bar.tsx
+++ b/cvat-ui/src/components/tasks-page/top-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/webhooks-page/empty-list.tsx
+++ b/cvat-ui/src/components/webhooks-page/empty-list.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/webhooks-page/styles.scss
+++ b/cvat-ui/src/components/webhooks-page/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/webhooks-page/top-bar.tsx
+++ b/cvat-ui/src/components/webhooks-page/top-bar.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/webhooks-page/webhook-item.tsx
+++ b/cvat-ui/src/components/webhooks-page/webhook-item.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/webhooks-page/webhooks-filter-configuration.ts
+++ b/cvat-ui/src/components/webhooks-page/webhooks-filter-configuration.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/webhooks-page/webhooks-list.tsx
+++ b/cvat-ui/src/components/webhooks-page/webhooks-list.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/webhooks-page/webhooks-page.tsx
+++ b/cvat-ui/src/components/webhooks-page/webhooks-page.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/config.tsx
+++ b/cvat-ui/src/config.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2019-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/actions-menu/actions-menu.tsx
+++ b/cvat-ui/src/containers/actions-menu/actions-menu.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/annotation-page/annotation-page.tsx
+++ b/cvat-ui/src/containers/annotation-page/annotation-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/annotation-page/canvas/canvas-context-menu.tsx
+++ b/cvat-ui/src/containers/annotation-page/canvas/canvas-context-menu.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/annotation-page/review-workspace/controls-side-bar/controls-side-bar.tsx
+++ b/cvat-ui/src/containers/annotation-page/review-workspace/controls-side-bar/controls-side-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/controls-side-bar.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/controls-side-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-buttons.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-buttons.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-item-details.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-item-details.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/objects-list.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/objects-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/annotation-page/standard3D-workspace/controls-side-bar/controls-side-bar.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard3D-workspace/controls-side-bar/controls-side-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/annotation-page/top-bar/top-bar.tsx
+++ b/cvat-ui/src/containers/annotation-page/top-bar/top-bar.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/create-task-page/create-task-page.tsx
+++ b/cvat-ui/src/containers/create-task-page/create-task-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/header/settings-modal/shortcuts-settings.tsx
+++ b/cvat-ui/src/containers/header/settings-modal/shortcuts-settings.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/register-page/register-page.tsx
+++ b/cvat-ui/src/containers/register-page/register-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/tasks-page/task-item.tsx
+++ b/cvat-ui/src/containers/tasks-page/task-item.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/tasks-page/tasks-list.tsx
+++ b/cvat-ui/src/containers/tasks-page/tasks-list.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/containers/tasks-page/tasks-page.tsx
+++ b/cvat-ui/src/containers/tasks-page/tasks-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/cvat-canvas3d-wrapper.ts
+++ b/cvat-ui/src/cvat-canvas3d-wrapper.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/cvat-core-wrapper.ts
+++ b/cvat-ui/src/cvat-core-wrapper.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/cvat-store.ts
+++ b/cvat-ui/src/cvat-store.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/icons.tsx
+++ b/cvat-ui/src/icons.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/index.html
+++ b/cvat-ui/src/index.html
@@ -1,6 +1,6 @@
 <!--
  Copyright (C) 2020-2022 Intel Corporation
- Copyright (C) 2023 CVAT.ai Corporation
+ Copyright (C) CVAT.ai Corporation
 
  SPDX-License-Identifier: MIT
 -->

--- a/cvat-ui/src/index.tsx
+++ b/cvat-ui/src/index.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/annotation-reducer.ts
+++ b/cvat-ui/src/reducers/annotation-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/auth-reducer.ts
+++ b/cvat-ui/src/reducers/auth-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/cloud-storages-reducer.ts
+++ b/cvat-ui/src/reducers/cloud-storages-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/export-reducer.ts
+++ b/cvat-ui/src/reducers/export-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/import-reducer.ts
+++ b/cvat-ui/src/reducers/import-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/invitations-reducer.ts
+++ b/cvat-ui/src/reducers/invitations-reducer.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/models-reducer.ts
+++ b/cvat-ui/src/reducers/models-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/navigation-reducer.ts
+++ b/cvat-ui/src/reducers/navigation-reducer.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/notifications-reducer.ts
+++ b/cvat-ui/src/reducers/notifications-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/organizations-reducer.ts
+++ b/cvat-ui/src/reducers/organizations-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/plugins-reducer.ts
+++ b/cvat-ui/src/reducers/plugins-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/projects-reducer.ts
+++ b/cvat-ui/src/reducers/projects-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/requests-reducer.ts
+++ b/cvat-ui/src/reducers/requests-reducer.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/review-reducer.ts
+++ b/cvat-ui/src/reducers/review-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/root-reducer.ts
+++ b/cvat-ui/src/reducers/root-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/server-api-reducer.ts
+++ b/cvat-ui/src/reducers/server-api-reducer.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/settings-reducer.ts
+++ b/cvat-ui/src/reducers/settings-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/shortcuts-reducer.ts
+++ b/cvat-ui/src/reducers/shortcuts-reducer.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/tasks-reducer.ts
+++ b/cvat-ui/src/reducers/tasks-reducer.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/reducers/webhooks-reducer.ts
+++ b/cvat-ui/src/reducers/webhooks-reducer.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/styles.scss
+++ b/cvat-ui/src/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/any-search.ts
+++ b/cvat-ui/src/utils/any-search.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/auth-query.ts
+++ b/cvat-ui/src/utils/auth-query.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/compute-text-color.ts
+++ b/cvat-ui/src/utils/compute-text-color.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/conflict-detector.ts
+++ b/cvat-ui/src/utils/conflict-detector.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/dimensions.ts
+++ b/cvat-ui/src/utils/dimensions.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/environment.ts
+++ b/cvat-ui/src/utils/environment.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/event-recorder.ts
+++ b/cvat-ui/src/utils/event-recorder.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/fabric-wrapper/fabric-wrapper.ts
+++ b/cvat-ui/src/utils/fabric-wrapper/fabric-wrapper.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/fabric-wrapper/gamma-correciton.ts
+++ b/cvat-ui/src/utils/fabric-wrapper/gamma-correciton.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/files.ts
+++ b/cvat-ui/src/utils/files.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/filter-annotations.ts
+++ b/cvat-ui/src/utils/filter-annotations.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/filter-applicable-labels.ts
+++ b/cvat-ui/src/utils/filter-applicable-labels.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/filter-null.ts
+++ b/cvat-ui/src/utils/filter-null.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/hooks.ts
+++ b/cvat-ui/src/utils/hooks.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/image-processing.tsx
+++ b/cvat-ui/src/utils/image-processing.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/is-able-to-change-frame.ts
+++ b/cvat-ui/src/utils/is-able-to-change-frame.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/mousetrap-react.tsx
+++ b/cvat-ui/src/utils/mousetrap-react.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/opencv-wrapper/annotations-actions/tracker-mil.ts
+++ b/cvat-ui/src/utils/opencv-wrapper/annotations-actions/tracker-mil.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/opencv-wrapper/histogram-equalization.ts
+++ b/cvat-ui/src/utils/opencv-wrapper/histogram-equalization.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/opencv-wrapper/intelligent-scissors.ts
+++ b/cvat-ui/src/utils/opencv-wrapper/intelligent-scissors.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/opencv-wrapper/opencv-interfaces.ts
+++ b/cvat-ui/src/utils/opencv-wrapper/opencv-interfaces.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/opencv-wrapper/opencv-wrapper.ts
+++ b/cvat-ui/src/utils/opencv-wrapper/opencv-wrapper.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/opencv-wrapper/tracker-mil.ts
+++ b/cvat-ui/src/utils/opencv-wrapper/tracker-mil.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/quality.ts
+++ b/cvat-ui/src/utils/quality.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/redux.ts
+++ b/cvat-ui/src/utils/redux.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/remember-latest-frame.ts
+++ b/cvat-ui/src/utils/remember-latest-frame.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/utils/validation-patterns.ts
+++ b/cvat-ui/src/utils/validation-patterns.ts
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/webpack.config.js
+++ b/cvat-ui/webpack.config.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/apps.py
+++ b/cvat/apps/analytics_report/apps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/models.py
+++ b/cvat/apps/analytics_report/models.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/permissions.py
+++ b/cvat/apps/analytics_report/permissions.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/create.py
+++ b/cvat/apps/analytics_report/report/create.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/derived_metrics/__init__.py
+++ b/cvat/apps/analytics_report/report/derived_metrics/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/derived_metrics/annotation_speed.py
+++ b/cvat/apps/analytics_report/report/derived_metrics/annotation_speed.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/derived_metrics/annotation_time.py
+++ b/cvat/apps/analytics_report/report/derived_metrics/annotation_time.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/derived_metrics/average_annotation_speed.py
+++ b/cvat/apps/analytics_report/report/derived_metrics/average_annotation_speed.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/derived_metrics/base.py
+++ b/cvat/apps/analytics_report/report/derived_metrics/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/derived_metrics/objects.py
+++ b/cvat/apps/analytics_report/report/derived_metrics/objects.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/derived_metrics/total_object_count.py
+++ b/cvat/apps/analytics_report/report/derived_metrics/total_object_count.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/get.py
+++ b/cvat/apps/analytics_report/report/get.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/primary_metrics/__init__.py
+++ b/cvat/apps/analytics_report/report/primary_metrics/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/primary_metrics/annotation_speed.py
+++ b/cvat/apps/analytics_report/report/primary_metrics/annotation_speed.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/primary_metrics/annotation_time.py
+++ b/cvat/apps/analytics_report/report/primary_metrics/annotation_time.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/primary_metrics/base.py
+++ b/cvat/apps/analytics_report/report/primary_metrics/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/primary_metrics/objects.py
+++ b/cvat/apps/analytics_report/report/primary_metrics/objects.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/report/primary_metrics/utils.py
+++ b/cvat/apps/analytics_report/report/primary_metrics/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/serializers.py
+++ b/cvat/apps/analytics_report/serializers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/urls.py
+++ b/cvat/apps/analytics_report/urls.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/analytics_report/views.py
+++ b/cvat/apps/analytics_report/views.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/annotation.py
+++ b/cvat/apps/dataset_manager/annotation.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/apps.py
+++ b/cvat/apps/dataset_manager/apps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/cron.py
+++ b/cvat/apps/dataset_manager/cron.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/camvid.py
+++ b/cvat/apps/dataset_manager/formats/camvid.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/cityscapes.py
+++ b/cvat/apps/dataset_manager/formats/cityscapes.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/coco.py
+++ b/cvat/apps/dataset_manager/formats/coco.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/cvat.py
+++ b/cvat/apps/dataset_manager/formats/cvat.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/datumaro.py
+++ b/cvat/apps/dataset_manager/formats/datumaro.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/icdar.py
+++ b/cvat/apps/dataset_manager/formats/icdar.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/imagenet.py
+++ b/cvat/apps/dataset_manager/formats/imagenet.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/kitti.py
+++ b/cvat/apps/dataset_manager/formats/kitti.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/labelme.py
+++ b/cvat/apps/dataset_manager/formats/labelme.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/lfw.py
+++ b/cvat/apps/dataset_manager/formats/lfw.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/market1501.py
+++ b/cvat/apps/dataset_manager/formats/market1501.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/mask.py
+++ b/cvat/apps/dataset_manager/formats/mask.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/mot.py
+++ b/cvat/apps/dataset_manager/formats/mot.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/mots.py
+++ b/cvat/apps/dataset_manager/formats/mots.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/openimages.py
+++ b/cvat/apps/dataset_manager/formats/openimages.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/pascal_voc.py
+++ b/cvat/apps/dataset_manager/formats/pascal_voc.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/pointcloud.py
+++ b/cvat/apps/dataset_manager/formats/pointcloud.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/transformations.py
+++ b/cvat/apps/dataset_manager/formats/transformations.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/velodynepoint.py
+++ b/cvat/apps/dataset_manager/formats/velodynepoint.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/vggface2.py
+++ b/cvat/apps/dataset_manager/formats/vggface2.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/widerface.py
+++ b/cvat/apps/dataset_manager/formats/widerface.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/formats/yolo.py
+++ b/cvat/apps/dataset_manager/formats/yolo.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 import os.path as osp

--- a/cvat/apps/dataset_manager/management/__init__.py
+++ b/cvat/apps/dataset_manager/management/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/management/commands/__init__.py
+++ b/cvat/apps/dataset_manager/management/commands/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/management/commands/cleanuplegacyexportcache.py
+++ b/cvat/apps/dataset_manager/management/commands/cleanuplegacyexportcache.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/project.py
+++ b/cvat/apps/dataset_manager/project.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2022-2025 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/tests/test_formats.py
+++ b/cvat/apps/dataset_manager/tests/test_formats.py
@@ -1,6 +1,6 @@
 
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
+++ b/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/tests/utils.py
+++ b/cvat/apps/dataset_manager/tests/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/util.py
+++ b/cvat/apps/dataset_manager/util.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2023-2025 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/dataset_manager/views.py
+++ b/cvat/apps/dataset_manager/views.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/__init__.py
+++ b/cvat/apps/engine/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/apps.py
+++ b/cvat/apps/engine/apps.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2022 Intel Corporation
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/background.py
+++ b/cvat/apps/engine/background.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/backup.py
+++ b/cvat/apps/engine/backup.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/cache.py
+++ b/cvat/apps/engine/cache.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2023 Intel Corporation
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/default_settings.py
+++ b/cvat/apps/engine/default_settings.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/field_validation.py
+++ b/cvat/apps/engine/field_validation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/filters.py
+++ b/cvat/apps/engine/filters.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/frame_provider.py
+++ b/cvat/apps/engine/frame_provider.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/handlers.py
+++ b/cvat/apps/engine/handlers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/lazy_list.py
+++ b/cvat/apps/engine/lazy_list.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/location.py
+++ b/cvat/apps/engine/location.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/log.py
+++ b/cvat/apps/engine/log.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2022 Intel Corporation
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/management/commands/syncperiodicjobs.py
+++ b/cvat/apps/engine/management/commands/syncperiodicjobs.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/middleware.py
+++ b/cvat/apps/engine/middleware.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/mixins.py
+++ b/cvat/apps/engine/mixins.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/model_utils.py
+++ b/cvat/apps/engine/model_utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/permissions.py
+++ b/cvat/apps/engine/permissions.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/rq_job_handler.py
+++ b/cvat/apps/engine/rq_job_handler.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/rules/tests/generators/annotationguides_test.gen.rego.py
+++ b/cvat/apps/engine/rules/tests/generators/annotationguides_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/rules/tests/generators/cloudstorages_test.gen.rego.py
+++ b/cvat/apps/engine/rules/tests/generators/cloudstorages_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/rules/tests/generators/comments_test.gen.rego.py
+++ b/cvat/apps/engine/rules/tests/generators/comments_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/rules/tests/generators/issues_test.gen.rego.py
+++ b/cvat/apps/engine/rules/tests/generators/issues_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/rules/tests/generators/jobs_test.gen.rego.py
+++ b/cvat/apps/engine/rules/tests/generators/jobs_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/rules/tests/generators/projects_test.gen.rego.py
+++ b/cvat/apps/engine/rules/tests/generators/projects_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/rules/tests/generators/server_test.gen.rego.py
+++ b/cvat/apps/engine/rules/tests/generators/server_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/rules/tests/generators/tasks_test.gen.rego.py
+++ b/cvat/apps/engine/rules/tests/generators/tasks_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/rules/tests/generators/users_test.gen.rego.py
+++ b/cvat/apps/engine/rules/tests/generators/users_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/schema.py
+++ b/cvat/apps/engine/schema.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/signals.py
+++ b/cvat/apps/engine/signals.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 import functools

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/task_validation.py
+++ b/cvat/apps/engine/task_validation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/tests/test_rest_api_3D.py
+++ b/cvat/apps/engine/tests/test_rest_api_3D.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/tests/utils.py
+++ b/cvat/apps/engine/tests/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/urls.py
+++ b/cvat/apps/engine/urls.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/utils.py
+++ b/cvat/apps/engine/utils.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/view_utils.py
+++ b/cvat/apps/engine/view_utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/apps.py
+++ b/cvat/apps/events/apps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/cache.py
+++ b/cvat/apps/events/cache.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/const.py
+++ b/cvat/apps/events/const.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/event.py
+++ b/cvat/apps/events/event.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/export.py
+++ b/cvat/apps/events/export.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/permissions.py
+++ b/cvat/apps/events/permissions.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/rules/tests/generators/events_test.gen.rego.py
+++ b/cvat/apps/events/rules/tests/generators/events_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/serializers.py
+++ b/cvat/apps/events/serializers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/signals.py
+++ b/cvat/apps/events/signals.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/tests/test_events.py
+++ b/cvat/apps/events/tests/test_events.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/urls.py
+++ b/cvat/apps/events/urls.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/utils.py
+++ b/cvat/apps/events/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/events/views.py
+++ b/cvat/apps/events/views.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/health/__init__.py
+++ b/cvat/apps/health/__init__.py
@@ -1,3 +1,3 @@
-#  Copyright (C) 2022 CVAT.ai Corporation
+#  Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT

--- a/cvat/apps/health/apps.py
+++ b/cvat/apps/health/apps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/health/backends.py
+++ b/cvat/apps/health/backends.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/__init__.py
+++ b/cvat/apps/iam/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT

--- a/cvat/apps/iam/adapters.py
+++ b/cvat/apps/iam/adapters.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/admin.py
+++ b/cvat/apps/iam/admin.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/apps.py
+++ b/cvat/apps/iam/apps.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/forms.py
+++ b/cvat/apps/iam/forms.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/middleware.py
+++ b/cvat/apps/iam/middleware.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/migrations/__init__.py
+++ b/cvat/apps/iam/migrations/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT

--- a/cvat/apps/iam/permissions.py
+++ b/cvat/apps/iam/permissions.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/rules/tests/generate_tests.py
+++ b/cvat/apps/iam/rules/tests/generate_tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/schema.py
+++ b/cvat/apps/iam/schema.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/serializers.py
+++ b/cvat/apps/iam/serializers.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/tests/test_rest_api.py
+++ b/cvat/apps/iam/tests/test_rest_api.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/urls.py
+++ b/cvat/apps/iam/urls.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/views.py
+++ b/cvat/apps/iam/views.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/lambda_manager/apps.py
+++ b/cvat/apps/lambda_manager/apps.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2021 Intel Corporation
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/lambda_manager/models.py
+++ b/cvat/apps/lambda_manager/models.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/lambda_manager/permissions.py
+++ b/cvat/apps/lambda_manager/permissions.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/lambda_manager/rules/tests/generators/lambda_test.gen.rego.py
+++ b/cvat/apps/lambda_manager/rules/tests/generators/lambda_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/lambda_manager/serializers.py
+++ b/cvat/apps/lambda_manager/serializers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/lambda_manager/signals.py
+++ b/cvat/apps/lambda_manager/signals.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/log_viewer/apps.py
+++ b/cvat/apps/log_viewer/apps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/log_viewer/permissions.py
+++ b/cvat/apps/log_viewer/permissions.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/log_viewer/rules/tests/generators/analytics_test.gen.rego.py
+++ b/cvat/apps/log_viewer/rules/tests/generators/analytics_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/organizations/admin.py
+++ b/cvat/apps/organizations/admin.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/organizations/apps.py
+++ b/cvat/apps/organizations/apps.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021 Intel Corporation
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/organizations/models.py
+++ b/cvat/apps/organizations/models.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/organizations/permissions.py
+++ b/cvat/apps/organizations/permissions.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/organizations/rules/tests/generators/invitations_test.gen.rego.py
+++ b/cvat/apps/organizations/rules/tests/generators/invitations_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/organizations/rules/tests/generators/memberships_test.gen.rego.py
+++ b/cvat/apps/organizations/rules/tests/generators/memberships_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/organizations/rules/tests/generators/organizations_test.gen.rego.py
+++ b/cvat/apps/organizations/rules/tests/generators/organizations_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/organizations/serializers.py
+++ b/cvat/apps/organizations/serializers.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/organizations/throttle.py
+++ b/cvat/apps/organizations/throttle.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/organizations/views.py
+++ b/cvat/apps/organizations/views.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/quality_control/apps.py
+++ b/cvat/apps/quality_control/apps.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2023 Intel Corporation
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/quality_control/models.py
+++ b/cvat/apps/quality_control/models.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/quality_control/permissions.py
+++ b/cvat/apps/quality_control/permissions.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/quality_control/serializers.py
+++ b/cvat/apps/quality_control/serializers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/quality_control/signals.py
+++ b/cvat/apps/quality_control/signals.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/quality_control/urls.py
+++ b/cvat/apps/quality_control/urls.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/quality_control/views.py
+++ b/cvat/apps/quality_control/views.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/webhooks/apps.py
+++ b/cvat/apps/webhooks/apps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/webhooks/event_type.py
+++ b/cvat/apps/webhooks/event_type.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/webhooks/models.py
+++ b/cvat/apps/webhooks/models.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/webhooks/permissions.py
+++ b/cvat/apps/webhooks/permissions.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/webhooks/rules/tests/generators/webhooks_test.gen.rego.py
+++ b/cvat/apps/webhooks/rules/tests/generators/webhooks_test.gen.rego.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/webhooks/serializers.py
+++ b/cvat/apps/webhooks/serializers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/webhooks/signals.py
+++ b/cvat/apps/webhooks/signals.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/webhooks/urls.py
+++ b/cvat/apps/webhooks/urls.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/webhooks/views.py
+++ b/cvat/apps/webhooks/views.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/asgi.py
+++ b/cvat/asgi.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/rq_patching.py
+++ b/cvat/rq_patching.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/rqworker.py
+++ b/cvat/rqworker.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/settings/email_settings.py
+++ b/cvat/settings/email_settings.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/settings/testing_rest.py
+++ b/cvat/settings/testing_rest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/utils/remote_debugger.py
+++ b/cvat/utils/remote_debugger.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 #

--- a/docker-compose.external_db.yml
+++ b/docker-compose.external_db.yml
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2022 Intel Corporation
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/onnx/WongKinYiu/yolov7/nuclio/model_handler.py
+++ b/serverless/onnx/WongKinYiu/yolov7/nuclio/model_handler.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/openvino/base/shared.py
+++ b/serverless/openvino/base/shared.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/openvino/omz/intel/semantic-segmentation-adas-0001/nuclio/model_handler.py
+++ b/serverless/openvino/omz/intel/semantic-segmentation-adas-0001/nuclio/model_handler.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/openvino/omz/intel/text-detection-0004/nuclio/model_handler.py
+++ b/serverless/openvino/omz/intel/text-detection-0004/nuclio/model_handler.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/openvino/omz/public/mask_rcnn_inception_resnet_v2_atrous_coco/nuclio/model_handler.py
+++ b/serverless/openvino/omz/public/mask_rcnn_inception_resnet_v2_atrous_coco/nuclio/model_handler.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/pytorch/dschoerk/transt/nuclio/model_handler.py
+++ b/serverless/pytorch/dschoerk/transt/nuclio/model_handler.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/pytorch/facebookresearch/sam/nuclio/function-gpu.yaml
+++ b/serverless/pytorch/facebookresearch/sam/nuclio/function-gpu.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/pytorch/facebookresearch/sam/nuclio/function.yaml
+++ b/serverless/pytorch/facebookresearch/sam/nuclio/function.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/pytorch/facebookresearch/sam/nuclio/main.py
+++ b/serverless/pytorch/facebookresearch/sam/nuclio/main.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/pytorch/facebookresearch/sam/nuclio/model_handler.py
+++ b/serverless/pytorch/facebookresearch/sam/nuclio/model_handler.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/pytorch/mmpose/hrnet32/nuclio/main.py
+++ b/serverless/pytorch/mmpose/hrnet32/nuclio/main.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/pytorch/saic-vul/fbrs/nuclio/main.py
+++ b/serverless/pytorch/saic-vul/fbrs/nuclio/main.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/pytorch/saic-vul/fbrs/nuclio/model_handler.py
+++ b/serverless/pytorch/saic-vul/fbrs/nuclio/model_handler.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/pytorch/saic-vul/hrnet/nuclio/main.py
+++ b/serverless/pytorch/saic-vul/hrnet/nuclio/main.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/pytorch/saic-vul/hrnet/nuclio/model_handler.py
+++ b/serverless/pytorch/saic-vul/hrnet/nuclio/model_handler.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/pytorch/shiyinzhang/iog/nuclio/main.py
+++ b/serverless/pytorch/shiyinzhang/iog/nuclio/main.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/serverless/pytorch/shiyinzhang/iog/nuclio/model_handler.py
+++ b/serverless/pytorch/shiyinzhang/iog/nuclio/model_handler.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/site/build_docs.py
+++ b/site/build_docs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/site/process_sdk_docs.py
+++ b/site/process_sdk_docs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/cypress.base.config.js
+++ b/tests/cypress.base.config.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 const plugins = require('./cypress/plugins/index');

--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/case_20_objects_ordering_feature.js
+++ b/tests/cypress/e2e/actions_objects/case_20_objects_ordering_feature.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/case_24_delete_unlock_lock_object.js
+++ b/tests/cypress/e2e/actions_objects/case_24_delete_unlock_lock_object.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/case_34_drawing_with_predefined_number_points.js
+++ b/tests/cypress/e2e/actions_objects/case_34_drawing_with_predefined_number_points.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/case_36_always_show_object_details_feature.js
+++ b/tests/cypress/e2e/actions_objects/case_36_always_show_object_details_feature.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/case_37_object_make_copy.js
+++ b/tests/cypress/e2e/actions_objects/case_37_object_make_copy.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/case_53_object_propagate.js
+++ b/tests/cypress/e2e/actions_objects/case_53_object_propagate.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/case_54_redraw_feature.js
+++ b/tests/cypress/e2e/actions_objects/case_54_redraw_feature.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/case_55_repeat_draw_feature.js
+++ b/tests/cypress/e2e/actions_objects/case_55_repeat_draw_feature.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/case_59_edit_handler.js
+++ b/tests/cypress/e2e/actions_objects/case_59_edit_handler.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/case_60_autoborder_feature.js
+++ b/tests/cypress/e2e/actions_objects/case_60_autoborder_feature.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/case_99_save_filtered_object_in_AAM.js
+++ b/tests/cypress/e2e/actions_objects/case_99_save_filtered_object_in_AAM.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/count_objects.js
+++ b/tests/cypress/e2e/actions_objects/count_objects.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/regression_tests.js
+++ b/tests/cypress/e2e/actions_objects/regression_tests.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects/test_annotations_saving.js
+++ b/tests/cypress/e2e/actions_objects/test_annotations_saving.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_108_rotated_bounding_boxes.js
+++ b/tests/cypress/e2e/actions_objects2/case_108_rotated_bounding_boxes.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_10_polygon_shape_track_label_points.js
+++ b/tests/cypress/e2e/actions_objects2/case_10_polygon_shape_track_label_points.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_115_ellipse_shape_track_label.js
+++ b/tests/cypress/e2e/actions_objects2/case_115_ellipse_shape_track_label.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_11_polylines_shape_track_label_points.js
+++ b/tests/cypress/e2e/actions_objects2/case_11_polylines_shape_track_label_points.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_12_points_shape_track_label.js
+++ b/tests/cypress/e2e/actions_objects2/case_12_points_shape_track_label.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_13_merge_split_features.js
+++ b/tests/cypress/e2e/actions_objects2/case_13_merge_split_features.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_14_appearance_features.js
+++ b/tests/cypress/e2e/actions_objects2/case_14_appearance_features.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_15_group_features.js
+++ b/tests/cypress/e2e/actions_objects2/case_15_group_features.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_16_z_order_features.js
+++ b/tests/cypress/e2e/actions_objects2/case_16_z_order_features.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_17_lock_hide_features.js
+++ b/tests/cypress/e2e/actions_objects2/case_17_lock_hide_features.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_77_cropping_polygon_in_some_corner_cases.js
+++ b/tests/cypress/e2e/actions_objects2/case_77_cropping_polygon_in_some_corner_cases.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_8_rectangle_shape_track_label.js
+++ b/tests/cypress/e2e/actions_objects2/case_8_rectangle_shape_track_label.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_objects2/case_9_cuboid_shape_track_label.js
+++ b/tests/cypress/e2e/actions_objects2/case_9_cuboid_shape_track_label.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_projects_models/case_103_project_export.js
+++ b/tests/cypress/e2e/actions_projects_models/case_103_project_export.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_projects_models/case_104_project_export_3d.js
+++ b/tests/cypress/e2e/actions_projects_models/case_104_project_export_3d.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_projects_models/case_116_creating_project_by_inserting_labels_from_task.js
+++ b/tests/cypress/e2e/actions_projects_models/case_116_creating_project_by_inserting_labels_from_task.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_projects_models/case_117_backup_restore_project_to_various_storages.js
+++ b/tests/cypress/e2e/actions_projects_models/case_117_backup_restore_project_to_various_storages.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_projects_models/issue_2900_creating_more_one_tasks_from_project_per_time.js
+++ b/tests/cypress/e2e/actions_projects_models/issue_2900_creating_more_one_tasks_from_project_per_time.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_projects_models/markdown_base_pipeline.js
+++ b/tests/cypress/e2e/actions_projects_models/markdown_base_pipeline.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_projects_models/registration_involved/base_actions_project_task_user.js
+++ b/tests/cypress/e2e/actions_projects_models/registration_involved/base_actions_project_task_user.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/case_100_settings_default_number_of_points_in_polygon_approximation.js
+++ b/tests/cypress/e2e/actions_tasks/case_100_settings_default_number_of_points_in_polygon_approximation.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/case_102_create_link_shape_frame.js
+++ b/tests/cypress/e2e/actions_tasks/case_102_create_link_shape_frame.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/case_110_settings_smooth_image_option.js
+++ b/tests/cypress/e2e/actions_tasks/case_110_settings_smooth_image_option.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/case_117_paste_labels_from_another_task.js
+++ b/tests/cypress/e2e/actions_tasks/case_117_paste_labels_from_another_task.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/case_51_settings_auto_save.js
+++ b/tests/cypress/e2e/actions_tasks/case_51_settings_auto_save.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/case_52_dump_upload_annotation.js
+++ b/tests/cypress/e2e/actions_tasks/case_52_dump_upload_annotation.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/case_61_create_task_set_issue_tracker.js
+++ b/tests/cypress/e2e/actions_tasks/case_61_create_task_set_issue_tracker.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/case_66_rename_label_raw_editor.js
+++ b/tests/cypress/e2e/actions_tasks/case_66_rename_label_raw_editor.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/case_67_intelligent_polygon_cropping.js
+++ b/tests/cypress/e2e/actions_tasks/case_67_intelligent_polygon_cropping.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/case_72_hotkeys_change_labels.js
+++ b/tests/cypress/e2e/actions_tasks/case_72_hotkeys_change_labels.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/issue_2473_import_annotations_frames_dots_in_name.js
+++ b/tests/cypress/e2e/actions_tasks/issue_2473_import_annotations_frames_dots_in_name.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/mutable_attributes.js
+++ b/tests/cypress/e2e/actions_tasks/mutable_attributes.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/registration_involved/case_39_issue_2572_rename_task.js
+++ b/tests/cypress/e2e/actions_tasks/registration_involved/case_39_issue_2572_rename_task.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/registration_involved/case_69_filters_sorting_jobs.js
+++ b/tests/cypress/e2e/actions_tasks/registration_involved/case_69_filters_sorting_jobs.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/task_changes_status_after_initial_save.js
+++ b/tests/cypress/e2e/actions_tasks/task_changes_status_after_initial_save.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks/task_rectangles_only.js
+++ b/tests/cypress/e2e/actions_tasks/task_rectangles_only.js
@@ -1,5 +1,5 @@
-// Copyright (C) 2022 CVAT.ai Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
+++ b/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_111_settings_text_size_position_label_content.js
+++ b/tests/cypress/e2e/actions_tasks2/case_111_settings_text_size_position_label_content.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_118_create_label_with_empty_label_name.js
+++ b/tests/cypress/e2e/actions_tasks2/case_118_create_label_with_empty_label_name.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_21_canvas_color_feature.js
+++ b/tests/cypress/e2e/actions_tasks2/case_21_canvas_color_feature.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_23_canvas_grid_feature.js
+++ b/tests/cypress/e2e/actions_tasks2/case_23_canvas_grid_feature.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_26_canvas_color_settings_feature.js
+++ b/tests/cypress/e2e/actions_tasks2/case_26_canvas_color_settings_feature.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_29_settings_player_step.js
+++ b/tests/cypress/e2e/actions_tasks2/case_29_settings_player_step.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_30_collapse_sidebar_appearance.js
+++ b/tests/cypress/e2e/actions_tasks2/case_30_collapse_sidebar_appearance.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_31_label_constructor_color_name_label.js
+++ b/tests/cypress/e2e/actions_tasks2/case_31_label_constructor_color_name_label.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_32_attribute_annotation_mode_zoom_margin_feature.js
+++ b/tests/cypress/e2e/actions_tasks2/case_32_attribute_annotation_mode_zoom_margin_feature.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_33_button_continue_label_editor.js
+++ b/tests/cypress/e2e/actions_tasks2/case_33_button_continue_label_editor.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_40_create_task_without_necessary_arguments.js
+++ b/tests/cypress/e2e/actions_tasks2/case_40_create_task_without_necessary_arguments.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_42_change_label_name_via_label_constructor.js
+++ b/tests/cypress/e2e/actions_tasks2/case_42_change_label_name_via_label_constructor.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/case_97_export_import_task.js
+++ b/tests/cypress/e2e/actions_tasks2/case_97_export_import_task.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/fit_image_different_res.js
+++ b/tests/cypress/e2e/actions_tasks2/fit_image_different_res.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks2/test_default_attribute.js
+++ b/tests/cypress/e2e/actions_tasks2/test_default_attribute.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_105_cloud_storage.js
+++ b/tests/cypress/e2e/actions_tasks3/case_105_cloud_storage.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_107_connected_file_share.js
+++ b/tests/cypress/e2e/actions_tasks3/case_107_connected_file_share.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_109_dummy_cloud_storage.js
+++ b/tests/cypress/e2e/actions_tasks3/case_109_dummy_cloud_storage.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_113_use_default_project_storage_for_import_export_annotations.js
+++ b/tests/cypress/e2e/actions_tasks3/case_113_use_default_project_storage_for_import_export_annotations.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_114_use_default_task_storage_for_import_export_annotations.js
+++ b/tests/cypress/e2e/actions_tasks3/case_114_use_default_task_storage_for_import_export_annotations.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_115_use_custom_storage_for_import_export_annotations.js
+++ b/tests/cypress/e2e/actions_tasks3/case_115_use_custom_storage_for_import_export_annotations.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_118_multi_tasks.js
+++ b/tests/cypress/e2e/actions_tasks3/case_118_multi_tasks.js
@@ -1,5 +1,5 @@
-// Copyright (C) 2022-2023 CVAT.ai Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_18_filters_functionality.js
+++ b/tests/cypress/e2e/actions_tasks3/case_18_filters_functionality.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_19_all_image_rotate_features.js
+++ b/tests/cypress/e2e/actions_tasks3/case_19_all_image_rotate_features.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_1_create_delete_task_label_color.js
+++ b/tests/cypress/e2e/actions_tasks3/case_1_create_delete_task_label_color.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/e2e/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_46_create_task_with_files_from_remote_sources.js
+++ b/tests/cypress/e2e/actions_tasks3/case_46_create_task_with_files_from_remote_sources.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_47_export_dataset.js
+++ b/tests/cypress/e2e/actions_tasks3/case_47_export_dataset.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_50_settings_player_speed.js
+++ b/tests/cypress/e2e/actions_tasks3/case_50_settings_player_speed.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_74_drag_canvas.js
+++ b/tests/cypress/e2e/actions_tasks3/case_74_drag_canvas.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_7_image_scale_roi.js
+++ b/tests/cypress/e2e/actions_tasks3/case_7_image_scale_roi.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_tasks3/case_90_context_image.js
+++ b/tests/cypress/e2e/actions_tasks3/case_90_context_image.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_users/issue_1810_login_logout.js
+++ b/tests/cypress/e2e/actions_users/issue_1810_login_logout.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_users/issue_2440_value_must_be_a_user_instance.js
+++ b/tests/cypress/e2e/actions_users/issue_2440_value_must_be_a_user_instance.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
+++ b/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_users/registration_involved/case_2_register_user_change_pass.js
+++ b/tests/cypress/e2e/actions_users/registration_involved/case_2_register_user_change_pass.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_users/registration_involved/issue_1599_ch_user_registration.js
+++ b/tests/cypress/e2e/actions_users/registration_involved/issue_1599_ch_user_registration.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/actions_users/registration_involved/issue_1599_pl_user_registration.js
+++ b/tests/cypress/e2e/actions_users/registration_involved/issue_1599_pl_user_registration.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality/case_83_canvas3d_functionality_cuboid_grouping.js
+++ b/tests/cypress/e2e/canvas3d_functionality/case_83_canvas3d_functionality_cuboid_grouping.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality/case_84_canvas3d_functionality_cuboid_redraw.js
+++ b/tests/cypress/e2e/canvas3d_functionality/case_84_canvas3d_functionality_cuboid_redraw.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality/case_85_canvas3d_functionality_cuboid_cancel_drawing.js
+++ b/tests/cypress/e2e/canvas3d_functionality/case_85_canvas3d_functionality_cuboid_cancel_drawing.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality/case_87_canvas3d_functionality_cuboid_delete.js
+++ b/tests/cypress/e2e/canvas3d_functionality/case_87_canvas3d_functionality_cuboid_delete.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality/case_88_canvas3d_functionality_save_job_remove_annotation.js
+++ b/tests/cypress/e2e/canvas3d_functionality/case_88_canvas3d_functionality_save_job_remove_annotation.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality/case_89_canvas3d_functionality_filters.js
+++ b/tests/cypress/e2e/canvas3d_functionality/case_89_canvas3d_functionality_filters.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality/case_91_canvas3d_functionality_dump_upload_annotation_point_cloud_format.js
+++ b/tests/cypress/e2e/canvas3d_functionality/case_91_canvas3d_functionality_dump_upload_annotation_point_cloud_format.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality/case_92_canvas3d_functionality_dump_upload_annotation_velodyne_points_format.js
+++ b/tests/cypress/e2e/canvas3d_functionality/case_92_canvas3d_functionality_dump_upload_annotation_velodyne_points_format.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality/case_93_canvas3d_functionality_export_dataset.js
+++ b/tests/cypress/e2e/canvas3d_functionality/case_93_canvas3d_functionality_export_dataset.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality_2/case_56_canvas3d_functionality_basic_actions.js
+++ b/tests/cypress/e2e/canvas3d_functionality_2/case_56_canvas3d_functionality_basic_actions.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality_2/case_63_canvas3d_functionality_control_button_mouse_interaction.js
+++ b/tests/cypress/e2e/canvas3d_functionality_2/case_63_canvas3d_functionality_control_button_mouse_interaction.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality_2/case_64_canvas3d_functionality_cuboid.js
+++ b/tests/cypress/e2e/canvas3d_functionality_2/case_64_canvas3d_functionality_cuboid.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality_2/case_78_canvas3d_functionality_cuboid_label.js
+++ b/tests/cypress/e2e/canvas3d_functionality_2/case_78_canvas3d_functionality_cuboid_label.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality_2/case_80_canvas3d_functionality_cuboid_make_copy.js
+++ b/tests/cypress/e2e/canvas3d_functionality_2/case_80_canvas3d_functionality_cuboid_make_copy.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality_2/case_81_canvas3d_functionality_cuboid_propagate.js
+++ b/tests/cypress/e2e/canvas3d_functionality_2/case_81_canvas3d_functionality_cuboid_propagate.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality_2/case_82_canvas3d_functionality_cuboid_opacity_outlined_borders.js
+++ b/tests/cypress/e2e/canvas3d_functionality_2/case_82_canvas3d_functionality_cuboid_opacity_outlined_borders.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/canvas3d_functionality_2/cuboid_interpolation_pipeline.js
+++ b/tests/cypress/e2e/canvas3d_functionality_2/cuboid_interpolation_pipeline.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/features/analytics_pipeline.js
+++ b/tests/cypress/e2e/features/analytics_pipeline.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/features/annotations_actions.js
+++ b/tests/cypress/e2e/features/annotations_actions.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
+++ b/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/features/ground_truth_jobs.js
+++ b/tests/cypress/e2e/features/ground_truth_jobs.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/features/requests_page.js
+++ b/tests/cypress/e2e/features/requests_page.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/features/shortcuts.js
+++ b/tests/cypress/e2e/features/shortcuts.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/features/single_object_annotation.js
+++ b/tests/cypress/e2e/features/single_object_annotation.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/features/skeletons_pipeline.js
+++ b/tests/cypress/e2e/features/skeletons_pipeline.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/features/slice_join.js
+++ b/tests/cypress/e2e/features/slice_join.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/features/webhooks.js
+++ b/tests/cypress/e2e/features/webhooks.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs/issue_1882_polygon_interpolation.js
+++ b/tests/cypress/e2e/issues_prs/issue_1882_polygon_interpolation.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs/issue_2230_maintenance_popover_visibility.js
+++ b/tests/cypress/e2e/issues_prs/issue_2230_maintenance_popover_visibility.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs/issue_2411_deleting_attributes.js
+++ b/tests/cypress/e2e/issues_prs/issue_2411_deleting_attributes.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs/issue_2485_navigation_empty_frames.js
+++ b/tests/cypress/e2e/issues_prs/issue_2485_navigation_empty_frames.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs/issue_2486_not_edit_object_aam.js
+++ b/tests/cypress/e2e/issues_prs/issue_2486_not_edit_object_aam.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs/issue_2487_extra_instances_canvas_grouping.js
+++ b/tests/cypress/e2e/issues_prs/issue_2487_extra_instances_canvas_grouping.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs/issue_2807_polyline_editing.js
+++ b/tests/cypress/e2e/issues_prs/issue_2807_polyline_editing.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs/issue_5381_empty_project_formats.js
+++ b/tests/cypress/e2e/issues_prs/issue_5381_empty_project_formats.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs/issue_5566_filter_url.js
+++ b/tests/cypress/e2e/issues_prs/issue_5566_filter_url.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs/pr_1370_check_UI_fail_with_object_dragging_and_go_next_frame.js
+++ b/tests/cypress/e2e/issues_prs/pr_1370_check_UI_fail_with_object_dragging_and_go_next_frame.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_1216_Check_if_UI_not_fails_with_shape_dragging_over_sidebar.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1216_Check_if_UI_not_fails_with_shape_dragging_over_sidebar.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_1368_points_track_invisible_next_frame.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1368_points_track_invisible_next_frame.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_1391_delete_point.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1391_delete_point.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_1429_check_new_label.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1429_check_new_label.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_1433_hide_functionality.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1433_hide_functionality.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_1438_cancel_multiple_paste_ui_not_lock.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1438_cancel_multiple_paste_ui_not_lock.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_1568_cuboid_dump_annotation.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1568_cuboid_dump_annotation.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_1785_propagation_latest_frame.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1785_propagation_latest_frame.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_1819_first_part_split_track_visible.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1819_first_part_split_track_visible.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_1823_opening_context_menu_when_switching_another_frame.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1823_opening_context_menu_when_switching_another_frame.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_1825_tooltip_hidden_mouseout.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1825_tooltip_hidden_mouseout.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_1870_cursor_not_jump_to_end.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1870_cursor_not_jump_to_end.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_3821_delete_point.js
+++ b/tests/cypress/e2e/issues_prs2/issue_3821_delete_point.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_5274_upload_annotations_different_file_formats.js
+++ b/tests/cypress/e2e/issues_prs2/issue_5274_upload_annotations_different_file_formats.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_7428_importing_annotation_from_cloud_after_local_import.js
+++ b/tests/cypress/e2e/issues_prs2/issue_7428_importing_annotation_from_cloud_after_local_import.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/e2e/issues_prs2/issue_8785_update_job_metadata.js
+++ b/tests/cypress/e2e/issues_prs2/issue_8785_update_job_metadata.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/plugins/unpackZipArchive/addPlugin.js
+++ b/tests/cypress/plugins/unpackZipArchive/addPlugin.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/plugins/unpackZipArchive/unpackZipArchiveCommand.js
+++ b/tests/cypress/plugins/unpackZipArchive/unpackZipArchiveCommand.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/commands_annotations_actions.js
+++ b/tests/cypress/support/commands_annotations_actions.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/commands_canvas3d.js
+++ b/tests/cypress/support/commands_canvas3d.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2022-2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/commands_cloud_storages.js
+++ b/tests/cypress/support/commands_cloud_storages.js
@@ -1,5 +1,5 @@
-// Copyright (C) 2022 CVAT.ai Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/commands_filters_feature.js
+++ b/tests/cypress/support/commands_filters_feature.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2021-2022 Intel Corporation
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/commands_opencv.js
+++ b/tests/cypress/support/commands_opencv.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023-2025 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/commands_organizations.js
+++ b/tests/cypress/support/commands_organizations.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/commands_projects.js
+++ b/tests/cypress/support/commands_projects.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/commands_review_pipeline.js
+++ b/tests/cypress/support/commands_review_pipeline.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/commands_webhooks.js
+++ b/tests/cypress/support/commands_webhooks.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/const.js
+++ b/tests/cypress/support/const.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/const_project.js
+++ b/tests/cypress/support/const_project.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/default-specs.js
+++ b/tests/cypress/support/default-specs.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress_canvas3d.config.js
+++ b/tests/cypress_canvas3d.config.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 CVAT.ai Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/python/cli/cmtp_function.py
+++ b/tests/python/cli/cmtp_function.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/cli/conf_threshold_function.py
+++ b/tests/python/cli/conf_threshold_function.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/cli/conftest.py
+++ b/tests/python/cli/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/cli/example_function.py
+++ b/tests/python/cli/example_function.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/cli/example_parameterized_function.py
+++ b/tests/python/cli/example_parameterized_function.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/cli/test_cli_misc.py
+++ b/tests/python/cli/test_cli_misc.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/cli/test_cli_projects.py
+++ b/tests/python/cli/test_cli_projects.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/cli/test_cli_tasks.py
+++ b/tests/python/cli/test_cli_tasks.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/cli/util.py
+++ b/tests/python/cli/util.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_analytics.py
+++ b/tests/python/rest_api/test_analytics.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_analytics_reports.py
+++ b/tests/python/rest_api/test_analytics_reports.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_auth.py
+++ b/tests/python/rest_api/test_auth.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_cache_policy.py
+++ b/tests/python/rest_api/test_cache_policy.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_check_objects_integrity.py
+++ b/tests/python/rest_api/test_check_objects_integrity.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_cloud_storages.py
+++ b/tests/python/rest_api/test_cloud_storages.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_csrf_workaround.py
+++ b/tests/python/rest_api/test_csrf_workaround.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_invitations.py
+++ b/tests/python/rest_api/test_invitations.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_issues.py
+++ b/tests/python/rest_api/test_issues.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_jobs.py
+++ b/tests/python/rest_api/test_jobs.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_labels.py
+++ b/tests/python/rest_api/test_labels.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_memberships.py
+++ b/tests/python/rest_api/test_memberships.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_organizations.py
+++ b/tests/python/rest_api/test_organizations.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_projects.py
+++ b/tests/python/rest_api/test_projects.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_quality_control.py
+++ b/tests/python/rest_api/test_quality_control.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_queues.py
+++ b/tests/python/rest_api/test_queues.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_remote_url.py
+++ b/tests/python/rest_api/test_remote_url.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_requests.py
+++ b/tests/python/rest_api/test_requests.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_resource_import_export.py
+++ b/tests/python/rest_api/test_resource_import_export.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_server.py
+++ b/tests/python/rest_api/test_server.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_users.py
+++ b/tests/python/rest_api/test_users.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_webhooks.py
+++ b/tests/python/rest_api/test_webhooks.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/test_webhooks_sender.py
+++ b/tests/python/rest_api/test_webhooks_sender.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/rest_api/utils.py
+++ b/tests/python/rest_api/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/common.py
+++ b/tests/python/sdk/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 import io

--- a/tests/python/sdk/conftest.py
+++ b/tests/python/sdk/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/fixtures.py
+++ b/tests/python/sdk/fixtures.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_api_wrappers.py
+++ b/tests/python/sdk/test_api_wrappers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_auto_annotation.py
+++ b/tests/python/sdk/test_auto_annotation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_client.py
+++ b/tests/python/sdk/test_client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_datasets.py
+++ b/tests/python/sdk/test_datasets.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_issues_comments.py
+++ b/tests/python/sdk/test_issues_comments.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_jobs.py
+++ b/tests/python/sdk/test_jobs.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_masks.py
+++ b/tests/python/sdk/test_masks.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_organizations.py
+++ b/tests/python/sdk/test_organizations.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_progress.py
+++ b/tests/python/sdk/test_progress.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_projects.py
+++ b/tests/python/sdk/test_projects.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_pytorch.py
+++ b/tests/python/sdk/test_pytorch.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_tasks.py
+++ b/tests/python/sdk/test_tasks.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/test_users.py
+++ b/tests/python/sdk/test_users.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/sdk/util.py
+++ b/tests/python/sdk/util.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/shared/fixtures/data.py
+++ b/tests/python/shared/fixtures/data.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/shared/fixtures/util.py
+++ b/tests/python/shared/fixtures/util.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/shared/utils/config.py
+++ b/tests/python/shared/utils/config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/shared/utils/dump_objects.py
+++ b/tests/python/shared/utils/dump_objects.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2025 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/shared/utils/helpers.py
+++ b/tests/python/shared/utils/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/shared/utils/s3.py
+++ b/tests/python/shared/utils/s3.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/python/webhook_receiver/server.py
+++ b/tests/python/webhook_receiver/server.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/utils/dataset_manifest/core.py
+++ b/utils/dataset_manifest/core.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/utils/dataset_manifest/create.py
+++ b/utils/dataset_manifest/create.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022-2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/utils/dataset_manifest/errors.py
+++ b/utils/dataset_manifest/errors.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/utils/dataset_manifest/types.py
+++ b/utils/dataset_manifest/types.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/wait_for_deps.sh
+++ b/wait_for_deps.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (C) 2023 CVAT.ai Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
1. Updating license headers each year is painful and adds overhead to the development team.
2. Storing years in a copyright seems to be useless for an open source license as code is free anyway.

Some more thoughts may be found here:
https://aboutcode.org/2023/update-copyright-each-new-year/

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
