### PR TITLE
Reworked headlessCreateUser command in Cypress

### DIFF
--- a/tests/cypress/e2e/actions_objects/count_objects.js
+++ b/tests/cypress/e2e/actions_objects/count_objects.js
@@ -22,7 +22,7 @@ context('Count total annotation, issues and labels', () => {
     const serverFiles = ['images/image_1.jpg'];
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.url().should('contain', '/tasks');
         cy.headlessCreateTask({

--- a/tests/cypress/e2e/actions_objects/regression_tests.js
+++ b/tests/cypress/e2e/actions_objects/regression_tests.js
@@ -35,7 +35,7 @@ context('Regression tests', () => {
     };
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
 
         cy.headlessCreateTask(taskPayload, dataPayload).then((response) => {

--- a/tests/cypress/e2e/actions_projects_models/case_114_backup_restore_project.js
+++ b/tests/cypress/e2e/actions_projects_models/case_114_backup_restore_project.js
@@ -53,7 +53,7 @@ context('Backup, restore a project.', { browser: '!firefox' }, () => {
     };
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, project.label, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_projects_models/case_114_backup_restore_project.js
+++ b/tests/cypress/e2e/actions_projects_models/case_114_backup_restore_project.js
@@ -53,7 +53,7 @@ context('Backup, restore a project.', { browser: '!firefox' }, () => {
     };
 
     before(() => {
-        cy.visit('/');
+        cy.visit('auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, project.label, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_projects_models/case_116_creating_project_by_inserting_labels_from_task.js
+++ b/tests/cypress/e2e/actions_projects_models/case_116_creating_project_by_inserting_labels_from_task.js
@@ -30,7 +30,7 @@ context('Creating a project by inserting labels from a task.', { browser: '!fire
     const directoryToArchive = imagesFolder;
 
     before(() => {
-        cy.visit('/');
+        cy.visit('auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, task.name, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_projects_models/case_116_creating_project_by_inserting_labels_from_task.js
+++ b/tests/cypress/e2e/actions_projects_models/case_116_creating_project_by_inserting_labels_from_task.js
@@ -30,7 +30,7 @@ context('Creating a project by inserting labels from a task.', { browser: '!fire
     const directoryToArchive = imagesFolder;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, task.name, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_projects_models/case_117_backup_restore_project_to_various_storages.js
+++ b/tests/cypress/e2e/actions_projects_models/case_117_backup_restore_project_to_various_storages.js
@@ -86,7 +86,7 @@ context('Tests source & target storage for backups.', () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         createdCloudStorageId = cy.attachS3Bucket(cloudStorageData);
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);

--- a/tests/cypress/e2e/actions_projects_models/case_94_move_task_between_projects.js
+++ b/tests/cypress/e2e/actions_projects_models/case_94_move_task_between_projects.js
@@ -58,7 +58,7 @@ context('Move a task between projects.', () => {
             imagesCount,
         );
         cy.createZipArchive(directoryToArchive, archivePath);
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
     });
 

--- a/tests/cypress/e2e/actions_projects_models/case_94_move_task_between_projects.js
+++ b/tests/cypress/e2e/actions_projects_models/case_94_move_task_between_projects.js
@@ -58,7 +58,7 @@ context('Move a task between projects.', () => {
             imagesCount,
         );
         cy.createZipArchive(directoryToArchive, archivePath);
-        cy.visit('/');
+        cy.visit('auth/login');
         cy.login();
     });
 

--- a/tests/cypress/e2e/actions_projects_models/case_95_move_task_to_project.js
+++ b/tests/cypress/e2e/actions_projects_models/case_95_move_task_to_project.js
@@ -45,7 +45,7 @@ context('Move a task to a project.', { browser: '!firefox' }, () => {
     const directoryToArchive = imagesFolder;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, task.name, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_projects_models/case_95_move_task_to_project.js
+++ b/tests/cypress/e2e/actions_projects_models/case_95_move_task_to_project.js
@@ -45,7 +45,7 @@ context('Move a task to a project.', { browser: '!firefox' }, () => {
     const directoryToArchive = imagesFolder;
 
     before(() => {
-        cy.visit('/');
+        cy.visit('auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, task.name, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_projects_models/case_98_models_page.js
+++ b/tests/cypress/e2e/actions_projects_models/case_98_models_page.js
@@ -8,7 +8,7 @@ context('Models page.', () => {
     const caseId = '51';
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
     });
 

--- a/tests/cypress/e2e/actions_projects_models/case_98_models_page.js
+++ b/tests/cypress/e2e/actions_projects_models/case_98_models_page.js
@@ -8,7 +8,7 @@ context('Models page.', () => {
     const caseId = '51';
 
     before(() => {
-        cy.visit('/');
+        cy.visit('auth/login');
         cy.login();
     });
 

--- a/tests/cypress/e2e/actions_projects_models/markdown_base_pipeline.js
+++ b/tests/cypress/e2e/actions_projects_models/markdown_base_pipeline.js
@@ -40,7 +40,7 @@ context('Basic markdown pipeline', () => {
 
     before(() => {
         cy.headlessLogout();
-        cy.visit('/');
+        cy.visit('/auth/login');
         cy.get('.cvat-login-form-wrapper').should('exist').and('be.visible');
 
         for (const user of Object.values(additionalUsers)) {

--- a/tests/cypress/e2e/actions_projects_models/markdown_base_pipeline.js
+++ b/tests/cypress/e2e/actions_projects_models/markdown_base_pipeline.js
@@ -39,12 +39,12 @@ context('Basic markdown pipeline', () => {
     let assetID = null;
 
     before(() => {
+        cy.headlessLogout();
         cy.visit('/');
         cy.get('.cvat-login-form-wrapper').should('exist').and('be.visible');
 
         for (const user of Object.values(additionalUsers)) {
             cy.headlessCreateUser(user);
-            cy.headlessLogout();
         }
 
         cy.login();

--- a/tests/cypress/e2e/actions_tasks/case_117_paste_labels_from_another_task.js
+++ b/tests/cypress/e2e/actions_tasks/case_117_paste_labels_from_another_task.js
@@ -32,7 +32,7 @@ context('Paste labels from one task to another.', { browser: '!firefox' }, () =>
     const directoryToArchive = imagesFolder;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, task.name, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks/case_117_paste_labels_from_another_task.js
+++ b/tests/cypress/e2e/actions_tasks/case_117_paste_labels_from_another_task.js
@@ -32,7 +32,7 @@ context('Paste labels from one task to another.', { browser: '!firefox' }, () =>
     const directoryToArchive = imagesFolder;
 
     before(() => {
-        cy.visit('/');
+        cy.visit('auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, task.name, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks/case_58_task_label_deleting_feature.js
+++ b/tests/cypress/e2e/actions_tasks/case_58_task_label_deleting_feature.js
@@ -23,7 +23,7 @@ context('Delete a label from a task.', () => {
     const directoryToArchive = imagesFolder;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks/case_61_create_task_set_issue_tracker.js
+++ b/tests/cypress/e2e/actions_tasks/case_61_create_task_set_issue_tracker.js
@@ -24,7 +24,7 @@ context('Create a task with set an issue tracker.', () => {
     const incorrectBugTrackerUrl = 'somebugtracker.info/task12';
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks/case_65_create_task_with_manifest.js
+++ b/tests/cypress/e2e/actions_tasks/case_65_create_task_with_manifest.js
@@ -20,7 +20,7 @@ context('Create an annotation task with manifest.', () => {
     ];
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
     });
 

--- a/tests/cypress/e2e/actions_tasks/case_66_rename_label_raw_editor.js
+++ b/tests/cypress/e2e/actions_tasks/case_66_rename_label_raw_editor.js
@@ -39,7 +39,7 @@ context('Rename a label via raw editor.', () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks/case_72_hotkeys_change_labels.js
+++ b/tests/cypress/e2e/actions_tasks/case_72_hotkeys_change_labels.js
@@ -50,7 +50,7 @@ context('Hotkeys to change labels feature.', () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks/case_75_overlap_size.js
+++ b/tests/cypress/e2e/actions_tasks/case_75_overlap_size.js
@@ -29,7 +29,7 @@ context('Overlap size.', () => {
     const calculatedOverlapSize = advancedConfigurationParams.segmentSize - advancedConfigurationParams.overlapSize;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks/issue_2473_import_annotations_frames_dots_in_name.js
+++ b/tests/cypress/e2e/actions_tasks/issue_2473_import_annotations_frames_dots_in_name.js
@@ -61,7 +61,7 @@ context('Import annotations for frames with dots in name.', { browser: '!firefox
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks/navigate_specific_frame.js
+++ b/tests/cypress/e2e/actions_tasks/navigate_specific_frame.js
@@ -25,7 +25,7 @@ context('Paste labels from one task to another.', { browser: '!firefox' }, () =>
     const directoryToArchive = imagesFolder;
 
     before(() => {
-        cy.visit('/');
+        cy.visit('auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, task.name, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks/navigate_specific_frame.js
+++ b/tests/cypress/e2e/actions_tasks/navigate_specific_frame.js
@@ -25,7 +25,7 @@ context('Paste labels from one task to another.', { browser: '!firefox' }, () =>
     const directoryToArchive = imagesFolder;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, task.name, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks/task_changes_status_after_initial_save.js
+++ b/tests/cypress/e2e/actions_tasks/task_changes_status_after_initial_save.js
@@ -24,7 +24,7 @@ context('Task status updated after initial save.', () => {
 
     before(() => {
         cy.headlessLogout();
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.url().should('contain', '/tasks');
         cy.headlessCreateTask({

--- a/tests/cypress/e2e/actions_tasks/task_rectangles_only.js
+++ b/tests/cypress/e2e/actions_tasks/task_rectangles_only.js
@@ -25,7 +25,7 @@ context('Creating a task with only bounding boxes', () => {
     let taskID = null;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(
             imagesFolder,

--- a/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
+++ b/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
@@ -69,7 +69,7 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
     const extension = 'jpg';
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         for (let i = 0; i < imagesCount; i++) {
             cy.imageGenerator(imagesFolder, imageFileName + i, width, height, color, posX + i * 5,

--- a/tests/cypress/e2e/actions_tasks2/case_111_settings_text_size_position_label_content.js
+++ b/tests/cypress/e2e/actions_tasks2/case_111_settings_text_size_position_label_content.js
@@ -138,7 +138,7 @@ context('Settings. Text size/position. Text labels content.', () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.get('.cvat-tasks-page').should('exist').and('be.visible');
 

--- a/tests/cypress/e2e/actions_tasks2/case_40_create_task_without_necessary_arguments.js
+++ b/tests/cypress/e2e/actions_tasks2/case_40_create_task_without_necessary_arguments.js
@@ -22,7 +22,7 @@ context('Try to create a task without necessary arguments.', () => {
     const directoryToArchive = imagesFolder;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks2/case_41_add_delete_label_attribute.js
+++ b/tests/cypress/e2e/actions_tasks2/case_41_add_delete_label_attribute.js
@@ -11,7 +11,7 @@ context('Add/delete labels and attributes.', () => {
     const textDefaultValue = 'Some default value for type Text';
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.get('.cvat-create-task-dropdown').click();
         cy.get('.cvat-create-task-button').click();

--- a/tests/cypress/e2e/actions_tasks2/case_42_change_label_name_via_label_constructor.js
+++ b/tests/cypress/e2e/actions_tasks2/case_42_change_label_name_via_label_constructor.js
@@ -11,7 +11,7 @@ context('Changing a label name via label constructor.', () => {
     const secondLabelName = `Second case ${caseId}`;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.get('.cvat-create-task-dropdown').click();
         cy.get('.cvat-create-task-button').click();

--- a/tests/cypress/e2e/actions_tasks2/case_97_export_import_task.js
+++ b/tests/cypress/e2e/actions_tasks2/case_97_export_import_task.js
@@ -38,7 +38,7 @@ context('Export, import an annotation task.', { browser: '!firefox' }, () => {
     };
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks2/fit_image_different_res.js
+++ b/tests/cypress/e2e/actions_tasks2/fit_image_different_res.js
@@ -12,7 +12,7 @@ context('Correct behaviour of fit when navigating between frames with different 
     let jobID = null;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.url().should('contain', '/tasks');
         cy.headlessCreateTask({

--- a/tests/cypress/e2e/actions_tasks3/case_105_cloud_storage.js
+++ b/tests/cypress/e2e/actions_tasks3/case_105_cloud_storage.js
@@ -32,7 +32,7 @@ context('Cloud storage.', () => {
     };
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
     });
 

--- a/tests/cypress/e2e/actions_tasks3/case_107_connected_file_share.js
+++ b/tests/cypress/e2e/actions_tasks3/case_107_connected_file_share.js
@@ -24,7 +24,7 @@ context('Connected file share.', () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
     });
 

--- a/tests/cypress/e2e/actions_tasks3/case_109_dummy_cloud_storage.js
+++ b/tests/cypress/e2e/actions_tasks3/case_109_dummy_cloud_storage.js
@@ -87,7 +87,7 @@ context('Dummy cloud storages.', { browser: '!firefox' }, () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
     });
 
     beforeEach(() => {

--- a/tests/cypress/e2e/actions_tasks3/case_112_tus_upload.js
+++ b/tests/cypress/e2e/actions_tasks3/case_112_tus_upload.js
@@ -25,7 +25,7 @@ context('Create task with tus file', () => {
     const extension = 'bmp';
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX,
             posY, labelName, imagesCount, extension);

--- a/tests/cypress/e2e/actions_tasks3/case_113_use_default_project_storage_for_import_export_annotations.js
+++ b/tests/cypress/e2e/actions_tasks3/case_113_use_default_project_storage_for_import_export_annotations.js
@@ -91,7 +91,7 @@ context('Tests for source and target storage.', () => {
     };
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         createdCloudStorageId = cy.attachS3Bucket(cloudStorageData);
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);

--- a/tests/cypress/e2e/actions_tasks3/case_114_use_default_task_storage_for_import_export_annotations.js
+++ b/tests/cypress/e2e/actions_tasks3/case_114_use_default_task_storage_for_import_export_annotations.js
@@ -92,7 +92,7 @@ context('Tests for source and target storage.', () => {
     };
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         createdCloudStorageId = cy.attachS3Bucket(cloudStorageData);
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);

--- a/tests/cypress/e2e/actions_tasks3/case_115_use_custom_storage_for_import_export_annotations.js
+++ b/tests/cypress/e2e/actions_tasks3/case_115_use_custom_storage_for_import_export_annotations.js
@@ -62,7 +62,7 @@ context('Import and export annotations: specify source and target storage in mod
     };
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         createdCloudStorageId = cy.attachS3Bucket(cloudStorageData);
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);

--- a/tests/cypress/e2e/actions_tasks3/case_118_multi_tasks.js
+++ b/tests/cypress/e2e/actions_tasks3/case_118_multi_tasks.js
@@ -44,7 +44,7 @@ context('Create mutli tasks.', () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
     });
 

--- a/tests/cypress/e2e/actions_tasks3/case_1_create_delete_task_label_color.js
+++ b/tests/cypress/e2e/actions_tasks3/case_1_create_delete_task_label_color.js
@@ -25,7 +25,7 @@ context('Create and delete a annotation task. Color collision.', () => {
     const newLabelName = 'adia';
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks3/case_3_task_start_stop_step_frame.js
+++ b/tests/cypress/e2e/actions_tasks3/case_3_task_start_stop_step_frame.js
@@ -30,7 +30,7 @@ context('Check if parameters "startFrame", "stopFrame", "frameStep" works as exp
     };
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/actions_tasks3/case_46_create_task_with_files_from_remote_sources.js
+++ b/tests/cypress/e2e/actions_tasks3/case_46_create_task_with_files_from_remote_sources.js
@@ -14,7 +14,7 @@ context('Create a task with files from remote sources.', () => {
     const correctUrl = wrongUrl.replace('cvatt.jpg', 'cvat.jpg');
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.get('.cvat-create-task-dropdown').click();
         cy.get('.cvat-create-task-button').click();

--- a/tests/cypress/e2e/actions_tasks3/case_90_context_image.js
+++ b/tests/cypress/e2e/actions_tasks3/case_90_context_image.js
@@ -14,7 +14,7 @@ context('Context images for 2D tasks.', () => {
     const pathToArchive = `../../${__dirname}/assets/case_90/case_90_context_image.zip`;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, pathToArchive);
         cy.openTaskJob(taskName);

--- a/tests/cypress/e2e/actions_tasks3/issue_6528_upload_filename_special_character.js
+++ b/tests/cypress/e2e/actions_tasks3/issue_6528_upload_filename_special_character.js
@@ -25,7 +25,7 @@ context('Create task with special character in uploaded filename', () => {
     const extension = 'bmp';
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX,
             posY, labelName, imagesCount, extension);

--- a/tests/cypress/e2e/actions_users/case_73_reset_password_notification.js
+++ b/tests/cypress/e2e/actions_users/case_73_reset_password_notification.js
@@ -9,7 +9,7 @@ context('Reset password notification.', () => {
     const dummyEmail = 'admin@local.local';
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
     });
 
     describe(`Testing case "${caseId}"`, () => {

--- a/tests/cypress/e2e/actions_users/issue_1810_login_logout.js
+++ b/tests/cypress/e2e/actions_users/issue_1810_login_logout.js
@@ -21,7 +21,7 @@ context('When clicking on the Logout button, get the user session closed.', () =
 
     before(() => {
         cy.headlessLogout();
-        cy.visit('auth/login');
+        cy.visit('/');
     });
 
     describe(`Testing issue "${issueId}"`, () => {

--- a/tests/cypress/e2e/actions_users/issue_1810_login_logout.js
+++ b/tests/cypress/e2e/actions_users/issue_1810_login_logout.js
@@ -21,7 +21,7 @@ context('When clicking on the Logout button, get the user session closed.', () =
 
     before(() => {
         cy.headlessLogout();
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
     });
 
     describe(`Testing issue "${issueId}"`, () => {

--- a/tests/cypress/e2e/actions_users/issue_1810_login_logout.js
+++ b/tests/cypress/e2e/actions_users/issue_1810_login_logout.js
@@ -21,7 +21,7 @@ context('When clicking on the Logout button, get the user session closed.', () =
 
     before(() => {
         cy.headlessLogout();
-        cy.visit('/');
+        cy.visit('auth/login');
     });
 
     describe(`Testing issue "${issueId}"`, () => {

--- a/tests/cypress/e2e/actions_users/issue_2524_2633_issue_not_reset_after_change_task_issue_point_firefox.js
+++ b/tests/cypress/e2e/actions_users/issue_2524_2633_issue_not_reset_after_change_task_issue_point_firefox.js
@@ -43,7 +43,7 @@ context('Some parts of the Redux state (issues) is not reset after changing a ta
     before(() => {
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.createAnnotationTask(taskName.firstTaskName, labelName, attrName, textDefaultValue, archiveName);
         cy.goToTaskList();

--- a/tests/cypress/e2e/actions_users/issue_2524_2633_issue_not_reset_after_change_task_issue_point_firefox.js
+++ b/tests/cypress/e2e/actions_users/issue_2524_2633_issue_not_reset_after_change_task_issue_point_firefox.js
@@ -43,7 +43,7 @@ context('Some parts of the Redux state (issues) is not reset after changing a ta
     before(() => {
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);
-        cy.visit('/');
+        cy.visit('auth/login');
         cy.login();
         cy.createAnnotationTask(taskName.firstTaskName, labelName, attrName, textDefaultValue, archiveName);
         cy.goToTaskList();

--- a/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
+++ b/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
@@ -57,7 +57,8 @@ context('Review pipeline feature', () => {
 
     before(() => {
         cy.headlessLogout();
-        cy.visit('/');
+        cy.visit('auth/login');
+        cy.get('.cvat-login-form-wrapper').should('exist').and('be.visible');
 
         // register additional users
         for (const user of Object.values(additionalUsers)) {

--- a/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
+++ b/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
@@ -57,15 +57,11 @@ context('Review pipeline feature', () => {
 
     before(() => {
         cy.headlessLogout();
-
-        cy.visit('auth/login');
-        cy.get('.cvat-login-form-wrapper').should('exist').and('be.visible');
+        cy.visit('/');
 
         // register additional users
-        cy.headlessLogout();
         for (const user of Object.values(additionalUsers)) {
             cy.headlessCreateUser(user);
-            cy.headlessLogout();
         }
 
         // create main task

--- a/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
+++ b/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
@@ -57,7 +57,7 @@ context('Review pipeline feature', () => {
 
     before(() => {
         cy.headlessLogout();
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.get('.cvat-login-form-wrapper').should('exist').and('be.visible');
 
         // register additional users

--- a/tests/cypress/e2e/auth_page.js
+++ b/tests/cypress/e2e/auth_page.js
@@ -6,7 +6,7 @@
 
 describe('Check server availability', () => {
     it('Server web interface is available', () => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
     });
 
     it('"/auth/login" contains in the URL', () => {

--- a/tests/cypress/e2e/auth_page.js
+++ b/tests/cypress/e2e/auth_page.js
@@ -6,7 +6,7 @@
 
 describe('Check server availability', () => {
     it('Server web interface is available', () => {
-        cy.visit('/');
+        cy.visit('auth/login');
     });
 
     it('"/auth/login" contains in the URL', () => {

--- a/tests/cypress/e2e/auth_page.js
+++ b/tests/cypress/e2e/auth_page.js
@@ -1,27 +1,21 @@
 // Copyright (C) 2020-2022 Intel Corporation
+// Copyright (C) CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 
 /// <reference types="cypress" />
 
-describe('Check server availability', () => {
-    it('Server web interface is available', () => {
-        cy.visit('/auth/login');
+describe('Auth page cases', () => {
+    before(() => {
+        cy.headlessLogout();
     });
 
-    it('"/auth/login" contains in the URL', () => {
+    it('Admin can login on the server using valid credentials', () => {
+        cy.visit('/');
         cy.url().should('include', '/auth/login');
-    });
-
-    it('Check placeholder "Username"', () => {
         cy.get('#credential').type(Cypress.env('user'));
-    });
-
-    it('Check placeholder "Password"', () => {
         cy.get('#password').type(Cypress.env('password'));
-    });
-
-    it('Click to "Sign in" button', () => {
         cy.get('[type="submit"]').click();
+        cy.get('.cvat-tasks-page').should('exist').and('be.visible');
     });
 });

--- a/tests/cypress/e2e/features/analytics_pipeline.js
+++ b/tests/cypress/e2e/features/analytics_pipeline.js
@@ -95,7 +95,7 @@ context('Analytics pipeline', () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.get('.cvat-tasks-page').should('exist').and('be.visible');
     });

--- a/tests/cypress/e2e/features/annotations_actions.js
+++ b/tests/cypress/e2e/features/annotations_actions.js
@@ -37,7 +37,7 @@ context('Testing annotations actions workflow', () => {
     };
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
 
         cy.headlessCreateTask(taskPayload, dataPayload).then((response) => {

--- a/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
+++ b/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
@@ -86,7 +86,7 @@ context('New organization pipeline.', () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(
             imagesFolder,

--- a/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
+++ b/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
@@ -86,7 +86,7 @@ context('New organization pipeline.', () => {
     }
 
     before(() => {
-        cy.visit('/');
+        cy.visit('auth/login');
         cy.login();
         cy.imageGenerator(
             imagesFolder,

--- a/tests/cypress/e2e/features/ground_truth_jobs.js
+++ b/tests/cypress/e2e/features/ground_truth_jobs.js
@@ -120,7 +120,7 @@ context('Ground truth jobs', () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
     });
 

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -37,7 +37,7 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
     let jobID = null;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.headlessCreateTask({
             labels: [{ name: 'mask label', attributes: [], type: 'any' }],

--- a/tests/cypress/e2e/features/shortcuts.js
+++ b/tests/cypress/e2e/features/shortcuts.js
@@ -57,7 +57,7 @@ context('Customizable Shortcuts', () => {
     };
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.get('.cvat-tasks-page').should('exist').and('be.visible');
         cy.url().should('contain', '/tasks');

--- a/tests/cypress/e2e/features/single_object_annotation.js
+++ b/tests/cypress/e2e/features/single_object_annotation.js
@@ -115,7 +115,7 @@ context('Single object annotation mode', { scrollBehavior: false }, () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.headlessCreateTask({
             labels: [

--- a/tests/cypress/e2e/features/skeletons_pipeline.js
+++ b/tests/cypress/e2e/features/skeletons_pipeline.js
@@ -37,7 +37,7 @@ context('Manipulations with skeletons', { scrollBehavior: false }, () => {
     let taskID = null;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(
             imagesFolder,

--- a/tests/cypress/e2e/features/slice_join.js
+++ b/tests/cypress/e2e/features/slice_join.js
@@ -47,7 +47,7 @@ context('Slice and join tools', { scrollBehavior: false }, () => {
     let jobID = null;
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.headlessCreateTask({
             labels: [

--- a/tests/cypress/e2e/features/webhooks.js
+++ b/tests/cypress/e2e/features/webhooks.js
@@ -48,7 +48,7 @@ context('Webhooks pipeline.', () => {
     };
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.createOrganization(organizationParams);
         cy.visit('/projects');

--- a/tests/cypress/e2e/issues_prs/issue_2411_deleting_attributes.js
+++ b/tests/cypress/e2e/issues_prs/issue_2411_deleting_attributes.js
@@ -35,7 +35,7 @@ context('Wrong attribute is removed in label constructor.', () => {
     ];
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
     });
 

--- a/tests/cypress/e2e/issues_prs/issue_2661_displaying_attached_files_when_creating_task.js
+++ b/tests/cypress/e2e/issues_prs/issue_2661_displaying_attached_files_when_creating_task.js
@@ -24,7 +24,7 @@ context('Displaying attached files when creating a task.', () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/e2e/issues_prs/issue_5381_empty_project_formats.js
+++ b/tests/cypress/e2e/issues_prs/issue_5381_empty_project_formats.js
@@ -14,7 +14,7 @@ const project = {
 
 context('List of export formats for a project without tasks is not empty', () => {
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.goToProjectsList();
         cy.createProjects(project.name, project.label, project.attrName, project.attrVaue);

--- a/tests/cypress/e2e/issues_prs/issue_5566_filter_url.js
+++ b/tests/cypress/e2e/issues_prs/issue_5566_filter_url.js
@@ -26,7 +26,7 @@ context('The filter in the URL is correctly escaped', () => {
     }
 
     before(() => {
-        cy.visit('/');
+        cy.visit('auth/login');
         cy.login();
 
         cy.goToProjectsList();

--- a/tests/cypress/e2e/issues_prs/issue_5566_filter_url.js
+++ b/tests/cypress/e2e/issues_prs/issue_5566_filter_url.js
@@ -26,7 +26,7 @@ context('The filter in the URL is correctly escaped', () => {
     }
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
 
         cy.goToProjectsList();

--- a/tests/cypress/e2e/issues_prs2/issue_1568_cuboid_dump_annotation.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1568_cuboid_dump_annotation.js
@@ -14,7 +14,7 @@ context('Dump annotation if cuboid created.', () => {
     const labelName = 'label';
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.headlessCreateTask({
             labels: [{ name: labelName, attributes: [], type: 'cuboid' }],

--- a/tests/cypress/e2e/issues_prs2/issue_1823_opening_context_menu_when_switching_another_frame.js
+++ b/tests/cypress/e2e/issues_prs2/issue_1823_opening_context_menu_when_switching_another_frame.js
@@ -52,7 +52,7 @@ context('Cannot read property label of undefined', { browser: ['!chrome', '!fire
     };
 
     before(() => {
-        cy.visit('auth/login');
+        cy.visit('/auth/login');
         cy.login();
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -265,7 +265,7 @@ Cypress.Commands.add('selectFilesFromShare', (serverFiles) => {
 });
 
 Cypress.Commands.add('headlessLogin', (username = Cypress.env('user'), password = Cypress.env('password')) => {
-    cy.visit('auth/login');
+    cy.visit('/auth/login');
     cy.get('#root').should('exist').and('be.visible');
     cy.window().then(async ($win) => {
         await $win.cvat.server.login(username, password);

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -265,7 +265,7 @@ Cypress.Commands.add('selectFilesFromShare', (serverFiles) => {
 });
 
 Cypress.Commands.add('headlessLogin', (username = Cypress.env('user'), password = Cypress.env('password')) => {
-    cy.visit('/');
+    cy.visit('auth/login');
     cy.get('#root').should('exist').and('be.visible');
     cy.window().then(async ($win) => {
         await $win.cvat.server.login(username, password);

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -344,29 +344,32 @@ Cypress.Commands.add('headlessDeleteTask', (taskID) => {
     });
 });
 
-Cypress.Commands.add('headlessCreateUser', (userSpec) => (
-    cy.request({
-        method: 'POST',
-        url: '/api/auth/register',
-        body: {
-            confirmations: [],
-            password1: userSpec.password,
-            password2: userSpec.password,
-            email: userSpec.email,
-            first_name: userSpec.firstName,
-            last_name: userSpec.lastName,
-            username: userSpec.username,
-        },
-        headers: {
-            'Content-type': 'application/json',
-        },
-    }).then((response) => {
-        expect(response.status).to.eq(201);
+Cypress.Commands.add('headlessCreateUser', (userSpec) => {
+    cy.intercept('POST', '/api/auth/register**', (req) => {
+        req.continue((res) => {
+            delete res.headers['set-cookie'];
+        });
+    }).as('registerRequest');
+
+    cy.window().then(async ($win) => {
+        await $win.cvat.server.register(
+            userSpec.username,
+            userSpec.firstName,
+            userSpec.lastName,
+            userSpec.email,
+            userSpec.password,
+            [],
+        );
+        return cy.wrap();
+    });
+
+    cy.wait('@registerRequest').then((interception) => {
+        const { response } = interception;
+        expect(response.statusCode).to.eq(201);
         expect(response.body.username).to.eq(userSpec.username);
         expect(response.body.email).to.eq(userSpec.email);
-        return cy.wrap();
-    })
-));
+    });
+});
 
 Cypress.Commands.add('headlessLogout', () => {
     cy.clearCookies();

--- a/tests/cypress/support/const.js
+++ b/tests/cypress/support/const.js
@@ -35,7 +35,7 @@ export const multiAttrParams = {
 };
 
 it('Prepare to testing', () => {
-    cy.visit('/');
+    cy.visit('auth/login');
     cy.login();
     cy.get('.cvat-tasks-page').should('exist');
     const listItems = [];

--- a/tests/cypress/support/const.js
+++ b/tests/cypress/support/const.js
@@ -35,7 +35,7 @@ export const multiAttrParams = {
 };
 
 it('Prepare to testing', () => {
-    cy.visit('auth/login');
+    cy.visit('/auth/login');
     cy.login();
     cy.get('.cvat-tasks-page').should('exist');
     const listItems = [];

--- a/tests/cypress/support/const_canvas3d.js
+++ b/tests/cypress/support/const_canvas3d.js
@@ -13,7 +13,7 @@ export const advancedConfigurationParams = false;
 export const multiAttrParams = false;
 
 it('Prepare to testing', () => {
-    cy.visit('auth/login');
+    cy.visit('/auth/login');
     cy.login();
     cy.get('.cvat-tasks-page').should('exist');
     const listItems = [];

--- a/tests/cypress/support/const_canvas3d.js
+++ b/tests/cypress/support/const_canvas3d.js
@@ -13,7 +13,7 @@ export const advancedConfigurationParams = false;
 export const multiAttrParams = false;
 
 it('Prepare to testing', () => {
-    cy.visit('/');
+    cy.visit('auth/login');
     cy.login();
     cy.get('.cvat-tasks-page').should('exist');
     const listItems = [];

--- a/tests/cypress/support/const_project.js
+++ b/tests/cypress/support/const_project.js
@@ -16,7 +16,7 @@ export const multiAttrParams = {
 };
 
 it('Prepare to testing', () => {
-    cy.visit('/');
+    cy.visit('auth/login');
     cy.login();
     cy.goToProjectsList();
     cy.get('.cvat-projects-page').should('exist');

--- a/tests/cypress/support/const_project.js
+++ b/tests/cypress/support/const_project.js
@@ -16,7 +16,7 @@ export const multiAttrParams = {
 };
 
 it('Prepare to testing', () => {
-    cy.visit('auth/login');
+    cy.visit('/auth/login');
     cy.login();
     cy.goToProjectsList();
     cy.get('.cvat-projects-page').should('exist');


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Now the command does not set any cookies to the browser automatically.
So, we do not have to use `clearCookies()` each time after calling `cy.headlessCreateUser()`

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
