### PR TITLE
Refactored couple of Cypress commands

### DIFF
--- a/tests/cypress/e2e/actions_objects/test_annotations_saving.js
+++ b/tests/cypress/e2e/actions_objects/test_annotations_saving.js
@@ -37,8 +37,10 @@ context('Test annotations saving works correctly', () => {
     }
 
     before(() => {
-        cy.headlessLogin();
-        cy.visit('/tasks/create');
+        cy.visit('/auth/login').then(() => {
+            cy.headlessLogin({ nextURL: '/tasks/create' });
+        });
+
         cy.get('#name').type(taskName);
         cy.addNewLabel({ name: generalLabel.name });
         cy.addNewSkeletonLabel(skeletonLabel);

--- a/tests/cypress/e2e/actions_objects/test_annotations_saving.js
+++ b/tests/cypress/e2e/actions_objects/test_annotations_saving.js
@@ -37,10 +37,8 @@ context('Test annotations saving works correctly', () => {
     }
 
     before(() => {
-        cy.visit('/auth/login').then(() => {
-            cy.headlessLogin({ nextURL: '/tasks/create' });
-        });
-
+        cy.visit('/auth/login');
+        cy.headlessLogin({ nextURL: '/tasks/create' });
         cy.get('#name').type(taskName);
         cy.addNewLabel({ name: generalLabel.name });
         cy.addNewSkeletonLabel(skeletonLabel);

--- a/tests/cypress/e2e/actions_projects_models/markdown_base_pipeline.js
+++ b/tests/cypress/e2e/actions_projects_models/markdown_base_pipeline.js
@@ -41,7 +41,6 @@ context('Basic markdown pipeline', () => {
     before(() => {
         cy.headlessLogout();
         cy.visit('/auth/login');
-        cy.get('.cvat-login-form-wrapper').should('exist').and('be.visible');
 
         for (const user of Object.values(additionalUsers)) {
             cy.headlessCreateUser(user);

--- a/tests/cypress/e2e/actions_tasks2/test_default_attribute.js
+++ b/tests/cypress/e2e/actions_tasks2/test_default_attribute.js
@@ -50,8 +50,10 @@ context('Test default value for an attribute', () => {
     }
 
     before(() => {
-        cy.headlessLogin();
-        cy.visit('/tasks/create');
+        cy.visit('/auth/login').then(() => {
+            cy.headlessLogin({ nextURL: '/tasks/create' });
+        });
+
         cy.get('#name').type(taskName);
         cy.addNewLabel({ name: label }, attributes);
         cy.selectFilesFromShare(serverFiles);

--- a/tests/cypress/e2e/actions_tasks2/test_default_attribute.js
+++ b/tests/cypress/e2e/actions_tasks2/test_default_attribute.js
@@ -50,10 +50,8 @@ context('Test default value for an attribute', () => {
     }
 
     before(() => {
-        cy.visit('/auth/login').then(() => {
-            cy.headlessLogin({ nextURL: '/tasks/create' });
-        });
-
+        cy.visit('/auth/login');
+        cy.headlessLogin({ nextURL: '/tasks/create' });
         cy.get('#name').type(taskName);
         cy.addNewLabel({ name: label }, attributes);
         cy.selectFilesFromShare(serverFiles);

--- a/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
+++ b/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
@@ -58,7 +58,6 @@ context('Review pipeline feature', () => {
     before(() => {
         cy.headlessLogout();
         cy.visit('/auth/login');
-        cy.get('.cvat-login-form-wrapper').should('exist').and('be.visible');
 
         // register additional users
         for (const user of Object.values(additionalUsers)) {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -335,7 +335,7 @@ Cypress.Commands.add('headlessCreateTask', (taskSpec, dataSpec, extras) => {
 Cypress.Commands.add('headlessCreateProject', (projectSpec) => {
     cy.window().then(async ($win) => {
         const project = new $win.cvat.classes.Project({
-            ...projectSpe,
+            ...projectSpec,
         });
 
         const result = await project.save();

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -269,8 +269,8 @@ Cypress.Commands.add('headlessLogin', ({
     password,
     nextURL,
 } = {}) => {
-    username = username ?? Cypress.env('user');
-    password = password ?? Cypress.env('password');
+    username = username || Cypress.env('user');
+    password = password || Cypress.env('password');
 
     cy.window().then((win) => {
         cy.headlessLogout().then(() => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -270,8 +270,8 @@ Cypress.Commands.add('headlessLogin', ({
     nextURL,
 } = {}) => {
     cy.window().then((win) => {
-        cy.headlessLogout().then(() => {
-            return win.cvat.server.login(
+        cy.headlessLogout().then(() => (
+            win.cvat.server.login(
                 username || Cypress.env('user'),
                 password || Cypress.env('password'),
             ).then(() => win.cvat.users.get({ self: true }).then((users) => {
@@ -280,8 +280,8 @@ Cypress.Commands.add('headlessLogin', ({
                 }
 
                 return users[0];
-            }));
-        });
+            }))
+        ));
     });
 });
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -269,9 +269,6 @@ Cypress.Commands.add('headlessLogin', ({
     password,
     nextURL,
 } = {}) => {
-    username = username || Cypress.env('user');
-    password = password || Cypress.env('password');
-
     cy.window().then((win) => {
         cy.headlessLogout().then(() => {
             if (!win.cvat) {
@@ -280,15 +277,16 @@ Cypress.Commands.add('headlessLogin', ({
                 cy.get('#root').should('exist').and('be.visible');
             }
 
-            return win.cvat.server.login(username, password)
-                .then(() => win.cvat.users.get({ self: true })
-                .then((users) => {
-                    if (nextURL) {
-                        cy.visit(nextURL);
-                    }
+            return win.cvat.server.login(
+                username || Cypress.env('user'),
+                password || Cypress.env('password'),
+            ).then(() => win.cvat.users.get({ self: true }).then((users) => {
+                if (nextURL) {
+                    cy.visit(nextURL);
+                }
 
-                    return users[0];
-                }))
+                return users[0];
+            }));
         });
     });
 });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -359,6 +359,7 @@ Cypress.Commands.add('headlessDeleteTask', (taskID) => {
 });
 
 Cypress.Commands.add('headlessCreateUser', (userSpec) => {
+    cy.window().its('cvat', { timeout: 25000 }).should('not.be.undefined');
     cy.intercept('POST', '/api/auth/register**', (req) => {
         req.continue((response) => {
             delete response.headers['set-cookie'];

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -271,12 +271,6 @@ Cypress.Commands.add('headlessLogin', ({
 } = {}) => {
     cy.window().then((win) => {
         cy.headlessLogout().then(() => {
-            if (!win.cvat) {
-                // application was not yet initialized
-                cy.visit('/auth/login');
-                cy.get('#root').should('exist').and('be.visible');
-            }
-
             return win.cvat.server.login(
                 username || Cypress.env('user'),
                 password || Cypress.env('password'),
@@ -341,7 +335,7 @@ Cypress.Commands.add('headlessCreateTask', (taskSpec, dataSpec, extras) => {
 Cypress.Commands.add('headlessCreateProject', (projectSpec) => {
     cy.window().then(async ($win) => {
         const project = new $win.cvat.classes.Project({
-            ...projectSpec,
+            ...projectSpe,
         });
 
         const result = await project.save();

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -269,6 +269,7 @@ Cypress.Commands.add('headlessLogin', ({
     password,
     nextURL,
 } = {}) => {
+    cy.window().its('cvat', { timeout: 25000 }).should('not.be.undefined');
     cy.window().then((win) => {
         cy.headlessLogout().then(() => (
             win.cvat.server.login(


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
`headlessCreateUser` now looks easier
`headlessLogin` is more efficient. It allows to get logged in user and immediately go to the target page, additionally handling logout logic. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
