### PR TITLE
Add bandit suppressions to tracker functions

### DIFF
--- a/serverless/pytorch/dschoerk/transt/nuclio/model_handler.py
+++ b/serverless/pytorch/dschoerk/transt/nuclio/model_handler.py
@@ -18,20 +18,24 @@ class ModelHandler:
         self.tracker = Tracker(name='transt', net=net, window_penalty=0.49, exemplar_size=128, instance_size=256)
 
     def decode_state(self, state):
-        self.tracker.net.net.zf = jsonpickle.decode(state['model.net.net.zf'])
-        self.tracker.net.net.pos_template = jsonpickle.decode(state['model.net.net.pos_template'])
+        # The server ensures that `state` is one of the values that the function itself
+        # has previously output. Therefore it should be safe to use jsonpickle.
+        decode = jsonpickle.decode  # nosec: B301
 
-        self.tracker.window = jsonpickle.decode(state['model.window'])
-        self.tracker.center_pos = jsonpickle.decode(state['model.center_pos'])
-        self.tracker.size = jsonpickle.decode(state['model.size'])
-        self.tracker.channel_average = jsonpickle.decode(state['model.channel_average'])
-        self.tracker.mean = jsonpickle.decode(state['model.mean'])
-        self.tracker.std = jsonpickle.decode(state['model.std'])
-        self.tracker.inplace = jsonpickle.decode(state['model.inplace'])
+        self.tracker.net.net.zf = decode(state['model.net.net.zf'])
+        self.tracker.net.net.pos_template = decode(state['model.net.net.pos_template'])
+
+        self.tracker.window = decode(state['model.window'])
+        self.tracker.center_pos = decode(state['model.center_pos'])
+        self.tracker.size = decode(state['model.size'])
+        self.tracker.channel_average = decode(state['model.channel_average'])
+        self.tracker.mean = decode(state['model.mean'])
+        self.tracker.std = decode(state['model.std'])
+        self.tracker.inplace = decode(state['model.inplace'])
 
         self.tracker.features_initialized = False
         if 'model.features_initialized' in state:
-            self.tracker.features_initialized = jsonpickle.decode(state['model.features_initialized'])
+            self.tracker.features_initialized = decode(state['model.features_initialized'])
 
     def encode_state(self):
         state = {}

--- a/serverless/pytorch/foolwood/siammask/nuclio/model_handler.py
+++ b/serverless/pytorch/foolwood/siammask/nuclio/model_handler.py
@@ -37,7 +37,9 @@ class ModelHandler:
 
     def decode_state(self, state):
         for k,v in state.items():
-            state[k] = jsonpickle.decode(v)
+            # The server ensures that `state` is one of the values that the function itself
+            # has previously output. Therefore it should be safe to use jsonpickle.
+            state[k] = jsonpickle.decode(v)  # nosec: B301
 
         state['net'] = copy(self.siammask)
         state['net'].zf = state['net.zf']

--- a/serverless/pytorch/foolwood/siammask/nuclio/model_handler.py
+++ b/serverless/pytorch/foolwood/siammask/nuclio/model_handler.py
@@ -2,11 +2,16 @@
 #
 # SPDX-License-Identifier: MIT
 
-from tools.test import *
 import os
 from copy import copy
+
 import jsonpickle
 import numpy as np
+import torch
+
+from tools.test import siamese_init, siamese_track
+from utils.config_helper import load_config
+from utils.load_helper import load_pretrain
 
 class ModelHandler:
     def __init__(self):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Now that GHSA-wq36-mxf8-hv62 is fixed, it is actually safe to use jsonpickle in this context.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I manually tested TransT.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
