### PR TITLE
AA functions: add more stringent label/shape type compatibility checking

### DIFF
--- a/changelog.d/20250128_144218_roman_aa_fun_label_types.md
+++ b/changelog.d/20250128_144218_roman_aa_fun_label_types.md
@@ -1,0 +1,5 @@
+### Added
+
+- \[SDK\] The shapes output by auto-annotation functions are now checked
+  for compatibility with the function's and the task's label specs
+  (<https://github.com/cvat-ai/cvat/pull/9005>)

--- a/cvat-sdk/cvat_sdk/auto_annotation/functions/_torchvision.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/functions/_torchvision.py
@@ -10,6 +10,8 @@ import cvat_sdk.auto_annotation as cvataa
 
 
 class TorchvisionFunction:
+    _label_type = "any"
+
     def __init__(self, model_name: str, weights_name: str = "DEFAULT", **kwargs) -> None:
         weights_enum = torchvision.models.get_model_weights(model_name)
         self._weights = weights_enum[weights_name]
@@ -21,7 +23,7 @@ class TorchvisionFunction:
     def spec(self) -> cvataa.DetectionFunctionSpec:
         return cvataa.DetectionFunctionSpec(
             labels=[
-                cvataa.label_spec(cat, i)
+                cvataa.label_spec(cat, i, type=self._label_type)
                 for i, cat in enumerate(self._weights.meta["categories"])
                 if cat != "N/A"
             ]

--- a/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_detection.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_detection.py
@@ -11,6 +11,8 @@ from ._torchvision import TorchvisionFunction
 
 
 class _TorchvisionDetectionFunction(TorchvisionFunction):
+    _label_type = "rectangle"
+
     def detect(
         self, context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
     ) -> list[models.LabeledShapeRequest]:

--- a/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_instance_segmentation.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/functions/torchvision_instance_segmentation.py
@@ -50,6 +50,8 @@ def _generate_shapes(
 
 
 class _TorchvisionInstanceSegmentationFunction(TorchvisionFunction):
+    _label_type = "mask"
+
     def detect(
         self, context: cvataa.DetectionFunctionContext, image: PIL.Image.Image
     ) -> list[models.LabeledShapeRequest]:

--- a/site/content/en/docs/api_sdk/sdk/auto-annotation.md
+++ b/site/content/en/docs/api_sdk/sdk/auto-annotation.md
@@ -63,8 +63,9 @@ class TorchvisionDetectionFunction:
         # describe the annotations
         return cvataa.DetectionFunctionSpec(
             labels=[
-                cvataa.label_spec(cat, i)
-                for i, cat in enumerate(self._weights.meta['categories'])
+                cvataa.label_spec(cat, i, type="rectangle")
+                for i, cat in enumerate(self._weights.meta["categories"])
+                if cat != "N/A"
             ]
         )
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
These changes are meant to enforce several conditions:

1. A function should not be able to create shapes of type incompatible with the type of the label it declares (for example, if a 
  function's label has type `rectangle`, it should not be able to create ellipses with that label).

2. A function should not be able to create shapes of type incompatible with the type of the label in the task being annotated.

3. If a function's declared label has a type incompatible with the type of the corresponding task label, then it should not run at all (since it would be impossible for it to output a shape with that label that wouldn't violate either condition 1 or 2).

Altogether, these restrictions ensure that we don't create any shapes in a task that aren't compatible with that task's label types.

In addition, set explicit label types for the predefined functions.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Unit tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
