### PR TITLE
CLI: Let `function create-native` submit label types to the server

### DIFF
--- a/changelog.d/20250207_153348_roman_native_function_label_type.md
+++ b/changelog.d/20250207_153348_roman_native_function_label_type.md
@@ -1,0 +1,5 @@
+### Added
+
+- \[CLI\] `function create-native` now sends the function's declared label types
+  to the server
+  (<https://github.com/cvat-ai/cvat/pull/9035>)

--- a/cvat-cli/src/cvat_cli/_internal/commands_functions.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_functions.py
@@ -62,6 +62,11 @@ class FunctionCreateNative:
                         "name": label_spec.name,
                     }
                 )
+
+                if getattr(label_spec, "type", "any") != "any":
+                    # Add the type conditionally, to stay compatible with older
+                    # CVAT versions when the function doesn't define label types.
+                    remote_function["labels_v2"][-1]["type"] = label_spec.type
         else:
             raise cvataa.BadFunctionError(
                 f"Unsupported function spec type: {type(function.spec).__name__}"


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This will enable more accurate label type information in the function API, which is used in a few places (for example, in the "From model" feature available when configuring labels for a task).

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
There will be tests in the private repo.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
