### PR TITLE
CI: run Stylelint on all files, not just changed ones

### DIFF
--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -8,23 +8,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
             node-version: '16.x'
-      - id: files
-        uses: tj-actions/changed-files@v41.0.0
-        with:
-          files: |
-              **/*.css
-              **/*.scss
+
+      - name: Install dependencies
+        run: |
+          yarn install --frozen-lockfile
 
       - name: Run checks
         run: |
-          CHANGED_FILES="${{steps.files.outputs.all_changed_files}}"
-
-          if [[ ! -z $CHANGED_FILES ]]; then
-            yarn install --frozen-lockfile
-
-            echo "StyleLint version: "$(npx stylelint --version)
-            echo "The files will be checked: "$(echo $CHANGED_FILES)
-            npx stylelint $CHANGED_FILES
-          else
-            echo "No files with the \"css|scss\" extension found"
-          fi
+          echo "StyleLint version: "$(yarn run -s stylelint --version)
+          yarn run stylelint '**/*.css' '**/*.scss'

--- a/cvat-ui/src/components/export-backup/styles.scss
+++ b/cvat-ui/src/components/export-backup/styles.scss
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-@import '../../base.scss';
+@import '../../base';
 
 .cvat-modal-export-option-item > .ant-select-item-option-content,
 .cvat-modal-export-select .ant-select-selection-item {

--- a/cvat-ui/src/components/export-dataset/styles.scss
+++ b/cvat-ui/src/components/export-dataset/styles.scss
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-@import '../../base.scss';
+@import '../../base';
 
 .cvat-modal-export-option-item > .ant-select-item-option-content,
 .cvat-modal-export-select .ant-select-selection-item {

--- a/cvat-ui/src/components/global-error-boundary/styles.scss
+++ b/cvat-ui/src/components/global-error-boundary/styles.scss
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-@import '../../base.scss';
+@import '../../base';
 
 .cvat-global-boundary {
     .ant-result > .ant-result-content {

--- a/cvat-ui/src/components/layout-grid/styles.scss
+++ b/cvat-ui/src/components/layout-grid/styles.scss
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-@import './../../base.scss';
+@import './../../base';
 
 .grid {
     display: grid;

--- a/cvat-ui/src/components/storage/styles.scss
+++ b/cvat-ui/src/components/storage/styles.scss
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-@import '../../base.scss';
+@import '../../base';
 
 .cvat-question-circle-filled-icon {
     font-size: $grid-unit-size * 14;

--- a/cvat-ui/src/components/update-cloud-storage-page/styles.scss
+++ b/cvat-ui/src/components/update-cloud-storage-page/styles.scss
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-@import '../../base.scss';
+@import '../../base';
 
 .cvat-update-cloud-storage-form-wrapper {
     text-align: center;

--- a/site/assets/scss/_variables_project.scss
+++ b/site/assets/scss/_variables_project.scss
@@ -13,5 +13,4 @@ Add styles or override variables from the theme here.
 $enable-gradients: false;
 $enable-rounded: true;
 $enable-shadows: true;
-
 $info: #f1f1f1;


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This is the equivalent of #5720, but for Stylelint. Inspired by the CI failures in #8998.

Fix all remaining Stylelint warnings, so that CI stays green.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
