### PR TITLE
Add skeleton support for native functions

### DIFF
--- a/changelog.d/20250219_184104_roman_agent_skeletons.md
+++ b/changelog.d/20250219_184104_roman_agent_skeletons.md
@@ -1,0 +1,12 @@
+### Added
+
+- \[SDK\] Auto-auuotation functions that output skeletons can now be used
+  via agents
+  (<https://github.com/cvat-ai/cvat/pull/9122>)
+
+### Changed
+
+- \[SDK\] `DetectionFunctionSpec` now requires that the type of keypoint
+  sublabels is set to `points`. Accordingly, `keypoint_spec` now sets
+  this type by default
+  (<https://github.com/cvat-ai/cvat/pull/9122>)

--- a/changelog.d/20250219_184104_roman_agent_skeletons.md
+++ b/changelog.d/20250219_184104_roman_agent_skeletons.md
@@ -1,6 +1,6 @@
 ### Added
 
-- \[SDK\] Auto-auuotation functions that output skeletons can now be used
+- \[SDK\] Auto-annotation functions that output skeletons can now be used
   via agents
   (<https://github.com/cvat-ai/cvat/pull/9122>)
 

--- a/cvat-cli/src/cvat_cli/_internal/commands_functions.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_functions.py
@@ -6,9 +6,10 @@ import argparse
 import json
 import textwrap
 from collections.abc import Sequence
+from typing import Union
 
 import cvat_sdk.auto_annotation as cvataa
-from cvat_sdk import Client
+from cvat_sdk import Client, models
 
 from .agent import FUNCTION_KIND_DETECTOR, FUNCTION_PROVIDER_NATIVE, run_agent
 from .command_base import CommandGroup
@@ -33,6 +34,29 @@ class FunctionCreateNative:
 
         configure_function_implementation_arguments(parser)
 
+    @staticmethod
+    def _dump_sublabel_spec(
+        sl_spec: Union[models.SublabelRequest, models.PatchedLabelRequest],
+    ) -> dict:
+        result = {
+            "name": sl_spec.name,
+            "attributes": [
+                {
+                    "name": attribute_spec.name,
+                    "input_type": attribute_spec.input_type,
+                    "values": attribute_spec.values,
+                }
+                for attribute_spec in getattr(sl_spec, "attributes", [])
+            ],
+        }
+
+        if getattr(sl_spec, "type", "any") != "any":
+            # Add the type conditionally, to stay compatible with older
+            # CVAT versions when the function doesn't define label types.
+            result["type"] = sl_spec.type
+
+        return result
+
     def execute(
         self,
         client: Client,
@@ -52,29 +76,12 @@ class FunctionCreateNative:
             remote_function["labels_v2"] = []
 
             for label_spec in function.spec.labels:
-                if getattr(label_spec, "sublabels", None):
-                    raise cvataa.BadFunctionError(
-                        f"Function label {label_spec.name!r} has sublabels. This is currently not supported."
-                    )
+                remote_function["labels_v2"].append(self._dump_sublabel_spec(label_spec))
 
-                remote_function["labels_v2"].append(
-                    {
-                        "name": label_spec.name,
-                        "attributes": [
-                            {
-                                "name": attribute_spec.name,
-                                "input_type": attribute_spec.input_type,
-                                "values": attribute_spec.values,
-                            }
-                            for attribute_spec in getattr(label_spec, "attributes", [])
-                        ],
-                    }
-                )
-
-                if getattr(label_spec, "type", "any") != "any":
-                    # Add the type conditionally, to stay compatible with older
-                    # CVAT versions when the function doesn't define label types.
-                    remote_function["labels_v2"][-1]["type"] = label_spec.type
+                if sublabels := getattr(label_spec, "sublabels", None):
+                    remote_function["labels_v2"][-1]["sublabels"] = [
+                        self._dump_sublabel_spec(sublabel) for sublabel in sublabels
+                    ]
         else:
             raise cvataa.BadFunctionError(
                 f"Unsupported function spec type: {type(function.spec).__name__}"

--- a/cvat-sdk/cvat_sdk/auto_annotation/interface.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/interface.py
@@ -94,6 +94,9 @@ class DetectionFunctionSpec:
 
                 seen_sl_ids.add(sl.id)
 
+                if sl.type != "points":
+                    raise BadFunctionError(f"{sl_desc} has type {sl.type!r} (should be 'points')")
+
                 cls._validate_attributes(getattr(sl, "attributes", []), sl_desc)
 
     @labels.validator
@@ -236,8 +239,8 @@ def skeleton_label_spec(
 
 # pylint: disable-next=redefined-builtin
 def keypoint_spec(name: str, id: int, **kwargs) -> models.SublabelRequest:
-    """Helper factory function for SublabelRequest."""
-    return models.SublabelRequest(name=name, id=id, **kwargs)
+    """Helper factory function for SublabelRequest with type="points"."""
+    return models.SublabelRequest(name=name, id=id, type="points", **kwargs)
 
 
 def attribute_spec(

--- a/site/content/en/docs/api_sdk/sdk/auto-annotation.md
+++ b/site/content/en/docs/api_sdk/sdk/auto-annotation.md
@@ -176,7 +176,7 @@ The following helpers are available for building specifications:
 |---------------------------|-----------------------|-------------------------------------------------------|
 | `label_spec`              | `PatchedLabelRequest` | -                                                     |
 | `skeleton_label_spec`     | `PatchedLabelRequest` | `type="skeleton"`                                     |
-| `keypoint_spec`           | `SublabelRequest`     | -                                                     |
+| `keypoint_spec`           | `SublabelRequest`     | `type="points"`                                       |
 | `attribute_spec`          | `AttributeRequest`    | `mutable=False`                                       |
 | `checkbox_attribute_spec` | `AttributeRequest`    | `mutable=False`, `input_type="checkbox"`, `values=[]` |
 | `number_attribute_spec`   | `AttributeRequest`    | `mutable=False`, `input_type="number"`                |

--- a/tests/python/sdk/test_auto_annotation.py
+++ b/tests/python/sdk/test_auto_annotation.py
@@ -139,6 +139,16 @@ class TestDetectionFunctionSpec:
             ],
         )
 
+    def test_sublabel_wrong_type(self):
+        self._test_bad_spec(
+            "should be 'points'",
+            labels=[
+                cvataa.skeleton_label_spec(
+                    "cat", 123, [models.SublabelRequest(name="head", id=1, type="any")]
+                )
+            ],
+        )
+
 
 class TestTaskAutoAnnotation:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
All of the support code in the auto-annotation SDK layer is already there, we just need to send sublabel information when creating a native function, and validate it when running an agent.

In addition, force keypoint sublabel types to be "points", since this is how the UI creates them for tasks/projects.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Tests will be added in the private repository.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
