### PR TITLE
Fixed Duplicate Buttons in Skeleton Point Config Modal (#9070)

### DIFF
--- a/cvat-ui/src/components/labels-editor/skeleton-element-context-menu.tsx
+++ b/cvat-ui/src/components/labels-editor/skeleton-element-context-menu.tsx
@@ -31,10 +31,11 @@ function WrappedSkeletonElementLabelForm(props: ContextMenuProps & { hideConfigu
         <Modal
             visible
             width={700}
-            cancelButtonProps={{ hidden: true }}
-            okButtonProps={{ hidden: true }}
+            cancelButtonProps={{ style: { display: 'none' } }} // More explicit than hidden
+            okButtonProps={{ style: { display: 'none' } }} // More explicit than hidden
             closable={false}
             destroyOnClose
+            footer={null} // Explicitly remove default footer
         >
             <LabelForm
                 label={elementLabel}


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

### Motivation and Context
Fixes [Issue #9070](https://github.com/cvat-ai/cvat/issues/9070): duplicate buttons ("Done" & "Cancel" and "Cancel" & "OK") in the skeleton point configuration modal.

### How Has This Been Tested?
- Applied changes, rebuilt CVAT with `npm run build` and `docker-compose up -d --build`, tested in Chrome: only "Done" & "Cancel" appear and work.

### Changes
- **File**: `cvat-ui/src/components/labels-editor/skeleton-element-context-menu.tsx`
- **Code**:
  - Added `footer={null}` to `<Modal>` to disable default Ant Design footer.
  - Updated `cancelButtonProps` and `okButtonProps` to `{ style: { display: 'none' } }` from `{ hidden: true }`.

### Checklist
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues

### License
- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.

Closes #9070.
