### PR TITLE
Added feature to display dimensions of rectangles and ellipses

### DIFF
--- a/changelog.d/20250224_114044_sekachev.bs_display_dimensions_support.md
+++ b/changelog.d/20250224_114044_sekachev.bs_display_dimensions_support.md
@@ -1,0 +1,4 @@
+### Added
+
+- A setting to display rectangles and ellipses dimensions and rotation
+  (<https://github.com/cvat-ai/cvat/pull/9142>)

--- a/cvat-canvas/src/scss/canvas.scss
+++ b/cvat-canvas/src/scss/canvas.scss
@@ -54,7 +54,7 @@ polyline.cvat_shape_drawing_opacity {
 }
 
 .cvat_canvas_text_dimensions {
-    fill: cyan;
+    fill: lightskyblue;
 }
 
 .cvat_canvas_text_description {

--- a/cvat-canvas/src/scss/canvas.scss
+++ b/cvat-canvas/src/scss/canvas.scss
@@ -48,10 +48,13 @@ polyline.cvat_shape_drawing_opacity {
     font-weight: bold;
     fill: white;
     cursor: default;
-    font-family: Calibri, Candara, Segoe, 'Segoe UI', Optima, Arial, sans-serif;
-    text-shadow: 0 0 4px black;
+    filter: drop-shadow(1px 1px 1px black) drop-shadow(-1px -1px 1px black);
     user-select: none;
     pointer-events: none;
+}
+
+.cvat_canvas_text_dimensions {
+    fill: cyan;
 }
 
 .cvat_canvas_text_description {

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -939,7 +939,7 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
 
         if (typeof configuration.textContent === 'string') {
             const splitted = configuration.textContent.split(',').filter((entry: string) => !!entry);
-            if (splitted.every((entry: string) => ['id', 'label', 'attributes', 'source', 'descriptions'].includes(entry))) {
+            if (splitted.every((entry: string) => ['id', 'label', 'attributes', 'source', 'descriptions', 'dimensions'].includes(entry))) {
                 this.data.configuration.textContent = configuration.textContent;
             }
         }

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -3131,10 +3131,10 @@ export class CanvasViewImpl implements CanvasView, Listener {
 
                     const normWidth = width.toFixed(1);
                     const normHeight = height.toFixed(1);
-                    const normRot = state.rotation === 0 ? '' : `\u00B0${state.rotation.toFixed(1)}`;
+                    const normRot = state.rotation === 0 ? '' : `${state.rotation.toFixed(1)}\u00B0`;
 
                     block
-                        .tspan(`${normWidth}x${normHeight}${normRot}`)
+                        .tspan(`${normWidth}x${normHeight}px${normRot}`)
                         .attr({
                             dy: '1em',
                             x: 0,

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -32,6 +32,7 @@ import {
     vectorLength, ShapeSizeElement, DrawnState, rotate2DPoints,
     readPointsFromShape, setupSkeletonEdges, makeSVGFromTemplate,
     imageDataToDataURL, expandChannels, stringifyPoints, zipChannels,
+    composeShapeDimensions,
 } from './shared';
 import {
     CanvasModel, Geometry, UpdateReasons, FrameZoom, ActiveElement,
@@ -3120,6 +3121,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 `${withSource ? `(${source})` : ''}`).style({
                     'text-transform': 'uppercase',
                 });
+
                 if (withDimensions && ['rectangle', 'ellipse'].includes(state.shapeType)) {
                     let width = state.points[2] - state.points[0];
                     let height = state.points[3] - state.points[1];
@@ -3129,34 +3131,32 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         height *= -2;
                     }
 
-                    const normWidth = width.toFixed(1);
-                    const normHeight = height.toFixed(1);
-                    const normRot = state.rotation === 0 ? '' : `${state.rotation.toFixed(1)}\u00B0`;
-
                     block
-                        .tspan(`${normWidth}x${normHeight}px ${normRot}`)
+                        .tspan(composeShapeDimensions(width, height, state.rotation))
                         .attr({
-                            dy: '1em',
+                            dy: '1.25em',
                             x: 0,
                         })
                         .addClass('cvat_canvas_text_dimensions');
                 }
                 if (withDescriptions) {
-                    for (const desc of descriptions) {
+                    descriptions.forEach((desc: string, idx: number) => {
                         block
                             .tspan(`${desc}`)
                             .attr({
-                                dy: '1em',
+                                dy: idx === 0 ? '1.25em' : '1em',
                                 x: 0,
                             })
                             .addClass('cvat_canvas_text_description');
-                    }
+                    });
                 }
                 if (withAttr) {
-                    for (const attrID of Object.keys(attributes)) {
-                        const values = `${attributes[attrID] === undefinedAttrValue ? '' : attributes[attrID]}`.split('\n');
+                    Object.keys(attributes).forEach((attrID: string, idx: number) => {
+                        const values = `${attributes[attrID] === undefinedAttrValue ?
+                            '' : attributes[attrID]}`.split('\n');
                         const parent = block.tspan(`${attrNames[attrID]}: `)
-                            .attr({ attrID, dy: '1em', x: 0 }).addClass('cvat_canvas_text_attribute');
+                            .attr({ attrID, dy: idx === 0 ? '1.25em' : '1em', x: 0 })
+                            .addClass('cvat_canvas_text_attribute');
                         values.forEach((attrLine: string, index: number) => {
                             parent
                                 .tspan(attrLine)
@@ -3164,7 +3164,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                                     dy: index === 0 ? 0 : '1em',
                                 });
                         });
-                    }
+                    });
                 }
             })
             .move(0, 0)

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -3134,7 +3134,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     const normRot = state.rotation === 0 ? '' : `${state.rotation.toFixed(1)}\u00B0`;
 
                     block
-                        .tspan(`${normWidth}x${normHeight}px${normRot}`)
+                        .tspan(`${normWidth}x${normHeight}px ${normRot}`)
                         .attr({
                             dy: '1em',
                             x: 0,

--- a/cvat-canvas/src/typescript/shared.ts
+++ b/cvat-canvas/src/typescript/shared.ts
@@ -100,7 +100,7 @@ export function displayShapeSize(shapesContainer: SVG.Container, textContainer: 
             .fill('white')
             .addClass('cvat_canvas_text'),
         update(shape: SVG.Shape): void {
-            let text = `${Math.floor(shape.width())}x${Math.floor(shape.height())}px`;
+            let text = `${shape.width().toFixed(1)}x${shape.height().toFixed(1)}px`;
             if (shape.type === 'rect' || shape.type === 'ellipse') {
                 let rotation = shape.transform().rotation || 0;
                 // be sure, that rotation in range [0; 360]

--- a/cvat-canvas/src/typescript/shared.ts
+++ b/cvat-canvas/src/typescript/shared.ts
@@ -90,6 +90,21 @@ export function translateToSVG(svg: SVGSVGElement, points: number[]): number[] {
     return output;
 }
 
+export function composeShapeDimensions(width: number, height: number, rotation: number | null): string {
+    const text = `${width.toFixed(1)}x${height.toFixed(1)}px`;
+    let adjustableRotation = rotation;
+    if (adjustableRotation) {
+        // make sure, that rotation is in range [0; 360]
+        while (adjustableRotation < 0) {
+            adjustableRotation += 360;
+        }
+        adjustableRotation %= 360;
+        return `${text} ${adjustableRotation.toFixed(1)}\u00B0`;
+    }
+
+    return text;
+}
+
 export function displayShapeSize(shapesContainer: SVG.Container, textContainer: SVG.Container): ShapeSizeElement {
     const shapeSize: ShapeSizeElement = {
         sizeElement: textContainer
@@ -100,16 +115,9 @@ export function displayShapeSize(shapesContainer: SVG.Container, textContainer: 
             .fill('white')
             .addClass('cvat_canvas_text'),
         update(shape: SVG.Shape): void {
-            let text = `${shape.width().toFixed(1)}x${shape.height().toFixed(1)}px`;
-            if (shape.type === 'rect' || shape.type === 'ellipse') {
-                let rotation = shape.transform().rotation || 0;
-                // be sure, that rotation in range [0; 360]
-                while (rotation < 0) rotation += 360;
-                rotation %= 360;
-                if (rotation) {
-                    text = `${text} ${rotation.toFixed(1)}\u00B0`;
-                }
-            }
+            const rotation = shape.type === 'rect' || shape.type === 'ellipse' ?
+                shape.transform().rotation ?? 0 : null;
+            const text = composeShapeDimensions(shape.width(), shape.height(), rotation);
             const [x, y, cx, cy]: number[] = translateToSVG(
                 (textContainer.node as any) as SVGSVGElement,
                 translateFromSVG((shapesContainer.node as any) as SVGSVGElement, [

--- a/cvat-ui/src/components/header/settings-modal/workspace-settings.tsx
+++ b/cvat-ui/src/components/header/settings-modal/workspace-settings.tsx
@@ -168,6 +168,7 @@ function WorkspaceSettingsComponent(props: Props): JSX.Element {
                         <Select.Option value='attributes'>Attributes</Select.Option>
                         <Select.Option value='source'>Source</Select.Option>
                         <Select.Option value='descriptions'>Descriptions</Select.Option>
+                        <Select.Option value='dimensions'>Dimensions</Select.Option>
                     </Select>
                 </Col>
             </Row>

--- a/cvat-ui/src/reducers/settings-reducer.ts
+++ b/cvat-ui/src/reducers/settings-reducer.ts
@@ -35,7 +35,7 @@ const defaultState: SettingsState = {
         textFontSize: 14,
         controlPointsSize: 5,
         textPosition: 'auto',
-        textContent: 'id,source,label,attributes,descriptions',
+        textContent: 'id,source,label,attributes,descriptions,dimensions',
         toolsBlockerState: {
             algorithmsLocked: false,
             buttonVisible: false,

--- a/site/content/en/docs/manual/basics/settings.md
+++ b/site/content/en/docs/manual/basics/settings.md
@@ -43,6 +43,8 @@ In tab `Workspace` you can:
   - `Label` - object label.
   - `Source`- source of creating of objects `MANUAL`, `AUTO` or `SEMI-AUTO`.
   - `Descriptions` - description of attributes.
+  - `Dimensions` - width, height and rotation for rectangles and ellipses.
+
 
 - `Position of a text` - text positioning mode selection:
   - `Auto` - the object details will be automatically placed where free space is.


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Added setting to display shape size of rectangles and ellipses without dragging/resizing them:

<img width="502" alt="image" src="https://github.com/user-attachments/assets/139460c4-4f08-4074-979f-ba9203000324" />


<img width="760" alt="image" src="https://github.com/user-attachments/assets/cbee395e-09f8-4d8a-995e-6cbc073f8b1f" />

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
