### PR TITLE
Make the dump_objects.py script easier to use in the private repo

### DIFF
--- a/tests/python/shared/utils/dump_objects.py
+++ b/tests/python/shared/utils/dump_objects.py
@@ -2,9 +2,11 @@
 #
 # SPDX-License-Identifier: MIT
 
+import argparse
 import json
 from datetime import timezone
 from http import HTTPStatus
+from pathlib import Path
 from typing import Any
 
 from config import ASSETS_DIR, get_method
@@ -34,41 +36,39 @@ def clean_list_response(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
-if __name__ == "__main__":
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--assets-dir", type=Path, default=ASSETS_DIR)
+    args = parser.parse_args()
+
+    assets_dir: Path = args.assets_dir
+
     annotations = {}
 
-    for obj in [
-        "user",
-        "project",
-        "task",
-        "job",
-        "organization",
-        "membership",
-        "invitation",
-        "cloudstorage",
-        "comment",
-        "issue",
-        "webhook",
-        "label",
-        "quality/report",
-        "quality/conflict",
-        "quality/setting",
-        "consensus/setting",
-    ]:
-        response = get_method("admin1", f"{obj}s", page_size="all")
+    for dump_path in assets_dir.glob("*.json"):
+        endpoint = dump_path.stem.replace("_", "/")
 
-        filename = f"{obj}s.json".replace("/", "_")
-        with open(ASSETS_DIR / filename, "w") as f:
-            f.write(json.dumps(clean_list_response(response.json()), indent=2, sort_keys=True))
+        if endpoint == "annotations":
+            continue  # this will be handled at the end
 
-        if obj in ["job", "task"]:
+        response = get_method("admin1", endpoint, page_size="all")
+
+        with open(dump_path, "w") as f:
+            json.dump(clean_list_response(response.json()), f, indent=2, sort_keys=True)
+
+        if endpoint in ["jobs", "tasks"]:
+            obj = endpoint.removesuffix("s")
             annotations[obj] = {}
             for _obj in response.json()["results"]:
                 oid = _obj["id"]
 
-                response = get_method("admin1", f"{obj}s/{oid}/annotations")
+                response = get_method("admin1", f"{endpoint}/{oid}/annotations")
                 if response.status_code == HTTPStatus.OK:
                     annotations[obj][oid] = response.json()
 
-    with open(ASSETS_DIR / "annotations.json", "w") as f:
+    with open(assets_dir / "annotations.json", "w") as f:
         json.dump(annotations, f, indent=2, sort_keys=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/shared/utils/dump_objects.py
+++ b/tests/python/shared/utils/dump_objects.py
@@ -2,6 +2,19 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""
+This script lists resources on the CVAT server
+and saves them to JSON files in the `assets` directory.
+Before running it, start the test instance by running:
+
+    pytest tests/python --start-services
+
+The script determines which endpoints to query by looking at the set of existing JSON files.
+For example, if `tasks.json` exists, the script will overwrite it with output of `GET /api/tasks`.
+Underscores in the file name are replaced with slashes in the URL path.
+In addition, `annotations.json` is always saved.
+"""
+
 import argparse
 import json
 from datetime import timezone


### PR DESCRIPTION
This involves two things:

1. Make the output directory configurable.
2. Instead of hardcoding resource types, rewrite every file that already exists.

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
