### PR TITLE
[Dependent] Fix related image display in gt jobs

### DIFF
--- a/changelog.d/20250228_163221_mzhiltso_fix_included_frame_handling.md
+++ b/changelog.d/20250228_163221_mzhiltso_fix_included_frame_handling.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Invalid display of images in simple GT jobs
+  (<https://github.com/cvat-ai/cvat/pull/9155>)

--- a/cvat-core/src/frames.ts
+++ b/cvat-core/src/frames.ts
@@ -744,7 +744,9 @@ export async function getContextImage(jobID: number, frame: number): Promise<Rec
     const meta = await frameData.getMeta();
     const requestId = frame;
     const { jobStartFrame } = frameData;
-    const { related_files: relatedFiles } = meta.frames[frame - jobStartFrame];
+    const dataFrameNumber = meta.getDataFrameNumber(frame - jobStartFrame);
+    const frameIndex = meta.getFrameIndex(dataFrameNumber);
+    const { related_files: relatedFiles } = meta.frames[frameIndex];
     return new Promise<Record<string, ImageBitmap>>((resolve, reject) => {
         if (!(jobID in frameDataCache)) {
             reject(new Error(


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Depends on #9155

- Fixed display of related images in simple GT jobs with non-default frame step / start frame

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
