### PR TITLE
Helm: support adding backend environment variables from supercharts

### DIFF
--- a/changelog.d/20250314_163649_roman_superchart_env.md
+++ b/changelog.d/20250314_163649_roman_superchart_env.md
@@ -1,0 +1,5 @@
+### Added
+
+- \[Helm\] Added a new value, `cvat.backend.extensionEnv`, to support
+  supercharts adding environment variables to backend containers
+  (<https://github.com/cvat-ai/cvat/pull/9214>)

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -138,6 +138,11 @@ The name of the service account to use for backend pods
 - name: CVAT_NUCLIO_FUNCTION_NAMESPACE
   value: "{{ .Release.Namespace }}"
 {{- end }}
+
+{{- range $envName, $envValueTemplate := .Values.cvat.backend.extensionEnv }}
+- name: {{ $envName | toYaml }}
+  value: {{ tpl $envValueTemplate $ | toYaml }}
+{{- end }}
 {{- end }}
 
 {{- define "cvat.sharedClickhouseEnv" }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -15,6 +15,11 @@ cvat:
     affinity: {}
     tolerations: []
     additionalEnv: []
+
+    # This should only be used by supercharts;
+    # to set custom environment for a Helm release, use additionalEnv.
+    extensionEnv: {}
+
     additionalVolumes: []
     additionalVolumeMounts: []
     # -- The service account the backend pods will use to interact with the Kubernetes API


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
I have a need to add an environment variable for backend containers in the Enterprise version. `additionalEnv` doesn't work very well for this, because:

* It is an array, so if a user specifies a different value for it with `--set`, any defaults set by the superchart will disappear.

* It is inserted into the resource definition verbatim, so you can't refer to things like the release name.

This patch introduces a separate setting for this purpose. It takes a map, and runs the variable values through `tpl` to support interpolation.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
