### PR TITLE
Dockerfile: fix an "undefined variable" warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ FROM ${BASE_IMAGE}
 
 ARG http_proxy
 ARG https_proxy
-ARG no_proxy="nuclio,${no_proxy}"
+ARG no_proxy
 ARG socks_proxy
 ARG TZ="Etc/UTC"
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
There is no point in adding "nuclio" to `no_proxy` by default.

* During the build, Nuclio isn't used.
* When deploying with Docker Compose, the Compose file overrides `no_proxy`.
* When deploying with Helm, Nuclio has a different hostname.

Even if you're deploying manually, you still have to override `no_proxy`, since there are many other internal hosts besides `nuclio` (like `opa`).

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
