### PR TITLE
Fixed 500 status code that could occur when listing requests by `GET /api/requests`

### DIFF
--- a/changelog.d/20250320_144532_maria_fix_500_status_code_in_requests_api.md
+++ b/changelog.d/20250320_144532_maria_fix_500_status_code_in_requests_api.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed a 500 status code that could occur when listing requests by GET /api/requests
+  (<https://github.com/cvat-ai/cvat/pull/9236>)

--- a/cvat/apps/engine/rq.py
+++ b/cvat/apps/engine/rq.py
@@ -163,7 +163,7 @@ class AbstractRQMeta(metaclass=ABCMeta):
     def get_meta_on_retry(self) -> dict[str, Any]:
         resettable_fields = self._get_resettable_fields()
 
-        return {k: v for k, v in self._job.meta.items() if k not in resettable_fields}
+        return {k: v for k, v in self._meta.items() if k not in resettable_fields}
 
 
 class RQMetaWithFailureInfo(AbstractRQMeta):
@@ -193,14 +193,29 @@ class RQMetaWithFailureInfo(AbstractRQMeta):
 
 
 class BaseRQMeta(RQMetaWithFailureInfo):
-    # immutable && required fields
+    # immutable fields
+    # FUTURE-TODO: change to required fields when each enqueued job
+    # regardless of queue type will have these fields
+    # Blocked now by:
+    # - [annotation queue] Some jobs may have no user/request info
+    # - [chunks queue] Each job has no user/request info
+    # - [import queue] Jobs running to cleanup uploaded files have no user/request info
+    # - [export queue] Jobs preparing events have no user/request info.
+    # - [export queue] Jobs running to cleanup csv files with events have no user/request info
+
     @property
     def user(self):
-        return UserMeta(self.meta[RQJobMetaField.USER])
+        if user_info := self.meta.get(RQJobMetaField.USER):
+            return UserMeta(user_info)
+
+        return None
 
     @property
     def request(self):
-        return RequestMeta(self.meta[RQJobMetaField.REQUEST])
+        if request_info := self.meta.get(RQJobMetaField.REQUEST):
+            return RequestMeta(request_info)
+
+        return None
 
     # immutable && optional fields
     org_id: int | None = ImmutableRQMetaAttribute(RQJobMetaField.ORG_ID, optional=True)
@@ -322,7 +337,10 @@ class ImportRQMeta(BaseRQMeta):
 
 
 def is_rq_job_owner(rq_job: RQJob, user_id: int) -> bool:
-    return BaseRQMeta.for_job(rq_job).user.id == user_id
+    if user := BaseRQMeta.for_job(rq_job).user:
+        return user.id == user_id
+
+    return False
 
 
 @attrs.frozen()
@@ -464,7 +482,7 @@ def define_dependent_job(
         job_ids = q.get_job_ids()
         jobs = q.job_class.fetch_many(job_ids, q.connection)
         jobs = filter(
-            lambda job: job and BaseRQMeta.for_job(job).user.id == user_id and f(job), jobs
+            lambda job: job and (user := BaseRQMeta.for_job(job).user) and user.id == user_id and f(job), jobs
         )
         all_user_jobs.extend(jobs)
 

--- a/cvat/apps/engine/rq.py
+++ b/cvat/apps/engine/rq.py
@@ -482,7 +482,11 @@ def define_dependent_job(
         job_ids = q.get_job_ids()
         jobs = q.job_class.fetch_many(job_ids, q.connection)
         jobs = filter(
-            lambda job: job and (user := BaseRQMeta.for_job(job).user) and user.id == user_id and f(job), jobs
+            lambda job: job
+            and (user := BaseRQMeta.for_job(job).user)
+            and user.id == user_id
+            and f(job),
+            jobs,
         )
         all_user_jobs.extend(jobs)
 

--- a/cvat/apps/engine/rq.py
+++ b/cvat/apps/engine/rq.py
@@ -482,10 +482,7 @@ def define_dependent_job(
         job_ids = q.get_job_ids()
         jobs = q.job_class.fetch_many(job_ids, q.connection)
         jobs = filter(
-            lambda job: job
-            and (user := BaseRQMeta.for_job(job).user)
-            and user.id == user_id
-            and f(job),
+            lambda job: job and is_rq_job_owner(job, user_id) and f(job),
             jobs,
         )
         all_user_jobs.extend(jobs)

--- a/cvat/apps/events/export.py
+++ b/cvat/apps/events/export.py
@@ -17,7 +17,7 @@ from rest_framework.response import Response
 
 from cvat.apps.dataset_manager.views import log_exception
 from cvat.apps.engine.log import ServerLogManager
-from cvat.apps.engine.rq import RQMetaWithFailureInfo, BaseRQMeta
+from cvat.apps.engine.rq import BaseRQMeta, RQMetaWithFailureInfo
 from cvat.apps.engine.utils import sendfile
 
 slogger = ServerLogManager(__name__)

--- a/cvat/apps/events/export.py
+++ b/cvat/apps/events/export.py
@@ -17,7 +17,7 @@ from rest_framework.response import Response
 
 from cvat.apps.dataset_manager.views import log_exception
 from cvat.apps.engine.log import ServerLogManager
-from cvat.apps.engine.rq import RQMetaWithFailureInfo
+from cvat.apps.engine.rq import RQMetaWithFailureInfo, BaseRQMeta
 from cvat.apps.engine.utils import sendfile
 
 slogger = ServerLogManager(__name__)
@@ -165,7 +165,7 @@ def export(request, filter_query, queue_name):
         func=_create_csv,
         args=(query_params, output_filename, DEFAULT_CACHE_TTL),
         job_id=rq_id,
-        meta={},
+        meta=BaseRQMeta.build(request=request, db_obj=None),
         result_ttl=ttl,
         failure_ttl=ttl,
     )

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -99,11 +99,9 @@ def job_id(instance):
 
 def get_user(instance=None) -> User | dict | None:
     def _get_user_from_rq_job(rq_job: rq.job.Job) -> dict | None:
-        # RQ jobs created in the chunks|annotation queues have no user info
-        try:
-            return BaseRQMeta.for_job(rq_job).user.to_dict()
-        except KeyError:
-            return None
+        if user := BaseRQMeta.for_job(rq_job).user:
+            return user.to_dict()
+        return None
 
     # Try to get current user from request
     user = get_current_user()
@@ -126,11 +124,9 @@ def get_user(instance=None) -> User | dict | None:
 
 def get_request(instance=None):
     def _get_request_from_rq_job(rq_job: rq.job.Job) -> dict | None:
-        # RQ jobs created in the chunks|annotation queues have no request info
-        try:
-            return BaseRQMeta.for_job(rq_job).request.to_dict()
-        except KeyError:
-            return None
+        if request := BaseRQMeta.for_job(rq_job).request:
+            return request.to_dict()
+        return None
 
     request = get_current_request()
     if request is not None:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This PR addresses the `KeyError` by making user/request fields in the meta nullable. The issue with empty meta should still be investigated.
### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
