### PR TITLE
do not keep deleted annotations in ram

### DIFF
--- a/changelog.d/20250325_151144_dmitrii.lavrukhin_less_ram_on_job_annotations_import.md
+++ b/changelog.d/20250325_151144_dmitrii.lavrukhin_less_ram_on_job_annotations_import.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Reduced memory consumption for annotation import to jobs
+  (<https://github.com/cvat-ai/cvat/pull/9256>)

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -489,18 +489,10 @@ class JobAnnotation:
             self.init_from_db()
             deleted_data = self.data
             models.clear_annotations_in_jobs([self.db_job.id])
-            self.reset()
         else:
             labeledimage_ids = [image["id"] for image in data["tags"]]
             labeledshape_ids = [shape["id"] for shape in data["shapes"]]
             labeledtrack_ids = [track["id"] for track in data["tracks"]]
-
-            # It is not important for us that data had some "invalid" objects
-            # which were skipped (not actually deleted). The main idea is to
-            # say that all requested objects are absent in DB after the method.
-            self.ir_data.tags = data['tags']
-            self.ir_data.shapes = data['shapes']
-            self.ir_data.tracks = data['tracks']
 
             for labeledimage_ids_chunk in take_by(labeledimage_ids, chunk_size=1000):
                 self._delete_job_labeledimages(labeledimage_ids_chunk)
@@ -512,11 +504,13 @@ class JobAnnotation:
                 self._delete_job_labeledtracks(labeledtrack_ids_chunk)
 
             deleted_data = {
+                "version": self.ir_data.version,
                 "tags": data["tags"],
                 "shapes": data["shapes"],
                 "tracks": data["tracks"],
             }
 
+        self.reset()
         return deleted_data
 
     def delete(self, data=None):
@@ -525,6 +519,7 @@ class JobAnnotation:
             self._set_updated_date()
 
         handle_annotations_change(self.db_job, deleted_data, "delete")
+        return deleted_data
 
     @staticmethod
     def _extend_attributes(attributeval_set, default_attribute_values):
@@ -1032,7 +1027,7 @@ def patch_job_data(pk, data: AnnotationIR | dict, action: PatchAction, *, db_job
     elif action == PatchAction.UPDATE:
         annotation.update(data)
     elif action == PatchAction.DELETE:
-        annotation.delete(data)
+        return annotation.delete(data)
 
     return annotation.data
 

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -489,6 +489,7 @@ class JobAnnotation:
             self.init_from_db()
             deleted_data = self.data
             models.clear_annotations_in_jobs([self.db_job.id])
+            self.reset()
         else:
             labeledimage_ids = [image["id"] for image in data["tags"]]
             labeledshape_ids = [shape["id"] for shape in data["shapes"]]
@@ -761,7 +762,6 @@ class JobAnnotation:
             create_callback=self.create,
         )
         self.delete()
-        self.reset()
 
         with TmpDirManager.get_tmp_directory() as temp_dir:
             try:

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -516,6 +516,7 @@ class JobAnnotation:
                 "tracks": data["tracks"],
             }
 
+        self.reset()
         return deleted_data
 
     def delete(self, data=None):

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -516,7 +516,6 @@ class JobAnnotation:
                 "tracks": data["tracks"],
             }
 
-        self.reset()
         return deleted_data
 
     def delete(self, data=None):
@@ -762,6 +761,7 @@ class JobAnnotation:
             create_callback=self.create,
         )
         self.delete()
+        self.reset()
 
         with TmpDirManager.get_tmp_directory() as temp_dir:
             try:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

When annotations are imported into a job, previous annotations are deleted. But after deletion they are kept in memolry for no reason, which can be a problem if they are large.
Dont keep deleted annotations in memory anymore.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
