### PR TITLE
Fixed: Rotated rectangles and ellipses unstably reset after resizing

### DIFF
--- a/changelog.d/20250331_123416_sekachev.bs_fixed_rotated_shapes_issue.md
+++ b/changelog.d/20250331_123416_sekachev.bs_fixed_rotated_shapes_issue.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Rotated rectangles and ellipses unstably reset after resizing
+  (<https://github.com/cvat-ai/cvat/pull/XXX>)

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -32,7 +32,7 @@ import {
     vectorLength, ShapeSizeElement, DrawnState, rotate2DPoints,
     readPointsFromShape, setupSkeletonEdges, makeSVGFromTemplate,
     imageDataToDataURL, expandChannels, stringifyPoints, zipChannels,
-    composeShapeDimensions,
+    composeShapeDimensions, getRoundedRotation,
 } from './shared';
 import {
     CanvasModel, Geometry, UpdateReasons, FrameZoom, ActiveElement,
@@ -1390,7 +1390,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     this.resizableShape = null;
 
                     // be sure, that rotation in range [0; 360]
-                    let rotation = shape.transform().rotation || 0;
+                    let rotation = getRoundedRotation(shape);
                     while (rotation < 0) rotation += 360;
                     rotation %= 360;
 
@@ -2962,7 +2962,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
 
         text.untransform();
         text.style({ 'font-size': `${textFontSize}px` });
-        const rotation = options.rotation?.angle || shape.transform().rotation;
+        const rotation = options.rotation?.angle || getRoundedRotation(shape);
 
         // Find the best place for a text
         let [clientX, clientY, clientCX, clientCY]: number[] = [0, 0, 0, 0];

--- a/cvat-canvas/src/typescript/shared.ts
+++ b/cvat-canvas/src/typescript/shared.ts
@@ -105,6 +105,16 @@ export function composeShapeDimensions(width: number, height: number, rotation: 
     return text;
 }
 
+export function getRoundedRotation(shape: SVG.Shape, defaultValue: number = 0): number {
+    const rotation = shape.transform().rotation ?? defaultValue;
+    // Due to floating point arithmeic, rotation value may be updated incorrectly
+    // even when no rotation actually happened.
+    // E.g. in one call it may be 16.000000000000014
+    // On the next call it may be 16.00000000000003
+    // As it may lead to other issues, we round this value up to 5 digits after "."
+    return +rotation.toFixed(5);
+}
+
 export function displayShapeSize(shapesContainer: SVG.Container, textContainer: SVG.Container): ShapeSizeElement {
     const shapeSize: ShapeSizeElement = {
         sizeElement: textContainer
@@ -116,7 +126,7 @@ export function displayShapeSize(shapesContainer: SVG.Container, textContainer: 
             .addClass('cvat_canvas_text'),
         update(shape: SVG.Shape): void {
             const rotation = shape.type === 'rect' || shape.type === 'ellipse' ?
-                shape.transform().rotation ?? 0 : null;
+                getRoundedRotation(shape) : null;
             const text = composeShapeDimensions(shape.width(), shape.height(), rotation);
             const [x, y, cx, cy]: number[] = translateToSVG(
                 (textContainer.node as any) as SVGSVGElement,
@@ -131,7 +141,7 @@ export function displayShapeSize(shapesContainer: SVG.Container, textContainer: 
                 .clear()
                 .plain(text)
                 .move(x + consts.TEXT_MARGIN, y + consts.TEXT_MARGIN)
-                .rotate(shape.transform().rotation, cx, cy);
+                .rotate(rotation ?? 0, cx, cy);
         },
         rm(): void {
             if (this.sizeElement) {

--- a/cvat-core/src/annotations-objects.ts
+++ b/cvat-core/src/annotations-objects.ts
@@ -754,8 +754,10 @@ export class Shape extends Drawn {
             updated[readOnlyField] = false;
         }
 
+        console.log('saved points', data);
         const fittedPoints = this.validateStateBeforeSave(data, updated, frame);
         const { rotation } = data;
+        console.log('fitted points', fittedPoints);
 
         // Now when all fields are validated, we can apply them
         if (updated.label) {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Fixed #9203

Due to floating point arithmeic, rotation value may be updated incorrectly even when no rotation actually happened.
E.g. in one call it may be 16.000000000000014
On the next call it may be 16.00000000000003
It leads to rotationBefore !== rotationAfter resizing and `rotation` value get's updated instead of `points`.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
