### PR TITLE
fix: explicit docker-compose read mode

### DIFF
--- a/docker-compose.external_db.yml
+++ b/docker-compose.external_db.yml
@@ -12,7 +12,8 @@ x-backend-settings: &backend-settings
     CVAT_POSTGRES_USER:
     CVAT_POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
   secrets:
-    - postgres_password
+    - source: postgres_password
+      mode: '0444'
 
 services:
   cvat_db:


### PR DESCRIPTION
### Motivation and context
Making the mode explicit for the container cvat_server to retrieve the external_db password would help to avoid the issue as below. link to docker defaults [link](https://docs.docker.com/reference/compose-file/services/#long-syntax-4)

<img width="971" alt="Screenshot 2025-04-01 at 5 58 46 PM" src="https://github.com/user-attachments/assets/65d23d15-81d8-45e6-9177-b560deb7db98" />

### How has this been tested?
Running container with the following changes in the docker file

### Checklist
- [ x ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ x ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
