### PR TITLE
Merge the `_xxx_request` helper methods in unit tests

### DIFF
--- a/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
+++ b/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
@@ -306,7 +306,7 @@ class _DbTestBase(ExportApiTestBase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.json())
 
     def _upload_file(self, url, data, user):
-        response = self._put_request(url, user, data={"annotation_file": data})
+        response = self._put_request(url, user, data={"annotation_file": data}, format="multipart")
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         response = self._put_request(url, user)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -435,7 +435,12 @@ class TaskDumpUploadTest(_DbTestBase):
                             url = self._generate_url_upload_tasks_annotations(task_id, upload_format_name)
 
                             with open(file_zip_name, 'rb') as binary_file:
-                                response = self._put_request(url, user, data={"annotation_file": binary_file})
+                                response = self._put_request(
+                                    url,
+                                    user,
+                                    data={"annotation_file": binary_file},
+                                    format="multipart",
+                                )
                                 self.assertEqual(response.status_code, edata['accept code'])
                                 response = self._put_request(url, user)
                                 self.assertEqual(response.status_code, edata['create code'])
@@ -527,7 +532,12 @@ class TaskDumpUploadTest(_DbTestBase):
                             url = self._generate_url_upload_tasks_annotations(task_id, upload_format_name)
 
                             with open(file_zip_name, 'rb') as binary_file:
-                                response = self._put_request(url, user, data={"annotation_file": binary_file})
+                                response = self._put_request(
+                                    url,
+                                    user,
+                                    data={"annotation_file": binary_file},
+                                    format="multipart",
+                                )
                                 self.assertEqual(response.status_code, edata['accept code'])
                                 response = self._put_request(url, user)
                                 self.assertEqual(response.status_code, edata['create code'])
@@ -845,7 +855,12 @@ class TaskDumpUploadTest(_DbTestBase):
                     url = self._generate_url_upload_tasks_annotations(task_id, upload_format_name)
 
                     with open(file_zip_name, 'rb') as binary_file:
-                        response = self._put_request(url, self.admin, data={"annotation_file": binary_file})
+                        response = self._put_request(
+                            url,
+                            self.admin,
+                            data={"annotation_file": binary_file},
+                            format="multipart",
+                        )
                         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
                         response = self._put_request(url, self.admin)
                         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -2099,7 +2114,12 @@ class ProjectDumpUpload(_DbTestBase):
 
                     if osp.exists(file_zip_name):
                         with open(file_zip_name, 'rb') as binary_file:
-                            response = self._post_request(url, user, data={"dataset_file": binary_file})
+                            response = self._post_request(
+                                url,
+                                user,
+                                data={"dataset_file": binary_file},
+                                format="multipart",
+                            )
                             self.assertEqual(response.status_code, edata['accept code'])
 
     def test_api_v2_export_annotations(self):
@@ -2186,7 +2206,12 @@ class ProjectDumpUpload(_DbTestBase):
             url = self._generate_url_upload_project_dataset(project["id"], upload_format_name)
 
             with open(file_zip_name, 'rb') as binary_file:
-                response = self._post_request(url, user, data={"dataset_file": binary_file})
+                response = self._post_request(
+                    url,
+                    user,
+                    data={"dataset_file": binary_file},
+                    format="multipart",
+                )
                 self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
             # equals annotations

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -6968,10 +6968,12 @@ class TaskAnnotation2DContext(ApiTestBase):
             }
             task = self._create_task(self.task , img_data)
             task_id = task["id"]
-            data = {
+            query_params = {
                 "quality": "original",
                 "type": "context_image",
                 "number": 0
             }
-            response = self._get_request("/api/tasks/%s/data" % task_id, self.admin, data=data)
+            response = self._get_request(
+                "/api/tasks/%s/data" % task_id, self.admin, query_params=query_params
+            )
             self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/cvat/apps/engine/tests/test_rest_api_3D.py
+++ b/cvat/apps/engine/tests/test_rest_api_3D.py
@@ -137,7 +137,7 @@ class _DbTestBase(ExportApiTestBase):
         return values
 
     def _upload_file(self, url, data, user):
-        response = self._put_request(url, user, data={"annotation_file": data})
+        response = self._put_request(url, user, data={"annotation_file": data}, format="multipart")
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         response = self._put_request(url, user)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -212,53 +212,6 @@ class _LambdaTestCaseBase(ApiTestBase):
     def setUpTestData(cls):
         cls._create_db_users()
 
-    def _get_request(self, path, user, *, org_id=None):
-        with ForceLogin(user, self.client):
-            response = self.client.get(
-                path, QUERY_STRING=f"org_id={org_id}" if org_id is not None else ""
-            )
-        return response
-
-    def _delete_request(self, path, user, *, org_id=None):
-        with ForceLogin(user, self.client):
-            response = self.client.delete(
-                path, QUERY_STRING=f"org_id={org_id}" if org_id is not None else ""
-            )
-        return response
-
-    def _post_request(self, path, user, data, *, org_id=None):
-        data = json.dumps(data)
-        with ForceLogin(user, self.client):
-            response = self.client.post(
-                path,
-                data=data,
-                content_type="application/json",
-                QUERY_STRING=f"org_id={org_id}" if org_id is not None else "",
-            )
-        return response
-
-    def _patch_request(self, path, user, data, *, org_id=None):
-        data = json.dumps(data)
-        with ForceLogin(user, self.client):
-            response = self.client.patch(
-                path,
-                data=data,
-                content_type="application/json",
-                QUERY_STRING=f"org_id={org_id}" if org_id is not None else "",
-            )
-        return response
-
-    def _put_request(self, path, user, data, *, org_id=None):
-        data = json.dumps(data)
-        with ForceLogin(user, self.client):
-            response = self.client.put(
-                path,
-                data=data,
-                content_type="application/json",
-                QUERY_STRING=f"org_id={org_id}" if org_id is not None else "",
-            )
-        return response
-
     def _check_expected_keys_in_response_function(self, data):
         kind = data["kind"]
         if kind == "interactor":
@@ -411,7 +364,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "car": {"name": "car"},
             },
         }
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data_main_task)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data_main_task)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         id_request = response.data["id"]
 
@@ -449,7 +402,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "car": {"name": "car"},
             },
         }
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         id_request = response.data["id"]
 
         response = self._delete_request(f"{LAMBDA_REQUESTS_PATH}/{id_request}", None)
@@ -460,7 +413,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
         response = self._get_request(f"{LAMBDA_REQUESTS_PATH}/{id_request}", self.admin)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         id_request = response.data["id"]
         response = self._delete_request(f"{LAMBDA_REQUESTS_PATH}/{id_request}", self.user)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -501,7 +454,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 },
             }
 
-            response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data_main_task)
+            response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data_main_task)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             for key in expected_keys_in_response_requests:
                 self.assertIn(key, response.data)
@@ -509,7 +462,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             self._delete_lambda_request(response.data["id"])
 
             response = self._post_request(
-                LAMBDA_REQUESTS_PATH, self.user, data_assigneed_to_user_task
+                LAMBDA_REQUESTS_PATH, self.user, data=data_assigneed_to_user_task
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             for key in expected_keys_in_response_requests:
@@ -517,10 +470,10 @@ class LambdaTestCases(_LambdaTestCaseBase):
 
             self._delete_lambda_request(response.data["id"], self.user)
 
-            response = self._post_request(LAMBDA_REQUESTS_PATH, self.user, data_main_task)
+            response = self._post_request(LAMBDA_REQUESTS_PATH, self.user, data=data_main_task)
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-            response = self._post_request(LAMBDA_REQUESTS_PATH, None, data_main_task)
+            response = self._post_request(LAMBDA_REQUESTS_PATH, None, data=data_main_task)
             self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_api_v2_lambda_requests_create_negative(self):
@@ -543,12 +496,12 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "cvat.apps.lambda_manager.views.LambdaGateway._http",
                 return_value=functions["negative"][id_func],
             ):
-                response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+                response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
                 self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def test_api_v2_lambda_requests_create_empty_data(self):
         data = {}
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_api_v2_lambda_requests_create_without_function(self):
@@ -559,7 +512,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "car": {"name": "car"},
             },
         }
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_api_v2_lambda_requests_create_wrong_id_function(self):
@@ -571,7 +524,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "car": {"name": "car"},
             },
         }
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @skip("Fail: add mock")
@@ -584,8 +537,8 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "car": {"name": "car"},
             },
         }
-        request_id = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data).data["id"]
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+        request_id = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data).data["id"]
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
 
         self._delete_lambda_request(request_id)
@@ -597,7 +550,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             "cleanup": True,
             "mapping": {},
         }
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for key in expected_keys_in_response_requests:
             self.assertIn(key, response.data)
@@ -612,7 +565,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "car": {"name": "car"},
             },
         }
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for key in expected_keys_in_response_requests:
             self.assertIn(key, response.data)
@@ -625,7 +578,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             "task": self.main_task["id"],
             "cleanup": True,
         }
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for key in expected_keys_in_response_requests:
             self.assertIn(key, response.data)
@@ -640,7 +593,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "car": {"name": "car"},
             },
         }
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_api_v2_lambda_requests_create_wrong_id_task(self):
@@ -652,7 +605,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "car": {"name": "car"},
             },
         }
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_api_v2_lambda_requests_create_is_not_ready(self):
@@ -668,7 +621,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 },
             }
 
-            response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data)
+            response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
             self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def test_api_v2_lambda_functions_create_detector(self):
@@ -691,19 +644,19 @@ class LambdaTestCases(_LambdaTestCaseBase):
         }
 
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data_main_task
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data_main_task
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self._post_request(
             f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}",
             self.user,
-            data_assigneed_to_user_task,
+            data=data_assigneed_to_user_task,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", None, data_main_task
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", None, data=data_main_task
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -720,7 +673,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             },
         }
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.user, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.user, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -760,19 +713,19 @@ class LambdaTestCases(_LambdaTestCaseBase):
         }
 
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_interactor}", self.admin, data_main_task
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_interactor}", self.admin, data=data_main_task
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self._post_request(
             f"{LAMBDA_FUNCTIONS_PATH}/{id_function_interactor}",
             self.user,
-            data_assigneed_to_user_task,
+            data=data_assigneed_to_user_task,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_interactor}", None, data_main_task
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_interactor}", None, data=data_main_task
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -789,17 +742,19 @@ class LambdaTestCases(_LambdaTestCaseBase):
         }
 
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_tracker}", self.admin, data_main_task
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_tracker}", self.admin, data=data_main_task
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_tracker}", self.user, data_assigneed_to_user_task
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_tracker}",
+            self.user,
+            data=data_assigneed_to_user_task,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_tracker}", None, data_main_task
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_tracker}", None, data=data_main_task
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -814,7 +769,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
         }
 
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_tracker}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_tracker}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("Invalid or expired tracker state", response.content.decode("UTF-8"))
@@ -973,40 +928,42 @@ class LambdaTestCases(_LambdaTestCaseBase):
         response = self._post_request(
             f"{LAMBDA_FUNCTIONS_PATH}/{id_function_reid_with_response_data}",
             self.admin,
-            data_main_task,
+            data=data_main_task,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self._post_request(
             f"{LAMBDA_FUNCTIONS_PATH}/{id_function_reid_with_response_data}",
             self.user,
-            data_assigneed_to_user_task,
+            data=data_assigneed_to_user_task,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_reid_with_response_data}", None, data_main_task
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_reid_with_response_data}",
+            None,
+            data=data_main_task,
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         response = self._post_request(
             f"{LAMBDA_FUNCTIONS_PATH}/{id_function_reid_with_no_response_data}",
             self.admin,
-            data_main_task,
+            data=data_main_task,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self._post_request(
             f"{LAMBDA_FUNCTIONS_PATH}/{id_function_reid_with_no_response_data}",
             self.user,
-            data_assigneed_to_user_task,
+            data=data_assigneed_to_user_task,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self._post_request(
             f"{LAMBDA_FUNCTIONS_PATH}/{id_function_reid_with_no_response_data}",
             None,
-            data_main_task,
+            data=data_main_task,
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -1031,7 +988,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 return_value=functions["negative"][id_func],
             ):
                 response = self._post_request(
-                    f"{LAMBDA_FUNCTIONS_PATH}/{id_func}", self.admin, data
+                    f"{LAMBDA_FUNCTIONS_PATH}/{id_func}", self.admin, data=data
                 )
                 self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
@@ -1044,7 +1001,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "car": {"name": "car"},
             },
         }
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data_main_task)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data_main_task)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         id_request = response.data["id"]
 
@@ -1068,7 +1025,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
     def test_api_v2_lambda_functions_create_empty_data(self):
         data = {}
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -1080,7 +1037,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             "mapping": {},
         }
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1093,7 +1050,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             },
         }
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1104,7 +1061,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             "cleanup": True,
         }
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1115,7 +1072,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             "mapping": {"person": {"name": "person"}},
         }
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), [])
@@ -1129,7 +1086,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             },
         }
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -1142,7 +1099,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             },
         }
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -1156,7 +1113,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             },
         }
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/test-functions-wrong-id", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/test-functions-wrong-id", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -1170,7 +1127,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             },
         }
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -1185,7 +1142,7 @@ class LambdaTestCases(_LambdaTestCaseBase):
             },
         }
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -1199,9 +1156,9 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "car": {"name": "car"},
             },
         }
-        self._post_request(f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data)
+        self._post_request(f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data)
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
 
@@ -1215,12 +1172,12 @@ class LambdaTestCases(_LambdaTestCaseBase):
             },
         }
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_state_building}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_state_building}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         response = self._post_request(
-            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_state_error}", self.admin, data
+            f"{LAMBDA_FUNCTIONS_PATH}/{id_function_state_error}", self.admin, data=data
         )
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
@@ -1308,7 +1265,7 @@ class TestComplexFrameSetupCases(_LambdaTestCaseBase):
 
     def _run_offline_function(self, function_id, data, user):
         data["function"] = function_id
-        response = self._post_request(LAMBDA_REQUESTS_PATH, user, data)
+        response = self._post_request(LAMBDA_REQUESTS_PATH, user, data=data)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         request_id = response.json()["id"]
 
@@ -1326,7 +1283,7 @@ class TestComplexFrameSetupCases(_LambdaTestCaseBase):
         return request_status
 
     def _run_online_function(self, function_id, data, user):
-        response = self._post_request(f"{LAMBDA_FUNCTIONS_PATH}/{function_id}", user, data)
+        response = self._post_request(f"{LAMBDA_FUNCTIONS_PATH}/{function_id}", user, data=data)
         return response
 
     def test_can_run_offline_detector_function_on_whole_task(self):
@@ -1706,33 +1663,29 @@ class Issue4996_Cases(_LambdaTestCaseBase):
                     "email": user["email"],
                     "role": role,
                 },
-                org_id=org["id"],
+                query_params={"org_id": org["id"]},
             )
             assert invitation.status_code == status.HTTP_201_CREATED
 
         return org
 
-    def _set_task_assignee(
-        self, task: int, assignee: Optional[int], *, org_id: Optional[int] = None
-    ):
+    def _set_task_assignee(self, task: int, assignee: Optional[int]):
         response = self._patch_request(
             f"/api/tasks/{task}",
             user=self.admin,
             data={
                 "assignee_id": assignee,
             },
-            org_id=org_id,
         )
         assert response.status_code == status.HTTP_200_OK
 
-    def _set_job_assignee(self, job: int, assignee: Optional[int], *, org_id: Optional[int] = None):
+    def _set_job_assignee(self, job: int, assignee: Optional[int]):
         response = self._patch_request(
             f"/api/jobs/{job}",
             user=self.admin,
             data={
                 "assignee": assignee,
             },
-            org_id=org_id,
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -1751,9 +1704,9 @@ class Issue4996_Cases(_LambdaTestCaseBase):
 
         jobs = get_paginated_collection(
             lambda page: self._get_request(
-                f"/api/jobs?task_id={self.task['id']}&page={page}",
+                "/api/jobs",
                 self.admin,
-                org_id=self.org["id"],
+                query_params={"task_id": self.task["id"], "page": page, "org_id": self.org["id"]},
             )
         )
         self.job = jobs[1]
@@ -1784,57 +1737,71 @@ class Issue4996_Cases(_LambdaTestCaseBase):
     ):
         data = self.common_request_data.copy()
         with self.subTest(job=None, assignee=None):
-            response = self._post_request(self.function_url, self.user, data, org_id=self.org["id"])
+            response = self._post_request(
+                self.function_url, self.user, data=data, query_params={"org_id": self.org["id"]}
+            )
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_can_call_function_for_job_worker_in_org__deny_unassigned_worker_with_job_request(self):
         data = self._get_valid_job_request_data()
         with self.subTest(job="defined", assignee=None):
-            response = self._post_request(self.function_url, self.user, data, org_id=self.org["id"])
+            response = self._post_request(
+                self.function_url, self.user, data=data, query_params={"org_id": self.org["id"]}
+            )
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_can_call_function_for_job_worker_in_org__allow_task_assigned_worker_with_task_request(
         self,
     ):
-        self._set_task_assignee(self.task["id"], self.user.id, org_id=self.org["id"])
+        self._set_task_assignee(self.task["id"], self.user.id)
 
         data = self.common_request_data.copy()
         with self.subTest(job=None, assignee="task"):
-            response = self._post_request(self.function_url, self.user, data, org_id=self.org["id"])
+            response = self._post_request(
+                self.function_url, self.user, data=data, query_params={"org_id": self.org["id"]}
+            )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_can_call_function_for_job_worker_in_org__deny_job_assigned_worker_with_task_request(
         self,
     ):
-        self._set_job_assignee(self.job["id"], self.user.id, org_id=self.org["id"])
+        self._set_job_assignee(self.job["id"], self.user.id)
 
         data = self.common_request_data.copy()
         with self.subTest(job=None, assignee="job"):
-            response = self._post_request(self.function_url, self.user, data, org_id=self.org["id"])
+            response = self._post_request(
+                self.function_url, self.user, data=data, query_params={"org_id": self.org["id"]}
+            )
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_can_call_function_for_job_worker_in_org__allow_job_assigned_worker_with_job_request(
         self,
     ):
-        self._set_job_assignee(self.job["id"], self.user.id, org_id=self.org["id"])
+        self._set_job_assignee(self.job["id"], self.user.id)
 
         data = self._get_valid_job_request_data()
         with self.subTest(job="defined", assignee="job"):
-            response = self._post_request(self.function_url, self.user, data, org_id=self.org["id"])
+            response = self._post_request(
+                self.function_url, self.user, data=data, query_params={"org_id": self.org["id"]}
+            )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_can_check_job_boundaries_in_function_call__fail_for_frame_outside_job(self):
-        self._set_job_assignee(self.job["id"], self.user.id, org_id=self.org["id"])
+        self._set_job_assignee(self.job["id"], self.user.id)
 
         data = self._get_invalid_job_request_data()
         with self.subTest(job="defined", frame="outside"):
-            response = self._post_request(self.function_url, self.user, data, org_id=self.org["id"])
+            response = self._post_request(
+                self.function_url, self.user, data=data, query_params={"org_id": self.org["id"]}
+            )
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_can_check_job_boundaries_in_function_call__ok_for_frame_inside_job(self):
-        self._set_job_assignee(self.job["id"], self.user.id, org_id=self.org["id"])
+        self._set_job_assignee(self.job["id"], self.user.id)
 
         data = self._get_valid_job_request_data()
         with self.subTest(job="defined", frame="inside"):
-            response = self._post_request(self.function_url, self.user, data, org_id=self.org["id"])
+            response = self._post_request(
+                self.function_url, self.user, data=data, query_params={"org_id": self.org["id"]}
+            )
             self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
There are two different versions of these methods, in `ApiTestBase` and in `_LambdaTestCaseBase`. Since the latter inherits from the former, Pylint warns that the overridden methods are incompatible (and they are!). To fix this, merge these two sets of methods into one, with all needed capabilities.

Some notes on the decisions I made WRT the merged methods:

1. In `_post_request` I emulated the `query_params` parameter from Django 5.1.

2. In `_get_request` I renamed `data` to `query_params` for consistency.

3. In `_patch_request` I decided not to add a `query_params` parameter for now, since it wasn't needed. While some lambda tests called `_patch_request` with an org ID, this parameter was unnecessary, so I just removed it.

4. I set the default format to "json" everywhere, since CVAT's API is mostly JSON-based.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
It tests itself. 🙂 

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
