### PR TITLE
Fix `test_tasks.py::TestImportTaskAnnotations::test_check_import_error_on_wrong_file_structure`

### DIFF
--- a/changelog.d/20250409_175541_maria_fix_test_check_import_error_on_wrong_file_structure.md
+++ b/changelog.d/20250409_175541_maria_fix_test_check_import_error_on_wrong_file_structure.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Dataset structure validation now runs when uploading task/job annotations in CVAT format
+  (<https://github.com/cvat-ai/cvat/pull/9303>)

--- a/cvat/apps/dataset_manager/formats/cvat.py
+++ b/cvat/apps/dataset_manager/formats/cvat.py
@@ -1674,8 +1674,8 @@ def _import(src_file, temp_dir, instance_data, load_data_callback=None, **kwargs
     if is_zip:
         zipfile.ZipFile(src_file).extractall(temp_dir)
 
+        detect_dataset(temp_dir, format_name="cvat", importer=_CvatImporter)
         if isinstance(instance_data, ProjectData):
-            detect_dataset(temp_dir, format_name="cvat", importer=_CvatImporter)
             dataset = Dataset.import_from(temp_dir, "cvat", env=dm_env)
             if load_data_callback is not None:
                 load_data_callback(dataset, instance_data)

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -5678,11 +5678,11 @@ class TestImportTaskAnnotations:
         with pytest.raises(exceptions.ApiException) as capture:
             task.import_annotations(format_name, source_archive_path)
 
-        assert "Check [format docs]" in str(capture.value)
-        try:
-            assert "Dataset must contain a file:" in str(capture.value)
-        except:
-            assert "specific requirement information unavailable" in str(capture.value)
+        error_message = str(capture.value)
+        assert "Check [format docs]" in error_message
+
+        if "specific requirement information unavailable" not in error_message:
+            assert "Dataset must contain a file:" in error_message
 
 
 @pytest.mark.usefixtures("restore_redis_inmem_per_function")


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
There were several issues with this test, like:
- the archive being created was not closed
- exception capture details were never checked
- not all formats return expected error format
### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
