### PR TITLE
[wip]  fix sluggish logout in test for assigning tasks to users

### DIFF
--- a/tests/cypress/e2e/actions_users/registration_involved/case_4_assign_task_job_users.js
+++ b/tests/cypress/e2e/actions_users/registration_involved/case_4_assign_task_job_users.js
@@ -134,9 +134,11 @@ context('Multiple users. Assign task, job. Deactivating users.', () => {
         });
 
         it('Third user login. The task does not exist. Logout', () => {
-            cy.login(thirdUserName, thirdUser.password);
-            cy.contains('strong', taskName).should('not.exist');
-            cy.logout();
+            cy.then(() => {
+                cy.login(thirdUserName, thirdUser.password);
+                cy.contains('strong', taskName).should('not.exist');
+                cy.logout();
+            });
         });
 
         it('First user login and assign the job to the third user. Logout', () => {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
