### PR TITLE
Re-use common env variables in dev env

### DIFF
--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.tsx",
   "scripts": {
     "build": "webpack --config ./webpack.config.js",
-    "start": "webpack serve --env API_URL=http://localhost:7000 --config ./webpack.config.js --mode=development",
+    "start": "webpack serve --env API_URL=\"http://${CVAT_HOST:-'localhost'}:7000\" --config ./webpack.config.js --mode=development",
     "type-check": "tsc --noEmit",
     "type-check:watch": "yarn run type-check --watch",
     "lint": "eslint './src/**/*.{ts,tsx}'",

--- a/cvat/apps/iam/serializers.py
+++ b/cvat/apps/iam/serializers.py
@@ -108,8 +108,8 @@ class PasswordResetSerializerEx(PasswordResetSerializer):
 
     def get_email_options(self):
         domain = None
-        if hasattr(settings, "CVAT_UI_HOST") and settings.CVAT_UI_HOST:
-            domain = settings.CVAT_UI_HOST
+        if hasattr(settings, "UI_HOST") and settings.UI_HOST:
+            domain = settings.UI_HOST
             if hasattr(settings, "UI_PORT") and settings.UI_PORT:
                 domain += ":{}".format(settings.UI_PORT)
         return {"domain_override": domain}

--- a/cvat/apps/iam/serializers.py
+++ b/cvat/apps/iam/serializers.py
@@ -108,8 +108,8 @@ class PasswordResetSerializerEx(PasswordResetSerializer):
 
     def get_email_options(self):
         domain = None
-        if hasattr(settings, "UI_HOST") and settings.UI_HOST:
-            domain = settings.UI_HOST
+        if hasattr(settings, "CVAT_UI_HOST") and settings.CVAT_UI_HOST:
+            domain = settings.CVAT_UI_HOST
             if hasattr(settings, "UI_PORT") and settings.UI_PORT:
                 domain += ":{}".format(settings.UI_PORT)
         return {"domain_override": domain}

--- a/cvat/settings/development.py
+++ b/cvat/settings/development.py
@@ -19,14 +19,14 @@ ALLOWED_HOSTS.append("testserver")
 SENDFILE_BACKEND = "django_sendfile.backends.development"
 
 # Cross-Origin Resource Sharing settings for CVAT UI
-UI_SCHEME = os.environ.get("UI_SCHEME", "http")
-UI_HOST = os.environ.get("UI_HOST", "localhost")
-UI_PORT = os.environ.get("UI_PORT", 3000)
+CVAT_UI_SCHEME = os.environ.get("CVAT_UI_SCHEME", "http")
+CVAT_UI_HOST = os.environ.get("CVAT_UI_HOST", "localhost")
+CVAT_UI_PORT = os.environ.get("CVAT_UI_PORT", 3000)
 CORS_ALLOW_CREDENTIALS = True
-UI_URL = "{}://{}".format(UI_SCHEME, UI_HOST)
+UI_URL = "{}://{}".format(CVAT_UI_SCHEME, CVAT_UI_HOST)
 
-if UI_PORT and UI_PORT != "80":
-    UI_URL += ":{}".format(UI_PORT)
+if CVAT_UI_PORT and CVAT_UI_PORT != "80":
+    UI_URL += ":{}".format(CVAT_UI_PORT)
 
 CSRF_TRUSTED_ORIGINS = [UI_URL]
 

--- a/cvat/settings/development.py
+++ b/cvat/settings/development.py
@@ -19,14 +19,14 @@ ALLOWED_HOSTS.append("testserver")
 SENDFILE_BACKEND = "django_sendfile.backends.development"
 
 # Cross-Origin Resource Sharing settings for CVAT UI
-CVAT_UI_SCHEME = os.environ.get("CVAT_UI_SCHEME", "http")
-CVAT_UI_HOST = os.environ.get("CVAT_UI_HOST", "localhost")
-CVAT_UI_PORT = os.environ.get("CVAT_UI_PORT", 3000)
+UI_SCHEME = os.environ.get("CVAT_UI_SCHEME", "http")
+UI_HOST = os.environ.get("CVAT_UI_HOST", "localhost")
+UI_PORT = os.environ.get("CVAT_UI_PORT", 3000)
 CORS_ALLOW_CREDENTIALS = True
-UI_URL = "{}://{}".format(CVAT_UI_SCHEME, CVAT_UI_HOST)
+UI_URL = "{}://{}".format(UI_SCHEME, UI_HOST)
 
-if CVAT_UI_PORT and CVAT_UI_PORT != "80":
-    UI_URL += ":{}".format(CVAT_UI_PORT)
+if UI_PORT and UI_PORT != "80":
+    UI_URL += ":{}".format(UI_PORT)
 
 CSRF_TRUSTED_ORIGINS = [UI_URL]
 

--- a/site/content/en/docs/contributing/development-environment.md
+++ b/site/content/en/docs/contributing/development-environment.md
@@ -194,7 +194,7 @@ description: 'Installing a development environment for different operating syste
     ```
   - If you want to access CVAT from outside of your host:
     ```sh
-    CVAT_UI_HOST='<YOUR_HOST_IP>' yarn run start:cvat-ui
+    CVAT_UI_HOST='<YOUR_HOST_IP>' CVAT_UI_PORT='<YOUR_PORT>' yarn run start:cvat-ui
     ```
 - Open a new terminal window.
 - Run VScode from the virtual environment (run the following command from CVAT root directory):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Webpack uses `CVAT_UI_HOST` and `CVAT_UI_PORT`
Server uses `UI_HOST` and `UI_PORT`.

This patch removes the duplication. 

Additionally webpack dev server may be initialized by `CVAT_HOST` now. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
