### PR TITLE
Do not expose debug services to outside networks

### DIFF
--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.tsx",
   "scripts": {
     "build": "webpack --config ./webpack.config.js",
-    "start": "webpack serve --env API_URL=\"http://${CVAT_HOST:-'localhost'}:7000\" --config ./webpack.config.js --mode=development",
+    "start": "webpack serve --env API_URL=http://localhost:7000 --config ./webpack.config.js --mode=development",
     "type-check": "tsc --noEmit",
     "type-check:watch": "yarn run type-check --watch",
     "lint": "eslint './src/**/*.{ts,tsx}'",

--- a/cvat-ui/webpack.config.js
+++ b/cvat-ui/webpack.config.js
@@ -72,6 +72,12 @@ module.exports = (env) => {
                 target: env && env.API_URL,
                 secure: false,
                 changeOrigin: true,
+                onProxyReq: (proxyReq, req) => {
+                    const forwardedHost = req.headers.host;
+                    if (forwardedHost) {
+                        proxyReq.setHeader('X-FORWARDED-HOST', forwardedHost);
+                    }
+                },
             }],
         },
         resolve: {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@
 services:
   cvat_db:
     ports:
-      - '5432:5432'
+      - '127.0.0.1:5432:5432'
 
   cvat_server:
     build:
@@ -28,7 +28,7 @@ services:
       CVAT_DEBUG_WAIT: '${CVAT_DEBUG_WAIT_CLIENT:-no}'
       COVERAGE_PROCESS_START:
     ports:
-      - '9090:9090'
+      - '127.0.0.1:9090:9090'
 
   cvat_worker_export:
     environment:
@@ -52,7 +52,7 @@ services:
       CVAT_DEBUG_PORT: '9093'
       COVERAGE_PROCESS_START:
     ports:
-      - '9093:9093'
+      - '127.0.0.1:9093:9093'
 
   cvat_worker_quality_reports:
     environment:
@@ -64,7 +64,7 @@ services:
       CVAT_DEBUG_PORT: '9094'
       COVERAGE_PROCESS_START:
     ports:
-      - '9094:9094'
+      - '127.0.0.1:9094:9094'
 
   cvat_worker_consensus:
     environment:
@@ -76,7 +76,7 @@ services:
       CVAT_DEBUG_PORT: '9096'
       COVERAGE_PROCESS_START:
     ports:
-      - '9096:9096'
+      - '127.0.0.1:9096:9096'
 
   cvat_worker_annotation:
     environment:
@@ -88,7 +88,7 @@ services:
       CVAT_DEBUG_PORT: '9091'
       COVERAGE_PROCESS_START:
     ports:
-      - '9091:9091'
+      - '127.0.0.1:9091:9091'
 
   cvat_ui:
     build:
@@ -102,20 +102,20 @@ services:
 
   cvat_clickhouse:
     ports:
-      - '8123:8123'
+      - '127.0.0.1:8123:8123'
 
   cvat_opa:
     ports:
-      - '8181:8181'
+      - '127.0.0.1:8181:8181'
 
   cvat_redis_inmem:
     ports:
-      - '6379:6379'
+      - '127.0.0.1:6379:6379'
 
   cvat_redis_ondisk:
     ports:
-      - '6666:6666'
+      - '127.0.0.1:6666:6666'
 
   cvat_vector:
     ports:
-      - '8282:80'
+      - '127.0.0.1:8282:80'


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Currently our `docker-compose.dev.yml` (which is used only in dev purposes) forwards ports, binding them to all network interfaces.
It is not safe and creates potential vulnerabilities, e.g. redis clients may be easily attacked as they even does not have any passwords. 
Instead, let's perform forwarding only from local interface 127.0.0.1


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
