### PR TITLE
Use x-forwared-host on debug web server

### DIFF
--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.tsx",
   "scripts": {
     "build": "webpack --config ./webpack.config.js",
-    "start": "webpack serve --env API_URL=\"http://${CVAT_HOST:-'localhost'}:7000\" --config ./webpack.config.js --mode=development",
+    "start": "webpack serve --env API_URL=http://localhost:7000 --config ./webpack.config.js --mode=development",
     "type-check": "tsc --noEmit",
     "type-check:watch": "yarn run type-check --watch",
     "lint": "eslint './src/**/*.{ts,tsx}'",

--- a/cvat-ui/webpack.config.js
+++ b/cvat-ui/webpack.config.js
@@ -33,6 +33,8 @@ module.exports = (env) => {
     console.log('Source maps: ', sourceMapsDisabled ? 'disabled' : 'enabled');
     console.log('List of plugins: ', Object.values(transformedPlugins).map((plugin) => plugin.import));
 
+    const host = process.env.CVAT_UI_HOST ?? 'localhost';
+    const port = process.env.CVAT_UI_PORT ?? 3000;
     return {
         target: 'web',
         mode: 'production',
@@ -47,13 +49,13 @@ module.exports = (env) => {
             publicPath: '/',
         },
         devServer: {
+            host,
+            port,
             compress: false,
-            host: process.env.CVAT_UI_HOST ?? 'localhost',
             client: {
                 overlay: false,
                 webSocketURL: 'ws://0.0.0.0:0/ws',
             },
-            port: process.env.CVAT_UI_PORT ?? 3000,
             historyApiFallback: true,
             static: {
                 directory: path.join(__dirname, 'dist'),
@@ -72,6 +74,9 @@ module.exports = (env) => {
                 target: env && env.API_URL,
                 secure: false,
                 changeOrigin: true,
+                onProxyReq: (proxyReq) => {
+                    proxyReq.setHeader('X-FORWARDED-HOST', `${host}:${port}`);
+                },
             }],
         },
         resolve: {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Without this header CVAT backend generates wrong links for logo, exports, etc when webpack dev server is running on something else rather than `localhost`.

Alternative solution we used before is to expose backend server together with frontend server, however:

1. Additional configuration is required to run django server outside. 
2. It works, but URLs anyway have different ports. 
3. Two exposed ports worse than one exposed port. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
