### PR TITLE
Fixed rotation of shapes existing in CVAT before #9289

### DIFF
--- a/changelog.d/20250417_121137_sekachev.bs_truncate_rotation.md
+++ b/changelog.d/20250417_121137_sekachev.bs_truncate_rotation.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed rotation of shapes existing in CVAT before #9289
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/changelog.d/20250417_121137_sekachev.bs_truncate_rotation.md
+++ b/changelog.d/20250417_121137_sekachev.bs_truncate_rotation.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - Fixed rotation of shapes existing in CVAT before #9289
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/9337>)

--- a/cvat-core/src/annotations-objects.ts
+++ b/cvat-core/src/annotations-objects.ts
@@ -521,7 +521,7 @@ export class Shape extends Drawn {
     ) {
         super(data, clientID, color, injection);
         this.points = data.points;
-        this.rotation = data.rotation || 0;
+        this.rotation = +(data.rotation ?? 0).toFixed(5);
         this.occluded = data.occluded || false;
         this.outside = data.outside || false;
         this.zOrder = data.z_order;


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
In #9289 we truncate rotation with precision 5 digits because of floating arithmetics. 
However for existing rotated shapes saved with higher precision the first resizing the issue is still relevant 

Resolved #9308

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
