### PR TITLE
Update service name cvat_utils to cvat_worker_utils

### DIFF
--- a/changelog.d/20250428_153328_fix_service_name.md
+++ b/changelog.d/20250428_153328_fix_service_name.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed service name of utils worker in `docker-compose.external_db.yml`
+  (<https://github.com/cvat-ai/cvat/pull/9352>)

--- a/docker-compose.external_db.yml
+++ b/docker-compose.external_db.yml
@@ -20,7 +20,7 @@ services:
       replicas: 0
 
   cvat_server: *backend-settings
-  cvat_utils: *backend-settings
+  cvat_worker_utils: *backend-settings
   cvat_worker_annotation: *backend-settings
   cvat_worker_export: *backend-settings
   cvat_worker_import: *backend-settings


### PR DESCRIPTION
### What I did
- In docker-compose.external_db.yml, update service name cvat_utils to cvat_worker_utils

### Motivation and context
Change is required for CVAT deployments that connect to an external DB

### How has this been tested?
This resolved an observed issue with a CVAT deployment that connects to an external DB

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->~~
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- [x ] I have linked related issues (see [PR #9200 Rework startup of container processes breaks External DB docker compose up](
  https://github.com/cvat-ai/cvat/issues/9334))

### License

- [ x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
