### PR TITLE
sn/make-aws-anonymous-access-explicit

### DIFF
--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -400,6 +400,7 @@ def get_cloud_storage_instance(
             region=specific_attributes.get('region'),
             endpoint_url=specific_attributes.get('endpoint_url'),
             prefix=specific_attributes.get('prefix'),
+            anonymous_access = credentials.credentials_type == CredentialsTypeChoice.ANONYMOUS_ACCESS,
         )
     elif cloud_provider == CloudProviderChoice.AZURE_CONTAINER:
         instance = AzureBlobContainer(
@@ -434,6 +435,7 @@ class AWS_S3(_CloudStorage):
 
     def __init__(self,
                 bucket: str,
+                anonymous_access: bool = False,
                 *,
                 region: Optional[str] = None,
                 access_key_id: Optional[str] = None,
@@ -471,8 +473,8 @@ class AWS_S3(_CloudStorage):
             config=Config(proxies=PROXIES_FOR_UNTRUSTED_URLS or {}),
         )
 
-        # anonymous access
-        if not any([access_key_id, secret_key, session_token]):
+        # anonymous access - disable signing
+        if anonymous:_access:
             self._s3.meta.client.meta.events.register(
                 "choose-signer.s3.*", disable_signing
             )


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Currently there is no way to use the environmental credentials chain for aws cloud storages. You must either explicitly set your credentials or cvat will assume you are attempting to do anonymous access and signing requests will be disabled entirely. I added the ability for the credentials type to be specified and passed on to the aws provider. If anonymous is requested, then signing requests will still be disabled. If credentials are given, they will be used to access aws, if credentials are not explicitly given, boto3 will look for them in the environment. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] ~I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
