### PR TITLE
Fixed exception when paste polygon with ctrl hold

### DIFF
--- a/changelog.d/20250425_104058_sekachev.bs_fixed_exception.md
+++ b/changelog.d/20250425_104058_sekachev.bs_fixed_exception.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- UI crashes when paste cuboids with hold Ctrl key
+  (<https://github.com/cvat-ai/cvat/pull/9367>)

--- a/cvat-canvas/src/typescript/drawHandler.ts
+++ b/cvat-canvas/src/typescript/drawHandler.ts
@@ -1346,7 +1346,7 @@ export class DrawHandlerImpl implements DrawHandler {
             });
         }
 
-        if (this.drawInstance && (isFilalblePolygon)) {
+        if (this.drawInstance && isFilalblePolygon) {
             const paintHandler = this.drawInstance.remember('_paintHandler');
             if (paintHandler) {
                 for (const point of (paintHandler as any).set.members) {
@@ -1398,17 +1398,17 @@ export class DrawHandlerImpl implements DrawHandler {
         }
 
         if (this.drawInstance) {
-            this.drawInstance.draw('transform');
             this.drawInstance.attr({
                 'stroke-width': consts.BASE_STROKE_WIDTH / geometry.scale,
             });
 
             const paintHandler = this.drawInstance.remember('_paintHandler');
-
-            for (const point of (paintHandler as any).set.members) {
-                this.strokePoint(point);
-                point.attr('stroke-width', `${consts.POINTS_STROKE_WIDTH / geometry.scale}`);
-                point.attr('r', `${this.controlPointsSize / geometry.scale}`);
+            if (paintHandler) {
+                for (const point of (paintHandler as any).set.members) {
+                    this.strokePoint(point);
+                    point.attr('stroke-width', `${consts.POINTS_STROKE_WIDTH / geometry.scale}`);
+                    point.attr('r', `${this.controlPointsSize / geometry.scale}`);
+                }
             }
         }
     }

--- a/cvat-canvas/src/typescript/editHandler.ts
+++ b/cvat-canvas/src/typescript/editHandler.ts
@@ -463,7 +463,6 @@ export class EditHandlerImpl implements EditHandler {
         }
 
         if (this.editLine) {
-            (this.editLine as any).draw('transform');
             if (this.editData.state.shapeType !== 'points') {
                 this.editLine.attr({
                     'stroke-width': consts.BASE_STROKE_WIDTH / geometry.scale,
@@ -471,7 +470,6 @@ export class EditHandlerImpl implements EditHandler {
             }
 
             const paintHandler = this.editLine.remember('_paintHandler');
-
             for (const point of paintHandler.set.members) {
                 point.attr('stroke-width', `${consts.POINTS_STROKE_WIDTH / geometry.scale}`);
                 point.attr('r', `${this.controlPointsSize / geometry.scale}`);

--- a/cvat-canvas/src/typescript/svg.patch.ts
+++ b/cvat-canvas/src/typescript/svg.patch.ts
@@ -59,33 +59,6 @@ SVG.Element.prototype.draw.extend(
     }),
 );
 
-// Create transform for rect, polyline and polygon
-function transform(): void {
-    this.m = this.el.node.getScreenCTM().inverse();
-    this.offset = { x: window.pageXOffset, y: window.pageYOffset };
-}
-
-SVG.Element.prototype.draw.extend(
-    'rect',
-    Object.assign({}, SVG.Element.prototype.draw.plugins.rect, {
-        transform: transform,
-    }),
-);
-
-SVG.Element.prototype.draw.extend(
-    'polyline',
-    Object.assign({}, SVG.Element.prototype.draw.plugins.polyline, {
-        transform: transform,
-    }),
-);
-
-SVG.Element.prototype.draw.extend(
-    'polygon',
-    Object.assign({}, SVG.Element.prototype.draw.plugins.polygon, {
-        transform: transform,
-    }),
-);
-
 export const CIRCLE_STROKE = '#000';
 // Fix method drawCircles
 function drawCircles(): void {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Scenario
1. Draw a 2D cuboid
2. Copy it
3. Paste it with ctrl several times

UI crashes. 

Reason?

So, different things are not looks good. For example canvas should not be called .configure method on any change in annotations. `configure` probably should not call `transform` when unnecessary. Or unnecessary `paintHandler` objects should not be created when transform called for different shapes.

But the core reason for this error is that we call `transform` on any drawInstance when it only defined for `rect`, `polygon`, `points`. I tried to understand why we added these custom methods 5 years ago, unsuccessfully. Then I tried to remove them and everything works in latest Chrome and Mozilla. So, maybe we just do not need them. 


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
