### PR TITLE
Correct string case in consensus test

### DIFF
--- a/tests/cypress/e2e/features/consensus.js
+++ b/tests/cypress/e2e/features/consensus.js
@@ -214,7 +214,7 @@ context('Basic manipulations with consensus job replicas', () => {
                 cy.get('#cvat_canvas_text_content').should('be.visible')
                     .invoke('text')
                     .should('include', `${labelName}`)
-                    .and('include', 'consensus');
+                    .and('include', 'Consensus');
             });
             cy.go('back'); // go to previous page
             // After returning to task page, consensus job should be 'completed'


### PR DESCRIPTION
### Motivation and context

Now consensus tests don't fail because of wrong string case

### How has this been tested?


### Checklist
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
