### PR TITLE
CLI: don't prompt for the password until arguments are parsed

### DIFF
--- a/changelog.d/20250429_164556_roman_cli_password_prompt.md
+++ b/changelog.d/20250429_164556_roman_cli_password_prompt.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- \[CLI\] Commands with invalid arguments or `--help` no longer ask for the
+  server password
+  (<https://github.com/cvat-ai/cvat/pull/9375>)

--- a/cvat-cli/src/cvat_cli/_internal/common.py
+++ b/cvat-cli/src/cvat_cli/_internal/common.py
@@ -12,7 +12,7 @@ import os
 import sys
 from http.client import HTTPConnection
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import attrs
 import cvat_sdk.auto_annotation as cvataa
@@ -27,12 +27,20 @@ class CriticalError(Exception):
     pass
 
 
-def get_auth(s):
-    """Parse USER[:PASS] strings and prompt for password if none was
-    supplied."""
+def get_auth_factory(s: str) -> Callable[[str], tuple[str, str]]:
+    """
+    Parse a USER[:PASS] string and return a callable that takes the server URL
+    and returns a (user, pass) tuple for that URL.
+    The callable will prompt the user for the password if none was initially supplied.
+    """
     user, _, password = s.partition(":")
-    password = password or os.environ.get("PASS") or getpass.getpass()
-    return user, password
+    if not password:
+        password = os.environ.get("PASS")
+
+    if password:
+        return lambda _: (user, password)
+    else:
+        return lambda url: (user, getpass.getpass(f"Password for {user} at {url}: "))
 
 
 def configure_common_arguments(parser: argparse.ArgumentParser) -> None:
@@ -45,7 +53,7 @@ def configure_common_arguments(parser: argparse.ArgumentParser) -> None:
 
     parser.add_argument(
         "--auth",
-        type=get_auth,
+        type=get_auth_factory,
         metavar="USER:[PASS]",
         default=getpass.getuser(),
         help="""defaults to the current user and supports the PASS
@@ -107,7 +115,7 @@ def build_client(parsed_args: argparse.Namespace, logger: logging.Logger) -> Cli
         check_server_version=False,  # version is checked after auth to support versions < 2.3
     )
 
-    client.login(popattr(parsed_args, "auth"))
+    client.login(popattr(parsed_args, "auth")(client.api_client.configuration.host))
     client.check_server_version(fail_if_unsupported=False)
 
     client.organization_slug = popattr(parsed_args, "organization")


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The current behavior is mildly inconvenient, since if the user asks for `--help` or enters an invalid command, they are still prompted for the password, even though that password isn't used.

I also added a minor usability improvement, adding the server and username into the password prompt.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
