### PR TITLE
Added tooltip for search, adjusted styles, fixed types

### DIFF
--- a/cvat-ui/src/base.scss
+++ b/cvat-ui/src/base.scss
@@ -163,6 +163,12 @@ $scroll-breakpoint: 1300px;
                 .ant-table {
                     height: 100%;
                     overflow: auto;
+
+                    &:has(.ant-table-placeholder) {
+                        .ant-table-container, .ant-table-content, table {
+                            height: 100%;
+                        }
+                    }
                 }
             }
         }

--- a/cvat-ui/src/components/common/cvat-table.tsx
+++ b/cvat-ui/src/components/common/cvat-table.tsx
@@ -16,6 +16,7 @@ import { Config } from '@react-awesome-query-builder/antd';
 import jsonLogic from 'json-logic-js';
 
 import { ResourceFilterHOC, defaultVisibility } from 'components/resource-sorting-filtering';
+import CVATTooltip from './cvat-tooltip';
 
 type Props = TableProps & {
     onFilterDataSource?(data: TableProps['dataSource']): void;
@@ -33,6 +34,10 @@ type Props = TableProps & {
     tableTitle?: string;
     searchDataIndex?: (string | string[])[];
 };
+
+function stringifyDataIndex(dataIndex: string | string[]): string {
+    return [dataIndex].flat(Number.MAX_SAFE_INTEGER).join('.');
+}
 
 function getValueFromDataItem<T>(
     dataItem: NonNullable<TableProps['dataSource']>[0],
@@ -52,7 +57,7 @@ function getValueFromDataItem<T>(
     * titles
     * advanced filtration with json query
     * overall search
-    * csv export
+    * csv export (column must have dataIndex to be CSV-exportable)
     * show/hide columns
     Current restrictions:
     * queryBuilder prop is supposed to be static
@@ -76,15 +81,16 @@ function CVATTable(props: Props): JSX.Element {
     const [searchPhrase, setSearchPhrase] = useState<string | null>(null);
     const [visibility, setVisibility] = useState(defaultVisibility);
     const [filteredDataSource, setFilteredDataSource] = useState<typeof dataSource>(dataSource);
-    const [modifiedColumns, setModifiedColumns] = useState<typeof columns>([]);
+    const [modifiedColumns, setModifiedColumns] = useState<NonNullable<typeof columns>>([]);
 
     const downloadCSV = useCallback(() => {
         if (csvExport && columns) {
             // function to export as CSV properly handling commas, line breaks and double quotes in both header/fields
-            const header = columns.map((column: any) => ({
-                title: column.dataIndex ? `${[column.dataIndex as string | string[]].flat().join('.')}` : undefined,
-                dataIndex: (column as any).dataIndex as string | string[],
-            })).filter((column) => !!column.title);
+            const header = columns
+                .filter((column: any) => !!column.dataIndex).map((column: any) => ({
+                    title: stringifyDataIndex(column.dataIndex),
+                    dataIndex: column.dataIndex as string | string[],
+                }));
 
             let csv = '';
             if (dataSource) {
@@ -116,7 +122,9 @@ function CVATTable(props: Props): JSX.Element {
     }, [csvExport?.filename, dataSource, columns]);
 
     useEffect(() => {
-        setModifiedColumns(columns);
+        if (columns) {
+            setModifiedColumns(columns);
+        }
     }, [columns]);
 
     useEffect(() => {
@@ -183,12 +191,17 @@ function CVATTable(props: Props): JSX.Element {
                 <Col>
                     <Space align='center'>
                         {Array.isArray(searchDataIndex) && !!searchDataIndex.length && (
-                            <Input.Search
-                                className='cvat-table-search-bar'
-                                placeholder='Search ..'
-                                onSearch={setSearchPhrase}
-                                enterButton
-                            />
+                            <CVATTooltip
+                                title={`Search across fields: ${searchDataIndex
+                                    .map((dataIndex) => stringifyDataIndex(dataIndex)).join(', ')}`}
+                            >
+                                <Input.Search
+                                    className='cvat-table-search-bar'
+                                    placeholder='Search ..'
+                                    onSearch={setSearchPhrase}
+                                    enterButton
+                                />
+                            </CVATTooltip>
                         )}
                         <div>
                             { FilteringComponent !== null && (
@@ -218,31 +231,30 @@ function CVATTable(props: Props): JSX.Element {
                             placement='right'
                             trigger={['click']}
                             content={() => {
-                                const items = modifiedColumns?.map((column, idx: number) => {
-                                    const isHidden = column.hidden ?? false;
-                                    return (
-                                        <Checkbox
-                                            onChange={(e: CheckboxChangeEvent) => {
-                                                const newIsHidden = !e.target.checked;
-                                                setModifiedColumns([
-                                                    ...modifiedColumns.slice(0, idx),
-                                                    {
-                                                        ...column,
-                                                        hidden: newIsHidden,
-                                                    },
-                                                    ...modifiedColumns.slice(idx + 1),
-                                                ]);
+                                const items = modifiedColumns.map((column, idx: number) => (
+                                    <Checkbox
+                                        key={idx}
+                                        onChange={(e: CheckboxChangeEvent) => {
+                                            const newIsHidden = !e.target.checked;
+                                            setModifiedColumns([
+                                                ...modifiedColumns.slice(0, idx),
+                                                {
+                                                    ...column,
+                                                    hidden: newIsHidden,
+                                                },
+                                                ...modifiedColumns.slice(idx + 1),
+                                            ]);
 
-                                                if (onChangeColumnVisibility) {
-                                                    onChangeColumnVisibility(idx, newIsHidden);
-                                                }
-                                            }}
-                                            checked={!isHidden}
-                                        >
-                                            {column.title as string}
-                                        </Checkbox>
-                                    );
-                                });
+                                            if (onChangeColumnVisibility) {
+                                                onChangeColumnVisibility(idx, newIsHidden);
+                                            }
+                                        }}
+                                        checked={!(column.hidden ?? false)}
+                                    >
+                                        {typeof column.title === 'function' ?
+                                            column.title({}) : (column.title ?? '')}
+                                    </Checkbox>
+                                ));
 
                                 return (
                                     <div className='cvat-table-columns-settings-menu'>


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Minor improvements in CVAT Table component

Search tooltip:

<img width="260" alt="image" src="https://github.com/user-attachments/assets/f4848082-d862-461b-a69f-88ffb074d387" />

Empty position fixed:
<img width="1076" alt="image" src="https://github.com/user-attachments/assets/4966b5b6-b55d-426f-87ea-0a4d4a32dfc5" />

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
