### PR TITLE
SDK: Deprecate server URL scheme autodetection

### DIFF
--- a/changelog.d/20250501_200258_roman_deprecate_schema_autodetection.md
+++ b/changelog.d/20250501_200258_roman_deprecate_schema_autodetection.md
@@ -3,3 +3,8 @@
 - \[SDK, CLI\] Automatic server URL scheme detection is deprecated.
   Add `https://` or `http://` to the host explicitly to avoid future breakage
   (<https://github.com/cvat-ai/cvat/pull/9384>)
+
+### Changed
+
+- \[CLI\] The default value for `--server-host` is now `http://localhost`
+  (<https://github.com/cvat-ai/cvat/pull/9384>)

--- a/changelog.d/20250501_200258_roman_deprecate_schema_autodetection.md
+++ b/changelog.d/20250501_200258_roman_deprecate_schema_autodetection.md
@@ -1,0 +1,5 @@
+### Deprecated
+
+- \[SDK, CLI\] Automatic server URL scheme detection is deprecated.
+  Add `https://` or `http://` to the host explicitly to avoid future breakage
+  (<https://github.com/cvat-ai/cvat/pull/9384>)

--- a/cvat-cli/src/cvat_cli/_internal/common.py
+++ b/cvat-cli/src/cvat_cli/_internal/common.py
@@ -53,7 +53,7 @@ def configure_common_arguments(parser: argparse.ArgumentParser) -> None:
                 (default user: %(default)s).""",
     )
     parser.add_argument(
-        "--server-host", type=str, default="localhost", help="host (default: %(default)s)"
+        "--server-host", type=str, default="http://localhost", help="host (default: %(default)s)"
     )
     parser.add_argument(
         "--server-port",

--- a/site/content/en/docs/api_sdk/cli/_index.md
+++ b/site/content/en/docs/api_sdk/cli/_index.md
@@ -99,15 +99,15 @@ by using the {{< ilink "/docs/manual/basics/create_an_annotation_task#labels" "l
 </details>
 <br>
 
-- Create a task named "new task" on the default server "localhost:8080", labels from the file "labels.json"
+- Create a task named "new task" on the default server `http://localhost`, labels from the file "labels.json"
   and local images "file1.jpg" and "file2.jpg", the task will be created as current user:
   ```bash
   cvat-cli task create "new task" --labels labels.json local file1.jpg file2.jpg
   ```
-- Create a task named "task 1" on the server "example.com" labels from the file "labels.json"
+- Create a task named "task 1" on the server `https://example.com` labels from the file "labels.json"
   and local image "image1.jpg", the task will be created as user "user-1":
   ```bash
-  cvat-cli --server-host example.com --auth user-1 task create "task 1" \
+  cvat-cli --server-host https://example.com --auth user-1 task create "task 1" \
   --labels labels.json local image1.jpg
   ```
 - Create a task named "task 1" on the default server, with labels from "labels.json"
@@ -294,7 +294,7 @@ While creating a project, you may optionally define its labels.
 The `project create` command accepts labels in the same format as the `task create` command;
 see that command's examples for more information.
 
-- Create a project named "new project" on the default server "localhost:8080",
+- Create a project named "new project" on the default server `http://localhost`,
   with labels from the file "labels.json":
   ```bash
   cvat-cli project create "new project" --labels labels.json

--- a/site/content/en/docs/api_sdk/sdk/auto-annotation.md
+++ b/site/content/en/docs/api_sdk/sdk/auto-annotation.md
@@ -90,7 +90,7 @@ class TorchvisionDetectionFunction:
         ]
 
 # log into the CVAT server
-with make_client(host="localhost", credentials=("user", "password")) as client:
+with make_client(host="http://localhost", credentials=("user", "password")) as client:
     # annotate task 12345 using Faster R-CNN
     cvataa.annotate_task(client, 41617,
         TorchvisionDetectionFunction("fasterrcnn_resnet50_fpn_v2", "DEFAULT", box_score_thresh=0.5),

--- a/site/content/en/docs/api_sdk/sdk/highlevel-api.md
+++ b/site/content/en/docs/api_sdk/sdk/highlevel-api.md
@@ -24,7 +24,7 @@ from cvat_sdk import make_client, models
 from cvat_sdk.core.proxies.tasks import ResourceType, Task
 
 # Create a Client instance bound to a local server and authenticate using basic auth
-with make_client(host="localhost", credentials=('user', 'password')) as client:
+with make_client(host="http://localhost", credentials=('user', 'password')) as client:
     # Let's create a new task.
 
     # Fill in task parameters first.
@@ -108,7 +108,7 @@ You can create and start using a `Client` instance this way:
 ```python
 from cvat_sdk import make_client
 
-with make_client('localhost', port='8080', credentials=('user', 'password')) as client:
+with make_client('http://localhost', port='8080', credentials=('user', 'password')) as client:
     ...
 ```
 
@@ -123,18 +123,16 @@ from cvat_sdk import Config, Client
 config = Config()
 # set up some config fields ...
 
-with Client('localhost:8080', config=config) as client:
+with Client('http://localhost:8080', config=config) as client:
     client.login(('user', 'password'))
     ...
 ```
 
-You can specify server address both with and without the scheme. If the scheme is omitted,
-it will be deduced automatically.
-
-> The checks are performed in the following
-order: `https` (with the default port 8080), `http` (with the default port 80).
-In some cases it may lead to incorrect results - e.g. you have 2 servers running on the
-same host at default ports. In such cases just specify the schema manually: `https://localhost`.
+> **Note**: Historically, the SDK has allowed the URL scheme (`http:` or `https:`)
+> to be omitted, and would attempt to automatically detect the protocol.
+> This behavior is deprecated due to being inherently insecure,
+> and will be removed in a future version.
+> To avoid future breakage, make sure to specify the scheme explicitly.
 
 When the server is located, its version is checked. If an unsupported version is found,
 an error can be raised or suppressed (controlled by `config.allow_unsupported_server`).

--- a/site/content/en/docs/api_sdk/sdk/pytorch-adapter.md
+++ b/site/content/en/docs/api_sdk/sdk/pytorch-adapter.md
@@ -27,7 +27,7 @@ model = torchvision.models.resnet34(
 model.eval()
 
 # log into the CVAT server
-with make_client(host="localhost", credentials=('user', 'password')) as client:
+with make_client(host="http://localhost", credentials=('user', 'password')) as client:
     # get the dataset comprising all tasks for the Validation subset of project 12345
     dataset = ProjectVisionDataset(client, project_id=12345,
         include_subsets=['Validation'],


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This feature is fundamentally insecure. If a user makes use of this, then a MitM could trivially block the HTTPS connection attempt, causing the SDK to downgrade to HTTP. Even in the absence of an active attacker, a transient error could cause a downgrade, leading to request details and credentials being exposed in cleartext.

In addition, this feature creates a usability problem, because if the autodetection fails, the user is given no information about the cause. This could be fixed, but given the main issue, I don't think it's worthwhile.

I don't think we can just remove this feature immediately, given that the SDK has worked this way for a long time, and there are certainly people relying on it. Therefore, in this patch I just add a big warning, and recommend specifying the scheme explicitly. In a future release, we can drop the autodetection.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
