### PR TITLE
Resolve warnings of testing library

### DIFF
--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -404,7 +404,7 @@ class JobPartialUpdateAPITestCase(ApiTestBase):
     def test_api_v2_jobs_id_annotator_partial(self):
         data = {"stage": StageChoice.ANNOTATION}
         response = self._run_api_v2_jobs_id(self.job.id, self.annotator, data)
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN, response)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response)
 
     def test_api_v2_jobs_id_admin_partial(self):
         data = {"assignee": self.user.id}
@@ -414,7 +414,7 @@ class JobPartialUpdateAPITestCase(ApiTestBase):
     def test_api_v2_jobs_id_unknown_field(self):
         data = {"foo": "bar"}
         response = self._run_api_v2_jobs_id(self.job.id, self.admin, data)
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN, response)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response)
 
 class JobUpdateAPITestCase(ApiTestBase):
     def setUp(self):
@@ -437,12 +437,12 @@ class JobUpdateAPITestCase(ApiTestBase):
     def test_api_v2_jobs_id_annotator(self):
         data = {"stage": StageChoice.ANNOTATION}
         response = self._run_api_v2_jobs_id(self.job.id, self.annotator, data)
-        self.assertEquals(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED, response)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED, response)
 
     def test_api_v2_jobs_id_admin(self):
         data = {"assignee_id": self.user.id}
         response = self._run_api_v2_jobs_id(self.job.id, self.owner, data)
-        self.assertEquals(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED, response)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED, response)
 
 class JobDataMetaPartialUpdateAPITestCase(ApiTestBase):
     def setUp(self):
@@ -1179,7 +1179,7 @@ class ProjectPartialUpdateAPITestCase(ApiTestBase):
     def test_api_v2_projects_id_unknown_field(self):
         data = {"foo": "bar"}
         response = self._run_api_v2_projects_id(self.projects[0].id, self.admin, data)
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN, response)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response)
 
 class UpdateLabelsAPITestCase(ApiTestBase):
     def assertLabelsEqual(self, label1, label2):
@@ -2376,7 +2376,7 @@ class TaskPartialUpdateAPITestCase(ApiTestBase):
     def test_api_v2_tasks_id_unknown_field(self):
         data = {"foo": "bar"}
         response = self._run_api_v2_tasks_id(self.tasks[0].id, self.admin, data)
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN, response)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response)
 
 class TaskDataMetaPartialUpdateAPITestCase(ApiTestBase):
     @classmethod


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
This PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```

### How has this been tested?
Run tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
