### PR TITLE
Bugfix: project quality page

### DIFF
--- a/cvat-core/src/quality-settings.ts
+++ b/cvat-core/src/quality-settings.ts
@@ -36,7 +36,7 @@ export default class QualitySettings {
     #pointSizeBase: PointSizeBase;
     #lineThickness: number;
     #lowOverlapThreshold: number;
-    #orientedLines: boolean;
+    #compareLineOrientation: boolean;
     #lineOrientationThreshold: number;
     #compareGroups: boolean;
     #groupMatchThreshold: number;
@@ -60,7 +60,7 @@ export default class QualitySettings {
         this.#pointSizeBase = initialData.point_size_base as PointSizeBase;
         this.#lineThickness = initialData.line_thickness;
         this.#lowOverlapThreshold = initialData.low_overlap_threshold;
-        this.#orientedLines = initialData.compare_line_orientation;
+        this.#compareLineOrientation = initialData.compare_line_orientation;
         this.#lineOrientationThreshold = initialData.line_orientation_threshold;
         this.#compareGroups = initialData.compare_groups;
         this.#groupMatchThreshold = initialData.group_match_threshold;
@@ -102,8 +102,8 @@ export default class QualitySettings {
         return this.#lowOverlapThreshold;
     }
 
-    get orientedLines(): boolean {
-        return this.#orientedLines;
+    get compareLineOrientation(): boolean {
+        return this.#compareLineOrientation;
     }
 
     get lineOrientationThreshold(): number {

--- a/cvat-core/src/server-proxy.ts
+++ b/cvat-core/src/server-proxy.ts
@@ -727,14 +727,13 @@ async function getTasks(
     let response = null;
     try {
         if (aggregate) {
-            response = await Axios.get(`${backendAPI}/tasks`, {
-                params: {
+            response = {
+                data: await fetchAll(`${backendAPI}/tasks`, {
                     ...filter,
-                },
-            });
-        }
-
-        if ('id' in filter) {
+                    ...enableOrganization(),
+                }),
+            };
+        } else if ('id' in filter) {
             response = await Axios.get(`${backendAPI}/tasks/${filter.id}`);
             const results = [response.data];
             Object.defineProperty(results, 'count', {
@@ -742,14 +741,14 @@ async function getTasks(
             });
 
             return results as PaginatedResource<SerializedTask>;
+        } else {
+            response = await Axios.get(`${backendAPI}/tasks`, {
+                params: {
+                    ...filter,
+                    page_size: filter.page_size ?? 10,
+                },
+            });
         }
-
-        response = await Axios.get(`${backendAPI}/tasks`, {
-            params: {
-                ...filter,
-                page_size: filter.page_size ?? 10,
-            },
-        });
     } catch (errorData) {
         throw generateError(errorData);
     }

--- a/cvat-ui/src/components/quality-control/quality-settings-tab.tsx
+++ b/cvat-ui/src/components/quality-control/quality-settings-tab.tsx
@@ -43,7 +43,7 @@ function QualitySettingsTab(props: Readonly<Props>): JSX.Element | null {
     const onSave = useCallback(async () => {
         if (settings) {
             const values = await form.validateFields();
-            const fields = {
+            const fields: QualitySettingsSaveFields = {
                 targetMetric: values.targetMetric,
                 targetMetricThreshold: values.targetMetricThreshold / 100,
                 maxValidationsPerJob: values.maxValidationsPerJob,
@@ -55,7 +55,7 @@ function QualitySettingsTab(props: Readonly<Props>): JSX.Element | null {
                 pointSizeBase: values.pointSizeBase,
                 lineThickness: values.lineThickness / 100,
                 lineOrientationThreshold: values.lineOrientationThreshold / 100,
-                orientedLines: values.orientedLines,
+                compareLineOrientation: values.compareLineOrientation,
                 compareGroups: values.compareGroups,
                 groupMatchThreshold: values.groupMatchThreshold / 100,
                 checkCoveredAnnotations: values.checkCoveredAnnotations,

--- a/cvat-ui/src/components/quality-control/task-quality/quality-settings-form.tsx
+++ b/cvat-ui/src/components/quality-control/task-quality/quality-settings-form.tsx
@@ -51,7 +51,7 @@ export default function QualitySettingsForm(props: Readonly<Props>): JSX.Element
 
         lineThickness: settings.lineThickness * 100,
         lineOrientationThreshold: settings.lineOrientationThreshold * 100,
-        orientedLines: settings.orientedLines,
+        compareLineOrientation: settings.compareLineOrientation,
 
         compareGroups: settings.compareGroups,
         groupMatchThreshold: settings.groupMatchThreshold * 100,
@@ -376,7 +376,7 @@ export default function QualitySettingsForm(props: Readonly<Props>): JSX.Element
             <Row>
                 <Col span={12}>
                     <Form.Item
-                        name='orientedLines'
+                        name='compareLineOrientation'
                         rules={[{ required: true, message: 'This field is required' }]}
                         valuePropName='checked'
                     >


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Two issues were found on recently intoduced projects quality page:
- Checkbox for `line orientation` settings was not working
- Tasks table displayed only 10 first tasks

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
