### PR TITLE
Remove unnecessary uses of `str.format_map`

### DIFF
--- a/cvat/apps/dataset_manager/util.py
+++ b/cvat/apps/dataset_manager/util.py
@@ -247,15 +247,13 @@ class ExportCacheManager:
         file_type = ExportFileType.DATASET if save_images else ExportFileType.ANNOTATIONS
 
         normalized_format_name = make_file_name(to_snake_case(format_name))
-        filename = cls.FILE_NAME_TEMPLATE_WITH_INSTANCE.format_map(
-            {
-                "instance_type": instance_type,
-                "instance_id": instance_id,
-                "file_type": file_type,
-                "instance_timestamp": instance_timestamp,
-                "optional_suffix": cls.SPLITTER + normalized_format_name,
-                "file_ext": file_ext,
-            }
+        filename = cls.FILE_NAME_TEMPLATE_WITH_INSTANCE.format(
+            instance_type=instance_type,
+            instance_id=instance_id,
+            file_type=file_type,
+            instance_timestamp=instance_timestamp,
+            optional_suffix=cls.SPLITTER + normalized_format_name,
+            file_ext=file_ext,
         )
 
         return osp.join(cls.ROOT, filename)
@@ -269,15 +267,13 @@ class ExportCacheManager:
         instance_timestamp: float,
     ) -> str:
         instance_type = InstanceType(instance_type.lower())
-        filename = cls.FILE_NAME_TEMPLATE_WITH_INSTANCE.format_map(
-            {
-                "instance_type": instance_type,
-                "instance_id": instance_id,
-                "file_type": ExportFileType.BACKUP,
-                "instance_timestamp": instance_timestamp,
-                "optional_suffix": "",
-                "file_ext": "zip",
-            }
+        filename = cls.FILE_NAME_TEMPLATE_WITH_INSTANCE.format(
+            instance_type=instance_type,
+            instance_id=instance_id,
+            file_type=ExportFileType.BACKUP,
+            instance_timestamp=instance_timestamp,
+            optional_suffix="",
+            file_ext="zip",
         )
         return osp.join(cls.ROOT, filename)
 
@@ -289,11 +285,12 @@ class ExportCacheManager:
         file_id: UUID,
         file_ext: str,
     ) -> str:
-        filename = cls.FILE_NAME_TEMPLATE_WITHOUT_INSTANCE.format_map({
-            "file_type": ExportFileType(file_type), # convert here to be sure only expected types are used
-            "file_id": file_id,
-            "file_ext": file_ext,
-        })
+        filename = cls.FILE_NAME_TEMPLATE_WITHOUT_INSTANCE.format(
+            # convert here to be sure only expected types are used
+            file_type=ExportFileType(file_type),
+            file_id=file_id,
+            file_ext=file_ext,
+        )
         return osp.join(cls.ROOT, filename)
 
     @classmethod

--- a/cvat/apps/engine/filters.py
+++ b/cvat/apps/engine/filters.py
@@ -344,9 +344,9 @@ class SimpleFilter(DjangoFilterBackend):
             parameter = {
                 'name': field_name,
                 'in': 'query',
-                'description': force_str(self.filter_desc.format_map({
-                    'field_name': filter_.label if filter_.label is not None else field_name
-                })),
+                'description': force_str(self.filter_desc.format(
+                    field_name=filter_.label if filter_.label is not None else field_name
+                )),
                 'schema': parameter_schema,
             }
             if filter_.extra and 'choices' in filter_.extra:
@@ -402,9 +402,9 @@ class NonModelSimpleFilter(SimpleFilter, _NestedAttributeHandler):
                 parameter = {
                     'name': filter_name,
                     'in': 'query',
-                    'description': force_str(self.filter_desc.format_map({
-                        'field_name': filter_name
-                    })),
+                    'description': force_str(self.filter_desc.format(
+                        field_name=filter_name
+                    )),
                     'schema': {
                         'type': filter_type
                     },

--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -1089,8 +1089,8 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             the `GET /api/requests/<rq_id>`, where **rq_id** is request ID returned for this request.
 
             Once data is attached to a task, it cannot be detached or replaced.
-        """.format_map(
-            {'upload_file_order_field': _UPLOAD_FILE_ORDER_FIELD}
+        """.format(
+            upload_file_order_field=_UPLOAD_FILE_ORDER_FIELD
         )),
         # TODO: add a tutorial on this endpoint in the REST API docs
         request=DataSerializer(required=False),


### PR DESCRIPTION
Which, as it happens, is all of them. In all these cases, using `format` results in more compact, easier-to-read code.

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
I was looking into blackening some of these source files, and I saw that the `format_map` usage results in uglier formatting than it could be if we used `format`.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
