### PR TITLE
Removed extra filter in initcontentsize

### DIFF
--- a/cvat/apps/engine/management/commands/initcontentsize.py
+++ b/cvat/apps/engine/management/commands/initcontentsize.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
         is_failed = False
         for Model, get_directory_path, get_queryset in [
             (Asset, lambda asset: asset.get_asset_dir(), lambda: Asset.objects),
-            (Data, lambda data: data.get_upload_dirname(), lambda: Data.objects.exclude(size=0)),
+            (Data, lambda data: data.get_upload_dirname(), lambda: Data.objects),
         ]:
             total = 0
             self.stdout.write(f"Started for {Model.__name__}")


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
This filter does not seem to be necessary.
Initially I added it to calculate only those objects where data were extracted, segments prepared, etc.
However it is not really necessary, even if the command calculates not ready tasks yet, that is not scary. 
At the same time we want to know content_size for any Data object (including "broken" in the past)

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
