### PR TITLE
Update Docker Installation commands and links in documentation

### DIFF
--- a/site/content/en/docs/administration/basics/installation.md
+++ b/site/content/en/docs/administration/basics/installation.md
@@ -118,7 +118,7 @@ For access from China, read [sources for users from China](#sources-for-users-fr
   install it as well. Type commands below in a terminal window:
 
   ```shell
-  curl https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+  sudo curl https://dl-ssl.google.com/linux/linux_signing_key.pub -o /etc/apt/trusted.gpg.d/google.asc
   sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
   sudo apt-get update
   sudo apt-get --no-install-recommends install -y google-chrome-stable

--- a/site/content/en/docs/administration/basics/installation.md
+++ b/site/content/en/docs/administration/basics/installation.md
@@ -29,28 +29,29 @@ For access from China, read [sources for users from China](#sources-for-users-fr
   Ubuntu please read [the answer](https://askubuntu.com/questions/183775/how-do-i-open-a-terminal).
 
 - Type commands below into the terminal window to install Docker and Docker Compose. More
-  instructions can be found [here](https://docs.docker.com/install/linux/docker-ce/ubuntu/).
+  instructions can be found [here](https://docs.docker.com/engine/install/ubuntu/).
 
   ```shell
+  # Add Docker's official GPG key:
   sudo apt-get update
-  sudo apt-get --no-install-recommends install -y \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg-agent \
-    software-properties-common
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  sudo add-apt-repository \
-    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) \
-    stable"
+  sudo apt-get install ca-certificates curl
+  sudo install -m 0755 -d /etc/apt/keyrings
+  sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  sudo chmod a+r /etc/apt/keyrings/docker.asc
+  
+  # Add the repository to Apt sources:
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
   sudo apt-get update
-  sudo apt-get --no-install-recommends install -y \
-    docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+  # Install the Docker packages.
+  sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
   ```
 
 - (Optional) To avoid prefacing Docker commands with `sudo`,
-  you can perform the [post-installation steps](https://docs.docker.com/install/linux/linux-postinstall/).
+  you can perform the [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/).
   This involves creating a Unix group named `docker` and
   adding your current user to this group.
 


### PR DESCRIPTION
### Motivation and context
The current installation guide does not follow the current official Docker installation guide!
apt-key is deprecated
Finally, the links to the Docker official website are outdated

### How has this been tested?

### Checklist
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License
- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
