### PR TITLE
Fixed incorrect width of project field on webhook setup page

### DIFF
--- a/changelog.d/20250615_142005_sekachev.bs_fixed_project_search_width.md
+++ b/changelog.d/20250615_142005_sekachev.bs_fixed_project_search_width.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Incorrect width of project field on webhook setup page
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/cvat-ui/src/components/setup-webhook-pages/styles.scss
+++ b/cvat-ui/src/components/setup-webhook-pages/styles.scss
@@ -13,6 +13,10 @@
     padding: $grid-unit-size * 3;
     background: $background-color-1;
     text-align: initial;
+
+    .cvat-project-search-field {
+        width: 100%;
+    }
 }
 
 .cvat-create-webhook-page {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Before:

<img width="749" alt="image" src="https://github.com/user-attachments/assets/4182712a-5a94-46b0-9af4-1057857b4e97" />

After:
<img width="750" alt="image" src="https://github.com/user-attachments/assets/cfd85dc8-0bdf-411d-9d19-8bb5d682afdc" />



### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
