### PR TITLE
Fix zip handling of osx hidden dirs

### DIFF
--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -387,7 +387,7 @@ class DirectoryReader(ImageListReader):
         for source in source_path:
             for root, _, files in os.walk(source):
                 paths = [os.path.join(root, f) for f in files]
-                paths = filter(lambda x: get_mime(x) == 'image', paths)
+                paths = filter(lambda x: files_to_ignore(x) and get_mime(x) == 'image', paths)
                 image_paths.extend(paths)
         super().__init__(
             source_path=image_paths,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context

It looks like zip files sometimes (always?) get categorized as 'archive' and are handled by the ArchiveReader rather than the ZipReader. Add osx hidden dir checking to ArchiveReader as well.

This is done through ArchiveReader's parent class DirectoryReader for ease of implementation. I can't think of a reason why we wouldn't want to ignore these dirs; so at best we catch junk directories that could show up in other archive types and at worst there's a small overhead of string comparisons.

### How has this been tested?

I didn't see any existing tests of ZipReader's filtering logic and I didn't see an easy way to add a test for this. I tested these changes locally in a running server and verified an osx compressed archive gets processed to all expected images. Also verified there's no regressions in existing tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
