### PR TITLE
Prohibit creating annotations with preset ID

### DIFF
--- a/changelog.d/20250630_130504_roman_validate_annotation_id.md
+++ b/changelog.d/20250630_130504_roman_validate_annotation_id.md
@@ -1,0 +1,6 @@
+### Changed
+
+- The `PATCH` and `PUT` methods on the `/api/(tasks|jobs)/<id>/annotations`
+  paths now verify that annotation IDs are present/absent, depending on the
+  action
+  (<https://github.com/cvat-ai/cvat/pull/9583>)

--- a/cvat/apps/engine/tests/test_rest_api_3D.py
+++ b/cvat/apps/engine/tests/test_rest_api_3D.py
@@ -427,10 +427,11 @@ class Task3DTest(_DbTestBase):
             task_data = self.copy_pcd_file_and_get_task_data(test_dir)
             task = self._create_task(self.task, task_data)
             task_id = task["id"]
-            annotation = self._get_tmp_annotation(task, self.cuboid_example)
 
             for user, edata in list(self.expected_action.items()):
                 with self.subTest(format=edata["name"]):
+                    annotation = self._get_tmp_annotation(task, self.cuboid_example)
+
                     response = self._patch_api_v2_task_id_annotations(
                         task_id, annotation, CREATE_ACTION, self.admin
                     )
@@ -508,10 +509,11 @@ class Task3DTest(_DbTestBase):
             task = self._create_task(self.task, task_data)
             task_id = task["id"]
             jobs = self._get_jobs(task_id)
-            annotation = self._get_tmp_annotation(task, self.cuboid_example)
 
             for user, edata in list(self.expected_action.items()):
                 with self.subTest(format=edata["name"]):
+                    annotation = self._get_tmp_annotation(task, self.cuboid_example)
+
                     response = self._patch_api_v2_job_id_annotations(
                         jobs[0]["id"], annotation, CREATE_ACTION, self.admin
                     )

--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -1273,7 +1273,9 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             if {"format", "rq_id"} & set(request.query_params.keys()):
                 return get_410_response_when_checking_process_status("import")
 
-            serializer = LabeledDataSerializer(data=request.data)
+            serializer = LabeledDataSerializer(
+                data=request.data, context={"annotation_action": dm.task.PatchAction.CREATE}
+            )
             if serializer.is_valid(raise_exception=True):
                 data = dm.task.put_task_data(pk, serializer.validated_data)
                 return Response(data)
@@ -1286,7 +1288,9 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             if action not in dm.task.PatchAction.values():
                 raise serializers.ValidationError(
                     "Please specify a correct 'action' for the request")
-            serializer = LabeledDataSerializer(data=request.data)
+            serializer = LabeledDataSerializer(
+                data=request.data, context={"annotation_action": action}
+            )
             if serializer.is_valid(raise_exception=True):
                 try:
                     data = dm.task.patch_task_data(pk, serializer.validated_data, action)
@@ -1753,7 +1757,9 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
             if {"format", "rq_id"} & set(request.query_params.keys()):
                 return get_410_response_when_checking_process_status("import")
 
-            serializer = LabeledDataSerializer(data=request.data)
+            serializer = LabeledDataSerializer(
+                data=request.data, context={"annotation_action": dm.task.PatchAction.CREATE}
+            )
             if serializer.is_valid(raise_exception=True):
                 try:
                     data = dm.task.put_job_data(pk, serializer.validated_data)
@@ -1768,7 +1774,9 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
             if action not in dm.task.PatchAction.values():
                 raise serializers.ValidationError(
                     "Please specify a correct 'action' for the request")
-            serializer = LabeledDataSerializer(data=request.data)
+            serializer = LabeledDataSerializer(
+                data=request.data, context={"annotation_action": action}
+            )
             if serializer.is_valid(raise_exception=True):
                 try:
                     data = dm.task.patch_job_data(pk, serializer.validated_data, action)

--- a/tests/python/rest_api/test_quality_control.py
+++ b/tests/python/rest_api/test_quality_control.py
@@ -1569,7 +1569,7 @@ class TestQualityReportMetrics(_PermissionTestBase):
 
         with make_api_client(admin_user) as api_client:
             api_client.jobs_api.partial_update_annotations(
-                "update",
+                "create",
                 gt_job["id"],
                 patched_labeled_data_request=dict(
                     shapes=[

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -637,7 +637,7 @@ class TestPatchTaskAnnotations:
         response = patch_method("admin1", endpoint, annotations, action="create")
         assert response.status_code == HTTPStatus.OK, response.content
 
-        annotations["tracks"][0]["shapes"] = shapes0[1:]
+        annotations["tracks"][0]["shapes"] = response.json()["shapes"][1:]
         response = patch_method("admin1", endpoint, annotations, action="update")
         assert response.status_code == HTTPStatus.OK
 
@@ -837,9 +837,7 @@ class TestGetTaskDataset:
                 }
             ],
         }
-        response = patch_method(
-            admin_user, f"tasks/{tid}/annotations", annotations, action="update"
-        )
+        response = put_method(admin_user, f"tasks/{tid}/annotations", annotations)
         assert response.status_code == HTTPStatus.OK
 
         # check that we can export task dataset

--- a/tests/python/sdk/test_auto_annotation.py
+++ b/tests/python/sdk/test_auto_annotation.py
@@ -13,6 +13,7 @@ import PIL.Image
 import pytest
 from cvat_sdk import Client, models
 from cvat_sdk.attributes import attribute_vals_from_dict, number_attribute_values
+from cvat_sdk.core.proxies.annotations import AnnotationUpdateAction
 from cvat_sdk.core.proxies.tasks import ResourceType
 
 from shared.utils.helpers import generate_image_file
@@ -240,7 +241,8 @@ class TestTaskAutoAnnotation:
                         points=[1.0, 2.0, 3.0, 4.0],
                     ),
                 ],
-            )
+            ),
+            action=AnnotationUpdateAction.CREATE,
         )
 
     def test_detection_rectangle(self):

--- a/tests/python/sdk/test_datasets.py
+++ b/tests/python/sdk/test_datasets.py
@@ -10,6 +10,7 @@ import cvat_sdk.datasets as cvatds
 import PIL.Image
 import pytest
 from cvat_sdk import Client, models
+from cvat_sdk.core.proxies.annotations import AnnotationUpdateAction
 from cvat_sdk.core.proxies.tasks import ResourceType
 
 from shared.utils.helpers import generate_image_files
@@ -83,7 +84,8 @@ class TestTaskDataset:
                         points=[1.0, 2.0, 3.0, 4.0],
                     ),
                 ],
-            )
+            ),
+            action=AnnotationUpdateAction.CREATE,
         )
 
     @pytest.mark.parametrize("media_download_policy", cvatds.MediaDownloadPolicy)

--- a/tests/python/sdk/test_pytorch.py
+++ b/tests/python/sdk/test_pytorch.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 from cvat_sdk import Client, models
+from cvat_sdk.core.proxies.annotations import AnnotationUpdateAction
 from cvat_sdk.core.proxies.tasks import ResourceType
 
 try:
@@ -105,7 +106,8 @@ class TestTaskVisionDataset:
                         points=[1.1, 2.1, 3.1, 4.1],
                     ),
                 ],
-            )
+            ),
+            action=AnnotationUpdateAction.CREATE,
         )
 
     def test_basic(self):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This has no legitimate purpose, since a client cannot predict which IDs are available ahead of time. Moreover, if the specified ID is already taken, the client will receive a 500 error (on a PUT request) or a 400 error with a cryptic message (on a PATCH request).

For symmetry, also prohibit deleting annotations with no ID, although I believe such deletions were previously no-ops anyway.

I originally wanted to also require IDs on an `action=update` request, but tests show that a) currently "update" can also work as "create", and b) it's really easy to accidentally rely on this behavior. So for compatibility I decided to keep it. Maybe we could revisit this later. I updated the tests to fix such mistakes, though.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
