### PR TITLE
Adds support for YOLO11 from ultralytics + SAHI in serverless

### DIFF
--- a/changelog.d/20250702_031050_genaronadile_ultralytics_yolo11_sahi_support.md
+++ b/changelog.d/20250702_031050_genaronadile_ultralytics_yolo11_sahi_support.md
@@ -1,0 +1,4 @@
+### Added <!-- pick one -->
+
+- Support for automatic annotations with YOLO11 (ultralytics) + SAHI
+  (<https://github.com/cvat-ai/cvat/pull/9596>)

--- a/serverless/pytorch/ultralytics/YOLO11-SAHI/nuclio/function-gpu.yaml
+++ b/serverless/pytorch/ultralytics/YOLO11-SAHI/nuclio/function-gpu.yaml
@@ -1,0 +1,142 @@
+metadata:
+  name: gpu-yolov11-sahi
+  namespace: cvat
+  annotations:
+    name: GPU YOLOv11 with SAHI
+    type: detector
+    framework: pytorch
+    spec: |
+      [
+        { "id": 0, "name": "person", "type": "rectangle" },
+        { "id": 1, "name": "bicycle", "type": "rectangle" },
+        { "id": 2, "name": "car", "type": "rectangle" },
+        { "id": 3, "name": "motorcycle", "type": "rectangle" },
+        { "id": 4, "name": "airplane", "type": "rectangle" },
+        { "id": 5, "name": "bus", "type": "rectangle" },
+        { "id": 6, "name": "train", "type": "rectangle" },
+        { "id": 7, "name": "truck", "type": "rectangle" },
+        { "id": 8, "name": "boat", "type": "rectangle" },
+        { "id": 9, "name": "traffic light", "type": "rectangle" },
+        { "id": 10, "name": "fire hydrant", "type": "rectangle" },
+        { "id": 11, "name": "stop sign", "type": "rectangle" },
+        { "id": 12, "name": "parking meter", "type": "rectangle" },
+        { "id": 13, "name": "bench", "type": "rectangle" },
+        { "id": 14, "name": "bird", "type": "rectangle" },
+        { "id": 15, "name": "cat", "type": "rectangle" },
+        { "id": 16, "name": "dog", "type": "rectangle" },
+        { "id": 17, "name": "horse", "type": "rectangle" },
+        { "id": 18, "name": "sheep", "type": "rectangle" },
+        { "id": 19, "name": "cow", "type": "rectangle" },
+        { "id": 20, "name": "elephant", "type": "rectangle" },
+        { "id": 21, "name": "bear", "type": "rectangle" },
+        { "id": 22, "name": "zebra", "type": "rectangle" },
+        { "id": 23, "name": "giraffe", "type": "rectangle" },
+        { "id": 24, "name": "backpack", "type": "rectangle" },
+        { "id": 25, "name": "umbrella", "type": "rectangle" },
+        { "id": 26, "name": "handbag", "type": "rectangle" },
+        { "id": 27, "name": "tie", "type": "rectangle" },
+        { "id": 28, "name": "suitcase", "type": "rectangle" },
+        { "id": 29, "name": "frisbee", "type": "rectangle" },
+        { "id": 30, "name": "skis", "type": "rectangle" },
+        { "id": 31, "name": "snowboard", "type": "rectangle" },
+        { "id": 32, "name": "sports ball", "type": "rectangle" },
+        { "id": 33, "name": "kite", "type": "rectangle" },
+        { "id": 34, "name": "baseball bat", "type": "rectangle" },
+        { "id": 35, "name": "baseball glove", "type": "rectangle" },
+        { "id": 36, "name": "skateboard", "type": "rectangle" },
+        { "id": 37, "name": "surfboard", "type": "rectangle" },
+        { "id": 38, "name": "tennis racket", "type": "rectangle" },
+        { "id": 39, "name": "bottle", "type": "rectangle" },
+        { "id": 40, "name": "wine glass", "type": "rectangle" },
+        { "id": 41, "name": "cup", "type": "rectangle" },
+        { "id": 42, "name": "fork", "type": "rectangle" },
+        { "id": 43, "name": "knife", "type": "rectangle" },
+        { "id": 44, "name": "spoon", "type": "rectangle" },
+        { "id": 45, "name": "bowl", "type": "rectangle" },
+        { "id": 46, "name": "banana", "type": "rectangle" },
+        { "id": 47, "name": "apple", "type": "rectangle" },
+        { "id": 48, "name": "sandwich", "type": "rectangle" },
+        { "id": 49, "name": "orange", "type": "rectangle" },
+        { "id": 50, "name": "broccoli", "type": "rectangle" },
+        { "id": 51, "name": "carrot", "type": "rectangle" },
+        { "id": 52, "name": "hot dog", "type": "rectangle" },
+        { "id": 53, "name": "pizza", "type": "rectangle" },
+        { "id": 54, "name": "donut", "type": "rectangle" },
+        { "id": 55, "name": "cake", "type": "rectangle" },
+        { "id": 56, "name": "chair", "type": "rectangle" },
+        { "id": 57, "name": "couch", "type": "rectangle" },
+        { "id": 58, "name": "potted plant", "type": "rectangle" },
+        { "id": 59, "name": "bed", "type": "rectangle" },
+        { "id": 60, "name": "dining table", "type": "rectangle" },
+        { "id": 61, "name": "toilet", "type": "rectangle" },
+        { "id": 62, "name": "tv", "type": "rectangle" },
+        { "id": 63, "name": "laptop", "type": "rectangle" },
+        { "id": 64, "name": "mouse", "type": "rectangle" },
+        { "id": 65, "name": "remote", "type": "rectangle" },
+        { "id": 66, "name": "keyboard", "type": "rectangle" },
+        { "id": 67, "name": "cell phone", "type": "rectangle" },
+        { "id": 68, "name": "microwave", "type": "rectangle" },
+        { "id": 69, "name": "oven", "type": "rectangle" },
+        { "id": 70, "name": "toaster", "type": "rectangle" },
+        { "id": 71, "name": "sink", "type": "rectangle" },
+        { "id": 72, "name": "refrigerator", "type": "rectangle" },
+        { "id": 73, "name": "book", "type": "rectangle" },
+        { "id": 74, "name": "clock", "type": "rectangle" },
+        { "id": 75, "name": "vase", "type": "rectangle" },
+        { "id": 76, "name": "scissors", "type": "rectangle" },
+        { "id": 77, "name": "teddy bear", "type": "rectangle" },
+        { "id": 78, "name": "hair drier", "type": "rectangle" },
+        { "id": 79, "name": "toothbrush", "type": "rectangle" }
+      ]
+
+spec:
+  description: GPU YOLOv11 with SAHI for ants
+  runtime: 'python:3.9'
+  handler: main:handler
+  eventTimeout: 30s
+
+  build:
+    image: cvat.pth.fraunhofer.uam_upernet.gpu
+    baseImage: ultralytics/ultralytics
+
+    directives:
+      preCopy:
+        - kind: USER
+          value: root
+        - kind: ENV
+          value: NVIDIA_VISIBLE_DEVICES=all
+        - kind: ENV
+          value: NVIDIA_DRIVER_CAPABILITIES=compute,utility
+        - kind: ENV
+          value: RUN_ON_GPU="true"
+        - kind: RUN
+          value: export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y python-is-python3
+        - kind: RUN
+          value: pip install --no-cache-dir opencv-python-headless pillow pyyaml
+        - kind: RUN
+          value: pip uninstall -y torch torchvision torchaudio
+        - kind: RUN
+          value: pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+        - kind: RUN
+          value: pip install sahi
+        - kind: WORKDIR
+          value: /opt/nuclio
+
+  triggers:
+    myHttpTrigger:
+      maxWorkers: 1
+      kind: 'http'
+      workerAvailabilityTimeoutMilliseconds: 10000
+      attributes:
+        maxRequestBodySize: 524288000 # 500MB
+
+  resources:
+    limits:
+      nvidia.com/gpu: 1
+
+  platform:
+    attributes:
+      restartPolicy:
+        name: always
+        maximumRetryCount: 3
+      mountMode: volume

--- a/serverless/pytorch/ultralytics/YOLO11-SAHI/nuclio/main.py
+++ b/serverless/pytorch/ultralytics/YOLO11-SAHI/nuclio/main.py
@@ -1,0 +1,176 @@
+import io
+import base64
+import json
+import torch
+
+import cv2
+import numpy as np
+from ultralytics import YOLO
+from ultralytics.engine.results import Results
+from sahi.predict import get_sliced_prediction
+from torch import tensor
+from sahi import AutoDetectionModel
+
+LABELS_DETECTION_MAP = {
+    0: 'person',
+    1: 'bicycle',
+    2: 'car',
+    3: 'motorcycle',
+    4: 'airplane',
+    5: 'bus',
+    6: 'train',
+    7: 'truck',
+    8: 'boat',
+    9: 'traffic light',
+    10: 'fire hydrant',
+    11: 'stop sign',
+    12: 'parking meter',
+    13: 'bench',
+    14: 'bird',
+    15: 'cat',
+    16: 'dog',
+    17: 'horse',
+    18: 'sheep',
+    19: 'cow',
+    20: 'elephant',
+    21: 'bear',
+    22: 'zebra',
+    23: 'giraffe',
+    24: 'backpack',
+    25: 'umbrella',
+    26: 'handbag',
+    27: 'tie',
+    28: 'suitcase',
+    29: 'frisbee',
+    30: 'skis',
+    31: 'snowboard',
+    32: 'sports ball',
+    33: 'kite',
+    34: 'baseball bat',
+    35: 'baseball glove',
+    36: 'skateboard',
+    37: 'surfboard',
+    38: 'tennis racket',
+    39: 'bottle',
+    40: 'wine glass',
+    41: 'cup',
+    42: 'fork',
+    43: 'knife',
+    44: 'spoon',
+    45: 'bowl',
+    46: 'banana',
+    47: 'apple',
+    48: 'sandwich',
+    49: 'orange',
+    50: 'broccoli',
+    51: 'carrot',
+    52: 'hot dog',
+    53: 'pizza',
+    54: 'donut',
+    55: 'cake',
+    56: 'chair',
+    57: 'couch',
+    58: 'potted plant',
+    59: 'bed',
+    60: 'dining table',
+    61: 'toilet',
+    62: 'tv',
+    63: 'laptop',
+    64: 'mouse',
+    65: 'remote',
+    66: 'keyboard',
+    67: 'cell phone',
+    68: 'microwave',
+    69: 'oven',
+    70: 'toaster',
+    71: 'sink',
+    72: 'refrigerator',
+    73: 'book',
+    74: 'clock',
+    75: 'vase',
+    76: 'scissors',
+    77: 'teddy bear',
+    78: 'hair drier',
+    79: 'toothbrush'
+}
+
+
+def sahi_result_to_ultralytics_results(image_np, sahi_results):
+    return Results(
+        image_np,
+        "",
+        LABELS_DETECTION_MAP,
+        boxes=tensor(
+            [
+                [
+                    bb.bbox.minx,
+                    bb.bbox.miny,
+                    bb.bbox.maxx,
+                    bb.bbox.maxy,
+                    bb.score.value,
+                    bb.category.id,
+                ]
+                for bb in sahi_results.object_prediction_list
+            ]
+            if len(sahi_results.object_prediction_list) > 0
+            else torch.empty((0, 6))
+        ),
+    )
+
+
+def init_context(context):
+    model = YOLO("yolo11l")
+    context.user_data.model_handler = AutoDetectionModel.from_pretrained(
+        model_type="yolov11", model=model
+    )
+
+
+def handler(context, event):
+    context.logger.info("Run custom yolov11 model")
+    data = event.body
+    image_buffer = io.BytesIO(base64.b64decode(data["image"]))
+    image = cv2.imdecode(
+        np.frombuffer(image_buffer.getvalue(), np.uint8), cv2.IMREAD_COLOR
+    )
+
+    sahi_results = get_sliced_prediction(
+        image,
+        context.user_data.model_handler,
+        auto_slice_resolution=True,
+        verbose=True,
+    )
+
+    boxes = []
+    clss = []
+    confs = []
+    for prediction in sahi_results.object_prediction_list:
+        boxes.append(
+            [
+                prediction.bbox.minx,
+                prediction.bbox.miny,
+                prediction.bbox.maxx,
+                prediction.bbox.maxy,
+            ]
+        )
+        confs.append(prediction.score.value)
+        clss.append(prediction.category.id)
+
+
+    detections = []
+    for box, conf, class_value in zip(boxes, confs, clss):
+        label = LABELS_DETECTION_MAP[int(class_value)]
+        detections.append(
+            {
+                "confidence": str(float(conf)),
+                "label": label,
+                "points": box,
+                "type": "rectangle",
+            }
+        )
+
+    return context.Response(
+        body=json.dumps(detections),
+        headers={},
+        content_type="application/json",
+        status_code=200,
+    )


### PR DESCRIPTION
### Motivation and context
I had to annotate ants in a big image, where the ants where a small part of the pictures. To accelerate the process of annotations I added a serverless implementation that uses YOLO11 (ultralytics) + SAHI to help detect those small objects in the images.

Closes: #9595

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Environment:
- Windows 11 pro + WSL ubuntu
- Nvidia based GPU

Test:
- Created a project with the tag car, selected some images of cars on the highway, and ran the automatic annotation process over the images using the model `GPU YOLOv11 with SAHI`
- Glad to add unit tests if needed


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] ~~I have updated the documentation accordingly~~
- [ ] ~~I have added tests to cover my changes~~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
