### PR TITLE
[Documentation] Limit the documentation versions to the 6 ones

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,12 +32,8 @@ jobs:
           wget https://github.com/gohugoio/hugo/releases/download/v0.110.0/hugo_extended_0.110.0_Linux-64bit.tar.gz
           (mkdir hugo_extended_0.110.0_Linux-64bit && tar -xf hugo_extended_0.110.0_Linux-64bit.tar.gz -C hugo_extended_0.110.0_Linux-64bit)
 
-          wget https://github.com/gohugoio/hugo/releases/download/v0.83.0/hugo_extended_0.83.0_Linux-64bit.tar.gz
-          (mkdir hugo_extended_0.83.0_Linux-64bit && tar -xf hugo_extended_0.83.0_Linux-64bit.tar.gz -C hugo_extended_0.83.0_Linux-64bit)
-
           mkdir hugo
           cp hugo_extended_0.110.0_Linux-64bit/hugo hugo/hugo-0.110
-          cp hugo_extended_0.83.0_Linux-64bit/hugo hugo/hugo-0.83
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/site/README.md
+++ b/site/README.md
@@ -80,13 +80,11 @@ pip -m venv venv
 pip install -r requirements.txt
 ```
 
-The documentation site includes both old and new releases. Because of this,
-you will need tooling for all these releases. Currently, it means you need
-in your environment:
-- `hugo-0.110` - for new docs
-- `hugo-0.83` - for older docs
+The documentation site includes both old and new releases. Since we now only build
+the 6 most recent releases, you only need:
+- `hugo-0.110` - for all documentation builds
 
-Please download these hugo releases (both extended), and make such binaries
+Please download this hugo release (extended), and make the binary
 available in your `PATH` environment variable.
 
 On Linux, you can install it this way:
@@ -96,11 +94,6 @@ wget https://github.com/gohugoio/hugo/releases/download/v0.110.0/hugo_extended_0
 (mkdir hugo_extended_0.110.0_Linux-64bit && tar -xf hugo_extended_0.110.0_Linux-64bit.tar.gz -C hugo_extended_0.110.0_Linux-64bit)
 cd hugo_extended_0.110.0_Linux-64bit
 sudo cp hugo /usr/local/bin/hugo-0.110
-
-wget https://github.com/gohugoio/hugo/releases/download/v0.83.0/hugo_extended_0.83.0_Linux-64bit.tar.gz
-(mkdir hugo_extended_0.83.0_Linux-64bit && tar -xf hugo_extended_0.83.0_Linux-64bit.tar.gz -C hugo_extended_0.83.0_Linux-64bit)
-cd hugo_extended_0.83.0_Linux-64bit
-sudo cp hugo /usr/local/bin/hugo-0.83
 ```
 
 2. Use the commands that generate a static site in the `public/` folder:

--- a/site/README.md
+++ b/site/README.md
@@ -80,8 +80,8 @@ pip -m venv venv
 pip install -r requirements.txt
 ```
 
-The documentation site includes both old and new releases. Since we now only build
-the 6 most recent releases, you only need:
+The documentation site includes the last MAX_VERSIONS_TO_BUILD releases
+(they are defined in `build_docs.py`). To build the website, you only need:
 - `hugo-0.110` - for all documentation builds
 
 Please download this hugo release (extended), and make the binary
@@ -110,6 +110,11 @@ The resulting folder contains the whole site, which can be published by a server
 Read more [here](https://www.docsy.dev/docs/getting-started/)
 and [here](https://gohugo.io/hosting-and-deployment/).
 
+You can also deploy the website locally:
+```bash
+python -m http.server -d path/to/public
+```
+
 ### How to update the submodule of the Docsy theme
 
 To update the submodule of the docsy theme, you need to have a repository clone.
@@ -121,7 +126,7 @@ git submodule update --remote
 
 Add and then commit the change to project:
 
-```bash
+```bashs
 git add themes/
 git commit -m "Updating theme submodule"
 ```

--- a/site/README.md
+++ b/site/README.md
@@ -126,7 +126,7 @@ git submodule update --remote
 
 Add and then commit the change to project:
 
-```bashs
+```bash
 git add themes/
 git commit -m "Updating theme submodule"
 ```

--- a/site/build_docs.py
+++ b/site/build_docs.py
@@ -30,7 +30,9 @@ def prepare_tags(repo: git.Repo):
         tag_version = version.parse(tag.name)
         if not tag_version.is_prerelease:
             minor_key = (tag_version.major, tag_version.minor)
-            if minor_key not in minor_versions or tag_version > version.parse(minor_versions[minor_key].name):
+            if minor_key not in minor_versions or tag_version > version.parse(
+                minor_versions[minor_key].name
+            ):
                 minor_versions[minor_key] = tag
 
     # Sort minor versions by version in descending order (newest first)

--- a/site/build_docs.py
+++ b/site/build_docs.py
@@ -16,29 +16,19 @@ import git
 import toml
 from packaging import version
 
-# the initial version for the documentation site
-MINIMUM_VERSION = version.Version("1.5.0")
-
 # Number of most recent tags to build documentation for
 MAX_VERSIONS_TO_BUILD = 6
 
-# apply new hugo version starting from release 2.9.2
-UPDATED_HUGO_FROM = version.Version("2.9.2")
-
-# Start the name with HUGO_ for Hugo default security checks
-VERSION_URL_ENV_VAR = "HUGO_VERSION_REL_URL"
-
-# Hugo binaries for different versions
-hugo110 = "hugo-0.110"  # required for new docs
-hugo83 = "hugo-0.83"  # required for older docs
+# Hugo binary for documentation builds
+hugo110 = "hugo-0.110"  # used for all documentation builds
 
 
 def prepare_tags(repo: git.Repo):
-    # Get all non-prerelease tags that meet minimum version requirement
+    # Get all non-prerelease tags
     valid_tags = []
     for tag in repo.tags:
         tag_version = version.parse(tag.name)
-        if tag_version >= MINIMUM_VERSION and not tag_version.is_prerelease:
+        if not tag_version.is_prerelease:
             valid_tags.append(tag)
 
     # Sort tags by version in descending order (newest first)
@@ -102,15 +92,8 @@ def generate_docs(repo: git.Repo, output_dir: os.PathLike, tags):
         def run_hugo(
             destination_dir: os.PathLike,
             *,
-            extra_env_vars: dict[str, str] = None,
             executable: Optional[str] = "hugo",
         ):
-            extra_kwargs = {}
-
-            if extra_env_vars:
-                extra_kwargs["env"] = os.environ.copy()
-                extra_kwargs["env"].update(extra_env_vars)
-
             subprocess.run(  # nosec
                 [
                     executable,
@@ -121,7 +104,6 @@ def generate_docs(repo: git.Repo, output_dir: os.PathLike, tags):
                 ],
                 cwd=content_loc,
                 check=True,
-                **extra_kwargs,
             )
 
         versioning_toml_path = content_loc / "versioning.toml"
@@ -144,24 +126,19 @@ def generate_docs(repo: git.Repo, output_dir: os.PathLike, tags):
             change_version_menu_toml(versioning_toml_path, tag.name)
             run_npm_install()
 
-            # find correct hugo version
-            hugo = hugo110 if version.parse(tag.name) >= UPDATED_HUGO_FROM else hugo83
-
+            # Use hugo110 for all recent versions (since we only build the last MAX_VERSIONS_TO_BUILD tags)
             run_hugo(
                 output_dir / tag.name,
-                # This variable is no longer needed by the current version,
-                # but it was required in v2.11.2 and older.
-                extra_env_vars={VERSION_URL_ENV_VAR: f"/{tag.name}/docs"},
-                executable=hugo,
+                executable=hugo110,
             )
 
 
 def validate_env():
-    for hugo in [hugo83, hugo110]:
-        try:
-            subprocess.run([hugo, "version"], capture_output=True)  # nosec
-        except (subprocess.CalledProcessError, FileNotFoundError) as ex:
-            raise Exception(f"Failed to run '{hugo}', please make sure it exists.") from ex
+    # Only validate hugo110 since we use it for all builds now
+    try:
+        subprocess.run([hugo110, "version"], capture_output=True)  # nosec
+    except (subprocess.CalledProcessError, FileNotFoundError) as ex:
+        raise Exception(f"Failed to run '{hugo110}', please make sure it exists.") from ex
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Currently, we build the documentation for every repository tag starting from 1.5.0. This results in large list of the versions which do not differ too much between themselves. The drop-down menu in the website overflows the visible area at this point.
This PR limits the number of versions to 6 (changeable in `build_docs.py`). It also reverses the versions, so in the drop-down menu on the website, the versions go from the latest to the earliest top-down.

So far, the main blog had only one link to old version documetation, and it is changed now. I hope there are no other links to the old versions, so nothing is broken with this PR.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

- Run the website as for production (see site/README.md for instructions). Deploy with `python -m http.server -d <...>/public`
- Open the website
- Open the drop-down menu for versions. The menu should contain the six latest versions.
![image](https://github.com/user-attachments/assets/fb80d8c3-be26-4ebb-8a0b-836dd2a43fe7)


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
