### PR TITLE
Optimized fetching of shapes and tracks

### DIFF
--- a/changelog.d/20250704_141107_sekachev.bs_optimized_attributes.md
+++ b/changelog.d/20250704_141107_sekachev.bs_optimized_attributes.md
@@ -1,5 +1,5 @@
 ### Fixed
 
 - Optimized database queries for attribute value removal.
-Replaced inefficient queries that caused sequential scans of large tables, improving performance and scalability
-(<https://github.com/cvat-ai/cvat/pull/9606>)
+ Replaced inefficient queries that caused sequential scans of large tables,
+ improving performance and scalability (<https://github.com/cvat-ai/cvat/pull/9606>)

--- a/changelog.d/20250704_141107_sekachev.bs_optimized_attributes.md
+++ b/changelog.d/20250704_141107_sekachev.bs_optimized_attributes.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Optimized database queries for attribute value removal.
+Replaced inefficient queries that caused sequential scans of large tables, improving performance and scalability
+(<https://github.com/cvat-ai/cvat/pull/9606>)

--- a/changelog.d/20250704_141107_sekachev.bs_optimized_attributes.md
+++ b/changelog.d/20250704_141107_sekachev.bs_optimized_attributes.md
@@ -1,5 +1,5 @@
 ### Fixed
 
 - Optimized database queries for attribute value removal.
- Replaced inefficient queries that caused sequential scans of large tables,
- improving performance and scalability (<https://github.com/cvat-ai/cvat/pull/9606>)
+    Replaced inefficient queries that caused sequential scans of large tables,
+    improving performance and scalability (<https://github.com/cvat-ai/cvat/pull/9606>)

--- a/changelog.d/20250707_060201_sekachev.bs_optimized_attributes_2.md
+++ b/changelog.d/20250707_060201_sekachev.bs_optimized_attributes_2.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Optimized query performance of retrieving shapes/tags from the database
+  (<https://github.com/cvat-ai/cvat/pull/9609>)

--- a/cvat/apps/consensus/merging_manager.py
+++ b/cvat/apps/consensus/merging_manager.py
@@ -127,7 +127,7 @@ class _TaskMerger:
         # imported annotations
         clear_annotations_in_jobs(
             [parent_job_id],
-            (self._task.project or self._task)
+            attr_ids=(self._task.project or self._task)
             .get_attributes(only_parent=False)
             .values_list("id", flat=True),
         )

--- a/cvat/apps/consensus/merging_manager.py
+++ b/cvat/apps/consensus/merging_manager.py
@@ -128,7 +128,8 @@ class _TaskMerger:
         clear_annotations_in_jobs(
             [parent_job_id],
             (self._task.project or self._task)
-                .get_attributes(only_parent=False).values_list("id", flat=True),
+            .get_attributes(only_parent=False)
+            .values_list("id", flat=True),
         )
 
         parent_job_data_provider = JobDataProvider(parent_job_id)

--- a/cvat/apps/consensus/merging_manager.py
+++ b/cvat/apps/consensus/merging_manager.py
@@ -125,7 +125,11 @@ class _TaskMerger:
         # will be appended to the existing annotations, and thus updated annotation
         # would have both existing + imported annotations, but we only want the
         # imported annotations
-        clear_annotations_in_jobs([parent_job_id])
+        clear_annotations_in_jobs(
+            [parent_job_id],
+            (self._task.project or self._task)
+                .get_attributes(only_parent=False).values_list("id", flat=True),
+        )
 
         parent_job_data_provider = JobDataProvider(parent_job_id)
 

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -529,7 +529,7 @@ class JobAnnotation:
             self.init_from_db()
             deleted_data = self.data
             attr_ids = self.db_job.get_attributes(only_parent=False).values_list("id", flat=True)
-            models.clear_annotations_in_jobs([self.db_job.id], attr_ids)
+            models.clear_annotations_in_jobs([self.db_job.id], attr_ids=attr_ids)
         else:
             labeledimage_ids = [image["id"] for image in data["tags"]]
             labeledshape_ids = [shape["id"] for shape in data["shapes"]]

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -528,7 +528,8 @@ class JobAnnotation:
         if data is None:
             self.init_from_db()
             deleted_data = self.data
-            models.clear_annotations_in_jobs([self.db_job.id])
+            attr_ids = self.db_job.get_attributes(only_parent=False).values_list("id", flat=True)
+            models.clear_annotations_in_jobs([self.db_job.id], attr_ids)
         else:
             labeledimage_ids = [image["id"] for image in data["tags"]]
             labeledshape_ids = [shape["id"] for shape in data["shapes"]]

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -577,35 +577,36 @@ class JobAnnotation:
                 )
 
     def _init_tags_from_db(self):
-        # NOTE: do not use .prefetch_related() with .values() since it's useless:
-        # https://github.com/cvat-ai/cvat/pull/7748#issuecomment-2063695007
-        db_tags = (
-            self.db_job.labeledimage_set.values(
-                "id",
-                "frame",
-                "label_id",
-                "group",
-                "source",
-                "attribute__spec_id",
-                "attribute__value",
-                "attribute__id",
-            )
-            .order_by("frame")
-            .iterator(chunk_size=2000)
-        )
+        db_tags = {}
+        with transaction.atomic(savepoint=False):
+            db_tags = {
+                row["id"]: dotdict(row, attributes=[])
+                for row in self.db_job.labeledimage_set.values(
+                    "id",
+                    "frame",
+                    "label_id",
+                    "group",
+                    "source",
+                )
+                .order_by("frame")
+                .iterator(chunk_size=5000)
+            }
 
-        db_tags = merge_table_rows(
-            rows=db_tags,
-            keys_for_merge={
-                "attributes": [
-                    "attribute__spec_id",
-                    "attribute__value",
-                    "attribute__id",
-                ],
-            },
-            field_id="id",
-        )
+            for attr in models.LabeledImageAttributeVal.objects.filter(
+                spec__in=self.db_job.get_attributes(only_parent=False),
+                image__in=self.db_job.labeledimage_set.all(),
+            ).values(
+                "image_id", "spec_id", "value", "id",
+            ).iterator(chunk_size=5000):
+                db_tags[attr["image_id"]]["attributes"].append(
+                    dotdict({
+                        "id": attr["id"],
+                        "spec_id": attr["spec_id"],
+                        "value": attr["value"],
+                    })
+                )
 
+        db_tags = list(db_tags.values())
         for db_tag in db_tags:
             self._extend_attributes(
                 db_tag.attributes, self.db_attributes[db_tag.label_id]["all"].values()
@@ -615,45 +616,45 @@ class JobAnnotation:
         self.ir_data.tags = serializer.data
 
     def _init_shapes_from_db(self):
-        # NOTE: do not use .prefetch_related() with .values() since it's useless:
-        # https://github.com/cvat-ai/cvat/pull/7748#issuecomment-2063695007
-        db_shapes = (
-            self.db_job.labeledshape_set.values(
-                "id",
-                "label_id",
-                "type",
-                "frame",
-                "group",
-                "source",
-                "occluded",
-                "outside",
-                "z_order",
-                "rotation",
-                "points",
-                "parent",
-                "attribute__spec_id",
-                "attribute__value",
-                "attribute__id",
-            )
-            .order_by("frame")
-            .iterator(chunk_size=2000)
-        )
+        db_shapes = {}
+        with transaction.atomic(savepoint=False):
+            db_shapes = {
+                row["id"]: dotdict(row, attributes=[])
+                for row in self.db_job.labeledshape_set.values(
+                    "id",
+                    "label_id",
+                    "type",
+                    "frame",
+                    "group",
+                    "source",
+                    "occluded",
+                    "outside",
+                    "z_order",
+                    "rotation",
+                    "points",
+                    "parent",
+                )
+                .order_by("frame")
+                .iterator(chunk_size=5000)
+            }
 
-        db_shapes = merge_table_rows(
-            rows=db_shapes,
-            keys_for_merge={
-                "attributes": [
-                    "attribute__spec_id",
-                    "attribute__value",
-                    "attribute__id",
-                ],
-            },
-            field_id="id",
-        )
+            for attr in models.LabeledShapeAttributeVal.objects.filter(
+                spec__in=self.db_job.get_attributes(only_parent=False),
+                shape__in=self.db_job.labeledshape_set.all(),
+            ).values(
+                "shape_id", "spec_id", "value", "id",
+            ).iterator(chunk_size=5000):
+                db_shapes[attr["shape_id"]]["attributes"].append(
+                    dotdict({
+                        "id": attr["id"],
+                        "spec_id": attr["spec_id"],
+                        "value": attr["value"],
+                    })
+                )
 
         shapes = {}
         elements = {}
-        for db_shape in db_shapes:
+        for db_shape in db_shapes.values():
             self._extend_attributes(
                 db_shape.attributes, self.db_attributes[db_shape.label_id]["all"].values()
             )

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -592,18 +592,27 @@ class JobAnnotation:
                 .iterator(chunk_size=5000)
             }
 
-            for attr in models.LabeledImageAttributeVal.objects.filter(
-                spec__in=self.db_job.get_attributes(only_parent=False),
-                image__in=self.db_job.labeledimage_set.all(),
-            ).values(
-                "image_id", "spec_id", "value", "id",
-            ).iterator(chunk_size=5000):
+            for attr in (
+                models.LabeledImageAttributeVal.objects.filter(
+                    spec__in=self.db_job.get_attributes(only_parent=False),
+                    image__in=self.db_job.labeledimage_set.all(),
+                )
+                .values(
+                    "image_id",
+                    "spec_id",
+                    "value",
+                    "id",
+                )
+                .iterator(chunk_size=5000)
+            ):
                 db_tags[attr["image_id"]]["attributes"].append(
-                    dotdict({
-                        "id": attr["id"],
-                        "spec_id": attr["spec_id"],
-                        "value": attr["value"],
-                    })
+                    dotdict(
+                        {
+                            "id": attr["id"],
+                            "spec_id": attr["spec_id"],
+                            "value": attr["value"],
+                        }
+                    )
                 )
 
         db_tags = list(db_tags.values())
@@ -638,18 +647,27 @@ class JobAnnotation:
                 .iterator(chunk_size=5000)
             }
 
-            for attr in models.LabeledShapeAttributeVal.objects.filter(
-                spec__in=self.db_job.get_attributes(only_parent=False),
-                shape__in=self.db_job.labeledshape_set.all(),
-            ).values(
-                "shape_id", "spec_id", "value", "id",
-            ).iterator(chunk_size=5000):
+            for attr in (
+                models.LabeledShapeAttributeVal.objects.filter(
+                    spec__in=self.db_job.get_attributes(only_parent=False),
+                    shape__in=self.db_job.labeledshape_set.all(),
+                )
+                .values(
+                    "shape_id",
+                    "spec_id",
+                    "value",
+                    "id",
+                )
+                .iterator(chunk_size=5000)
+            ):
                 db_shapes[attr["shape_id"]]["attributes"].append(
-                    dotdict({
-                        "id": attr["id"],
-                        "spec_id": attr["spec_id"],
-                        "value": attr["value"],
-                    })
+                    dotdict(
+                        {
+                            "id": attr["id"],
+                            "spec_id": attr["spec_id"],
+                            "value": attr["value"],
+                        }
+                    )
                 )
 
         shapes = {}

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -654,7 +654,7 @@ class Task(TimestampedModel, FileSystemRelatedModel):
         return _get_labels(self.project or self, prefetch=prefetch, only_parent=only_parent)
 
     def get_attributes(self, only_parent=True) -> models.QuerySet[AttributeSpec]:
-        return _get_attributes(self, only_parent=only_parent)
+        return _get_attributes(self.project or self, only_parent=only_parent)
 
     def get_dirname(self) -> str:
         return os.path.join(settings.TASKS_ROOT, str(self.id))

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -457,7 +457,7 @@ class FileSystemRelatedModel(metaclass=ABCModelMeta):
 
 
 @transaction.atomic(savepoint=False)
-def clear_annotations_in_jobs(job_ids: Iterable[int], attrspec_ids: list[int]):
+def clear_annotations_in_jobs(job_ids: Iterable[int], attrspec_ids: models.QuerySet[list[int]]):
     # attrspec_ids helps to efficiently remove the following models:
     # LabeledImageAttributeVal, LabeledShapeAttributeVal, LabeledTrackAttributeVal, TrackedShapeAttributeVal
     # Before the database needs to join on two large tables (e.g. for LabeledShape):

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -526,7 +526,7 @@ def _get_labels(resource: Project | Task, prefetch: bool, only_parent: bool) -> 
     return queryset
 
 def _get_attributes(resource: Project | Task, only_parent: bool) -> models.QuerySet[AttributeSpec]:
-    return _get_labels(resource, prefetch=False, only_parent=only_parent)
+    return AttributeSpec.objects.filter(label__in=_get_labels(resource, prefetch=False, only_parent=only_parent))
 
 class Project(TimestampedModel, FileSystemRelatedModel):
     name = SafeCharField(max_length=256)


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

Depends on #9606

### Motivation and context
Implementation before generates CURSOR with the following query:

```
SELECT "engine_labeledshape"."id",
       "engine_labeledshape"."label_id",
       "engine_labeledshape"."type",
       "engine_labeledshape"."frame",
       "engine_labeledshape"."group",
       "engine_labeledshape"."source",
       "engine_labeledshape"."occluded",
       "engine_labeledshape"."outside",
       "engine_labeledshape"."z_order",
       "engine_labeledshape"."rotation",
       "engine_labeledshape"."points",
       "engine_labeledshape"."parent_id",
       "engine_labeledshapeattributeval"."spec_id",
       "engine_labeledshapeattributeval"."value",
       "engine_labeledshapeattributeval"."id"
FROM "engine_labeledshape"
LEFT OUTER JOIN "engine_labeledshapeattributeval" ON ("engine_labeledshape"."id" = "engine_labeledshapeattributeval"."shape_id")
WHERE "engine_labeledshape"."job_id" = 2639313
ORDER BY "engine_labeledshape"."frame" ASC
```

Which based on left join and leads to seq scan of the table:

```
Sort  (cost=3634774.78..3634841.38 rows=26641 width=234) (actual time=38497.664..38499.381 rows=12000 loops=1)
   Sort Key: engine_labeledshape.frame
   Sort Method: quicksort  Memory: 12572kB
   ->  Hash Right Join  (cost=30555.68..3632816.49 rows=26641 width=234) (actual time=13510.315..38492.097 rows=12000 loops=1)
         Hash Cond: (engine_labeledshapeattributeval.shape_id = engine_labeledshape.id)
         ->  Seq Scan on engine_labeledshapeattributeval  (cost=0.00..3134215.55 rows=178302955 width=29) (actual time=0.034..18147.832 rows=178338113 loops=1)
         ->  Hash  (cost=30222.67..30222.67 rows=26641 width=213) (actual time=2.713..2.714 rows=3000 loops=1)
               Buckets: 32768  Batches: 1  Memory Usage: 3220kB
               ->  Index Scan using engine_labeledshape_job_id_b7694c3a on engine_labeledshape  (cost=0.57..30222.67 rows=26641 width=213) (actual time=0.017..1.343 rows=3000 loops=1)
                     Index Cond: (job_id = 2639313)
 Planning Time: 0.247 ms
 Execution Time: 38499.927 ms
```

Instead, it is better to make two queries:


```
SELECT "engine_labeledshape"."id",
       "engine_labeledshape"."label_id",
       "engine_labeledshape"."type",
       "engine_labeledshape"."frame",
       "engine_labeledshape"."group",
       "engine_labeledshape"."source",
       "engine_labeledshape"."occluded",
       "engine_labeledshape"."outside",
       "engine_labeledshape"."z_order",
       "engine_labeledshape"."rotation",
       "engine_labeledshape"."points",
       "engine_labeledshape"."parent_id"
FROM "engine_labeledshape"
WHERE "engine_labeledshape"."job_id" = 2639313
ORDER BY "engine_labeledshape"."frame" ASC
```

with query plan:
```
Sort  (cost=32180.96..32247.56 rows=26641 width=213) (actual time=2.373..2.592 rows=3000 loops=1)
   Sort Key: frame
   Sort Method: quicksort  Memory: 3097kB
   ->  Index Scan using engine_labeledshape_job_id_b7694c3a on engine_labeledshape  (cost=0.57..30222.67 rows=26641 width=213) (actual time=0.031..1.344 rows=3000 loops=1)
         Index Cond: (job_id = 2639313)
 Planning Time: 0.093 ms
 Execution Time: 2.742 ms
```

AND

```
SELECT "engine_labeledshapeattributeval"."shape_id",
       "engine_labeledshapeattributeval"."spec_id",
       "engine_labeledshapeattributeval"."value",
       "engine_labeledshapeattributeval"."id"
FROM "engine_labeledshapeattributeval"
WHERE ("engine_labeledshapeattributeval"."shape_id" IN
         (SELECT U0."id"
          FROM "engine_labeledshape" U0
          WHERE U0."job_id" = 2639313)
       AND "engine_labeledshapeattributeval"."spec_id" IN
         (SELECT V0."id"
          FROM "engine_attributespec" V0
          WHERE V0."label_id" IN
              (SELECT U0."id"
               FROM "engine_label" U0
               WHERE U0."project_id" = 291299)))
```

with query plan:

```
Nested Loop  (cost=495.34..500816.96 rows=1 width=29) (actual time=50.782..181.421 rows=12000 loops=1)
   ->  Nested Loop  (cost=494.77..474328.18 rows=3408 width=29) (actual time=1.039..27.779 rows=63200 loops=1)
         ->  HashAggregate  (cost=494.20..494.32 rows=12 width=4) (actual time=0.041..0.063 rows=16 loops=1)
               Group Key: v0.id
               Batches: 1  Memory Usage: 24kB
               ->  Nested Loop  (cost=0.85..494.17 rows=12 width=4) (actual time=0.020..0.034 rows=16 loops=1)
                     ->  Index Scan using engine_label_project_id_7f02a656 on engine_label u0_1  (cost=0.43..31.96 rows=47 width=4) (actual time=0.010..0.011 rows=4 loops=1)
                           Index Cond: (project_id = 291299)
                     ->  Index Scan using engine_attributespec_label_id_274838ef on engine_attributespec v0  (cost=0.42..9.78 rows=5 width=8) (actual time=0.003..0.004 rows=4 loops=4)
                           Index Cond: (label_id = u0_1.id)
         ->  Index Scan using engine_labeledshapeattributeval_spec_id_144b73fa on engine_labeledshapeattributeval  (cost=0.57..39350.03 rows=13613 width=29) (actual time=0.127..1.213 rows=3950 loops=16)
               Index Cond: (spec_id = v0.id)
   ->  Index Scan using engine_labeledshape_pkey on engine_labeledshape u0  (cost=0.57..7.77 rows=1 width=8) (actual time=0.002..0.002 rows=0 loops=63200)
         Index Cond: (id = engine_labeledshapeattributeval.shape_id)
         Filter: (job_id = 2639313)
         Rows Removed by Filter: 1
 Planning Time: 5.272 ms
 Execution Time: 182.001 ms
```


Total execution time on the same data is about 200 times less.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
