### PR TITLE
Removed extra transaction atomic

### DIFF
--- a/cvat/apps/dataset_manager/project.py
+++ b/cvat/apps/dataset_manager/project.py
@@ -39,14 +39,8 @@ def export_project(
     save_images: bool = False,
     temp_dir: str | None = None,
 ):
-    # For big tasks dump function may run for a long time and
-    # we dont need to acquire lock after the task has been initialized from DB.
-    # But there is the bug with corrupted dump file in case 2 or
-    # more dump request received at the same time:
-    # https://github.com/cvat-ai/cvat/issues/217
-    with transaction.atomic():
-        project = ProjectAnnotationAndData(project_id)
-        project.init_from_db()
+    project = ProjectAnnotationAndData(project_id)
+    project.init_from_db()
 
     exporter = make_exporter(format_name)
     with open(dst_file, "wb") as f:

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -1170,14 +1170,8 @@ def export_task(
     save_images: bool = False,
     temp_dir: str | None = None,
 ):
-    # For big tasks dump function may run for a long time and
-    # we dont need to acquire lock after the task has been initialized from DB.
-    # But there is the bug with corrupted dump file in case 2 or
-    # more dump request received at the same time:
-    # https://github.com/cvat-ai/cvat/issues/217
-    with transaction.atomic():
-        task = TaskAnnotation(task_id)
-        task.init_from_db()
+    task = TaskAnnotation(task_id)
+    task.init_from_db()
 
     exporter = make_exporter(format_name)
     with open(dst_file, "wb") as f:

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -1108,14 +1108,8 @@ def export_job(
     save_images=False,
     temp_dir: str | None = None,
 ):
-    # For big tasks dump function may run for a long time and
-    # we dont need to acquire lock after the task has been initialized from DB.
-    # But there is the bug with corrupted dump file in case 2 or
-    # more dump request received at the same time:
-    # https://github.com/cvat-ai/cvat/issues/217
-    with transaction.atomic():
-        job = JobAnnotation(job_id, prefetch_images=True, lock_job_in_db=True)
-        job.init_from_db()
+    job = JobAnnotation(job_id, prefetch_images=True, lock_job_in_db=True)
+    job.init_from_db()
 
     exporter = make_exporter(format_name)
     with open(dst_file, "wb") as f:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
I do not think we need atomic transaction during project/task/job export as it only reads data from the database.
At the same time, it leads to locks in database.
During export we use cursor to iterate over annotations in the database. While cursor is active, users can't update any Task in the project (e.g. updated date), or Data object (e.g. deleted_frames), etc, as corresponding tuples are locked via ForeignKeys 

<img width="1754" alt="image" src="https://github.com/user-attachments/assets/8b7598cd-6cae-428c-b948-1166e958c9c3" />
<img width="649" alt="image" src="https://github.com/user-attachments/assets/c6bf3316-f42a-4bae-956a-31223fd339f2" />
<img width="1340" alt="image" src="https://github.com/user-attachments/assets/318d8dae-4f96-46c9-aa6d-b0b65a30118d" />
 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
