### PR TITLE
Fix test on creating new organization pipeline

### DIFF
--- a/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
+++ b/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
@@ -283,6 +283,7 @@ context('New organization pipeline.', () => {
 
         it('The owner of the organization removes the second user from it.', () => {
             cy.headlessLogin(makeLoginUser(firstUser));
+            cy.contains(firstUser.username).should('exist').and('be.visible');
             cy.activateOrganization(organizationParams.shortName);
             cy.openOrganization(organizationParams.shortName);
             cy.removeMemberFromOrganization(secondUserName);


### PR DESCRIPTION
### Motivation and context

Test `cypress/e2e/features/case_113_new_organization_pipeline.js` fails too much in our CI
Examples: [1](https://github.com/cvat-ai/cvat/actions/runs/16305366557/job/46050308820), [2](https://github.com/cvat-ai/cvat/actions/runs/15936847174/job/44958464729)

### What was the error?

Logs:

```New organization pipeline.
    Testing case "113"
      ✓ The first user creates an organization and activates it. (11576ms)
      ✓ Open the organization settings. Invite members. (2954ms)
      ✓ Search within organizations: All members shoould be queryable (1099ms)
      ✓ Search within organizations: Filters work correctly (517ms)
      ✓ Create a project, create a task. Deactivate organization. (12991ms)
      ✓ The project, the task are invisible now. (13

9ms)
      ✓ Admin tries to leave from organization (not successfully because he is not a member of it). (4046ms)
      ✓ The second user login. The user is able to see the organization, can't see the task. (2295ms)
      ✓ The second user activates the organization, can't see the project because it is not assigned to him. (2052ms)
      ✓ The first user login. Assign the project to the second user. (4643ms)
      ✓ The second user login. Now he sees the project and can open it. (3878ms)
      ✓ Open the task, assign one of jobs to the third user. Rename the task. (2272ms)
      ✓ Logout, the third user login. The user does not see the project, the task. (1488ms)
      ✓ User can open the job using direct link. Organization is set automatically. Create an object, save annotations. (5226ms)
      1) The owner of the organization removes the second user from it.
      2) The organization, project, task is no longer available to the second user.
      ✓ Logout. Remove the first, the second user (deletion occurs from user admin). (476ms)
      ✓ Login as the third user. The organization page can be opened. The job can be opened. (7343ms)


  16 passing (2m)
  2 failing

  1) New organization pipeline.
       Testing case "113"
         The owner of the organization removes the second user from it.:

     CypressError: Timed out retrying after 25050ms: `cy.click()` failed because the page updated while this command was executing. Cypress tried to locate elements based on this query:

> <span.ant-dropdown-trigger.cvat-header-menu-user-dropdown>

We initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page. Common situations why this happens:
  - Your JS framework re-rendered asynchronously
  - Your app code reacted to an event firing and removed the element
  ...
```

#### Video: https://github.com/user-attachments/assets/62514072-9d0b-4935-b7c6-1359000cc68c
Fail at around 1:01

#### Reason
This fails because `.cvat-header-menu-user-dropdown` is clicked too soon: `cy.headlessLogin(makeLoginUser(firstUser));` navigates to `/tasks` and the dropdown is occasionally clicked on too soon before the page finishes loading. 

All the fails of this test have the same reason

#### Fix
A `cy.contains(<userName>)` to wait when the new dropdown with the new username gets rendered on the page.


### Checklist

- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
