### PR TITLE
Fix test of frame url creation in annotation view

### DIFF
--- a/tests/cypress/e2e/actions_tasks/case_102_create_link_shape_frame.js
+++ b/tests/cypress/e2e/actions_tasks/case_102_create_link_shape_frame.js
@@ -61,7 +61,8 @@ context('Create a link for shape, frame.', () => {
                     cy.spy(clipboard, 'writeText').as('copyTextToClipboard');
                 });
 
-            cy.get('.cvat-player-frame-url-icon').click();
+            cy.get('.cvat-player-frame-url-icon').click({ scrollBehavior: false });
+            cy.contains('Create frame URL').should('exist').and('be.visible'); // wait for tooltip
             cy.get('@copyTextToClipboard').should('be.called');
             cy.get('@copyTextToClipboard').then((stub) => {
                 const url = stub.args[0][0];


### PR DESCRIPTION
Fix a flaky clipboard test 

### Motivation and context

`cypress/e2e/actions_tasks/case_102_create_link_shape_frame.js` fails often in our CI, ex: [1](https://github.com/cvat-ai/cvat/actions/runs/15356615927/job/43217000996), [2](https://github.com/cvat-ai/cvat/actions/runs/15220022457/job/42813904209), [3](https://github.com/cvat-ai/cvat/actions/runs/15124133585/job/42512955325) and [more...](https://github.com/cvat-ai/cvat/actions/workflows/schedule.yml?page=3)


### What was the error?

https://github.com/user-attachments/assets/35a3728f-993b-4532-8891-146ac53db3da
Fail around 00:30 - clipboard spy is checked for events before cypress finishes scrolling into view - and the button is pressed only after scrolling. 

### Fix

Add a `{scrollBehavior: false}` on clicking. Also wait for the tooltip on the `copy-frame-url` button and click only after that.

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
