### PR TITLE
Fixed deletion cache on server level if request id is None

### DIFF
--- a/cvat/apps/events/cache.py
+++ b/cvat/apps/events/cache.py
@@ -4,20 +4,18 @@
 
 _caches = {}
 
+def _default_cache_value():
+    from cvat.apps.engine.models import Comment, Issue, Job, Task
+    return {
+        Task: {},
+        Job: {},
+        Issue: {},
+        Comment: {},
+    }
 
 class DeleteCache:
     def __init__(self, cache_id):
-        from cvat.apps.engine.models import Comment, Issue, Job, Task
-
-        self._cache = _caches.setdefault(
-            cache_id,
-            {
-                Task: {},
-                Job: {},
-                Issue: {},
-                Comment: {},
-            },
-        )
+        self._cache = _caches.setdefault(cache_id, _default_cache_value())
 
     def set(self, instance_class, instance_id, value):
         self._cache[instance_class][instance_id] = value
@@ -33,6 +31,7 @@ class DeleteCache:
 
     def clear(self):
         self._cache.clear()
+        self._cache.update(_default_cache_value())
 
 
 def get_cache():

--- a/cvat/apps/events/cache.py
+++ b/cvat/apps/events/cache.py
@@ -2,9 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
+from functools import cache
+
 _caches = {}
 
 
+@cache
 def _default_cache_value():
     from cvat.apps.engine.models import Comment, Issue, Job, Task
 

--- a/cvat/apps/events/cache.py
+++ b/cvat/apps/events/cache.py
@@ -4,14 +4,17 @@
 
 _caches = {}
 
+
 def _default_cache_value():
     from cvat.apps.engine.models import Comment, Issue, Job, Task
+
     return {
         Task: {},
         Job: {},
         Issue: {},
         Comment: {},
     }
+
 
 class DeleteCache:
     def __init__(self, cache_id):

--- a/cvat/apps/events/cache.py
+++ b/cvat/apps/events/cache.py
@@ -2,12 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-from functools import cache
-
 _caches = {}
 
 
-@cache
 def _default_cache_value():
     from cvat.apps.engine.models import Comment, Issue, Job, Task
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
- `request_id` used for getting cache may be None, what seems to be normal when deletion from shell or some workers. 
- after calling `cache.clear()` for the first time, it removes default value initialized in constructor
- further deletion from the same process/shell does not work

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
