### PR TITLE
parametrize fast batch of rest_api tests by cache 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,14 +235,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{
-            contains(matrix.pattern, 'not')
-              && 'allure-results-tests-api'
-              || format(
-                  'allure-results-tests-api-{0}-cache-{1}',
-                  matrix.pattern, matrix.allow_cache
-                )
-            }}
+          name: format(
+              'allure-results-tests-api-{0}-cache-{1}',
+              matrix.pattern,matrix.allow_cache
+            )
           path: tests/python/allure-results
 
   unit_testing:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,14 +195,10 @@ jobs:
       - name: Uploading code coverage results as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{
-            contains(matrix.pattern, 'not')
-              && 'coverage_results_rest_api'
-              || format(
-                  'coverage_results_rest_api-{0}-cache-{1}',
-                  matrix.pattern, matrix.allow_cache
-                )
-            }}
+          name: ${{format(
+            'coverage_results_rest_api-{0}-cache-{1}',
+            matrix.pattern, matrix.allow_cache
+            )}}
           path: |
             coverage*.json
 
@@ -221,24 +217,20 @@ jobs:
         if: failure() && steps.run_tests.conclusion == 'failure'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{
-            contains(matrix.pattern, 'not')
-              && 'rest_api_container_logs'
-              || format(
-                  'rest_api_container_logs-{0}-cache-{1}',
-                  matrix.pattern, matrix.allow_cache
-                )
-            }}
+          name: ${{format(
+              'rest_api_container_logs-{0}-cache-{1}',
+              matrix.pattern, matrix.allow_cache
+            )}}
           path: "${{ github.workspace }}/rest_api_testing"
 
       - name: Upload allure results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: format(
+          name: ${{format(
               'allure-results-tests-api-{0}-cache-{1}',
               matrix.pattern,matrix.allow_cache
-            )
+            )}}
           path: tests/python/allure-results
 
   unit_testing:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,6 +144,8 @@ jobs:
             allow_cache: 'no'
           - pattern: "not test_task_data"
             allow_cache: 'no'
+          - pattern: "not test_task_data"
+            allow_cache: 'true'
     name: rest_api_testing [${{ matrix.pattern }}, cache-${{ matrix.allow_cache }}]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation and context

Reproducibility of some bugs in dev wip is dependent on whether the `CVAT_ALLOW_STATIC_CACHE` is enabled. This PR adds an extra worker that runs the 'not test_task_data' tests with and without caching.

### How has this been tested?


### Checklist

- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
