### PR TITLE
Reset selection when clicking menu of non-selected element

### DIFF
--- a/cvat-ui/src/components/bulk-wrapper.tsx
+++ b/cvat-ui/src/components/bulk-wrapper.tsx
@@ -116,7 +116,9 @@ function BulkWrapper(props: Readonly<BulkWrapperProps>): JSX.Element {
                 'rc-virtual-list',
             ];
             const hasKeepClass = keepClasses.some((cls) => target.classList.contains(cls) || target.closest(`.${cls}`));
-            if (hasKeepClass) return;
+            if (hasKeepClass) {
+                return;
+            }
 
             const modal = document.querySelector('.ant-modal');
             if (modal && (modal as HTMLElement).offsetParent !== null) return;
@@ -202,18 +204,22 @@ function BulkWrapper(props: Readonly<BulkWrapperProps>): JSX.Element {
                 }
 
                 // Watch for click on menu inside the card
-                if (event) {
+                // Consider only selected items, if menu inside not selected card, selection will be reset
+                if (event && isSelected) {
                     const keepParentClasses = [
                         'cvat-actions-menu-button',
                         'ant-dropdown-menu',
                         'ant-select-selector',
                     ];
+
                     let hasAllowedParentClass = false;
                     let parent = (event.target as HTMLElement);
                     let depth = 0;
+
                     const hasParentClass = (element: HTMLElement | null): boolean => (
                         !!element && keepParentClasses.some((cls) => element.classList.contains(cls))
                     );
+
                     while (parent && depth < 5) {
                         if (hasParentClass(parent)) {
                             hasAllowedParentClass = true;
@@ -226,7 +232,10 @@ function BulkWrapper(props: Readonly<BulkWrapperProps>): JSX.Element {
                         }
                         depth += 1;
                     }
-                    if (hasAllowedParentClass) return true;
+
+                    if (hasAllowedParentClass) {
+                        return true;
+                    }
                 }
 
                 // Regular click: reset selection


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
There is a bug, e.g.:
1. Select two items
2. Click menu of non selected element
3. Menu will be opened as like the bulk action will be applied to two previous elements
4. However it will be applied only to the current (not selected)
5. I believe correct behaviour is to reset selection of previous elements in this case

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
