### PR TITLE
Make the server Docker image compatible with the k8s runAsNonRoot setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ COPY --from=build-smokescreen /tmp/smokescreen /usr/local/bin/smokescreen
 # Add a non-root user
 ENV USER=${USER}
 ENV HOME /home/${USER}
-RUN adduser --shell /bin/bash --disabled-password --gecos "" ${USER}
+RUN adduser --uid=1000 --shell /bin/bash --disabled-password --gecos "" ${USER}
 
 ARG CLAM_AV="no"
 RUN if [ "$CLAM_AV" = "yes" ]; then \
@@ -203,8 +203,9 @@ RUN if [ "${COVERAGE_PROCESS_START}" ]; then \
         echo "import coverage; coverage.process_startup()" > /opt/venv/lib/python3.10/site-packages/coverage_subprocess.pth; \
     fi
 
-# RUN all commands below as 'django' user
-USER ${USER}
+# RUN all commands below as 'django' user.
+# Use numeric UID/GID so that the image is compatible with the Kubernetes runAsNonRoot setting.
+USER 1000:1000
 WORKDIR ${HOME}
 
 RUN mkdir -p data share keys logs /tmp/supervisord static

--- a/changelog.d/20250821_170901_roman_non_root.md
+++ b/changelog.d/20250821_170901_roman_non_root.md
@@ -1,0 +1,5 @@
+### Changed
+
+- The cvat/server Docker image is now configured with a numeric UID
+  rather than a username
+  (<https://github.com/cvat-ai/cvat/pull/9743>)

--- a/helm-chart/templates/cvat_backend/initializer/job.yml
+++ b/helm-chart/templates/cvat_backend/initializer/job.yml
@@ -56,6 +56,8 @@ spec:
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          securityContext:
+            runAsNonRoot: true
       restartPolicy: OnFailure
       {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:

--- a/helm-chart/templates/cvat_backend/server/deployment.yml
+++ b/helm-chart/templates/cvat_backend/server/deployment.yml
@@ -93,6 +93,8 @@ spec:
           {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          securityContext:
+            runAsNonRoot: true
       initContainers:
         {{- if .Values.cvat.backend.permissionFix.enabled }}
         - name: user-data-permission-fix

--- a/helm-chart/templates/cvat_backend/worker_annotation/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_annotation/deployment.yml
@@ -82,6 +82,8 @@ spec:
           {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          securityContext:
+            runAsNonRoot: true
       initContainers:
         {{- if .Values.cvat.backend.permissionFix.enabled }}
         - name: user-data-permission-fix

--- a/helm-chart/templates/cvat_backend/worker_chunks/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_chunks/deployment.yml
@@ -73,6 +73,8 @@ spec:
           {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          securityContext:
+            runAsNonRoot: true
       {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}

--- a/helm-chart/templates/cvat_backend/worker_consensus/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_consensus/deployment.yml
@@ -67,6 +67,8 @@ spec:
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          securityContext:
+            runAsNonRoot: true
       {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}

--- a/helm-chart/templates/cvat_backend/worker_export/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_export/deployment.yml
@@ -82,6 +82,8 @@ spec:
           {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          securityContext:
+            runAsNonRoot: true
       initContainers:
         {{- if .Values.cvat.backend.permissionFix.enabled }}
         - name: user-data-permission-fix

--- a/helm-chart/templates/cvat_backend/worker_import/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_import/deployment.yml
@@ -82,6 +82,8 @@ spec:
           {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          securityContext:
+            runAsNonRoot: true
       initContainers:
         {{- if .Values.cvat.backend.permissionFix.enabled }}
         - name: user-data-permission-fix

--- a/helm-chart/templates/cvat_backend/worker_qualityreports/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_qualityreports/deployment.yml
@@ -67,6 +67,8 @@ spec:
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          securityContext:
+            runAsNonRoot: true
       {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}

--- a/helm-chart/templates/cvat_backend/worker_utils/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_utils/deployment.yml
@@ -83,6 +83,8 @@ spec:
           {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          securityContext:
+            runAsNonRoot: true
       initContainers:
         {{- if .Values.cvat.backend.permissionFix.enabled }}
         - name: user-data-permission-fix

--- a/helm-chart/templates/cvat_backend/worker_webhooks/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_webhooks/deployment.yml
@@ -67,6 +67,8 @@ spec:
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          securityContext:
+            runAsNonRoot: true
       {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
While the backend does not actually run as root, Kubernetes is unable to determine that from the username recorded in the Docker image. Fix it by using a numeric UID/GID. Also, set the UID explicitly when creating the user, to make sure it remains stable.

Add the setting itself to the Helm chart, so that we can verify that the change works.

A client requires this for their deployment, and it seems like a useful thing to implement in general.

Note that there are several other containers in the Helm chart that are still incompatible with `runAsNonRoot` (including ones that actually run as root). I plan to deal with those separately.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
