### PR TITLE
Remove seed parameter in GT job creation

### DIFF
--- a/cvat-ui/src/actions/jobs-actions.ts
+++ b/cvat-ui/src/actions/jobs-actions.ts
@@ -117,7 +117,7 @@ export const createJobAsync = (data: JobData): ThunkAction<Promise<Job>> => asyn
     try {
         const extras = {
             frame_selection_method: data.frameSelectionMethod,
-            seed: data.seed,
+            random_seed: data.randomSeed,
             frame_count: data.frameCount,
             frames_per_job_count: data.framesPerJobCount,
         };

--- a/cvat-ui/src/components/create-job-page/job-form.tsx
+++ b/cvat-ui/src/components/create-job-page/job-form.tsx
@@ -29,7 +29,7 @@ interface JobDataMutual {
     taskID: number;
     frameSelectionMethod: FrameSelectionMethod;
     type: JobType;
-    seed?: number;
+    randomSeed?: number;
 }
 
 export interface JobData extends JobDataMutual {
@@ -64,7 +64,7 @@ function JobForm(props: Props): JSX.Element {
                 taskID: task.id,
                 frameSelectionMethod: values.frameSelectionMethod,
                 type: values.type,
-                seed: values.seed,
+                randomSeed: values.randomSeed,
                 ...(values.frameSelectionMethod === FrameSelectionMethod.RANDOM ?
                     { frameCount: values.frameCount } : { framesPerJobCount: values.frameCount }
                 ),
@@ -230,7 +230,7 @@ function JobForm(props: Props): JSX.Element {
                             </Col>
                             <Col>
                                 <Form.Item
-                                    name='seed'
+                                    name='randomSeed'
                                     label='Seed'
                                 >
                                     <InputNumber

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -8194,10 +8194,6 @@ components:
             The same value will produce the same frame sets.
             Applicable only to random frame selection methods.
             By default, a random value is used.
-        seed:
-          type: integer
-          minimum: 0
-          description: Deprecated. Use random_seed instead.
         frames:
           type: array
           items:

--- a/tests/cypress/e2e/features/ground_truth_jobs.js
+++ b/tests/cypress/e2e/features/ground_truth_jobs.js
@@ -82,7 +82,7 @@ context('Ground truth jobs', () => {
     let taskID = null;
 
     // With seed = 1, frameCount = 4, totalFrames = 100 - predefined ground truth frames are:
-    const groundTruthFrames = [10, 23, 71, 87];
+    const groundTruthFrames = [10, 23, 72, 88];
 
     function checkRectangleAndObjectMenu(rectangle, isGroundTruthJob = false) {
         if (isGroundTruthJob) {
@@ -174,7 +174,7 @@ context('Ground truth jobs', () => {
             cy.createJob({
                 ...jobOptions,
                 frameCount: 4,
-                seed: 1,
+                randomSeed: 1,
             });
             cy.url().then((url) => {
                 groundTruthJobID = Number(url.split('/').slice(-1)[0].split('?')[0]);
@@ -436,7 +436,7 @@ context('Ground truth jobs', () => {
                     frame_count: 4,
                     type: 'ground_truth',
                     frame_selection_method: 'random_uniform',
-                    seed: 1,
+                    random_seed: 1,
                 }).then((jobResponse) => {
                     groundTruthJobID = jobResponse.jobID;
                     return cy.headlessCreateObjects(groundTruthFrames.map((frame, index) => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1546,7 +1546,7 @@ Cypress.Commands.add('createJob', (options = {
     frameSelectionMethod: 'Random',
     quantity: null,
     frameCount: null,
-    seed: null,
+    randomSeed: null,
     fromTaskPage: true,
 }) => {
     const {
@@ -1554,7 +1554,7 @@ Cypress.Commands.add('createJob', (options = {
         frameSelectionMethod,
         quantity,
         frameCount,
-        seed,
+        randomSeed,
         fromTaskPage,
     } = options;
 
@@ -1587,9 +1587,9 @@ Cypress.Commands.add('createJob', (options = {
         cy.get('.cvat-input-frame-count').type(frameCount);
     }
 
-    if (seed) {
+    if (randomSeed) {
         cy.get('.cvat-input-seed').clear();
-        cy.get('.cvat-input-seed').type(seed);
+        cy.get('.cvat-input-seed').type(randomSeed);
     }
 
     cy.contains('button', 'Submit').click();

--- a/tests/python/rest_api/test_jobs.py
+++ b/tests/python/rest_api/test_jobs.py
@@ -222,8 +222,8 @@ class TestPostJobs:
         [
             # The results have to be the same in different CVAT revisions,
             # so the task ids are fixed
-            (21, [3, 5, 7]),  # annotation task
-            (5, [11, 14, 20]),  # interpolation task
+            (21, [4, 6, 8]),  # annotation task
+            (5, [12, 15, 21]),  # interpolation task
         ],
     )
     def test_can_create_gt_job_with_random_frames_and_seed(self, admin_user, task_id, frame_ids):
@@ -233,7 +233,7 @@ class TestPostJobs:
             "type": "ground_truth",
             "frame_selection_method": "random_uniform",
             "frame_count": 3,
-            "seed": 42,
+            "random_seed": 42,
         }
 
         response = self._test_create_job_ok(user, job_spec)


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

There are 2 parameters in job creation: `seed` and `random_seed`. `seed` is the older one. It has a small implementation bug related to frame selection and it has been deprecated almost a year ago. The UI incorrectly uses the older parameter for the `random_per_job` frame selection method and this results in a server error. This change is expected to have a small impact on clients.

- Removed deprecated `seed` parameter in GT job creation in favor of newer `random_seed`
- Updated UI to use the `random_seed` parameter

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
