### PR TITLE
refactor: consolidate useSelector calls with shallowEqual

### DIFF
--- a/cvat-ui/src/components/project-page/project-page.tsx
+++ b/cvat-ui/src/components/project-page/project-page.tsx
@@ -59,8 +59,6 @@ export default function ProjectPageComponent(): JSX.Element {
     const id = +useParams<ParamType>().id;
     const dispatch = useDispatch();
     const history = useHistory();
-    const selectedCount = useSelector((state: CombinedState) => state.tasks.selected.length);
-    const bulkFetching = useSelector((state: CombinedState) => state.bulkActions.fetching);
 
     const [projectInstance, setProjectInstance] = useState<Project | null>(null);
     const [fechingProject, setFetchingProject] = useState(true);
@@ -74,6 +72,8 @@ export default function ProjectPageComponent(): JSX.Element {
         tasksQuery,
         tasksFetching,
         deletedTasks,
+        selectedCount,
+        bulkFetching,
     } = useSelector((state: CombinedState) => ({
         deletes: state.projects.activities.deletes,
         updates: state.projects.activities.updates,
@@ -82,6 +82,8 @@ export default function ProjectPageComponent(): JSX.Element {
         tasksQuery: state.projects.tasksGettingQuery,
         tasksFetching: state.tasks.fetching,
         deletedTasks: state.tasks.activities.deletes,
+        selectedCount: state.tasks.selected.length,
+        bulkFetching: state.bulkActions.fetching,
     }), shallowEqual);
     const [visibility, setVisibility] = useState(defaultVisibility);
 

--- a/cvat-ui/src/components/projects-page/project-list.tsx
+++ b/cvat-ui/src/components/projects-page/project-list.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Row, Col } from 'antd/lib/grid';
 import Pagination from 'antd/lib/pagination';
 
@@ -17,11 +17,19 @@ import ProjectItem from './project-item';
 
 export default function ProjectListComponent(): JSX.Element {
     const dispatch = useDispatch();
-    const projectsCount = useSelector((state: CombinedState) => state.projects.count);
-    const projects = useSelector((state: CombinedState) => state.projects.current);
-    const deletingProjects = useSelector((state: CombinedState) => state.projects.activities.deletes);
-    const gettingQuery = useSelector((state: CombinedState) => state.projects.gettingQuery);
-    const tasksQuery = useSelector((state: CombinedState) => state.projects.tasksGettingQuery);
+    const {
+        projectsCount,
+        projects,
+        deletingProjects,
+        gettingQuery,
+        tasksQuery,
+    } = useSelector((state: CombinedState) => ({
+        projectsCount: state.projects.count,
+        projects: state.projects.current,
+        deletingProjects: state.projects.activities.deletes,
+        gettingQuery: state.projects.gettingQuery,
+        tasksQuery: state.projects.tasksGettingQuery,
+    }), shallowEqual);
     const { page, pageSize } = gettingQuery;
 
     const changePage = useCallback((_page: number, _pageSize: number) => {

--- a/cvat-ui/src/components/projects-page/projects-page.tsx
+++ b/cvat-ui/src/components/projects-page/projects-page.tsx
@@ -6,7 +6,7 @@
 import './styles.scss';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import Spin from 'antd/lib/spin';
 import { CombinedState, ProjectsQuery, SelectedResourceType } from 'reducers';
 import { getProjectsAsync } from 'actions/projects-actions';
@@ -21,19 +21,31 @@ import ProjectListComponent from './project-list';
 export default function ProjectsPageComponent(): JSX.Element {
     const dispatch = useDispatch();
     const history = useHistory();
-    const fetching = useSelector((state: CombinedState) => state.projects.fetching);
-    const count = useSelector((state: CombinedState) => state.projects.current.length);
-    const query = useSelector((state: CombinedState) => state.projects.gettingQuery);
-    const tasksQuery = useSelector((state: CombinedState) => state.projects.tasksGettingQuery);
-    const importing = useSelector((state: CombinedState) => state.import.projects.backup.importing);
-    const bulkFetching = useSelector((state: CombinedState) => state.bulkActions.fetching);
+    const {
+        fetching,
+        count,
+        query,
+        tasksQuery,
+        importing,
+        bulkFetching,
+        allProjectIds,
+        deletedProjects,
+        selectedCount,
+    } = useSelector((state: CombinedState) => ({
+        fetching: state.projects.fetching,
+        count: state.projects.current.length,
+        query: state.projects.gettingQuery,
+        tasksQuery: state.projects.tasksGettingQuery,
+        importing: state.import.projects.backup.importing,
+        bulkFetching: state.bulkActions.fetching,
+        allProjectIds: state.projects.current.map((p) => p.id),
+        deletedProjects: state.projects.activities.deletes,
+        selectedCount: state.projects.selected.length,
+    }), shallowEqual);
     const [isMounted, setIsMounted] = useState(false);
     const isAnySearch = anySearch<ProjectsQuery>(query);
 
-    const allProjectIds = useSelector((state: CombinedState) => state.projects.current.map((p) => p.id));
-    const deletedProjects = useSelector((state: CombinedState) => state.projects.activities.deletes);
     const selectableProjectIds = allProjectIds.filter((id) => !deletedProjects[id]);
-    const selectedCount = useSelector((state: CombinedState) => state.projects.selected.length);
     const onSelectAll = useCallback(() => {
         dispatch(selectionActions.selectResources(selectableProjectIds, SelectedResourceType.PROJECTS));
     }, [selectableProjectIds]);

--- a/cvat-ui/src/components/requests-page/actions-menu.tsx
+++ b/cvat-ui/src/components/requests-page/actions-menu.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import Dropdown from 'antd/lib/dropdown';
 import { MenuProps } from 'antd/lib/menu';
 import { Request, RQStatus } from 'cvat-core-wrapper';
@@ -26,9 +26,11 @@ function RequestActionsComponent(props: Readonly<Props>): JSX.Element | null {
         renderTriggerIfEmpty = true,
     } = props;
     const dispatch = useDispatch();
-    const selectedIds = useSelector((state: CombinedState) => state.requests.selected);
-    const requestsMap = useSelector((state: CombinedState) => state.requests.requests);
-    const cancelled = useSelector((state: CombinedState) => state.requests.cancelled);
+    const { selectedIds, requestsMap, cancelled } = useSelector((state: CombinedState) => ({
+        selectedIds: state.requests.selected,
+        requestsMap: state.requests.requests,
+        cancelled: state.requests.cancelled,
+    }), shallowEqual);
     const allRequests = Object.values(requestsMap);
     const isCardMenu = !dropdownTrigger;
 

--- a/cvat-ui/src/components/requests-page/requests-list.tsx
+++ b/cvat-ui/src/components/requests-page/requests-list.tsx
@@ -34,14 +34,15 @@ function RequestsList(props: Readonly<Props>): JSX.Element {
     const dispatch = useDispatch();
     const { query, count } = props;
     const { page, pageSize } = query;
-    const { requests, cancelled } = useSelector((state: CombinedState) => ({
-        requests: state.requests.requests, cancelled: state.requests.cancelled,
+    const { requests, cancelled, selectedCount } = useSelector((state: CombinedState) => ({
+        requests: state.requests.requests,
+        cancelled: state.requests.cancelled,
+        selectedCount: state.requests.selected.length,
     }), shallowEqual);
 
     const requestList = Object.values(requests);
     const requestViews = setUpRequestsList(requestList, page, pageSize);
     const requestIds = requestViews.map((request) => request.id).filter((id) => !cancelled[id]);
-    const selectedCount = useSelector((state: CombinedState) => state.requests.selected.length);
     const onSelectAll = useCallback(() => {
         dispatch(selectionActions.selectResources(requestIds, SelectedResourceType.REQUESTS));
     }, [requestIds]);


### PR DESCRIPTION
## Summary
- reduce redundant `useSelector` calls by grouping selections with `shallowEqual`
- simplify project and request components by returning multiple slices of state at once

## Testing
- `yarn lint` *(fails: command not found: eslint)*

------
https://chatgpt.com/codex/tasks/task_b_68a5e61fae20832cbdd7d8298451dcf3