### PR TITLE
chore: add TypeScript annotations to data and core modules

### DIFF
--- a/cvat-core/src/event.ts
+++ b/cvat-core/src/event.ts
@@ -155,7 +155,7 @@ class EventWithExceptionInfo extends Event {
         }
     }
 
-    public dump(): any {
+    public dump(): SerializedEvent {
         const body = super.dump();
         const client = detect();
         body.payload = JSON.stringify({

--- a/cvat-core/src/index.ts
+++ b/cvat-core/src/index.ts
@@ -73,25 +73,32 @@ export default interface CVATCore {
             type: enums.ShareFileType;
         }[]>;
         formats: () => Promise<AnnotationFormats>;
-        userAgreements: typeof serverProxy.server.userAgreements,
-        register: any; // TODO: add types later
-        login: any;
-        logout: any;
-        changePassword: any;
-        requestPasswordReset: any;
-        resetPassword: any;
-        authenticated: any;
-        healthCheck: any;
-        request: any;
-        setAuthData: any;
-        installedApps: any;
+        userAgreements: typeof serverProxy.server.userAgreements;
+        register: (
+            username: string,
+            firstName: string,
+            lastName: string,
+            email: string,
+            password: string,
+            userConfirmations: Record<string, string>,
+        ) => Promise<User>;
+        login: typeof serverProxy.server.login;
+        logout: typeof serverProxy.server.logout;
+        changePassword: typeof serverProxy.server.changePassword;
+        requestPasswordReset: typeof serverProxy.server.requestPasswordReset;
+        resetPassword: typeof serverProxy.server.resetPassword;
+        authenticated: typeof serverProxy.server.authenticated;
+        healthCheck: typeof serverProxy.server.healthCheck;
+        request: typeof serverProxy.server.request;
+        setAuthData: typeof serverProxy.server.setAuthData;
+        installedApps: typeof serverProxy.server.installedApps;
         apiSchema: typeof serverProxy.server.apiSchema;
     };
     assets: {
-        create: any;
+        create: typeof serverProxy.assets.create;
     };
     users: {
-        get: any;
+        get: typeof serverProxy.users.get;
     };
     jobs: {
         get: (filter: {
@@ -127,15 +134,15 @@ export default interface CVATCore {
                 filter?: string;
             }
         ) => Promise<PaginatedResource<Project>>;
-        searchNames: any;
+        searchNames: typeof serverProxy.projects.searchNames;
     };
     cloudStorages: {
-        get: any;
+        get: typeof serverProxy.cloudStorages.get;
     };
     organizations: {
-        get: any;
-        activate: any;
-        deactivate: any;
+        get: typeof serverProxy.organizations.get;
+        activate: (organization: Organization) => void;
+        deactivate: () => void;
         acceptInvitation: (key: string) => Promise<string>;
         declineInvitation: (key: string) => Promise<void>;
         invitations: (filter: {
@@ -144,7 +151,7 @@ export default interface CVATCore {
         }) => Promise<Invitation[] & { count: number }>;
     };
     webhooks: {
-        get: any;
+        get: typeof serverProxy.webhooks.get;
     };
     consensus: {
         settings: {
@@ -167,7 +174,7 @@ export default interface CVATCore {
         };
     };
     frames: {
-        getMeta: any;
+        getMeta: typeof serverProxy.frames.getMeta;
     };
     requests: {
         list: () => Promise<PaginatedResource<Request>>;

--- a/cvat-core/src/lambda-manager.ts
+++ b/cvat-core/src/lambda-manager.ts
@@ -21,7 +21,7 @@ export interface MinimalShape {
 }
 
 export interface TrackerResults {
-    states: any[];
+    states: Record<string, unknown>[];
     shapes: MinimalShape[];
 }
 
@@ -54,7 +54,7 @@ class LambdaManager {
         return { models, count: lambdaFunctions.length };
     }
 
-    async run(taskID: number, model: MLModel, args: any): Promise<string> {
+    async run(taskID: number, model: MLModel, args: Record<string, unknown>): Promise<string> {
         if (!Number.isInteger(taskID) || taskID < 0) {
             throw new ArgumentError(`Argument taskID must be a positive integer. Got "${taskID}"`);
         }
@@ -79,7 +79,11 @@ class LambdaManager {
         return result.id;
     }
 
-    async call(taskID, model, args): Promise<TrackerResults | InteractorResults | SerializedCollection> {
+    async call(
+        taskID: number,
+        model: MLModel,
+        args: Record<string, unknown>,
+    ): Promise<TrackerResults | InteractorResults | SerializedCollection> {
         if (!Number.isInteger(taskID) || taskID < 0) {
             throw new ArgumentError(`Argument taskID must be a positive integer. Got "${taskID}"`);
         }
@@ -92,13 +96,13 @@ class LambdaManager {
         return result;
     }
 
-    async requests(): Promise<any[]> {
+    async requests(): Promise<Record<string, unknown>[]> {
         const lambdaRequests = await serverProxy.lambda.requests();
         return lambdaRequests
             .filter((request) => [RQStatus.QUEUED, RQStatus.STARTED].includes(request.status));
     }
 
-    async cancel(requestID, functionID): Promise<void> {
+    async cancel(requestID: string, functionID: number): Promise<void> {
         if (typeof requestID !== 'string') {
             throw new ArgumentError(`Request id argument is required to be a string. But got ${requestID}`);
         }

--- a/cvat-core/src/webhook.ts
+++ b/cvat-core/src/webhook.ts
@@ -8,6 +8,7 @@ import serverProxy from './server-proxy';
 import { WebhookSourceType, WebhookContentType } from './enums';
 import { isEnum } from './common';
 import { ArgumentError } from './exceptions';
+import { SerializedUser } from './server-response-types';
 
 interface RawWebhookData {
     id?: number;
@@ -21,7 +22,7 @@ interface RawWebhookData {
     enable_ssl: boolean;
     description?: string;
     is_active?: boolean;
-    owner?: any;
+    owner?: SerializedUser | User;
     created_date?: string;
     updated_date?: string;
     last_delivery_date?: string;
@@ -77,8 +78,8 @@ export default class Webhook {
             }
         }
 
-        if (data.owner) {
-            data.owner = new User(data.owner);
+        if (data.owner && !(data.owner instanceof User)) {
+            data.owner = new User(data.owner as SerializedUser);
         }
 
         Object.defineProperties(

--- a/cvat-data/src/ts/unzip_imgs.worker.ts
+++ b/cvat-data/src/ts/unzip_imgs.worker.ts
@@ -4,10 +4,19 @@
 // SPDX-License-Identifier: MIT
 
 import JSZip from 'jszip';
+import { DimensionType } from './cvat-data';
 
-onmessage = (e) => {
+interface UnzipMessage {
+    start: number;
+    end: number;
+    block: ArrayBuffer;
+    dimension: DimensionType;
+    dimension2D: DimensionType;
+}
+
+onmessage = (e: MessageEvent<UnzipMessage>) => {
     let errored = false;
-    function handleError(error): void {
+    function handleError(error: unknown): void {
         try {
             if (!errored) {
                 postMessage({ error });


### PR DESCRIPTION
## Summary
- refine decode context image workflow with explicit typing in cvat-data
- add strong typings for lambda manager and CVAT core API surfaces
- type webhook owner data and ensure event dumping returns SerializedEvent

## Testing
- `npx tsc --noEmit --skipLibCheck` (cvat-data)
- `npx tsc --noEmit --skipLibCheck` (cvat-core) *(fails: numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_689c5ef03ec0832c83f793cf6138dd84