### PR TITLE
refactor: consolidate redux selectors

### DIFF
--- a/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-sidebar/attribute-editor.tsx
+++ b/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-sidebar/attribute-editor.tsx
@@ -18,7 +18,7 @@ import { registerComponentShortcuts } from 'actions/shortcuts-actions';
 import { subKeyMap } from 'utils/component-subkeymap';
 import { isEqual } from 'lodash';
 import { CombinedState } from 'reducers';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import { useResetShortcutsOnUnmount } from 'utils/hooks';
 
 interface InputElementParameters {
@@ -32,7 +32,7 @@ interface InputElementParameters {
 
 const componentShortcuts: Record<string, KeyMapItem> = {};
 
-const makeKey = (index: number) => `AAM_SET_ATTR_VALUE_${index}`;
+const makeKey = (index: number): string => `AAM_SET_ATTR_VALUE_${index}`;
 
 for (const idx of Array.from({ length: 10 }, (_, i) => i)) {
     componentShortcuts[makeKey(idx)] = {
@@ -211,9 +211,10 @@ interface ListProps {
 
 function AttrValuesList(props: ListProps): JSX.Element | null {
     const { inputType, values, onChange } = props;
-
-    const { keyMap } = useSelector((state: CombinedState) => state.shortcuts);
-    const { normalizedKeyMap } = useSelector((state: CombinedState) => state.shortcuts);
+    const { keyMap, normalizedKeyMap } = useSelector((state: CombinedState) => ({
+        keyMap: state.shortcuts.keyMap,
+        normalizedKeyMap: state.shortcuts.normalizedKeyMap,
+    }), shallowEqual);
 
     const sortedValues = ['true', 'false'];
     const filteredValues = values.filter((value: string): boolean => value !== config.UNDEFINED_ATTRIBUTE_VALUE);

--- a/cvat-ui/src/components/annotation-page/canvas/grid-layout/canvas-layout.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/grid-layout/canvas-layout.tsx
@@ -6,7 +6,7 @@ import './styles.scss';
 import 'react-grid-layout/css/styles.css';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import RGL, { WidthProvider } from 'react-grid-layout';
 import PropTypes from 'prop-types';
 import { isEqual } from 'lodash';
@@ -142,9 +142,15 @@ const fitLayout = (type: DimensionType, layoutConfig: ItemLayout[]): ItemLayout[
 };
 
 function CanvasLayout({ type }: { type?: DimensionType }): JSX.Element {
-    const relatedFiles = useSelector((state: CombinedState) => state.annotation.player.frame.relatedFiles);
-    const canvasInstance = useSelector((state: CombinedState) => state.annotation.canvas.instance);
-    const canvasBackgroundColor = useSelector((state: CombinedState) => state.settings.player.canvasBackgroundColor);
+    const {
+        relatedFiles,
+        canvasInstance,
+        canvasBackgroundColor,
+    } = useSelector((state: CombinedState) => ({
+        relatedFiles: state.annotation.player.frame.relatedFiles,
+        canvasInstance: state.annotation.canvas.instance,
+        canvasBackgroundColor: state.settings.player.canvasBackgroundColor,
+    }), shallowEqual);
 
     const computeRowHeight = (): number => {
         const container = window.document.getElementsByClassName('cvat-annotation-header')[0];

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas3d/canvas-wrapper3D.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas3d/canvas-wrapper3D.tsx
@@ -5,7 +5,7 @@
 
 import './styles.scss';
 import React, { useEffect, useRef } from 'react';
-import { connect, useSelector } from 'react-redux';
+import { connect, shallowEqual, useSelector } from 'react-redux';
 import {
     ArrowDownOutlined, ArrowLeftOutlined, ArrowRightOutlined, ArrowUpOutlined,
 } from '@ant-design/icons';
@@ -249,9 +249,17 @@ const Spinner = React.memo(() => (
 export const PerspectiveViewComponent = React.memo(
     (): JSX.Element => {
         const ref = useRef<HTMLDivElement>(null);
-        const canvas = useSelector((state: CombinedState) => state.annotation.canvas.instance as Canvas3d);
-        const canvasIsReady = useSelector((state: CombinedState) => state.annotation.canvas.ready);
-        const { keyMap, normalizedKeyMap } = useSelector((state: CombinedState) => state.shortcuts);
+        const {
+            canvas,
+            canvasIsReady,
+            keyMap,
+            normalizedKeyMap,
+        } = useSelector((state: CombinedState) => ({
+            canvas: state.annotation.canvas.instance as Canvas3d,
+            canvasIsReady: state.annotation.canvas.ready,
+            keyMap: state.shortcuts.keyMap,
+            normalizedKeyMap: state.shortcuts.normalizedKeyMap,
+        }), shallowEqual);
 
         const screenKeyControl = (code: CameraAction, altKey: boolean, shiftKey: boolean): void => {
             canvas.keyControls(new KeyboardEvent('keydown', { code, altKey, shiftKey }));
@@ -403,8 +411,10 @@ export const PerspectiveViewComponent = React.memo(
 export const TopViewComponent = React.memo(
     (): JSX.Element => {
         const ref = useRef<HTMLDivElement>(null);
-        const canvas = useSelector((state: CombinedState) => state.annotation.canvas.instance as Canvas3d);
-        const canvasIsReady = useSelector((state: CombinedState) => state.annotation.canvas.ready);
+        const { canvas, canvasIsReady } = useSelector((state: CombinedState) => ({
+            canvas: state.annotation.canvas.instance as Canvas3d,
+            canvasIsReady: state.annotation.canvas.ready,
+        }), shallowEqual);
 
         useEffect(() => {
             if (ref.current) {
@@ -428,8 +438,10 @@ export const TopViewComponent = React.memo(
 export const SideViewComponent = React.memo(
     (): JSX.Element => {
         const ref = useRef<HTMLDivElement>(null);
-        const canvas = useSelector((state: CombinedState) => state.annotation.canvas.instance as Canvas3d);
-        const canvasIsReady = useSelector((state: CombinedState) => state.annotation.canvas.ready);
+        const { canvas, canvasIsReady } = useSelector((state: CombinedState) => ({
+            canvas: state.annotation.canvas.instance as Canvas3d,
+            canvasIsReady: state.annotation.canvas.ready,
+        }), shallowEqual);
 
         useEffect(() => {
             if (ref.current) {
@@ -453,8 +465,10 @@ export const SideViewComponent = React.memo(
 export const FrontViewComponent = React.memo(
     (): JSX.Element => {
         const ref = useRef<HTMLDivElement>(null);
-        const canvas = useSelector((state: CombinedState) => state.annotation.canvas.instance as Canvas3d);
-        const canvasIsReady = useSelector((state: CombinedState) => state.annotation.canvas.ready);
+        const { canvas, canvasIsReady } = useSelector((state: CombinedState) => ({
+            canvas: state.annotation.canvas.instance as Canvas3d,
+            canvasIsReady: state.annotation.canvas.ready,
+        }), shallowEqual);
 
         useEffect(() => {
             if (ref.current) {

--- a/cvat-ui/src/components/annotation-page/canvas/views/context-image/context-image.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/context-image/context-image.tsx
@@ -4,7 +4,7 @@
 
 import './styles.scss';
 import React, { useEffect, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import notification from 'antd/lib/notification';
 import Spin from 'antd/lib/spin';
@@ -25,8 +25,15 @@ function ContextImage(props: Props): JSX.Element {
     const defaultContextImageOffset = (offset[1] || 0);
 
     const canvasRef = useRef<HTMLCanvasElement>(null);
-    const job = useSelector((state: CombinedState) => state.annotation.job.instance);
-    const { number: frame, relatedFiles } = useSelector((state: CombinedState) => state.annotation.player.frame);
+    const {
+        job,
+        frame,
+        relatedFiles,
+    } = useSelector((state: CombinedState) => ({
+        job: state.annotation.job.instance!,
+        frame: state.annotation.player.frame.number,
+        relatedFiles: state.annotation.player.frame.relatedFiles,
+    }), shallowEqual);
     const frameIndex = frame + defaultFrameOffset;
 
     const [contextImageData, setContextImageData] = useState<Record<string, ImageBitmap>>({});

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/issues-list.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/issues-list.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import Icon, {
     LeftOutlined, RightOutlined, EyeInvisibleFilled, EyeOutlined,
     CheckCircleFilled, CheckCircleOutlined,
@@ -26,18 +26,33 @@ import { ShowGroundTruthIcon } from 'icons';
 
 export default function LabelsListComponent(): JSX.Element {
     const dispatch = useDispatch();
-    const frame = useSelector((state: CombinedState): number => state.annotation.player.frame.number);
-    const frameIssues = useSelector((state: CombinedState): Issue[] => state.review.frameIssues);
-    const frameConflicts = useSelector((state: CombinedState) => state.review.frameConflicts);
-    const showGroundTruth = useSelector((state: CombinedState) => state.settings.shapes.showGroundTruth);
-    const issues = useSelector((state: CombinedState): Issue[] => state.review.issues);
-    const conflicts = useSelector((state: CombinedState) => state.review.conflicts);
-    const issuesHidden = useSelector((state: CombinedState) => state.review.issuesHidden);
-    const issuesResolvedHidden = useSelector((state: CombinedState) => state.review.issuesResolvedHidden);
-    const highlightedConflict = useSelector((state: CombinedState) => state.annotation.annotations.highlightedConflict);
-    const workspace = useSelector((state: CombinedState) => state.annotation.workspace);
-    const ready = useSelector((state: CombinedState) => state.annotation.canvas.ready);
-    const activeControl = useSelector((state: CombinedState) => state.annotation.canvas.activeControl);
+    const {
+        frame,
+        frameIssues,
+        frameConflicts,
+        showGroundTruth,
+        issues,
+        conflicts,
+        issuesHidden,
+        issuesResolvedHidden,
+        highlightedConflict,
+        workspace,
+        ready,
+        activeControl,
+    } = useSelector((state: CombinedState) => ({
+        frame: state.annotation.player.frame.number,
+        frameIssues: state.review.frameIssues,
+        frameConflicts: state.review.frameConflicts,
+        showGroundTruth: state.settings.shapes.showGroundTruth,
+        issues: state.review.issues,
+        conflicts: state.review.conflicts,
+        issuesHidden: state.review.issuesHidden,
+        issuesResolvedHidden: state.review.issuesResolvedHidden,
+        highlightedConflict: state.annotation.annotations.highlightedConflict,
+        workspace: state.annotation.workspace,
+        ready: state.annotation.canvas.ready,
+        activeControl: state.annotation.canvas.activeControl,
+    }), shallowEqual);
 
     let frames = issues
         .filter((issue: Issue) => !issuesResolvedHidden || !issue.resolved)

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-element.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-element.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import Text from 'antd/lib/typography/Text';
 
 import { ObjectState } from 'cvat-core-wrapper';
@@ -25,9 +25,15 @@ function ObjectItemElementComponent(props: OwnProps): JSX.Element {
         clientID, parentID, readonly, onMouseLeave,
     } = props;
     const dispatch = useDispatch();
-    const states = useSelector((state: CombinedState) => state.annotation.annotations.states);
-    const activatedElementID = useSelector((state: CombinedState) => state.annotation.annotations.activatedElementID);
-    const colorBy = useSelector((state: CombinedState) => state.settings.shapes.colorBy);
+    const {
+        states,
+        activatedElementId,
+        colorBy,
+    } = useSelector((state: CombinedState) => ({
+        states: state.annotation.annotations.states,
+        activatedElementId: state.annotation.annotations.activatedElementID,
+        colorBy: state.settings.shapes.colorBy,
+    }), shallowEqual);
     const activate = useCallback(() => {
         dispatch(activateObject(parentID, clientID, null));
     }, [parentID, clientID]);
@@ -35,7 +41,7 @@ function ObjectItemElementComponent(props: OwnProps): JSX.Element {
     const element = state.elements.find((_element: ObjectState) => _element.clientID === clientID);
 
     const elementColor = getColor(element, colorBy);
-    const elementClassName = element.clientID === activatedElementID ?
+    const elementClassName = element.clientID === activatedElementId ?
         'cvat-objects-sidebar-state-item-elements cvat-objects-sidebar-state-active-element' :
         'cvat-objects-sidebar-state-item-elements';
 

--- a/cvat-ui/src/components/annotation-page/top-bar/filters-modal.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/filters-modal.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import {
     Builder, Config, ImmutableTree, JsonLogicTree, Query, Utils as QbUtils, AntdConfig, AntdWidgets,
 } from '@react-awesome-query-builder/antd';
@@ -74,9 +74,14 @@ const getAttributesSubfields = (labels: Label[]): Record<string, any> => {
 };
 
 function FiltersModalComponent(): JSX.Element {
-    const labels = useSelector((state: CombinedState) => state.annotation.job.labels);
-    const activeFilters = useSelector((state: CombinedState) => state.annotation.annotations.filters);
-    const visible = useSelector((state: CombinedState) => state.annotation.filtersPanelVisible);
+    const { labels, activeFilters, visible } = useSelector(
+        (state: CombinedState) => ({
+            labels: state.annotation.job.labels,
+            activeFilters: state.annotation.annotations.filters,
+            visible: state.annotation.filtersPanelVisible,
+        }),
+        shallowEqual,
+    );
     const [config, setConfig] = useState<Config>(AntdConfig);
 
     const dispatch = useDispatch();

--- a/cvat-ui/src/components/annotation-page/top-bar/search-modal.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/search-modal.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import Modal from 'antd/lib/modal';
 import Text from 'antd/lib/typography/Text';
 import AutoComplete from 'antd/lib/auto-complete';
@@ -26,9 +26,15 @@ function SearchFramesModal(): JSX.Element {
     const dispatch = useDispatch();
     const [searchTerm, setSearchTerm] = useState('');
     const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
-    const visible = useSelector((state: CombinedState) => state.annotation.search.visible);
-    const meta = useSelector((state: CombinedState) => state.annotation.job.meta);
-    const frameNumbers = useSelector((state: CombinedState) => state.annotation.job.frameNumbers);
+    const {
+        visible,
+        meta,
+        frameNumbers,
+    } = useSelector((state: CombinedState) => ({
+        visible: state.annotation.search.visible,
+        meta: state.annotation.job.meta,
+        frameNumbers: state.annotation.job.frameNumbers,
+    }), shallowEqual);
 
     const [searchData, setSearchData] = useState<SearchResult[]>([]);
     useEffect(() => {

--- a/cvat-ui/src/components/cloud-storages-page/cloud-storage-item.tsx
+++ b/cvat-ui/src/components/cloud-storages-page/cloud-storage-item.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import Card from 'antd/lib/card';
@@ -41,9 +41,15 @@ export default function CloudStorageItemComponent(props: Readonly<Props>): JSX.E
         updatedDate,
         description,
     } = cloudStorage;
-    const deletes = useSelector((state: CombinedState) => state.cloudStorages.activities.deletes);
+
+    const {
+        deletes,
+        selectedIds,
+    } = useSelector((state: CombinedState) => ({
+        deletes: state.cloudStorages.activities.deletes,
+        selectedIds: state.cloudStorages.selected,
+    }), shallowEqual);
     const deleted = cloudStorage.id in deletes ? deletes[cloudStorage.id] : false;
-    const selectedIds = useSelector((state: CombinedState) => state.cloudStorages.selected);
 
     const style: React.CSSProperties = {};
     if (deleted) {

--- a/cvat-ui/src/components/cloud-storages-page/cloud-storages-page.tsx
+++ b/cvat-ui/src/components/cloud-storages-page/cloud-storages-page.tsx
@@ -6,7 +6,7 @@
 import './styles.scss';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Row } from 'antd/lib/grid';
 import Spin from 'antd/lib/spin';
 
@@ -24,11 +24,21 @@ export default function StoragesPageComponent(): JSX.Element {
     const dispatch = useDispatch();
     const history = useHistory();
     const [isMounted, setIsMounted] = useState(false);
-    const totalCount = useSelector((state: CombinedState) => state.cloudStorages.count);
-    const fetching = useSelector((state: CombinedState) => state.cloudStorages.fetching);
-    const current = useSelector((state: CombinedState) => state.cloudStorages.current);
-    const query = useSelector((state: CombinedState) => state.cloudStorages.gettingQuery);
-    const bulkFetching = useSelector((state: CombinedState) => state.bulkActions.fetching);
+    const {
+        totalCount,
+        fetching,
+        current,
+        query,
+        bulkFetching,
+        selectedCount,
+    } = useSelector((state: CombinedState) => ({
+        totalCount: state.cloudStorages.count,
+        fetching: state.cloudStorages.fetching,
+        current: state.cloudStorages.current,
+        query: state.cloudStorages.gettingQuery,
+        bulkFetching: state.bulkActions.fetching,
+        selectedCount: state.cloudStorages.selected.length,
+    }), shallowEqual);
 
     const updatedQuery = useResourceQuery<CloudStoragesQuery>(query, { pageSize: 12 });
 
@@ -55,11 +65,12 @@ export default function StoragesPageComponent(): JSX.Element {
         [query],
     );
 
-    const allStorageIds = useSelector((state: CombinedState) => state.cloudStorages.current.map((s) => s.id));
-    const selectedCount = useSelector((state: CombinedState) => state.cloudStorages.selected.length);
     const onSelectAll = useCallback(() => {
-        dispatch(selectionActions.selectResources(allStorageIds, SelectedResourceType.CLOUD_STORAGES));
-    }, [allStorageIds]);
+        dispatch(
+            selectionActions.selectResources(current.map((s) => s.id),
+                SelectedResourceType.CLOUD_STORAGES,
+            ));
+    }, [current]);
 
     const isAnySearch = anySearch<CloudStoragesQuery>(query);
 

--- a/cvat-ui/src/components/create-cloud-storage-page/cloud-storage-form.tsx
+++ b/cvat-ui/src/components/create-cloud-storage-page/cloud-storage-form.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useState, useEffect, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import { Row, Col } from 'antd/lib/grid';
 import Button from 'antd/lib/button';
@@ -66,12 +66,18 @@ export default function CreateCloudStorageForm(props: Props): JSX.Element {
     const [providerType, setProviderType] = useState<ProviderType | null>(null);
     const [credentialsType, setCredentialsType] = useState<CredentialsType | null>(null);
     const [selectedRegion, setSelectedRegion] = useState<string | undefined>(undefined);
-    const newCloudStorageId = useSelector((state: CombinedState) => state.cloudStorages.activities.creates.id);
-    const attaching = useSelector((state: CombinedState) => state.cloudStorages.activities.creates.attaching);
-    const updating = useSelector((state: CombinedState) => state.cloudStorages.activities.updates.updating);
-    const updatedCloudStorageId = useSelector(
-        (state: CombinedState) => state.cloudStorages.activities.updates.cloudStorageID,
-    );
+    const {
+        newCloudStorageId,
+        attaching,
+        updating,
+        updatedCloudStorageId,
+    } = useSelector((state: CombinedState) => ({
+        newCloudStorageId: state.cloudStorages.activities.creates.id,
+        attaching: state.cloudStorages.activities.creates.attaching,
+        updating: state.cloudStorages.activities.updates.updating,
+        updatedCloudStorageId: state.cloudStorages.activities.updates.cloudStorageID,
+    }), shallowEqual);
+
     const loading = cloudStorage ? updating : attaching;
     const fakeCredentialsData = {
         accountName: 'X'.repeat(24),

--- a/cvat-ui/src/components/header/settings-modal/settings-modal.tsx
+++ b/cvat-ui/src/components/header/settings-modal/settings-modal.tsx
@@ -5,7 +5,7 @@
 
 import './styles.scss';
 import React, { useEffect, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import Tabs from 'antd/lib/tabs';
 import Text from 'antd/lib/typography/Text';
 import Modal from 'antd/lib/modal/Modal';
@@ -27,8 +27,10 @@ interface SettingsModalProps {
 function SettingsModal(props: SettingsModalProps): JSX.Element {
     const { visible, onClose } = props;
 
-    const settings = useSelector((state: CombinedState) => state.settings);
-    const shortcuts = useSelector((state: CombinedState) => state.shortcuts);
+    const { settings, shortcuts } = useSelector((state: CombinedState) => ({
+        settings: state.settings,
+        shortcuts: state.shortcuts,
+    }), shallowEqual);
     const [settingsInitialized, setSettingsInitialized] = useState(false);
     const dispatch = useDispatch();
 

--- a/cvat-ui/src/components/import-backup/import-backup-modal.tsx
+++ b/cvat-ui/src/components/import-backup/import-backup-modal.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useCallback, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import Modal from 'antd/lib/modal';
 import Form, { RuleObject } from 'antd/lib/form';
 import Text from 'antd/lib/typography/Text';
@@ -35,13 +35,16 @@ const initialValues: FormValues = {
 function ImportBackupModal(): JSX.Element {
     const [form] = Form.useForm();
     const [file, setFile] = useState<File | null>(null);
-    const instanceType = useSelector((state: CombinedState) => state.import.instanceType);
-    const modalVisible = useSelector((state: CombinedState) => {
-        if (instanceType && ['project', 'task'].includes(instanceType)) {
-            return state.import[`${instanceType}s` as 'projects' | 'tasks'].backup.modalVisible;
+    const { instanceType, modalVisible } = useSelector((state: CombinedState) => {
+        const { instanceType: instanceT } = state.import;
+        let visible = false;
+        if (instanceT && ['project', 'task'].includes(instanceT)) {
+            visible = state.import[`${instanceT}s` as 'projects' | 'tasks'].backup.modalVisible;
         }
-        return false;
-    });
+
+        return { instanceType: instanceT, modalVisible: visible };
+    }, shallowEqual);
+
     const dispatch = useDispatch();
     const [selectedSourceStorage, setSelectedSourceStorage] = useState<StorageData>({
         location: StorageLocation.LOCAL,

--- a/cvat-ui/src/components/import-backup/import-backup-modal.tsx
+++ b/cvat-ui/src/components/import-backup/import-backup-modal.tsx
@@ -36,10 +36,15 @@ function ImportBackupModal(): JSX.Element {
     const [form] = Form.useForm();
     const [file, setFile] = useState<File | null>(null);
     const { instanceType, modalVisible } = useSelector((state: CombinedState) => {
-        const { instanceType: instanceT } = state.import;
+        const instanceT = state.import.instanceType;
         let visible = false;
-        if (instanceT && ['project', 'task'].includes(instanceT)) {
-            visible = state.import[`${instanceT}s` as 'projects' | 'tasks'].backup.modalVisible;
+
+        if (instanceT === 'project') {
+            visible = state.import.projects.backup.modalVisible;
+        }
+
+        if (instanceT === 'task') {
+            visible = state.import.tasks.backup.modalVisible;
         }
 
         return { instanceType: instanceT, modalVisible: visible };

--- a/cvat-ui/src/components/invitations-page/invitations-list.tsx
+++ b/cvat-ui/src/components/invitations-page/invitations-list.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Row, Col } from 'antd/lib/grid';
 import Pagination from 'antd/lib/pagination';
 
@@ -21,8 +21,10 @@ export default function InvitationsListComponent(props: Props): JSX.Element {
     const { query } = props;
 
     const dispatch = useDispatch();
-    const invitations = useSelector((state: CombinedState) => state.invitations.current);
-    const totalCount = useSelector((state: CombinedState) => state.invitations.count);
+    const { invitations, totalCount } = useSelector((state: CombinedState) => ({
+        invitations: state.invitations.current,
+        totalCount: state.invitations.count,
+    }), shallowEqual);
 
     const onAccept = useCallback((invitationKey) => (
         dispatch(acceptInvitationAsync(invitationKey, (orgSlug: string) => {

--- a/cvat-ui/src/components/invitations-page/invitations-page.tsx
+++ b/cvat-ui/src/components/invitations-page/invitations-page.tsx
@@ -5,7 +5,7 @@
 import './styles.scss';
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import Spin from 'antd/lib/spin';
 import { CombinedState, InvitationsQuery } from 'reducers';
 import { useIsMounted, useResourceQuery } from 'utils/hooks';
@@ -19,9 +19,11 @@ export default function InvitationsPageComponent(): JSX.Element {
     const history = useHistory();
     const isMounted = useIsMounted();
 
-    const fetching = useSelector((state: CombinedState) => state.invitations.fetching);
-    const query = useSelector((state: CombinedState) => state.invitations.query);
-    const count = useSelector((state: CombinedState) => state.invitations.count);
+    const { fetching, query, count } = useSelector((state: CombinedState) => ({
+        fetching: state.invitations.fetching,
+        query: state.invitations.query,
+        count: state.invitations.count,
+    }), shallowEqual);
 
     const updatedQuery = useResourceQuery<InvitationsQuery>(query);
 

--- a/cvat-ui/src/components/jobs-page/actions-menu.tsx
+++ b/cvat-ui/src/components/jobs-page/actions-menu.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import Dropdown from 'antd/lib/dropdown';
 import Modal from 'antd/lib/modal';
 
@@ -42,11 +42,16 @@ function JobActionsComponent(
     const dispatch = useDispatch();
 
     const pluginActions = usePlugins((state: CombinedState) => state.plugins.components.jobActions.items, props);
-    const mergingConsensus = useSelector((state: CombinedState) => state.consensus.actions.merging);
-
-    const selectedIds = useSelector((state: CombinedState) => state.jobs.selected);
+    const {
+        mergingConsensus,
+        selectedIds,
+        allJobs,
+    } = useSelector((state: CombinedState) => ({
+        mergingConsensus: state.consensus.actions.merging,
+        selectedIds: state.jobs.selected,
+        allJobs: state.jobs.current,
+    }), shallowEqual);
     const isBulkMode = selectedIds.length > 1;
-    const allJobs = useSelector((state: CombinedState) => state.jobs.current);
 
     const {
         dropdownOpen,

--- a/cvat-ui/src/components/jobs-page/jobs-page.tsx
+++ b/cvat-ui/src/components/jobs-page/jobs-page.tsx
@@ -6,7 +6,7 @@
 import './styles.scss';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import Spin from 'antd/lib/spin';
 import { Col, Row } from 'antd/lib/grid';
 import Pagination from 'antd/lib/pagination';
@@ -26,15 +26,28 @@ function JobsPageComponent(): JSX.Element {
     const dispatch = useDispatch();
     const history = useHistory();
     const [isMounted, setIsMounted] = useState(false);
-    const query = useSelector((state: CombinedState) => state.jobs.query);
-    const fetching = useSelector((state: CombinedState) => state.jobs.fetching);
-    const count = useSelector((state: CombinedState) => state.jobs.count);
-    const allJobIds = useSelector((state: CombinedState) => state.jobs.current.map((j) => j.id));
-    const selectedCount = useSelector((state: CombinedState) => state.jobs.selected.length);
-    const bulkFetching = useSelector((state: CombinedState) => state.bulkActions.fetching);
+    const {
+        query,
+        fetching,
+        count,
+        currentJobs,
+        selectedCount,
+        bulkFetching,
+    } = useSelector((state: CombinedState) => ({
+        query: state.jobs.query,
+        fetching: state.jobs.fetching,
+        count: state.jobs.count,
+        currentJobs: state.jobs.current,
+        selectedCount: state.jobs.selected.length,
+        bulkFetching: state.bulkActions.fetching,
+    }), shallowEqual);
+
     const onSelectAll = useCallback(() => {
-        dispatch(selectionActions.selectResources(allJobIds, SelectedResourceType.JOBS));
-    }, [allJobIds]);
+        dispatch(selectionActions.selectResources(
+            currentJobs.map((j) => j.id),
+            SelectedResourceType.JOBS,
+        ));
+    }, [currentJobs]);
 
     const updatedQuery = useResourceQuery<JobsQuery>(query, { pageSize: 12 });
 

--- a/cvat-ui/src/components/models-page/actions-menu.tsx
+++ b/cvat-ui/src/components/models-page/actions-menu.tsx
@@ -9,7 +9,7 @@ import { MLModel, ModelProviders } from 'cvat-core-wrapper';
 import { usePlugins } from 'utils/hooks';
 import { CombinedState } from 'reducers';
 import { MenuProps } from 'antd/lib/menu';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 
 interface ModelActionsProps {
     model: MLModel;
@@ -25,13 +25,26 @@ function ModelActionsComponent(props: Readonly<ModelActionsProps>): JSX.Element 
         dropdownTrigger,
         renderTriggerIfEmpty = true,
     } = props;
-    const allModels = useSelector((state: CombinedState) => [
-        ...state.models.interactors,
-        ...state.models.detectors,
-        ...state.models.trackers,
-        ...state.models.reid,
-    ]);
-    const selectedIds = useSelector((state: CombinedState) => state.models.selected);
+    const {
+        interactors,
+        detectors,
+        trackers,
+        reid,
+        selectedIds,
+    } = useSelector((state: CombinedState) => ({
+        interactors: state.models.interactors,
+        detectors: state.models.detectors,
+        trackers: state.models.trackers,
+        reid: state.models.reid,
+        selectedIds: state.models.selected,
+    }), shallowEqual);
+
+    const allModels = [
+        ...interactors,
+        ...detectors,
+        ...trackers,
+        ...reid,
+    ];
 
     const menuPlugins = usePlugins(
         (state: CombinedState) => state.plugins.components.modelsPage.modelItem.menu.items,

--- a/cvat-ui/src/components/models-page/models-page.tsx
+++ b/cvat-ui/src/components/models-page/models-page.tsx
@@ -6,7 +6,7 @@
 import './styles.scss';
 import React, { useCallback, useEffect } from 'react';
 import { useHistory } from 'react-router';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import moment from 'moment';
 import { getModelsAsync } from 'actions/models-actions';
 import { updateHistoryFromQuery } from 'components/resource-sorting-filtering';
@@ -32,14 +32,27 @@ function setUpModelsList(models: MLModel[], newPage: number, pageSize: number): 
 function ModelsPageComponent(): JSX.Element {
     const history = useHistory();
     const dispatch = useDispatch();
-    const fetching = useSelector((state: CombinedState) => state.models.fetching);
-    const query = useSelector((state: CombinedState) => state.models.query);
-    const bulkFetching = useSelector((state: CombinedState) => state.bulkActions.fetching);
-    const interactors = useSelector((state: CombinedState) => state.models.interactors);
-    const detectors = useSelector((state: CombinedState) => state.models.detectors);
-    const trackers = useSelector((state: CombinedState) => state.models.trackers);
-    const reid = useSelector((state: CombinedState) => state.models.reid);
-    const totalCount = useSelector((state: CombinedState) => state.models.totalCount);
+    const {
+        fetching,
+        query,
+        bulkFetching,
+        interactors,
+        detectors,
+        trackers,
+        reid,
+        totalCount,
+        selectedCount,
+    } = useSelector((state: CombinedState) => ({
+        fetching: state.models.fetching,
+        query: state.models.query,
+        bulkFetching: state.bulkActions.fetching,
+        interactors: state.models.interactors,
+        detectors: state.models.detectors,
+        trackers: state.models.trackers,
+        reid: state.models.reid,
+        totalCount: state.models.totalCount,
+        selectedCount: state.models.selected.length,
+    }), shallowEqual);
 
     const updatedQuery = useResourceQuery<ModelsQuery>(query, { pageSize: 12 });
 
@@ -67,11 +80,12 @@ function ModelsPageComponent(): JSX.Element {
         }
     }, []);
 
-    const allModelIds = models.filter((m) => m.provider !== ModelProviders.CVAT).map((m) => m.id);
-    const selectedCount = useSelector((state: CombinedState) => state.models.selected.length);
     const onSelectAll = useCallback(() => {
-        dispatch(selectionActions.selectResources(allModelIds, SelectedResourceType.MODELS));
-    }, [allModelIds]);
+        dispatch(selectionActions.selectResources(
+            models.filter((m) => m.provider !== ModelProviders.CVAT).map((m) => m.id),
+            SelectedResourceType.MODELS,
+        ));
+    }, [models]);
 
     const content = (totalCount && !pageOutOfBounds) ? (
         <DeployedModelsList query={updatedQuery} models={models} totalCount={totalCount} />

--- a/cvat-ui/src/components/move-task-modal/move-task-modal.tsx
+++ b/cvat-ui/src/components/move-task-modal/move-task-modal.tsx
@@ -7,7 +7,7 @@ import './styles.scss';
 import React, {
     useState, useEffect, useCallback, useRef,
 } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import Modal from 'antd/lib/modal';
 import { Row, Col } from 'antd/lib/grid';
 import Divider from 'antd/lib/divider';
@@ -30,8 +30,10 @@ function MoveTaskModal({
     onUpdateTask?: (task: Task) => Promise<Task>;
 }): JSX.Element {
     const dispatch = useDispatch();
-    const visible = useSelector((state: CombinedState) => state.tasks.moveTask.modalVisible);
-    const taskId = useSelector((state: CombinedState) => state.tasks.moveTask.taskId);
+    const { visible, taskId } = useSelector((state: CombinedState) => ({
+        visible: state.tasks.moveTask.modalVisible,
+        taskId: state.tasks.moveTask.taskId,
+    }), shallowEqual);
     const mounted = useRef(false);
 
     const [taskFetching, setTaskFetching] = useState(false);

--- a/cvat-ui/src/components/organization-page/actions-menu.tsx
+++ b/cvat-ui/src/components/organization-page/actions-menu.tsx
@@ -8,11 +8,11 @@ import Dropdown from 'antd/lib/dropdown';
 import Modal from 'antd/lib/modal';
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
 import { MenuInfo } from 'components/dropdown-menu';
-import { Membership, Organization } from 'cvat-core-wrapper';
+import { Membership } from 'cvat-core-wrapper';
 import { useDropdownEditField } from 'utils/hooks';
 import { CVATMenuEditLabel } from 'components/common/cvat-menu-edit-label';
 import { MenuProps } from 'antd/lib/menu';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { CombinedState } from 'reducers';
 import { LabelWithCountHOF } from 'components/common/label-with-count';
 import { makeBulkOperationAsync } from 'actions/bulk-actions';
@@ -55,11 +55,17 @@ function MemberActionsMenu(props: Readonly<MemberActionsMenuProps>): JSX.Element
     } = useDropdownEditField();
 
     const dispatch = useDispatch();
-    const selectedIds = useSelector((state: CombinedState) => state.organizations.selectedMembers);
-    const isBulkMode = selectedIds.length > 1;
-    const members = useSelector((state: CombinedState) => state.organizations.members);
-    const organizationInstance = useSelector((state: CombinedState) => state.organizations.current) as Organization;
+    const {
+        selectedIds,
+        members,
+        organizationInstance,
+    } = useSelector((state: CombinedState) => ({
+        selectedIds: state.organizations.selectedMembers,
+        members: state.organizations.members,
+        organizationInstance: state.organizations.current!,
+    }), shallowEqual);
 
+    const isBulkMode = selectedIds.length > 1;
     let membershipsToAct: Membership[] = [membershipInstance];
     if (selectedIds.includes(membershipInstance.id)) {
         membershipsToAct = members.filter((m) => selectedIds.includes(m.id));
@@ -69,11 +75,11 @@ function MemberActionsMenu(props: Readonly<MemberActionsMenuProps>): JSX.Element
         MenuKeys.EDIT_ROLE, MenuKeys.RESEND_INVITATION,
         MenuKeys.REMOVE_MEMBER, MenuKeys.DELETE_INVITATION,
     ];
-    const canUpdateRole = (membership: Membership) => (membership.role !== 'owner');
-    const canOperateInvitation = (membership: Membership) => (
+    const canUpdateRole = (membership: Membership): boolean => (membership.role !== 'owner');
+    const canOperateInvitation = (membership: Membership): boolean => (
         Boolean(membership.invitation && !membership.isActive && membership.invitation.key)
     );
-    const canRemoveMembership = (membership: Membership) => (
+    const canRemoveMembership = (membership: Membership): boolean => (
         membership.role !== 'owner' && selfUserName !== membership.user.username && !canOperateInvitation(membership)
     );
     const actionsApplicable = {

--- a/cvat-ui/src/components/organization-page/member-item.tsx
+++ b/cvat-ui/src/components/organization-page/member-item.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import Text from 'antd/lib/typography/Text';
 import { Row, Col } from 'antd/lib/grid';
 import moment from 'moment';
@@ -33,13 +33,20 @@ function MemberItem(props: Readonly<Props>): JSX.Element {
     const { username, firstName, lastName } = user;
 
     const dispatch = useDispatch();
-    const memberships = useSelector((state: CombinedState) => state.organizations.members);
-    const organizationInstance = useSelector((state: CombinedState) => state.organizations.current);
-    const selectedIds = useSelector((state: CombinedState) => state.organizations.selectedMembers);
-    const { username: selfUserName } = useSelector((state: CombinedState) => state.auth.user || { username: '' });
-    const rowClassName = `cvat-organization-member-item${selected ? ' cvat-item-selected' : ''}`;
+    const {
+        memberships,
+        organizationInstance,
+        selectedIds,
+        selfUserName,
+    } = useSelector((state: CombinedState) => ({
+        memberships: state.organizations.members,
+        organizationInstance: state.organizations.current,
+        selectedIds: state.organizations.selectedMembers,
+        selfUserName: state.auth.user?.username ?? '',
+    }), shallowEqual);
 
-    const canUpdateRole = (membership: Membership) => (membership.role !== 'owner');
+    const rowClassName = `cvat-organization-member-item${selected ? ' cvat-item-selected' : ''}`;
+    const canUpdateRole = (membership: Membership): boolean => (membership.role !== 'owner');
     const onUpdateMembershipRole = (newRole: string): void => {
         const membershipToUpdate = selectedIds.includes(membershipInstance.id) ?
             memberships

--- a/cvat-ui/src/components/organization-page/members-list.tsx
+++ b/cvat-ui/src/components/organization-page/members-list.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import Pagination from 'antd/lib/pagination';
 import Spin from 'antd/lib/spin';
 
-import { useSelector } from 'react-redux';
+import { useSelector, shallowEqual } from 'react-redux';
 import { CombinedState, SelectedResourceType } from 'reducers';
 import { Membership } from 'cvat-core-wrapper';
 import BulkWrapper from 'components/bulk-wrapper';
@@ -29,9 +29,15 @@ function MembersList(props: Readonly<Props>): JSX.Element {
     const {
         fetching, members, pageSize, pageNumber, fetchMembers, onPageChange,
     } = props;
-    const inviting = useSelector((state: CombinedState) => state.organizations.inviting);
-    const updatingMember = useSelector((state: CombinedState) => state.organizations.updatingMember);
-    const removingMember = useSelector((state: CombinedState) => state.organizations.removingMember);
+    const {
+        inviting,
+        updatingMember,
+        removingMember,
+    } = useSelector((state: CombinedState) => ({
+        inviting: state.organizations.inviting,
+        updatingMember: state.organizations.updatingMember,
+        removingMember: state.organizations.removingMember,
+    }), shallowEqual);
 
     if (fetching || inviting || updatingMember || removingMember) {
         return <Spin className='cvat-spinner' />;

--- a/cvat-ui/src/components/organization-page/organization-page.tsx
+++ b/cvat-ui/src/components/organization-page/organization-page.tsx
@@ -5,7 +5,7 @@
 
 import './styles.scss';
 import React, { useCallback, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import Empty from 'antd/lib/empty';
 import Spin from 'antd/lib/spin';
 
@@ -17,14 +17,25 @@ import MembersList from './members-list';
 
 function OrganizationPage(): JSX.Element | null {
     const dispatch = useDispatch();
-    const organization = useSelector((state: CombinedState) => state.organizations.current);
-    const fetching = useSelector((state: CombinedState) => state.organizations.fetching);
-    const updating = useSelector((state: CombinedState) => state.organizations.updating);
-    const user = useSelector((state: CombinedState) => state.auth.user);
-    const members = useSelector((state: CombinedState) => state.organizations.members);
-    const fetchingMembers = useSelector((state: CombinedState) => state.organizations.fetchingMembers);
-    const query = useSelector((state: CombinedState) => state.organizations.membersQuery);
-    const selectedIds = useSelector((state: CombinedState) => state.organizations.selectedMembers);
+    const {
+        organization,
+        fetching,
+        updating,
+        user,
+        members,
+        fetchingMembers,
+        query,
+        selectedIds,
+    } = useSelector((state: CombinedState) => ({
+        organization: state.organizations.current,
+        fetching: state.organizations.fetching,
+        updating: state.organizations.updating,
+        user: state.auth.user,
+        members: state.organizations.members,
+        fetchingMembers: state.organizations.fetchingMembers,
+        query: state.organizations.membersQuery,
+        selectedIds: state.organizations.selectedMembers,
+    }), shallowEqual);
 
     const fetchMembersCallback = useCallback(() => {
         if (organization) {

--- a/cvat-ui/src/components/project-page/project-page.tsx
+++ b/cvat-ui/src/components/project-page/project-page.tsx
@@ -136,11 +136,12 @@ export default function ProjectPageComponent(): JSX.Element {
         }
     }, [deletes]);
 
-    const allTaskIds = tasks.map((t) => t.id);
-    const selectableTaskIds = allTaskIds.filter((taskId) => !deletedTasks[taskId]);
     const onSelectAll = useCallback(() => {
-        dispatch(selectionActions.selectResources(selectableTaskIds, SelectedResourceType.TASKS));
-    }, [selectableTaskIds]);
+        dispatch(selectionActions.selectResources(
+            tasks.map((t) => t.id).filter((taskId) => !deletedTasks[taskId]),
+            SelectedResourceType.TASKS,
+        ));
+    }, [tasks, deletedTasks]);
 
     const onUpdateProject = useCallback((project: Project) => {
         const promise = dispatch(updateProjectAsync(project));

--- a/cvat-ui/src/components/project-page/project-page.tsx
+++ b/cvat-ui/src/components/project-page/project-page.tsx
@@ -59,9 +59,6 @@ export default function ProjectPageComponent(): JSX.Element {
     const id = +useParams<ParamType>().id;
     const dispatch = useDispatch();
     const history = useHistory();
-    const selectedCount = useSelector((state: CombinedState) => state.tasks.selected.length);
-    const bulkFetching = useSelector((state: CombinedState) => state.bulkActions.fetching);
-
     const [projectInstance, setProjectInstance] = useState<Project | null>(null);
     const [fechingProject, setFetchingProject] = useState(true);
     const mounted = useRef(false);
@@ -74,6 +71,8 @@ export default function ProjectPageComponent(): JSX.Element {
         tasksQuery,
         tasksFetching,
         deletedTasks,
+        selectedCount,
+        bulkFetching,
     } = useSelector((state: CombinedState) => ({
         deletes: state.projects.activities.deletes,
         updates: state.projects.activities.updates,
@@ -82,6 +81,8 @@ export default function ProjectPageComponent(): JSX.Element {
         tasksQuery: state.projects.tasksGettingQuery,
         tasksFetching: state.tasks.fetching,
         deletedTasks: state.tasks.activities.deletes,
+        selectedCount: state.tasks.selected.length,
+        bulkFetching: state.bulkActions.fetching,
     }), shallowEqual);
     const [visibility, setVisibility] = useState(defaultVisibility);
 

--- a/cvat-ui/src/components/projects-page/project-list.tsx
+++ b/cvat-ui/src/components/projects-page/project-list.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Row, Col } from 'antd/lib/grid';
 import Pagination from 'antd/lib/pagination';
 
@@ -17,11 +17,20 @@ import ProjectItem from './project-item';
 
 export default function ProjectListComponent(): JSX.Element {
     const dispatch = useDispatch();
-    const projectsCount = useSelector((state: CombinedState) => state.projects.count);
-    const projects = useSelector((state: CombinedState) => state.projects.current);
-    const deletingProjects = useSelector((state: CombinedState) => state.projects.activities.deletes);
-    const gettingQuery = useSelector((state: CombinedState) => state.projects.gettingQuery);
-    const tasksQuery = useSelector((state: CombinedState) => state.projects.tasksGettingQuery);
+    const {
+        projectsCount,
+        projects,
+        deletingProjects,
+        gettingQuery,
+        tasksQuery,
+    } = useSelector((state: CombinedState) => ({
+        projectsCount: state.projects.count,
+        projects: state.projects.current,
+        deletingProjects: state.projects.activities.deletes,
+        gettingQuery: state.projects.gettingQuery,
+        tasksQuery: state.projects.tasksGettingQuery,
+    }), shallowEqual);
+
     const { page, pageSize } = gettingQuery;
 
     const changePage = useCallback((_page: number, _pageSize: number) => {

--- a/cvat-ui/src/components/projects-page/projects-page.tsx
+++ b/cvat-ui/src/components/projects-page/projects-page.tsx
@@ -28,7 +28,7 @@ export default function ProjectsPageComponent(): JSX.Element {
         tasksQuery,
         importing,
         bulkFetching,
-        allProjectIds,
+        currentProjects,
         deletedProjects,
         selectedCount,
     } = useSelector((state: CombinedState) => ({
@@ -38,14 +38,15 @@ export default function ProjectsPageComponent(): JSX.Element {
         tasksQuery: state.projects.tasksGettingQuery,
         importing: state.import.projects.backup.importing,
         bulkFetching: state.bulkActions.fetching,
-        allProjectIds: state.projects.current.map((p) => p.id),
+        currentProjects: state.projects.current,
         deletedProjects: state.projects.activities.deletes,
         selectedCount: state.projects.selected.length,
     }), shallowEqual);
     const [isMounted, setIsMounted] = useState(false);
     const isAnySearch = anySearch<ProjectsQuery>(query);
 
-    const selectableProjectIds = allProjectIds.filter((id) => !deletedProjects[id]);
+    const selectableProjectIds = currentProjects
+        .map((p) => p.id).filter((id) => !deletedProjects[id]);
     const onSelectAll = useCallback(() => {
         dispatch(selectionActions.selectResources(selectableProjectIds, SelectedResourceType.PROJECTS));
     }, [selectableProjectIds]);

--- a/cvat-ui/src/components/projects-page/projects-page.tsx
+++ b/cvat-ui/src/components/projects-page/projects-page.tsx
@@ -6,7 +6,7 @@
 import './styles.scss';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import Spin from 'antd/lib/spin';
 import { CombinedState, ProjectsQuery, SelectedResourceType } from 'reducers';
 import { getProjectsAsync } from 'actions/projects-actions';
@@ -21,19 +21,31 @@ import ProjectListComponent from './project-list';
 export default function ProjectsPageComponent(): JSX.Element {
     const dispatch = useDispatch();
     const history = useHistory();
-    const fetching = useSelector((state: CombinedState) => state.projects.fetching);
-    const count = useSelector((state: CombinedState) => state.projects.current.length);
-    const query = useSelector((state: CombinedState) => state.projects.gettingQuery);
-    const tasksQuery = useSelector((state: CombinedState) => state.projects.tasksGettingQuery);
-    const importing = useSelector((state: CombinedState) => state.import.projects.backup.importing);
-    const bulkFetching = useSelector((state: CombinedState) => state.bulkActions.fetching);
+    const {
+        fetching,
+        count,
+        query,
+        tasksQuery,
+        importing,
+        bulkFetching,
+        allProjectIds,
+        deletedProjects,
+        selectedCount,
+    } = useSelector((state: CombinedState) => ({
+        fetching: state.projects.fetching,
+        count: state.projects.current.length,
+        query: state.projects.gettingQuery,
+        tasksQuery: state.projects.tasksGettingQuery,
+        importing: state.import.projects.backup.importing,
+        bulkFetching: state.bulkActions.fetching,
+        allProjectIds: state.projects.current.map((p) => p.id),
+        deletedProjects: state.projects.activities.deletes,
+        selectedCount: state.projects.selected.length,
+    }), shallowEqual);
     const [isMounted, setIsMounted] = useState(false);
     const isAnySearch = anySearch<ProjectsQuery>(query);
 
-    const allProjectIds = useSelector((state: CombinedState) => state.projects.current.map((p) => p.id));
-    const deletedProjects = useSelector((state: CombinedState) => state.projects.activities.deletes);
     const selectableProjectIds = allProjectIds.filter((id) => !deletedProjects[id]);
-    const selectedCount = useSelector((state: CombinedState) => state.projects.selected.length);
     const onSelectAll = useCallback(() => {
         dispatch(selectionActions.selectResources(selectableProjectIds, SelectedResourceType.PROJECTS));
     }, [selectableProjectIds]);

--- a/cvat-ui/src/components/requests-page/actions-menu.tsx
+++ b/cvat-ui/src/components/requests-page/actions-menu.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import Dropdown from 'antd/lib/dropdown';
 import { MenuProps } from 'antd/lib/menu';
 import { Request, RQStatus } from 'cvat-core-wrapper';
@@ -26,9 +26,16 @@ function RequestActionsComponent(props: Readonly<Props>): JSX.Element | null {
         renderTriggerIfEmpty = true,
     } = props;
     const dispatch = useDispatch();
-    const selectedIds = useSelector((state: CombinedState) => state.requests.selected);
-    const requestsMap = useSelector((state: CombinedState) => state.requests.requests);
-    const cancelled = useSelector((state: CombinedState) => state.requests.cancelled);
+    const {
+        selectedIds,
+        requestsMap,
+        cancelled,
+    } = useSelector((state: CombinedState) => ({
+        selectedIds: state.requests.selected,
+        requestsMap: state.requests.requests,
+        cancelled: state.requests.cancelled,
+    }), shallowEqual);
+
     const allRequests = Object.values(requestsMap);
     const isCardMenu = !dropdownTrigger;
 

--- a/cvat-ui/src/components/requests-page/requests-list.tsx
+++ b/cvat-ui/src/components/requests-page/requests-list.tsx
@@ -34,14 +34,15 @@ function RequestsList(props: Readonly<Props>): JSX.Element {
     const dispatch = useDispatch();
     const { query, count } = props;
     const { page, pageSize } = query;
-    const { requests, cancelled } = useSelector((state: CombinedState) => ({
-        requests: state.requests.requests, cancelled: state.requests.cancelled,
+    const { requests, cancelled, selectedCount } = useSelector((state: CombinedState) => ({
+        requests: state.requests.requests,
+        cancelled: state.requests.cancelled,
+        selectedCount: state.requests.selected.length,
     }), shallowEqual);
 
     const requestList = Object.values(requests);
     const requestViews = setUpRequestsList(requestList, page, pageSize);
     const requestIds = requestViews.map((request) => request.id).filter((id) => !cancelled[id]);
-    const selectedCount = useSelector((state: CombinedState) => state.requests.selected.length);
     const onSelectAll = useCallback(() => {
         dispatch(selectionActions.selectResources(requestIds, SelectedResourceType.REQUESTS));
     }, [requestIds]);

--- a/cvat-ui/src/components/select-organization-modal/select-organization-modal.tsx
+++ b/cvat-ui/src/components/select-organization-modal/select-organization-modal.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import Modal from 'antd/lib/modal';
 
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { CombinedState } from 'reducers';
 
 import { Organization } from 'cvat-core-wrapper';
@@ -14,10 +14,13 @@ import OrganizationSelector from 'components/selectors/organization-selector';
 
 function SelectOrganizationModal(): JSX.Element {
     const dispatch = useDispatch();
-    const visible = useSelector((state: CombinedState) => state.organizations.selectModal.visible);
-    const onSelectCallback = useSelector(
-        (state: CombinedState) => state.organizations.selectModal.onSelectCallback,
-    );
+    const {
+        visible,
+        onSelectCallback,
+    } = useSelector((state: CombinedState) => ({
+        visible: state.organizations.selectModal.visible,
+        onSelectCallback: state.organizations.selectModal.onSelectCallback,
+    }), shallowEqual);
 
     return (
         <Modal

--- a/cvat-ui/src/components/tasks-page/tasks-page.tsx
+++ b/cvat-ui/src/components/tasks-page/tasks-page.tsx
@@ -39,12 +39,12 @@ function TasksPageComponent(props: Readonly<Props>): JSX.Element {
     const history = useHistory();
     const [isMounted, setIsMounted] = useState(false);
 
-    const { allTaskIds, deletedTasks, selectedCount } = useSelector((state: CombinedState) => ({
-        allTaskIds: state.tasks.current.map((t) => t.id),
+    const { currentTasks, deletedTasks, selectedCount } = useSelector((state: CombinedState) => ({
+        currentTasks: state.tasks.current,
         deletedTasks: state.tasks.activities.deletes,
         selectedCount: state.tasks.selected.length,
     }), shallowEqual);
-    const selectableTaskIds = allTaskIds.filter((id) => !deletedTasks[id]);
+    const selectableTaskIds = currentTasks.map((t) => t.id).filter((id) => !deletedTasks[id]);
     const onSelectAll = useCallback(() => {
         dispatch(selectionActions.selectResources(selectableTaskIds, SelectedResourceType.TASKS));
     }, [dispatch, selectableTaskIds]);

--- a/cvat-ui/src/components/tasks-page/tasks-page.tsx
+++ b/cvat-ui/src/components/tasks-page/tasks-page.tsx
@@ -44,10 +44,13 @@ function TasksPageComponent(props: Readonly<Props>): JSX.Element {
         deletedTasks: state.tasks.activities.deletes,
         selectedCount: state.tasks.selected.length,
     }), shallowEqual);
-    const selectableTaskIds = currentTasks.map((t) => t.id).filter((id) => !deletedTasks[id]);
+
     const onSelectAll = useCallback(() => {
-        dispatch(selectionActions.selectResources(selectableTaskIds, SelectedResourceType.TASKS));
-    }, [dispatch, selectableTaskIds]);
+        dispatch(selectionActions.selectResources(
+            currentTasks.map((t) => t.id).filter((id) => !deletedTasks[id]),
+            SelectedResourceType.TASKS,
+        ));
+    }, [currentTasks, deletedTasks]);
 
     const updatedQuery = useResourceQuery<TasksQuery>(query);
 

--- a/cvat-ui/src/components/tasks-page/tasks-page.tsx
+++ b/cvat-ui/src/components/tasks-page/tasks-page.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import './styles.scss';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import React, { useEffect, useState, useCallback } from 'react';
 import { useHistory } from 'react-router';
 import Spin from 'antd/lib/spin';
@@ -39,10 +39,12 @@ function TasksPageComponent(props: Readonly<Props>): JSX.Element {
     const history = useHistory();
     const [isMounted, setIsMounted] = useState(false);
 
-    const allTaskIds = useSelector((state: CombinedState) => state.tasks.current.map((t) => t.id));
-    const deletedTasks = useSelector((state: CombinedState) => state.tasks.activities.deletes);
+    const { allTaskIds, deletedTasks, selectedCount } = useSelector((state: CombinedState) => ({
+        allTaskIds: state.tasks.current.map((t) => t.id),
+        deletedTasks: state.tasks.activities.deletes,
+        selectedCount: state.tasks.selected.length,
+    }), shallowEqual);
     const selectableTaskIds = allTaskIds.filter((id) => !deletedTasks[id]);
-    const selectedCount = useSelector((state: CombinedState) => state.tasks.selected.length);
     const onSelectAll = useCallback(() => {
         dispatch(selectionActions.selectResources(selectableTaskIds, SelectedResourceType.TASKS));
     }, [dispatch, selectableTaskIds]);

--- a/cvat-ui/src/components/webhooks-page/actions-menu.tsx
+++ b/cvat-ui/src/components/webhooks-page/actions-menu.tsx
@@ -1,6 +1,10 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
 import React, { useCallback } from 'react';
 import { useHistory } from 'react-router';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import Dropdown from 'antd/lib/dropdown';
 import Modal from 'antd/lib/modal';
 import { MenuProps } from 'antd/lib/menu';
@@ -17,17 +21,20 @@ interface WebhookActionsMenuProps {
 }
 
 export default function WebhookActionsMenu(props: Readonly<WebhookActionsMenuProps>): JSX.Element {
-    const {
-        webhookInstance, triggerElement, dropdownTrigger,
-    } = props;
+    const { webhookInstance, triggerElement, dropdownTrigger } = props;
 
     const history = useHistory();
     const dispatch = useDispatch();
 
-    const selectedIds = useSelector((state: CombinedState) => state.webhooks.selected);
-    const allWebhooks = useSelector((state: CombinedState) => state.webhooks.current);
-    const isBulk = selectedIds.length > 1;
+    const {
+        selectedIds,
+        allWebhooks,
+    } = useSelector((state: CombinedState) => ({
+        selectedIds: state.webhooks.selected,
+        allWebhooks: state.webhooks.current,
+    }), shallowEqual);
 
+    const isBulk = selectedIds.length > 1;
     const onEdit = useCallback(() => {
         history.push(`/webhooks/update/${webhookInstance.id}`);
     }, [webhookInstance]);

--- a/cvat-ui/src/components/webhooks-page/webhooks-page.tsx
+++ b/cvat-ui/src/components/webhooks-page/webhooks-page.tsx
@@ -36,7 +36,7 @@ function WebhooksPage(): JSX.Element | null {
         totalCount,
         query,
         bulkFetching,
-        allWebhookIds,
+        currentWebhooks,
         selectedCount,
     } = useSelector((state: CombinedState) => ({
         organization: state.organizations.current,
@@ -44,7 +44,7 @@ function WebhooksPage(): JSX.Element | null {
         totalCount: state.webhooks.totalCount,
         query: state.webhooks.query,
         bulkFetching: state.bulkActions.fetching,
-        allWebhookIds: state.webhooks.current.map((w) => w.id),
+        currentWebhooks: state.webhooks.current,
         selectedCount: state.webhooks.selected.length,
     }), shallowEqual);
 
@@ -88,8 +88,11 @@ function WebhooksPage(): JSX.Element | null {
     }, [query]);
 
     const onSelectAll = useCallback(() => {
-        dispatch(selectionActions.selectResources(allWebhookIds, SelectedResourceType.WEBHOOKS));
-    }, [allWebhookIds]);
+        dispatch(selectionActions.selectResources(
+            currentWebhooks.map((w) => w.id),
+            SelectedResourceType.WEBHOOKS),
+        );
+    }, [currentWebhooks]);
 
     const content = totalCount ? (
         <>

--- a/cvat-ui/src/components/webhooks-page/webhooks-page.tsx
+++ b/cvat-ui/src/components/webhooks-page/webhooks-page.tsx
@@ -4,7 +4,7 @@
 
 import './styles.scss';
 import React, { useCallback, useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import {
     useHistory, useRouteMatch,
 } from 'react-router';
@@ -30,11 +30,23 @@ interface ProjectRouteMatch {
 function WebhooksPage(): JSX.Element | null {
     const dispatch = useDispatch();
     const history = useHistory();
-    const organization = useSelector((state: CombinedState) => state.organizations.current);
-    const fetching = useSelector((state: CombinedState) => state.webhooks.fetching);
-    const totalCount = useSelector((state: CombinedState) => state.webhooks.totalCount);
-    const query = useSelector((state: CombinedState) => state.webhooks.query);
-    const bulkFetching = useSelector((state: CombinedState) => state.bulkActions.fetching);
+    const {
+        organization,
+        fetching,
+        totalCount,
+        query,
+        bulkFetching,
+        allWebhookIds,
+        selectedCount,
+    } = useSelector((state: CombinedState) => ({
+        organization: state.organizations.current,
+        fetching: state.webhooks.fetching,
+        totalCount: state.webhooks.totalCount,
+        query: state.webhooks.query,
+        bulkFetching: state.bulkActions.fetching,
+        allWebhookIds: state.webhooks.current.map((w) => w.id),
+        selectedCount: state.webhooks.selected.length,
+    }), shallowEqual);
 
     const projectsMatch = useRouteMatch<ProjectRouteMatch>({ path: '/projects/:id/webhooks' });
 
@@ -75,8 +87,6 @@ function WebhooksPage(): JSX.Element | null {
         });
     }, [query]);
 
-    const allWebhookIds = useSelector((state: CombinedState) => state.webhooks.current.map((w) => w.id));
-    const selectedCount = useSelector((state: CombinedState) => state.webhooks.selected.length);
     const onSelectAll = useCallback(() => {
         dispatch(selectionActions.selectResources(allWebhookIds, SelectedResourceType.WEBHOOKS));
     }, [allWebhookIds]);


### PR DESCRIPTION
## Summary
- consolidate move task modal redux selectors
- consolidate selectors in webhooks page
- use single useSelector in tasks and projects pages
- streamline organization page selectors

## Testing
- `cd cvat-ui && yarn lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_68a8913b4884832cb2bfed4e9c39fa8a