### PR TITLE
Add `k6 --verbose` to perfkit to view JS console logs

### DIFF
--- a/tests/perf/perfkit/cluster.py
+++ b/tests/perf/perfkit/cluster.py
@@ -97,7 +97,9 @@ def _run_in_pty(cmd: list[str]) -> int:
     return pty.spawn(cmd, read)
 
 
-def run_k6_docker(k6_conf: K6Profile, tty_output: bool = False, silent: bool = False, verbose: bool = False) -> int:
+def run_k6_docker(
+    k6_conf: K6Profile, tty_output: bool = False, silent: bool = False, verbose: bool = False
+) -> int:
     docker_cmd: list[str] = k6_conf.build_run_cmd(verbose)
     cmd = docker_compose["run", "--rm", "perf-k6"][docker_cmd]
     if tty_output:

--- a/tests/perf/perfkit/cluster.py
+++ b/tests/perf/perfkit/cluster.py
@@ -97,8 +97,8 @@ def _run_in_pty(cmd: list[str]) -> int:
     return pty.spawn(cmd, read)
 
 
-def run_k6_docker(k6_conf: K6Profile, tty_output: bool = False, silent: bool = False) -> int:
-    docker_cmd: list[str] = k6_conf.build_run_cmd()
+def run_k6_docker(k6_conf: K6Profile, tty_output: bool = False, silent: bool = False, verbose: bool = False) -> int:
+    docker_cmd: list[str] = k6_conf.build_run_cmd(verbose)
     cmd = docker_compose["run", "--rm", "perf-k6"][docker_cmd]
     if tty_output:
         # print_info(f"🚀 running in pseudo-terminal: {' '.join(cmd.formulate())}")

--- a/tests/perf/perfkit/k6_profile.py
+++ b/tests/perf/perfkit/k6_profile.py
@@ -40,8 +40,8 @@ class K6Profile:
             result.extend(["-e", f"{key}={val}"])
         return result
 
-    def build_run_cmd(self) -> List[str]:
-        return [
+    def build_run_cmd(self, verbose=False) -> List[str]:
+        args = [
             "run",
             *self._build_env_list(),
             "--out",
@@ -54,6 +54,9 @@ class K6Profile:
             *self.args,
             str(self.test_file),
         ]
+        if verbose:
+            args.insert(1, "--verbose")
+        return args
 
     def __repr__(self):
         return f"<K6Config file={self.test_file.name} args={self.args} env={list(self.env_vars.keys())}>"

--- a/tests/perf/perfkit/main.py
+++ b/tests/perf/perfkit/main.py
@@ -107,7 +107,7 @@ def run_regression(
         False, help="Reuse existing cluster. Cluster won't be shutdown after test."
     ),
     no_warmup: bool = typer.Option(False, help="Disable warmup for test execution."),
-    verbose: bool = typer.Option(False, help="Show js console output")
+    verbose: bool = typer.Option(False, help="Show js console output"),
 ):
 
     def resolve_commit() -> str:

--- a/tests/perf/perfkit/main.py
+++ b/tests/perf/perfkit/main.py
@@ -40,6 +40,7 @@ def run_golden(
     save_baseline: bool = typer.Option(
         True, help="Save result as baseline. Be default prints it into the console."
     ),
+    verbose: bool = typer.Option(False, help="Show JS console output"),
 ):
     test_invalid = threading.Event()
     k6_metrics_total: list[K6Summary] = []
@@ -61,7 +62,7 @@ def run_golden(
             exit_with_error(f"warmup finished with an error. exit_code: {exit_code}")
         print_success("warmup completed")
         print_info(f"🚀 running test: {test_file}")
-        exit_code = run_k6_docker(K6Profile(test_file))
+        exit_code = run_k6_docker(K6Profile(test_file), verbose=verbose)
         if exit_code != 0:
             exit_with_error("K6 execution finished with an error.")
         k6_summary_metrics = parse_k6_summary(K6_OUTPUT_SUMMARY_JSON)
@@ -106,6 +107,7 @@ def run_regression(
         False, help="Reuse existing cluster. Cluster won't be shutdown after test."
     ),
     no_warmup: bool = typer.Option(False, help="Disable warmup for test execution."),
+    verbose: bool = typer.Option(False, help="Show js console output")
 ):
 
     def resolve_commit() -> str:
@@ -152,7 +154,7 @@ def run_regression(
     stop_metrics = start_metrics_watcher()
     if not no_warmup:
         run_k6_docker(warmup_profile)
-    run_k6_docker(K6Profile(test_file))
+    run_k6_docker(K6Profile(test_file), verbose=verbose)
     stop_metrics()
     if not reuse_cluster:
         stop_cluster()


### PR DESCRIPTION
### Motivation and context

This allows to view JS runtime's `console.log`-s during of scenarios debugging

### How has this been tested?

Scenarios with console logs are executed, perfkit output has the prints

### Checklist

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
