### PR TITLE
Add cy.cmds to open tasks and projects by ids with checks

### DIFF
--- a/tests/cypress/e2e/actions_projects_models/markdown_base_pipeline.js
+++ b/tests/cypress/e2e/actions_projects_models/markdown_base_pipeline.js
@@ -70,9 +70,7 @@ context('Basic markdown pipeline', () => {
             }).then((taskResponse) => {
                 taskID = taskResponse.taskID;
                 [jobID] = taskResponse.jobIDs;
-
-                cy.visit(`/tasks/${taskID}`);
-                cy.get('.cvat-task-details').should('exist').and('be.visible');
+                cy.openTaskByID(taskID);
                 cy.assignTaskToUser(additionalUsers.taskAssignee.username);
                 cy.assignJobToUser(jobID, additionalUsers.jobAssignee.username);
             });

--- a/tests/cypress/e2e/actions_projects_models/markdown_base_pipeline.js
+++ b/tests/cypress/e2e/actions_projects_models/markdown_base_pipeline.js
@@ -90,11 +90,6 @@ context('Basic markdown pipeline', () => {
     });
 
     describe('Markdown text can be bounded to the project', () => {
-        function openProject() {
-            cy.visit(`/projects/${projectID}`);
-            cy.get('.cvat-project-details').should('exist').and('be.visible');
-        }
-
         function openGuide() {
             cy.get('.cvat-md-guide-control-wrapper button').click();
             cy.url().should('to.match', /\/projects\/\d+\/guide/);
@@ -122,7 +117,7 @@ context('Basic markdown pipeline', () => {
         }
 
         function setupGuide(value) {
-            openProject();
+            cy.openProjectByID(projectID);
             openGuide();
             updatePlainText(value);
         }

--- a/tests/cypress/e2e/actions_tasks/task_changes_status_after_initial_save.js
+++ b/tests/cypress/e2e/actions_tasks/task_changes_status_after_initial_save.js
@@ -54,7 +54,7 @@ context('Task status updated after initial save.', () => {
     describe(`Testing "${labelName}"`, () => {
         it('State of the created task should be "new".', () => {
             cy.intercept('GET', `/tasks/${taskID}`).as('visitTaskPage');
-            cy.visit(`/tasks/${taskID}`);
+            cy.openTaskByID(taskID);
             cy.wait('@visitTaskPage');
             cy.get('.cvat-job-item .cvat-job-item-state .ant-select-selection-item').invoke('text').should('equal', 'new');
         });

--- a/tests/cypress/e2e/actions_tasks2/test_default_attribute.js
+++ b/tests/cypress/e2e/actions_tasks2/test_default_attribute.js
@@ -79,8 +79,7 @@ context('Test default value for an attribute', () => {
     describe('Test can change default attribute', () => {
         it('Can change default attribute value on task page', () => {
             const newDefaultValue = 'third';
-            cy.visit(`/tasks/${taskID}`);
-            cy.get('.cvat-task-details').should('exist').and('be.visible');
+            cy.openTaskByID(taskID);
             cy.get('.cvat-constructor-viewer-item').within(() => {
                 cy.get('[aria-label="edit"]').click();
             });

--- a/tests/cypress/e2e/features/bulk_actions.js
+++ b/tests/cypress/e2e/features/bulk_actions.js
@@ -100,7 +100,7 @@ context('Bulk actions in UI', () => {
 
     describe('Bulk-change object attributes, confirm UI state', () => {
         before(() => {
-            cy.visit(`/projects/${projectTwoTasks}`);
+            cy.openProjectByID(projectTwoTasks);
         });
         context('Project page, change tasks', () => {
             it('"Select all", all items are selected, "Deselect" button is visible', () => {
@@ -132,7 +132,7 @@ context('Bulk actions in UI', () => {
                 cy.get('.cvat-bulk-progress-wrapper').should('be.visible');
 
                 // Navigate to task with 2 jobs
-                cy.visit(`tasks/${taskTwoJobs.ID}`);
+                cy.openTaskByID(taskTwoJobs.ID);
                 cy.get('.cvat-spinner').should('not.exist');
                 cy.get('.cvat-task-details').should('exist');
 
@@ -146,7 +146,7 @@ context('Bulk actions in UI', () => {
 
         context('Task page, change jobs', () => {
             before(() => {
-                cy.visit(`tasks/${taskTwoJobs.ID}`);
+                cy.openTaskByID(taskTwoJobs.ID);
             });
 
             it('Bulk-change assignees', () => {
@@ -179,7 +179,7 @@ context('Bulk actions in UI', () => {
 
     describe('Bulk export', () => {
         before(() => {
-            cy.visit(`tasks/${taskTwoJobs.ID}`);
+            cy.openTaskByID(taskTwoJobs.ID);
         });
         it('Bulk-export job annotations', () => {
             getBulkActionsMenu().within(() => {
@@ -208,7 +208,7 @@ context('Bulk actions in UI', () => {
 
     describe('Delete all tasks in project', () => {
         before(() => {
-            cy.visit(`/projects/${projectTwoTasks}`);
+            cy.openProjectByID(projectTwoTasks);
         });
 
         it('Delete all tasks, ensure deletion', () => {

--- a/tests/cypress/e2e/features/ground_truth_jobs.js
+++ b/tests/cypress/e2e/features/ground_truth_jobs.js
@@ -126,8 +126,7 @@ context('Ground truth jobs', () => {
                 [jobID] = taskResponse.jobIDs;
             }
         }).then(() => {
-            cy.visit(`/tasks/${taskID}`);
-            cy.get('.cvat-task-details').should('exist').and('be.visible');
+            cy.openTaskByID(taskID);
         });
     }
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -493,6 +493,12 @@ Cypress.Commands.add('openTask', (taskName, projectSubsetFieldValue) => {
     }
 });
 
+Cypress.Commands.add('openTaskByID', (taskID) => {
+    cy.visit(`tasks/${taskID}`);
+    cy.get('.cvat-spinner').should('not.exist');
+    cy.get('.cvat-task-details').should('exist').and('be.visible');
+});
+
 Cypress.Commands.add('saveJob', (method = 'PATCH', status = 200, as = 'saveJob') => {
     cy.intercept(method, '/api/jobs/**').as(as);
     cy.clickSaveAnnotationView();

--- a/tests/cypress/support/commands_projects.js
+++ b/tests/cypress/support/commands_projects.js
@@ -81,6 +81,7 @@ Cypress.Commands.add('openProject', (projectName) => {
 Cypress.Commands.add('openProjectByID', (projectID) => {
     cy.visit(`/projects/${projectID}`);
     cy.get('.cvat-spinner').should('not.exist');
+    cy.get('.cvat-project-details').should('exist').and('be.visible');
 });
 
 Cypress.Commands.add('openProjectActions', (projectName) => {

--- a/tests/cypress/support/commands_projects.js
+++ b/tests/cypress/support/commands_projects.js
@@ -78,6 +78,11 @@ Cypress.Commands.add('openProject', (projectName) => {
     cy.get('.cvat-project-details').should('exist');
 });
 
+Cypress.Commands.add('openProjectByID', (projectID) => {
+    cy.visit(`/projects/${projectID}`);
+    cy.get('.cvat-spinner').should('not.exist');
+});
+
 Cypress.Commands.add('openProjectActions', (projectName) => {
     cy.contains('.cvat-projects-project-item-title', projectName)
         .parents('.cvat-projects-project-item-card')


### PR DESCRIPTION
### Motivation and context

Sometimes custom `cy.visit('/projects/**'`) and `cy.visit('/tasks/**'`) calls don't contain necessary checks like existence of `.cvat-spinner` and visibility of {tasks,projects} details. This PR adds a `Cypress.Command` that opens these resources by ID and performs the checks. The checks should ensure more stable e2e test runs

### How has this been tested?

All modified tests run and don't fail

### Checklist

- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
