### PR TITLE
Fixed ability to create wrong skeleton structure in constructor

### DIFF
--- a/cvat-ui/src/components/labels-editor/skeleton-configurator.tsx
+++ b/cvat-ui/src/components/labels-editor/skeleton-configurator.tsx
@@ -319,9 +319,12 @@ export default class SkeletonConfigurator extends React.PureComponent<Props, Sta
         });
 
         circle.addEventListener('contextmenu', () => {
-            this.setState({
-                contextMenuElement: elementID,
-            });
+            const { activeTool } = this.state;
+            if (activeTool !== 'join' || !this.findNotFinishedEdge()) {
+                this.setState({
+                    contextMenuElement: elementID,
+                });
+            }
         });
 
         circle.addEventListener('mouseout', () => {
@@ -577,6 +580,16 @@ export default class SkeletonConfigurator extends React.PureComponent<Props, Sta
         return null;
     }
 
+    private cancelNotFinishedEdge(): void {
+        const { activeTool } = this.state;
+        if (activeTool === 'join') {
+            const shape = this.findNotFinishedEdge();
+            if (shape) {
+                shape.remove();
+            }
+        }
+    }
+
     public submit(): SkeletonConfiguration | null {
         try {
             return this.wrappedSubmit();
@@ -600,12 +613,13 @@ export default class SkeletonConfigurator extends React.PureComponent<Props, Sta
 
     public wrappedSubmit(): SkeletonConfiguration {
         const svg = this.svgRef.current;
-
-        if (!svg) throw new Error('SVG reference is null');
+        if (!svg) {
+            throw new Error('SVG reference is null');
+        }
 
         const sublabels = Object.values(this.labels);
-
         let elements = 0;
+        this.cancelNotFinishedEdge();
         Array.from(svg.children as any as SVGElement[]).forEach((child: SVGElement) => {
             const dataType = child.getAttribute('data-type');
             if (dataType && dataType.includes('element')) {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
- Start adding new edge
- Click first point
- Do not click the second point, just click continue
- Edge added with target node undefined, when creating such element on canvas, UI fails

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
