### PR TITLE
Fix instability in bulk actions test

### DIFF
--- a/cvat-ui/src/components/cvat-app.tsx
+++ b/cvat-ui/src/components/cvat-app.tsx
@@ -396,6 +396,7 @@ class CVATApplication extends React.PureComponent<CVATAppProps & RouteComponentP
                     <CVATMarkdown history={history}>{notificationState?.description}</CVATMarkdown>
                 ),
                 duration: notificationState.duration ?? null,
+                className: notificationState.className,
             });
         }
 

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -526,6 +526,7 @@ export interface NotificationState {
     message: string;
     description?: string;
     duration?: number;
+    className?: string;
 }
 
 export interface BulkOperationsErrorState extends ErrorState {

--- a/cvat-ui/src/reducers/notifications-reducer.ts
+++ b/cvat-ui/src/reducers/notifications-reducer.ts
@@ -570,6 +570,7 @@ export default function (state = defaultState, action: AnyAction): Notifications
                         dataset: {
                             message: 'Export is finished',
                             duration: config.REQUEST_SUCCESS_NOTIFICATION_DURATION,
+                            className: `cvat-notification-notice-export-${instanceType.split(' ')[0]}-finished`,
                             description,
                         },
                     },

--- a/tests/cypress/e2e/features/bulk_actions.js
+++ b/tests/cypress/e2e/features/bulk_actions.js
@@ -195,11 +195,7 @@ context('Bulk actions in UI', () => {
                 .should('be.visible');
             cy.closeNotification('.cvat-notification-notice-export-job-start');
 
-            cy.get(':visible:contains("Export is finished")')
-            // cy.contains only yields the first
-            // https://docs.cypress.io/api/commands/contains#Single-Element
-                .should('have.length', nobjs)
-                .find('span[aria-label="close"]').click({ multiple: true });
+            cy.closeNotification('.cvat-notification-notice-export-job-finished', nobjs);
         });
     });
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1339,8 +1339,16 @@ Cypress.Commands.add('setJobStage', (jobID, stage) => {
     cy.get('.cvat-spinner').should('not.exist');
 });
 
-Cypress.Commands.add('closeNotification', (className) => {
-    cy.get(className).find('span[aria-label="close"]').click();
+Cypress.Commands.add('closeNotification', (className, numOfNotifications = 1) => {
+    cy.get(className)
+        .should('have.length', numOfNotifications)
+        .find('span[aria-label="close"]')
+        .then(($elements) => {
+            // Click in reverse order to avoid re-render instability
+            for (let i = $elements.length - 1; i >= 0; i--) {
+                cy.wrap($elements[i]).click();
+            }
+        });
     cy.get(className).should('not.exist');
 });
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The bulk_actions test seems to be unstable as it incorrectly closes notifications for export. This PR adds className for export notifications and improves closing notification command

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->~~
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
