### PR TITLE
Allow creating tasks without specifying the labels

### DIFF
--- a/changelog.d/20250911_182534_roman_task_create_without_labels.md
+++ b/changelog.d/20250911_182534_roman_task_create_without_labels.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Tasks can now be created without specifying the labels in advance
+  (<https://github.com/cvat-ai/cvat/pull/9822>)

--- a/cvat-ui/src/components/annotation-page/annotation-page.tsx
+++ b/cvat-ui/src/components/annotation-page/annotation-page.tsx
@@ -115,7 +115,7 @@ export default function AnnotationPageComponent(props: Props): JSX.Element {
                         <span>
                             {`${job.projectId ? 'Project' : 'Task'} ${
                                 job.projectId || job.taskId
-                            } does not contain any label. `}
+                            } does not contain any labels. `}
                             <a href={`/${job.projectId ? 'projects' : 'tasks'}/${job.projectId || job.taskId}/`}>
                                 Add
                             </a>

--- a/cvat-ui/src/components/create-task-page/create-task-content.tsx
+++ b/cvat-ui/src/components/create-task-page/create-task-content.tsx
@@ -206,11 +206,6 @@ class CreateTaskContent extends React.PureComponent<Props & RouteComponentProps,
         }));
     };
 
-    private validateLabelsOrProject = (): boolean => {
-        const { projectId, labels } = this.state;
-        return !!labels.length || !!projectId;
-    };
-
     private validateFiles = (): boolean => {
         const { activeFileManagerTab, files } = this.state;
 
@@ -442,15 +437,6 @@ class CreateTaskContent extends React.PureComponent<Props & RouteComponentProps,
 
     private validateBlocks = (): Promise<any> => new Promise((resolve, reject) => {
         const { projectId } = this.state;
-        if (!this.validateLabelsOrProject()) {
-            notification.error({
-                message: 'Could not create a task',
-                description: 'A task must contain at least one label or belong to some project',
-                className: 'cvat-notification-create-task-fail',
-            });
-            reject();
-            return;
-        }
 
         if (!this.validateFiles()) {
             notification.error({
@@ -859,7 +845,6 @@ class CreateTaskContent extends React.PureComponent<Props & RouteComponentProps,
 
         return (
             <Col span={24}>
-                <Text type='danger'>* </Text>
                 <Text className='cvat-text-color'>Labels</Text>
                 <LabelsEditor
                     labels={labels}

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -2516,7 +2516,7 @@ class TaskWriteSerializer(WriteOnceMixin, serializers.ModelSerializer, OrgTransf
     def create(self, validated_data):
         project_id = validated_data.get("project_id")
         if validated_data.get("label_set") and project_id:
-            raise serializers.ValidationError('Project must have only one of Label set or project_id')
+            raise serializers.ValidationError('Task must have only one of Label set or project_id')
 
         project = None
         if project_id:

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -2515,8 +2515,6 @@ class TaskWriteSerializer(WriteOnceMixin, serializers.ModelSerializer, OrgTransf
     @transaction.atomic
     def create(self, validated_data):
         project_id = validated_data.get("project_id")
-        if not (validated_data.get("label_set") or project_id):
-            raise serializers.ValidationError('Label set or project_id must be present')
         if validated_data.get("label_set") and project_id:
             raise serializers.ValidationError('Project must have only one of Label set or project_id')
 

--- a/tests/cypress/e2e/actions_projects_models/case_57_project_label_deleting_feature.js
+++ b/tests/cypress/e2e/actions_projects_models/case_57_project_label_deleting_feature.js
@@ -73,7 +73,7 @@ context('Delete a label from a project.', () => {
         it('Try to open job with no labels in the project. Successful.', () => {
             cy.openTaskJob(taskName);
             cy.get('.cvat-disabled-canvas-control').should('exist');
-            cy.contains('.cvat-notification-no-labels', 'does not contain any label').should('exist').and('be.visible');
+            cy.contains('.cvat-notification-no-labels', 'does not contain any labels').should('exist').and('be.visible');
         });
     });
 });

--- a/tests/cypress/e2e/actions_tasks/case_58_task_label_deleting_feature.js
+++ b/tests/cypress/e2e/actions_tasks/case_58_task_label_deleting_feature.js
@@ -44,7 +44,7 @@ context('Delete a label from a task.', () => {
         it('Try to open a job with no labels. Successful.', () => {
             cy.openJob();
             cy.get('.cvat-disabled-canvas-control').should('exist');
-            cy.contains('.cvat-notification-no-labels', 'does not contain any label').should('exist').and('be.visible');
+            cy.contains('.cvat-notification-no-labels', 'does not contain any labels').should('exist').and('be.visible');
         });
     });
 });

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -439,6 +439,16 @@ class TestPostTasks:
                 assert task.assignee is None
                 assert task.assignee_updated_date is None
 
+    def test_can_create_without_labels(self, admin_user):
+        task_spec = {"name": "test task without labels"}
+
+        with make_api_client(admin_user) as api_client:
+            (task, _) = api_client.tasks_api.create(task_write_request=task_spec)
+
+            (labels, _) = api_client.labels_api.list(task_id=task.id)
+
+            assert labels.count == 0
+
 
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestGetData:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The requirement to specify labels in advance seems entirely artificial and unnecessary. Sometimes it's more convenient to create the task first and add labels later. It's also inconsistent with projects, which can already be created without labels.

In this patch I also fixed a couple error messages related to labels.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Unit tests for the backend; frontend tested manually.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
