### PR TITLE
Remove the tuspy dependency

### DIFF
--- a/changelog.d/20250912_194630_roman_no_tuspy.md
+++ b/changelog.d/20250912_194630_roman_no_tuspy.md
@@ -1,0 +1,4 @@
+### Changed
+
+- \[SDK\] Removed the `tuspy` dependency
+  (<https://github.com/cvat-ai/cvat/pull/9824>)

--- a/cvat-sdk/cvat_sdk/core/uploading.py
+++ b/cvat-sdk/cvat_sdk/core/uploading.py
@@ -4,141 +4,120 @@
 
 from __future__ import annotations
 
+import base64
 import json
+import logging
 import os
 from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
-import requests
 import urllib3
 
 from cvat_sdk.api_client.api_client import ApiClient, Endpoint
-from cvat_sdk.api_client.exceptions import ApiException
-from cvat_sdk.api_client.rest import RESTClientObject
+from cvat_sdk.core.exceptions import CvatSdkException
 from cvat_sdk.core.helpers import StreamWithProgress, expect_status
 from cvat_sdk.core.progress import NullProgressReporter, ProgressReporter
 
 if TYPE_CHECKING:
     from cvat_sdk.core.client import Client
 
-import tusclient.uploader as tus_uploader
-from tusclient.client import TusClient as _TusClient
-from tusclient.client import Uploader as _TusUploader
-from tusclient.request import TusRequest as _TusRequest
-from tusclient.request import TusUploadFailed as _TusUploadFailed
-
 MAX_REQUEST_SIZE = 100 * 2**20
+MAX_TUS_RETRIES = 3
+TUS_CHUNK_SIZE = 10 * 2**20
 
 
-class _RestClientAdapter:
-    # Provides requests.Session-like interface for REST client
-    # only patch is called in the tus client
+def _upload_with_tus(
+    api_client: ApiClient,
+    create_url: str,
+    metadata: dict[str, str],
+    file_stream: StreamWithProgress,
+    logger: logging.Logger,
+) -> str:
+    common_headers = {**api_client.get_common_headers(), "Tus-Resumable": "1.0.0"}
 
-    def __init__(self, rest_client: RESTClientObject):
-        self.rest_client = rest_client
+    file_stream.seek(0, os.SEEK_END)
+    upload_length = file_stream.tell()
+    assert metadata
 
-    def _request(self, method, url, data=None, json=None, **kwargs):
-        raw = self.rest_client.request(
-            method=method,
-            url=url,
-            headers=kwargs.get("headers"),
-            query_params=kwargs.get("params"),
-            post_params=json,
-            body=data,
-            _parse_response=False,
-            _request_timeout=kwargs.get("timeout"),
-            _check_status=False,
-        )
+    response = api_client.rest_client.POST(
+        create_url,
+        headers={
+            **common_headers,
+            "Upload-Length": str(upload_length),
+            "Upload-Metadata": ",".join(
+                [f"{k} {base64.b64encode(v.encode()).decode()}" for k, v in metadata.items()]
+            ),
+        },
+    )
+    real_filename = response.headers.get("Upload-Filename")
 
-        result = requests.Response()
-        result._content = raw.data
-        result.raw = raw
-        result.headers.update(raw.headers)
-        result.status_code = raw.status
-        result.reason = raw.msg
-        return result
+    if not real_filename:
+        raise CvatSdkException("Server did not send Upload-Filename after upload creation")
 
-    def patch(self, *args, **kwargs):
-        return self._request("PATCH", *args, **kwargs)
+    upload_url = response.headers.get("Location")
+    if upload_url is None:
+        raise CvatSdkException("Server did not send Location after upload creation")
 
+    upload_offset = 0
+    num_errors = 0
 
-class _MyTusUploader(_TusUploader):
-    # Adjusts the library code for CVAT server
-    # Allows to reuse session
+    while True:
+        file_stream.seek(upload_offset)
+        chunk = file_stream.read(TUS_CHUNK_SIZE)
 
-    def __init__(self, *_args, api_client: ApiClient, **_kwargs):
-        self._api_client = api_client
-        super().__init__(*_args, **_kwargs)
-
-    def _do_request(self):
-        self.request = _TusRequest(self)
-        self.request.handle = _RestClientAdapter(self._api_client.rest_client)
         try:
-            self.request.perform()
-            self.verify_upload()
-        except _TusUploadFailed as error:
-            self._retry_or_cry(error)
-
-    @tus_uploader._catch_requests_error
-    def create_url(self):
-        """
-        Return upload url.
-
-        Makes request to tus server to create a new upload url for the required file upload.
-        """
-        headers = self.headers
-        headers["upload-length"] = str(self.file_size)
-        headers["upload-metadata"] = ",".join(self.encode_metadata())
-        resp = self._api_client.rest_client.POST(self.client.url, headers=headers)
-        self.real_filename = resp.headers.get("Upload-Filename")
-        url = resp.headers.get("location")
-        if url is None:
-            msg = "Attempt to retrieve create file url with status {}".format(resp.status_code)
-            raise tus_uploader.TusCommunicationError(msg, resp.status_code, resp.content)
-        return tus_uploader.urljoin(self.client.url, url)
-
-    @tus_uploader._catch_requests_error
-    def get_offset(self):
-        """
-        Return offset from tus server.
-
-        This is different from the instance attribute 'offset' because this makes an
-        http request to the tus server to retrieve the offset.
-        """
-        try:
-            resp = self._api_client.rest_client.HEAD(self.url, headers=self.headers)
-        except ApiException as ex:
-            if ex.status == 405:  # Method Not Allowed
-                # In CVAT up to version 2.2.0, HEAD requests were internally
-                # converted to GET by mod_wsgi, and subsequently rejected by the server.
-                # For compatibility with old servers, we'll handle such rejections by
-                # restarting the upload from the beginning.
-                return 0
-
-            raise tus_uploader.TusCommunicationError(
-                f"Attempt to retrieve offset failed with status {ex.status}",
-                ex.status,
-                ex.body,
-            ) from ex
-
-        offset = resp.headers.get("upload-offset")
-        if offset is None:
-            raise tus_uploader.TusCommunicationError(
-                f"Attempt to retrieve offset failed with status {resp.status}",
-                resp.status,
-                resp.data,
+            response = api_client.rest_client.PATCH(
+                upload_url,
+                headers={
+                    **common_headers,
+                    "Content-Type": "application/offset+octet-stream",
+                    "Upload-Offset": str(upload_offset),
+                },
+                body=chunk,
+                _check_status=False,
             )
+        except urllib3.exceptions.HTTPError as e:
+            logger.error("Chunk upload failed", exc_info=e)
+            new_upload_offset = None
+            num_errors += 1
+        else:
+            if "Upload-Offset" in response.headers:
+                new_upload_offset = int(response.headers["Upload-Offset"])
+            else:
+                new_upload_offset = None
 
-        return int(offset)
+            if 200 <= response.status < 300:
+                if new_upload_offset is None:
+                    raise CvatSdkException("Server did not send Upload-Offset after chunk upload")
+
+                # prevent the server from asking us to keep uploading the same chunk
+                if new_upload_offset < upload_offset + len(chunk):
+                    raise CvatSdkException("Server reported unexpected Upload-Offset")
+            else:
+                logger.error("Chunk upload returned status code %d", response.status)
+                num_errors += 1
+
+        if num_errors >= MAX_TUS_RETRIES:
+            raise CvatSdkException("Too many upload errors")
+
+        if new_upload_offset is None:
+            response = api_client.rest_client.HEAD(upload_url, headers=common_headers)
+            new_upload_offset = int(response.headers["Upload-Offset"])
+
+        if new_upload_offset == upload_length:
+            return real_filename
+
+        if not 0 <= new_upload_offset <= upload_length:
+            raise CvatSdkException("Server returned invalid upload offset")
+
+        upload_offset = new_upload_offset
 
 
 class Uploader:
     """
     Implements common uploading protocols
     """
-
-    _CHUNK_SIZE = 10 * 2**20
 
     def __init__(self, client: Client):
         self._client = client
@@ -200,29 +179,15 @@ class Uploader:
             total=total_size, desc="Uploading data", unit_scale=True, unit="B", unit_divisor=1024
         )
 
-    @staticmethod
-    def _make_tus_uploader(api_client: ApiClient, url: str, **kwargs):
-        # Add headers required by CVAT server
-        headers = {}
-        headers["Origin"] = api_client.configuration.host
-        headers.update(api_client.get_common_headers())
-
-        client = _TusClient(url, headers=headers)
-
-        return _MyTusUploader(client=client, api_client=api_client, **kwargs)
-
-    def _upload_file_data_with_tus(self, url, filename, *, meta=None, pbar, logger=None) -> str:
+    def _upload_file_data_with_tus(self, url, filename, *, meta, pbar, logger=None) -> str:
         with open(filename, "rb") as input_file:
-            tus_uploader = self._make_tus_uploader(
+            return _upload_with_tus(
                 self._client.api_client,
-                url=url.rstrip("/") + "/",
+                create_url=url.rstrip("/") + "/",
                 metadata=meta,
                 file_stream=StreamWithProgress(input_file, pbar),
-                chunk_size=Uploader._CHUNK_SIZE,
-                log_func=logger,
+                logger=logger or self._client.logger,
             )
-            tus_uploader.upload()
-            return tus_uploader.real_filename
 
     def _tus_start_upload(self, url, *, query_params=None):
         response = self._client.api_client.rest_client.POST(

--- a/cvat-sdk/requirements/base.txt
+++ b/cvat-sdk/requirements/base.txt
@@ -5,5 +5,4 @@ packaging >= 21.3
 Pillow >= 10.3.0
 platformdirs >= 2.1.0
 tqdm >= 4.64.0
-tuspy == 0.2.5 # have it pinned, because SDK has lots of patched TUS code
 typing_extensions >= 4.2.0

--- a/tests/python/sdk/test_tasks.py
+++ b/tests/python/sdk/test_tasks.py
@@ -12,10 +12,10 @@ from typing import Optional
 import pytest
 from cvat_sdk import Client, models
 from cvat_sdk.api_client import exceptions
+from cvat_sdk.api_client.rest import RESTClientObject
 from cvat_sdk.core.exceptions import BackgroundRequestException
 from cvat_sdk.core.proxies.tasks import ResourceType, Task
 from cvat_sdk.core.proxies.types import Location
-from cvat_sdk.core.uploading import Uploader, _MyTusUploader
 from PIL import Image
 from pytest_cases import fixture_ref, parametrize
 
@@ -470,17 +470,18 @@ class TestTaskUsecases(TestDatasetExport):
     def test_can_create_from_backup_in_chunks(
         self, monkeypatch: pytest.MonkeyPatch, fxt_new_task: Task, fxt_backup_file: Path
     ):
-        monkeypatch.setattr(Uploader, "_CHUNK_SIZE", 100)
+        monkeypatch.setattr("cvat_sdk.core.uploading.TUS_CHUNK_SIZE", 100)
 
         num_requests = 0
-        original_do_request = _MyTusUploader._do_request
+        original_request = RESTClientObject.request
 
-        def counting_do_request(uploader):
+        def counting_request(self, method, *args, headers, **kwargs):
             nonlocal num_requests
-            num_requests += 1
-            original_do_request(uploader)
+            if method.upper() == "PATCH" and "Upload-Offset" in headers:
+                num_requests += 1
+            return original_request(self, method, *args, headers=headers, **kwargs)
 
-        monkeypatch.setattr(_MyTusUploader, "_do_request", counting_do_request)
+        monkeypatch.setattr(RESTClientObject, "request", counting_request)
 
         self._test_can_create_from_backup(fxt_new_task, fxt_backup_file)
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The version we're depending on (0.2.5) has a dependency on python-future, which had a CVE filed against it (PythonCharmers/python-future#650). While the CVE itself seems to be bogus (and in fact, tuspy doesn't actually _use_ python-future), it would still be nice to get rid of this dependency to placate various security dependency scanners.

tuspy did remove this dependency in version 1.0.2. However, this version isn't immediately compatible with the various hacks we have applied to marry it to the API client. Instead of adapting them, I chose to throw tuspy out, and reimplement the TUS protocol. I think this is better for a few reasons:

* We won't have to keep adapting the hacks every time we need to update the dependency.

* The SDK can now be installed in an environment together with other packages that have incompatible tuspy requirements.

* The reimplementation turned out to be shorter than the original code.

I also removed the CVAT 2.2 compatibility code that was in `get_offset`, since we're no longer compatible with those versions for other reasons anyway (e.g., they don't have `/api/requests`).

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Unit tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
