### PR TITLE
fix: re-enable k8s pre-release compatibility for helm chart

### DIFF
--- a/changelog.d/20250919_132616_77135162+NobisIndustries.md
+++ b/changelog.d/20250919_132616_77135162+NobisIndustries.md
@@ -1,4 +1,4 @@
-### Fixed 
+### Fixed
 
-- Re-enables helm chart compatibilty with K8s pre-release versions
-(<https://github.com/cvat-ai/cvat/pull/9841>)
+- Re-enables helm chart compatibility with K8s pre-release versions
+  (<https://github.com/cvat-ai/cvat/pull/9841>)

--- a/changelog.d/20250919_132616_77135162+NobisIndustries.md
+++ b/changelog.d/20250919_132616_77135162+NobisIndustries.md
@@ -1,0 +1,5 @@
+### Added|Changed|Deprecated|Removed|Fixed|Security <!-- pick one -->
+
+- Describe your change here... 
+(<https://github.com/cvat-ai/cvat/pull/9841>)
+Re-enables helm chart compatibilty with K8s pre-release versions

--- a/changelog.d/20250919_132616_77135162+NobisIndustries.md
+++ b/changelog.d/20250919_132616_77135162+NobisIndustries.md
@@ -1,5 +1,4 @@
-### Added|Changed|Deprecated|Removed|Fixed|Security <!-- pick one -->
+### Fixed 
 
-- Describe your change here... 
+- Re-enables helm chart compatibilty with K8s pre-release versions
 (<https://github.com/cvat-ai/cvat/pull/9841>)
-Re-enables helm chart compatibilty with K8s pre-release versions

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cvat
-kubeVersion: ">= 1.23.0"
+kubeVersion: ">= 1.23.0-0"
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
fixes https://github.com/cvat-ai/cvat/issues/9839

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
The helm chart kubeVersion constraint accidentally dropped pre-release versions of K8s from its compatibility requirements - so it can't be rolled out in EKS clusters (which use AWS specific pre-release versions of K8s). This change reintroduces the old behavior.

### How has this been tested?
Worked for the helm charts before the dropped "-0" part, so this is a simple fix with no problems foreseen.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
~~- [] I have updated the documentation accordingly~~
~~- [] I have added tests to cover my changes~~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
