### PR TITLE
denote currently used yarn version in cvat/tests

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -19,7 +19,5 @@
     "jimp": "^0.22.10"
   },
   "version": "0.0.0",
-  "devDependencies": {
-    "@types/k6": "^1.1.1"
-  }
+  "packageManager": "yarn@4.9.2"
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -764,13 +764,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/k6@npm:^1.1.1":
-  version: 1.2.0
-  resolution: "@types/k6@npm:1.2.0"
-  checksum: 10c0/bab24bfcfb5e7d9645be7417b64f242c4e607658edce213a1077ba3ce5b0dc7531ea2087e2b5383f8b817eae3d1e572944d5511db20ee81c4188f9728b53cc9f
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:*, @types/node@npm:16.9.1":
   version: 16.9.1
   resolution: "@types/node@npm:16.9.1"
@@ -3302,7 +3295,6 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@cypress/code-coverage": "npm:^3.9.10"
-    "@types/k6": "npm:^1.1.1"
     allure-cypress: "npm:^3.2.2"
     archiver: "npm:^5.3.0"
     cy-verify-downloads: "npm:^0.0.5"


### PR DESCRIPTION
This is needed so that matrix jobs in private repo workflows can utilize the correct version of yarn when running the e2e tests in private repo

https://github.com/cvat-ai/app.cvat.ai/pull/669
CI Nightly passes: https://github.com/cvat-ai/cvat/actions/runs/17865769503

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
