### PR TITLE
ai-models/detector/yolo: add a default for the `device` parameter

### DIFF
--- a/ai-models/detector/yolo/func.py
+++ b/ai-models/detector/yolo/func.py
@@ -15,7 +15,7 @@ from ultralytics.engine.results import Results
 
 
 class YoloFunction(abc.ABC):
-    def __init__(self, model: YOLO, device: str) -> None:
+    def __init__(self, model: YOLO, *, device: str = "cpu") -> None:
         self._model = model
         self._device = device
 
@@ -126,15 +126,13 @@ DEFAULT_KEYPOINT_NAMES = [
 
 
 class YoloPoseEstimationFunction(YoloFunctionWithShapes):
-    def __init__(
-        self, model: YOLO, device: str, *, keypoint_names_path: Optional[str] = None
-    ) -> None:
+    def __init__(self, model: YOLO, *, keypoint_names_path: Optional[str] = None, **kwargs) -> None:
         if keypoint_names_path is None:
             self._keypoint_names = DEFAULT_KEYPOINT_NAMES
         else:
             self._keypoint_names = self._load_names(keypoint_names_path)
 
-        super().__init__(model, device)
+        super().__init__(model, **kwargs)
 
     def _load_names(self, path: str) -> list[str]:
         with open(path, "r") as f:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
I wrote in the README that the default is CPU, but I forgot to actually implement it. :facepalm: 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
