### PR TITLE
Fix `Cannot read properties of undefined (reading 'points')`

### DIFF
--- a/changelog.d/20250929_124206_klakhov_fix_points_undefined.md
+++ b/changelog.d/20250929_124206_klakhov_fix_points_undefined.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- UI error `Cannot read properties of undefined (reading 'points')` occurring in various scenarios
+  (<https://github.com/cvat-ai/cvat/pull/9855>)

--- a/cvat-canvas/src/typescript/sliceHandler.ts
+++ b/cvat-canvas/src/typescript/sliceHandler.ts
@@ -554,8 +554,12 @@ export class SliceHandlerImpl implements SliceHandler {
             }], 'slice');
 
             this.objectSelector.enable(([state]) => {
-                this.objectSelector.disable();
-                initializeWithContour(state);
+                if (state) {
+                    this.objectSelector.disable();
+                    initializeWithContour(state);
+                } else {
+                    this.release();
+                }
             }, { maxCount: 1, shapeType: ['polygon', 'mask'], objectType: ['shape'] });
         } else if (this.enabled && !sliceData.enabled) {
             this.release();

--- a/cvat-canvas/src/typescript/sliceHandler.ts
+++ b/cvat-canvas/src/typescript/sliceHandler.ts
@@ -557,8 +557,6 @@ export class SliceHandlerImpl implements SliceHandler {
                 if (state) {
                     this.objectSelector.disable();
                     initializeWithContour(state);
-                } else {
-                    this.release();
                 }
             }, { maxCount: 1, shapeType: ['polygon', 'mask'], objectType: ['shape'] });
         } else if (this.enabled && !sliceData.enabled) {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The `Cannot read properties of undefined (reading 'points')` error occurs in the `initializeWithContour` method when an incorrect `undefined` argument is passed.
This happens in the callback provided by the slice handler to the object selector. The selection callback can be invoked with an empty array, but the slice handler callback always expects at least one element. As a result, the error occurs.

Can be reproduced via different user actions that trigger this chain: `canvasInstance.setup -> UpdateReasons.OBJECTS_UPDATED -> objectSelector.resetSelected`, for example:

1. Enable slice tool
    1. Delete an object via sidebar
    2. Change z layer of an object via sidebar
    3. Enable gamma filter
    4. Add new Z layer
2. Get an error
<img width="391" height="139" alt="image" src="https://github.com/user-attachments/assets/b82450f4-f237-45e9-ab61-b326678028aa" />
 
### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
