### PR TITLE
Work around spurious "No module named 'pkg_resources'" errors

### DIFF
--- a/changelog.d/20251006_193945_roman_no_getouterframes.md
+++ b/changelog.d/20251006_193945_roman_no_getouterframes.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Worked around an issue that may cause an error message to be replaced
+  with "No module named 'pkg_resources'"
+  (<https://github.com/cvat-ai/cvat/pull/9869>)

--- a/cvat/apps/dataset_manager/util.py
+++ b/cvat/apps/dataset_manager/util.py
@@ -27,7 +27,15 @@ from pottery import Redlock
 
 
 def current_function_name(depth=1):
-    return inspect.getouterframes(inspect.currentframe())[depth].function
+    frame = inspect.currentframe()
+    if frame is None:
+        return "[unknown]"
+
+    for _ in range(depth):
+        frame = frame.f_back
+        assert frame is not None, "not enough stack frames"
+
+    return frame.f_code.co_name
 
 
 def make_zip_archive(src_path, dst_path):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Datumaro depends on the pyemd library, which fails to be imported in the CVAT Docker image, because it uses `pkg_resources` without declaring a dependency on setuptools (see also wmayner/pyemd#67).

Normally this isn't a problem, because Datumaro imports it lazily (and the Datumaro component that triggers its actual loading is not used by CVAT). However, the `current_function_name` function calls `inspect.getouterframes`, which indirectly causes every lazy-imported module to be loaded (this behavior might be a Python bug). In particular, this loads pyemd, which raises an exception.

`current_function_name` is usually called while handling another exception, so when this problem occurs, that original exception becomes lost.

Work around this by replacing `inspect.getouterframes` with custom code that does the bare minimum necessary to get the function name.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
