### PR TITLE
Fix manifest and frame order mismatches in task creations

### DIFF
--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -1135,16 +1135,16 @@ def create_thread(
                 manifest.init_index()
 
             # Align manifest order with the selected sorting method for image-based tasks.
-            try:
-                if data['sorting_method'] != models.SortingMethod.PREDEFINED:
-                    desired_order = [
-                        os.path.relpath(extractor.get_path(frame_id), upload_dir)
-                        for frame_id in extractor.frame_range
-                    ]
+            if data['sorting_method'] != models.SortingMethod.PREDEFINED:
+                desired_order = [
+                    os.path.relpath(extractor.get_path(frame_id), upload_dir)
+                    for frame_id in extractor.frame_range
+                ]
+
+                try:
                     manifest.reorder(desired_order)
-            except Exception as e:
-                # If reordering fails for some reason, proceed without altering
-                raise ValidationError("Manifest reordering failed") from e
+                except Exception as e:
+                    raise ValidationError("Manifest reordering failed") from e
 
             for frame_id in extractor.frame_range:
                 image_path = extractor.get_path(frame_id)

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -1142,9 +1142,9 @@ def create_thread(
                         for frame_id in extractor.frame_range
                     ]
                     manifest.reorder(desired_order)
-            except Exception:
+            except Exception as e:
                 # If reordering fails for some reason, proceed without altering
-                raise ValidationError("Manifest reordering failed")
+                raise ValidationError("Manifest reordering failed") from e
 
             for frame_id in extractor.frame_range:
                 image_path = extractor.get_path(frame_id)

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -480,7 +480,7 @@ class TestPostTasks:
         }
 
         client_files = images + [manifest_file]
-        #the same applies for random sorting as well
+        #the same applies for lexicographical and random sorting as well
         data_spec = {
             "image_quality": 75,
             "client_files": client_files,

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -455,7 +455,7 @@ class TestPostTasks:
         filenames = ["image_0.jpg", "image_1.jpg", "image_2.jpg"]
         images = generate_image_files(len(filenames), filenames=filenames)
 
-        #manifest with shuffled orde
+        # manifest with shuffled orde
         manifest_order = ["image_1.jpg", "image_2.jpg", "image_0.jpg"]
 
         manifest_content = {"version": "1.1"}
@@ -480,7 +480,7 @@ class TestPostTasks:
         }
 
         client_files = images + [manifest_file]
-        #the same applies for lexicographical and random sorting as well
+        # the same applies for lexicographical and random sorting as well
         data_spec = {
             "image_quality": 75,
             "client_files": client_files,
@@ -488,12 +488,14 @@ class TestPostTasks:
         }
 
         task_id, _ = create_task(admin_user, task_spec, data_spec)
-
         with make_api_client(admin_user) as api_client:
             (task, _) = api_client.tasks_api.retrieve(task_id)
             assert task.size == 3
-
-
+            (data, _) = api_client.tasks_api.retrieve_data_meta(task_id)
+            frames_meta = data.frames
+            assert frames_meta[0]["name"] == "image_0.jpg"
+            assert frames_meta[1]["name"] == "image_1.jpg"
+            assert frames_meta[2]["name"] == "image_2.jpg"
 
 
 @pytest.mark.usefixtures("restore_db_per_class")


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
closes #10104 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.

Fixes