### PR TITLE
Bump the NumPy server dependency to 2.x

### DIFF
--- a/cvat/requirements/base.in
+++ b/cvat/requirements/base.in
@@ -29,7 +29,7 @@ drf-spectacular==0.26.2
 google-cloud-storage~=3.0
 lxml>=5.2.1,<6
 natsort==8.0.0
-numpy~=1.22.2
+numpy~=2.0
 opencv-python-headless~=4.8
 
 # Partial json reading

--- a/utils/dataset_manifest/requirements.txt
+++ b/utils/dataset_manifest/requirements.txt
@@ -7,7 +7,7 @@ av==16.0.1
     # via -r utils/dataset_manifest/requirements.in
 natsort==8.0.0
     # via -r utils/dataset_manifest/requirements.in
-numpy==1.22.4
+numpy==2.2.6
     # via opencv-python-headless
 opencv-python-headless==4.11.0.86
     # via -r utils/dataset_manifest/requirements.in


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Main reason is to make it easier to switch to a newer Python version in the future, since 1.22.4 doesn't support anything newer than 3.10.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
