### PR TITLE
Fix serverless function sidebar scroll and accessibility issues

### DIFF
--- a/cvat-ui/src/components/annotation-page/standard-workspace/styles.scss
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/styles.scss
@@ -211,9 +211,23 @@
 .cvat-tools-control-popover-content,
 .cvat-opencv-control-popover-content {
     width: fit-content;
+    max-height: 80vh;
     padding: $grid-unit-size;
     border-radius: $grid-unit-size;
     background: $background-color-2;
+    display: flex;
+    flex-direction: column;
+
+    .ant-tabs {
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+
+        .ant-tabs-content-holder {
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+    }
 
     .ant-tabs-tab {
         width: $grid-unit-size * 14;

--- a/cvat-ui/src/components/model-runner-modal/styles.scss
+++ b/cvat-ui/src/components/model-runner-modal/styles.scss
@@ -53,14 +53,12 @@
     @extend .cvat-labels-attributes-mapper-tree;
 
     width: 100%;
+    max-height: $grid-unit-size * 64;
+    overflow-y: auto;
+    overflow-x: hidden;
 
     span {
         text-align: center;
-    }
-
-    &:has(.cvat-runner-label-mapper) {
-        max-height: $grid-unit-size * 64;
-        overflow: hidden auto;
     }
 
     > .cvat-runner-label-mapper {
@@ -92,8 +90,14 @@
 
 
 
-.cvat-run-model-content > div:not(first-child) {
-    margin-top: $grid-unit-size;
+.cvat-run-model-content {
+    max-height: 60vh;
+    overflow-y: auto;
+    overflow-x: hidden;
+
+    > div:not(first-child) {
+        margin-top: $grid-unit-size;
+    }
 }
 
 .cvat-run-model-content-remove-mapping-icon {


### PR DESCRIPTION
Fixes #10228

When a large number of classes or attributes are present in serverless functions, the sidebar would grow beyond screen bounds, causing scroll and accessibility issues.

Added max-height and overflow handling to popover and model runner content for proper scrolling.

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have linked related issues (Fixes #10228)
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
