### PR TITLE
Add text prompt input for promptable detectors

### DIFF
--- a/changelog.d/20260131_013717_son-hai.nguyen_feat_promptable_detectors.md
+++ b/changelog.d/20260131_013717_son-hai.nguyen_feat_promptable_detectors.md
@@ -1,0 +1,4 @@
+### Added
+
+- Support for text prompts in detectors models.
+  (<https://github.com/cvat-ai/cvat/pull/10243>)

--- a/cvat-core/src/core-types.ts
+++ b/cvat-core/src/core-types.ts
@@ -54,6 +54,7 @@ export interface SerializedModel {
     startswith_box_optional?: boolean;
     created_date?: string;
     updated_date?: string;
+    is_promptable?: boolean;
 }
 
 export interface UpdateStatusData {

--- a/cvat-core/src/ml-model.ts
+++ b/cvat-core/src/ml-model.ts
@@ -97,6 +97,10 @@ export default class MLModel {
         return this.serialized?.updated_date;
     }
 
+    public get isPromptable(): boolean {
+        return this.serialized?.is_promptable ?? false;
+    }
+
     public get url(): string | undefined {
         return this.serialized?.url;
     }

--- a/cvat-ui/src/components/model-runner-modal/detector-runner.tsx
+++ b/cvat-ui/src/components/model-runner-modal/detector-runner.tsx
@@ -12,6 +12,7 @@ import InputNumber from 'antd/lib/input-number';
 import Button from 'antd/lib/button';
 import Switch from 'antd/lib/switch';
 import Tag from 'antd/lib/tag';
+import Input from 'antd/lib/input';
 import notification from 'antd/lib/notification';
 import { ArrowRightOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 
@@ -22,7 +23,6 @@ import {
 } from 'cvat-core-wrapper';
 
 import LabelsMapperComponent, { LabelInterface, FullMapping } from './labels-mapper';
-import Input from 'antd/lib/input';
 
 interface Props {
     withCleanup: boolean;

--- a/cvat/apps/lambda_manager/serializers.py
+++ b/cvat/apps/lambda_manager/serializers.py
@@ -48,6 +48,7 @@ class FunctionCallRequestSerializer(serializers.Serializer):
         required=False,
         help_text="Label mapping from the model to the task labels",
     )
+    prompt = serializers.CharField(required=False, help_text="Prompt for the model")
 
 
 class FunctionCallParamsSerializer(serializers.Serializer):

--- a/site/content/en/docs/annotation/auto-annotation/ai-tools.md
+++ b/site/content/en/docs/annotation/auto-annotation/ai-tools.md
@@ -176,6 +176,16 @@ match them.
 For this reason, supported DL models are suitable only for certain labels.
 <br>To check the list of labels for each model, see [Detectors models](#detectors-models).
 
+### Text Prompts for Detectors
+
+Some detector models (e.g., GroundingDINO) support text prompts that allow you to specify which objects to detect using natural language.
+
+If the model is promptable, you will see a **Text Prompt** field where you can enter the prompt. The prompt tells the model what objects to look for in the images.
+
+{{% alert title="Note" color="primary" %}}
+Currently, detector classes are defined statically. The list of output classes from the detector will not be affected by the prompt.
+{{% /alert %}}
+
 ### Annotate with detectors
 
 To annotate with detectors, do the following:

--- a/site/content/en/docs/annotation/auto-annotation/ai-tools.md
+++ b/site/content/en/docs/annotation/auto-annotation/ai-tools.md
@@ -178,12 +178,15 @@ For this reason, supported DL models are suitable only for certain labels.
 
 ### Text Prompts for Detectors
 
-Some detector models (e.g., GroundingDINO) support text prompts that allow you to specify which objects to detect using natural language.
+Some detector models (e.g., GroundingDINO) support text prompts that allow you
+to specify which objects to detect using natural language.
 
-If the model is promptable, you will see a **Text Prompt** field where you can enter the prompt. The prompt tells the model what objects to look for in the images.
+If the model is promptable, you will see a **Text Prompt** field where you can enter the prompt.
+The prompt tells the model what objects to look for in the images.
 
 {{% alert title="Note" color="primary" %}}
-Currently, detector classes are defined statically. The list of output classes from the detector will not be affected by the prompt.
+Currently, detector classes are defined statically. The list of output classes from the detector
+will not be affected by the prompt.
 {{% /alert %}}
 
 ### Annotate with detectors

--- a/site/content/en/docs/guides/serverless-tutorial.md
+++ b/site/content/en/docs/guides/serverless-tutorial.md
@@ -707,6 +707,46 @@ absent. Theoretically it is possible to run different functions on different
 GPUs, but it requires to change source code on corresponding serverless
 functions to choose a free GPU._
 
+### Marking detectors as promptable
+
+Some detector models support text prompts that guide the detection process using natural language.
+To mark your detector as promptable, add the `is_promptable` field to the model's metadata annotations in `function.yaml`:
+
+```yaml
+metadata:
+  name: your-detector-name
+  namespace: cvat
+  annotations:
+    name: Your Detector Display Name
+    type: detector
+    framework: pytorch
+    is_promptable: true
+    spec: |
+      [
+        { "id": 0, "name": "person" },
+        { "id": 1, "name": "car" }
+      ]
+```
+
+When `is_promptable` is set to `true`, a **Text Prompt** input field in the CVAT UI
+when running the detector.
+
+{{% alert title="Important" color="primary" %}}
+- The `is_promptable` field only adds the UI input field.
+- Your model must be designed to accept and process text prompts.
+- Output classes remain defined by the `spec` field (static).
+- The prompt guides detection but doesn't change available labels.
+{{% /alert %}}
+
+#### Handling prompts in your serverless function
+
+The prompt text is passed to your function in the request body. Extract and use it in your handler:
+```python
+def handler(context, event):
+    data = event.body
+    prompt = data.get("prompt", "")
+```
+
 ### Debugging a serverless function
 
 Let's say you have a problem with your serverless function and want to debug it.


### PR DESCRIPTION


<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Allow users to provide text prompts when running detector models that support prompting (e.g., GroundingDINO). A prompt input field is displayed in the detector runner UI for models marked with the is_promptable flag.

Additionally, the prompt is passed to the detector is specified.

Closes #7129 

### How has this been tested?
Manual testing. Per image as well as task automatic annotation.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
