### PR TITLE
Fix degree to radian conversion in 3D track labelling

### DIFF
--- a/changelog.d/20260207_093540_fanxiule_fix_deg2rad.md
+++ b/changelog.d/20260207_093540_fanxiule_fix_deg2rad.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fix degree to radian conversion for rotation interpolation in 3D tracks
+  (<https://github.com/cvat-ai/cvat/pull/10262>)

--- a/cvat/apps/dataset_manager/annotation.py
+++ b/cvat/apps/dataset_manager/annotation.py
@@ -833,7 +833,7 @@ class TrackManager(ObjectManager):
                         angle1 = angles[i + 3]
                         angle0 = (angle0 if angle0 >= 0 else angle0 + math.pi * 2) * 180 / math.pi
                         angle1 = (angle1 if angle1 >= 0 else angle1 + math.pi * 2) * 180 / math.pi
-                        angle = angle0 + find_angle_diff(angle1, angle0) * offset * math.pi / 180
+                        angle = (angle0 + find_angle_diff(angle1, angle0) * offset) * math.pi / 180
                         shape["points"][i + 3] = angle if angle <= math.pi else angle - math.pi * 2
 
                 yield shape


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
In 3D cuboid tracking labelling, the rotation at non keyframe is interpolated given rotation at 2 keyframes. Currently, the keyframe rotations are first converted from rad to deg. However, the interpolation logic is incorrect, nor the deg to rad conversion for non keyframe rotation

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Label 3D cuboid track and define two keyframes in the track. Then export the annotations

Before
```
{
    "id": "1768937820207478936",
    "annotations": [
        {
            "id": 0,
            "type": "cuboid_3d",
            "attributes": {
                "occluded": false,
                "track_id": 0,
                "keyframe": true
            },
            "group": 0,
            "label_id": 0,
            "position": [
                -0.64,
                -1.93,
                0.93
            ],
            "rotation": [
                -0.68,
                0.44,
                0.48
            ],
            "scale": [
                2.25,
                0.49,
                0.72
            ]
        }
    ],
    "attr": {
        "frame": 0
    },
    "point_cloud": {
        "path": "pointcloud/1768937820207478936.pcd"
    }
},
{
    "id": "1768937820310911928",
    "annotations": [
        {
            "id": 0,
            "type": "cuboid_3d",
            "attributes": {
                "occluded": false,
                "track_id": 0,
                "keyframe": false
            },
            "group": 0,
            "label_id": 0,
            "position": [
                -1.55,
                -2.13,
                1.76
            ],
            "rotation": [
                315.17,
                18.83,
                21.14
            ],
            "scale": [
                1.75,
                0.32,
                0.58
            ]
        }
    ],
    "attr": {
        "frame": 1
    },
    "point_cloud": {
        "path": "pointcloud/1768937820310911928.pcd"
    }
},
{
    "id": "1768937820407606424",
    "annotations": [
        {
            "id": 0,
            "type": "cuboid_3d",
            "attributes": {
                "occluded": false,
                "track_id": 0,
                "keyframe": true
            },
            "group": 0,
            "label_id": 0,
            "position": [
                -2.47,
                -2.33,
                2.58
            ],
            "rotation": [
                0.04,
                -0.1,
                0.17
            ],
            "scale": [
                1.24,
                0.16,
                0.44
            ]
        }
    ],
    "attr": {
        "frame": 2
    },
    "point_cloud": {
        "path": "pointcloud/1768937820407606424.pcd"
    }
},
```

After
```
{
    "id": "1768937820207478936",
    "annotations": [
        {
            "id": 0,
            "type": "cuboid_3d",
            "attributes": {
                "occluded": false,
                "track_id": 0,
                "keyframe": true
            },
            "group": 0,
            "label_id": 0,
            "position": [
                -2.68,
                -1.21,
                0.33
            ],
            "rotation": [
                -0.34,
                0.95,
                -0.28
            ],
            "scale": [
                2.66,
                0.26,
                0.58
            ]
        }
    ],
    "attr": {
        "frame": 0
    },
    "point_cloud": {
        "path": "pointcloud/1768937820207478936.pcd"
    }
},
{
    "id": "1768937820310911928",
    "annotations": [
        {
            "id": 0,
            "type": "cuboid_3d",
            "attributes": {
                "occluded": false,
                "track_id": 0,
                "keyframe": false
            },
            "group": 0,
            "label_id": 0,
            "position": [
                -2.75,
                -0.86,
                0.43
            ],
            "rotation": [
                0.83,
                1.16,
                -1.64
            ],
            "scale": [
                2.01,
                0.5,
                0.39
            ]
        }
    ],
    "attr": {
        "frame": 1
    },
    "point_cloud": {
        "path": "pointcloud/1768937820310911928.pcd"
    }
},
{
    "id": "1768937820407606424",
    "annotations": [
        {
            "id": 0,
            "type": "cuboid_3d",
            "attributes": {
                "occluded": false,
                "track_id": 0,
                "keyframe": true
            },
            "group": 0,
            "label_id": 0,
            "position": [
                -2.83,
                -0.5,
                0.54
            ],
            "rotation": [
                2.01,
                1.37,
                -3.0
            ],
            "scale": [
                1.35,
                0.73,
                0.21
            ]
        }
    ],
    "attr": {
        "frame": 2
    },
    "point_cloud": {
        "path": "pointcloud/1768937820407606424.pcd"
    }
},
```

Note the rotation at frame 1, which is a non keyframe

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
