### PR TITLE
Fix: respect cloud storage prefix when exporting a project

### DIFF
--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -1179,6 +1179,10 @@ def export_resource_to_cloud_storage(
     rq_job_meta = ExportRQMeta.for_job(rq_job)
 
     storage = db_storage_to_storage_instance(db_storage)
-    storage.upload_file(Path(file_path), rq_job_meta.result_filename)
+    filename = rq_job_meta.result_filename
+    if storage.prefix:
+        filename = os.path.join(storage.prefix, filename)
+
+    storage.upload_file(Path(file_path), filename)
 
     return file_path


### PR DESCRIPTION
Fixes #10237

Previously, exporting a project dataset to cloud storage would ignore the `prefix` defined in the cloud storage configuration, placing the exported file in the root directory.

This change ensures that the `prefix` is prepended to the result filename before uploading.