### PR TITLE
Fix #10331: persist cloud storage link after task data import

### DIFF
--- a/changelog.d/20260318_162225_duarte.cruz_issue10331.md
+++ b/changelog.d/20260318_162225_duarte.cruz_issue10331.md
@@ -1,0 +1,2 @@
+### Fixed
+- Dropped cloud storage links reverting to local storage when importing data into tasks and projects (#10331)

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -354,6 +354,13 @@ class Storage(models.Model):
     class Meta:
         default_permissions = ()
 
+    @classmethod
+    def get_or_create_cloud_storage_link(cls, cloud_storage: CloudStorage) -> "Storage":
+        storage, _ = cls.objects.get_or_create(
+            location=Location.CLOUD_STORAGE,
+            cloud_storage=cloud_storage,
+        )
+        return storage
 
 class ValidationMode(str, Enum):
     GT = "gt"

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -3960,9 +3960,14 @@ def _configure_related_storages(validated_data: dict[str, Any]) -> dict[str, mod
                 not models.CloudStorage.objects.filter(id=cloud_storage_id).exists()
             ):
                 raise serializers.ValidationError(f'The specified cloud storage {cloud_storage_id} does not exist.')
-            storage_instance = models.Storage(**storage_conf)
-            storage_instance.save()
-            storages[i] = storage_instance
+            if storage_conf.get("location") == models.Location.CLOUD_STORAGE and cloud_storage_id:
+                storages[i] = models.Storage.get_or_create_cloud_storage_link(
+                    models.CloudStorage.objects.get(id=cloud_storage_id)
+                )
+            else:
+                storage_instance = models.Storage(**storage_conf)
+                storage_instance.save()
+                storages[i] = storage_instance
     return storages
 
 class AssetReadSerializer(WriteOnceMixin, serializers.ModelSerializer):

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -1155,6 +1155,48 @@ def create_thread(
     )
 
     db_data = db_task.require_data()
+
+    if db_data.cloud_storage:
+        cloud_link_storage = models.Storage.get_or_create_cloud_storage_link(db_data.cloud_storage)
+
+        def _is_default_local_storage(storage: models.Storage | None) -> bool:
+            return storage is None or (
+                storage.location == models.Location.LOCAL and storage.cloud_storage_id is None
+            )
+
+        old_task_source_storage = db_task.source_storage
+        if _is_default_local_storage(old_task_source_storage):
+            db_task.source_storage = cloud_link_storage
+            db_task.save(update_fields=["source_storage"])
+
+            if (
+                old_task_source_storage
+                and old_task_source_storage.location == models.Location.LOCAL
+                and old_task_source_storage.cloud_storage_id is None
+                and not models.Task.objects.filter(source_storage=old_task_source_storage).exists()
+                and not models.Project.objects.filter(source_storage=old_task_source_storage).exists()
+                and not models.Task.objects.filter(target_storage=old_task_source_storage).exists()
+                and not models.Project.objects.filter(target_storage=old_task_source_storage).exists()
+            ):
+                old_task_source_storage.delete()
+
+        if db_project := db_task.project:
+            old_project_source_storage = db_project.source_storage
+            if _is_default_local_storage(old_project_source_storage):
+                db_project.source_storage = cloud_link_storage
+                db_project.save(update_fields=["source_storage"])
+
+                if (
+                    old_project_source_storage
+                    and old_project_source_storage.location == models.Location.LOCAL
+                    and old_project_source_storage.cloud_storage_id is None
+                    and not models.Task.objects.filter(source_storage=old_project_source_storage).exists()
+                    and not models.Project.objects.filter(source_storage=old_project_source_storage).exists()
+                    and not models.Task.objects.filter(target_storage=old_project_source_storage).exists()
+                    and not models.Project.objects.filter(target_storage=old_project_source_storage).exists()
+                ):
+                    old_project_source_storage.delete()
+
     upload_dir = (
         db_data.get_upload_dirname()
         if db_data.storage != models.StorageChoice.SHARE

--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -1116,6 +1116,47 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 if db_data.cloud_storage:
                     self._object.data.storage = StorageChoice.CLOUD_STORAGE
                     self._object.data.save(update_fields=['storage'])
+                    cloud_link_storage = models.Storage.get_or_create_cloud_storage_link(
+                        db_data.cloud_storage
+                    )
+
+                    def _is_default_local_storage(storage: models.Storage | None) -> bool:
+                        return storage is None or (
+                            storage.location == models.Location.LOCAL and storage.cloud_storage_id is None
+                        )
+
+                    old_task_source_storage = self._object.source_storage
+                    if _is_default_local_storage(old_task_source_storage):
+                        self._object.source_storage = cloud_link_storage
+                        self._object.save(update_fields=["source_storage"])
+
+                        if (
+                            old_task_source_storage
+                            and old_task_source_storage.location == models.Location.LOCAL
+                            and old_task_source_storage.cloud_storage_id is None
+                            and not Task.objects.filter(source_storage=old_task_source_storage).exists()
+                            and not Project.objects.filter(source_storage=old_task_source_storage).exists()
+                            and not Task.objects.filter(target_storage=old_task_source_storage).exists()
+                            and not Project.objects.filter(target_storage=old_task_source_storage).exists()
+                        ):
+                            old_task_source_storage.delete()
+
+                    if db_project := self._object.project:
+                        old_project_source_storage = db_project.source_storage
+                        if _is_default_local_storage(old_project_source_storage):
+                            db_project.source_storage = cloud_link_storage
+                            db_project.save(update_fields=["source_storage"])
+
+                            if (
+                                old_project_source_storage
+                                and old_project_source_storage.location == models.Location.LOCAL
+                                and old_project_source_storage.cloud_storage_id is None
+                                and not Task.objects.filter(source_storage=old_project_source_storage).exists()
+                                and not Project.objects.filter(source_storage=old_project_source_storage).exists()
+                                and not Task.objects.filter(target_storage=old_project_source_storage).exists()
+                                and not Project.objects.filter(target_storage=old_project_source_storage).exists()
+                            ):
+                                old_project_source_storage.delete()
                 if 'stop_frame' not in serializer.validated_data:
                     # if the value of stop_frame is 0, then inside the function we cannot know
                     # the value specified by the user or it's default value from the database

--- a/tests/python/rest_api/test_task_data.py
+++ b/tests/python/rest_api/test_task_data.py
@@ -589,7 +589,60 @@ class TestPostTaskData:
         }
 
         kwargs = {"org_id": org_id} if org_id else {}
-        create_task(self._USERNAME, task_spec, data_spec, **kwargs)
+        task_id, _ = create_task(self._USERNAME, task_spec, data_spec, **kwargs)
+
+        response = get_method(self._USERNAME, f"tasks/{task_id}")
+        assert response.status_code == HTTPStatus.OK
+        task = response.json()
+        assert task["source_storage"]["location"] == "cloud_storage"
+        assert task["source_storage"]["cloud_storage_id"] == cloud_storage_id
+
+    @pytest.mark.with_external_services
+    @pytest.mark.parametrize("cloud_storage_id", [2])
+    def test_create_task_in_project_with_cloud_storage_files_persists_source_storage(
+        self,
+        cloud_storage_id: int,
+        cloud_storages,
+    ):
+        org_id = cloud_storages[cloud_storage_id]["organization"]
+
+        project_spec = {
+            "name": f"Project with cloud storage {cloud_storage_id}",
+            "labels": [{"name": "car"}],
+        }
+
+        response = post_method(self._USERNAME, "projects", project_spec, **({"org_id": org_id} if org_id else {}))
+        assert response.status_code == HTTPStatus.CREATED
+        project_id = response.json()["id"]
+
+        task_spec = {
+            "name": f"Task in project with files from cloud storage {cloud_storage_id}",
+            "project_id": project_id,
+        }
+
+        data_spec = {
+            "image_quality": 75,
+            "use_cache": True,
+            "cloud_storage_id": cloud_storage_id,
+            "server_files": [
+                "sub/images_with_manifest/image_case_65_1.png",
+            ],
+        }
+
+        kwargs = {"org_id": org_id} if org_id else {}
+        task_id, _ = create_task(self._USERNAME, task_spec, data_spec, **kwargs)
+
+        response = get_method(self._USERNAME, f"tasks/{task_id}")
+        assert response.status_code == HTTPStatus.OK
+        task = response.json()
+        assert task["source_storage"]["location"] == "cloud_storage"
+        assert task["source_storage"]["cloud_storage_id"] == cloud_storage_id
+
+        response = get_method(self._USERNAME, f"projects/{project_id}")
+        assert response.status_code == HTTPStatus.OK
+        project = response.json()
+        assert project["source_storage"]["location"] == "cloud_storage"
+        assert project["source_storage"]["cloud_storage_id"] == cloud_storage_id
 
     def _create_task_with_cloud_data(
         self,


### PR DESCRIPTION
When creating a task (and project task) from cloud storage, CVAT did not persist the originating cloud storage in `source_storage`, leaving it as local/empty and breaking traceability and defaults.

Persist the cloud storage link by setting Task/Project `source_storage` to a reusable cloud-backed Storage record when cloud data is used, and reuse Storage rows to avoid ID churn. Add REST API regression coverage.

### Motivation and context
Fixes #10331 

Currently, when creating a task (and project task) and importing data from an attached Cloud Storage, CVAT successfully fetches the data but fails to persist the originating cloud storage in the `source_storage` field of the Task/Project. Instead, it drops the reference and defaults back to local with a null cloud storage ID. This breaks data traceability and prevents expected default behaviors for cloud-backed pipelines.

### Changes described in detail
This PR introduces a fix in the engine's data import pipeline (cvat/apps/engine/views.py, cvat/apps/engine/task.py, cvat/apps/engine/models.py, and cvat/apps/engine/serializers.py).

- Storage Record Reusability (models.py & serializers.py): Added a get_or_create_cloud_storage_link classmethod to reuse existing cloud-backed Storage database records. The serializer now intercepts storage creation; if the payload specifies cloud storage, it uses this link to prevent database ID churn and bloat instead of creating new instances.

- Cloud Storage Persistence (views.py & task.py): When data is attached using a cloud_storage_id, the backend now explicitly checks the Task and associated Project storage configurations. If the `source_storage` is still set to the default local location, it updates it to point to the originating cloud storage link.

- Garbage Collection: Implemented logic to safely delete the old local storage records if they become completely orphaned (i.e., not used by any other Tasks or Projects as a source or target).

### How has this been tested?
#### Manual Testing:
- Deployed a local CVAT instance with an attached Cloud Storage.
- Created a new Project and a new Task via the web UI.
- Imported image data directly from the Cloud Storage tab.
- Verified via GET /api/tasks/{id} and GET /api/projects/{id} that source_storage correctly reflects location: "cloud_storage" and the correct cloud_storage_id, rather than reverting to local.

#### Automated Testing:
- Added REST API regression coverage (tests/python/rest_api/test_task_data.py) to verify that creating a task in a project using cloud storage files correctly mutates and persists the source_storage for both the task and the parent project.
- Ran the existing test suite (pytest) to ensure standard local file uploads and explicit storage assignments remain unaffected.

### Checklist
- [X] I submit my changes into the `develop` branch
- [X] I have created a changelog fragment
- [ ] ~~I have updated the documentation accordingly~~ (Not applicable: Backend bug fix, no public API schema changes)
- [X] I have added tests to cover my changes
- [X] I have linked related issues

### License

- [X] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
