### PR TITLE
Backend: harden chunk job errors and S3 status timeouts

### DIFF
--- a/changelog.d/20260418_160500_nmanovic_backend_timeout_and_chunk_failures.md
+++ b/changelog.d/20260418_160500_nmanovic_backend_timeout_and_chunk_failures.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Backend chunk job failures and S3 cloud-storage health checks are now more robust by preserving meaningful chunk creation errors and by making S3 status probes fail fast on unreachable or misconfigured endpoints.

--- a/changelog.d/20260418_160500_nmanovic_backend_timeout_and_chunk_failures.md
+++ b/changelog.d/20260418_160500_nmanovic_backend_timeout_and_chunk_failures.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Backend chunk job failures now preserve more meaningful exception details
+  (<https://github.com/cvat-ai/cvat/pull/10495>)
+- S3 cloud-storage status probes now fail fast on unreachable or misconfigured
+  endpoints
+  (<https://github.com/cvat-ai/cvat/pull/10495>)

--- a/cvat/apps/engine/cache.py
+++ b/cvat/apps/engine/cache.py
@@ -77,13 +77,13 @@ class ChunkCreationError(Exception):
 def _build_chunk_job_failure_exception(
     rq_job: rq.job.Job, job_meta: RQMetaWithFailureInfo
 ) -> Exception:
-    exc_type = job_meta.exc_type or Exception
+    exc_type = job_meta.exc_type or ChunkCreationError
     exc_args = job_meta.exc_args or ("Cannot create chunk",)
 
     try:
         return exc_type(*exc_args)
     except TypeError:
-        exc_name = getattr(exc_type, "__name__", repr(exc_type))
+        exc_name = exc_type.__name__
         details = job_meta.formatted_exception or repr(exc_args)
         return ChunkCreationError(
             f"Chunk job {rq_job.id} failed with {exc_name}: {details.strip()}"

--- a/cvat/apps/engine/cache.py
+++ b/cvat/apps/engine/cache.py
@@ -70,6 +70,26 @@ class CacheTooLargeDataError(Exception):
     pass
 
 
+class ChunkCreationError(Exception):
+    pass
+
+
+def _build_chunk_job_failure_exception(
+    rq_job: rq.job.Job, job_meta: RQMetaWithFailureInfo
+) -> Exception:
+    exc_type = job_meta.exc_type or Exception
+    exc_args = job_meta.exc_args or ("Cannot create chunk",)
+
+    try:
+        return exc_type(*exc_args)
+    except TypeError:
+        exc_name = getattr(exc_type, "__name__", repr(exc_type))
+        details = job_meta.formatted_exception or repr(exc_args)
+        return ChunkCreationError(
+            f"Chunk job {rq_job.id} failed with {exc_name}: {details.strip()}"
+        )
+
+
 def enqueue_create_chunk_job(
     queue: rq.Queue,
     rq_job_id: str,
@@ -110,9 +130,7 @@ def wait_for_rq_job(rq_job: rq.job.Job):
         elif job_status in ("failed",):
             rq_job.get_meta()  # refresh from Redis
             job_meta = RQMetaWithFailureInfo.for_job(rq_job)
-            exc_type = job_meta.exc_type or Exception
-            exc_args = job_meta.exc_args or ("Cannot create chunk",)
-            raise exc_type(*exc_args)
+            raise _build_chunk_job_failure_exception(rq_job, job_meta)
 
         time.sleep(settings.CVAT_CHUNK_CREATE_CHECK_INTERVAL)
         retries -= 1

--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -619,12 +619,6 @@ class S3CloudStorage(AbstractCloudStorage):
         # misconfigured. Keep a dedicated low-timeout client for head_bucket, while
         # the regular resource/client retain their standard retry behavior for normal
         # storage operations.
-        status_config = Config(
-            proxies=PROXIES_FOR_UNTRUSTED_URLS or {},
-            connect_timeout=2,
-            read_timeout=5,
-            retries={"total_max_attempts": 1, "mode": "standard"},
-        )
         self._s3 = session.resource(
             "s3",
             endpoint_url=endpoint_url,
@@ -639,7 +633,16 @@ class S3CloudStorage(AbstractCloudStorage):
                 ),
             ),
         )
-        self._status_client = session.client("s3", endpoint_url=endpoint_url, config=status_config)
+        self._status_client = session.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            config=Config(
+                proxies=PROXIES_FOR_UNTRUSTED_URLS or {},
+                connect_timeout=2,
+                read_timeout=5,
+                retries={"total_max_attempts": 1, "mode": "standard"},
+            ),
+        )
 
         # anonymous access
         if not any([access_key_id, secret_key, session_token]):

--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -24,7 +24,12 @@ from azure.storage.blob import BlobServiceClient, ContainerClient
 from azure.storage.blob._list_blobs_helper import BlobPrefix
 from boto3.s3.transfer import TransferConfig
 from botocore.client import Config
-from botocore.exceptions import ClientError, EndpointConnectionError
+from botocore.exceptions import (
+    ClientError,
+    ConnectTimeoutError,
+    EndpointConnectionError,
+    ReadTimeoutError,
+)
 from botocore.handlers import disable_signing
 from django.conf import settings
 from google.api_core.exceptions import RetryError
@@ -609,6 +614,21 @@ class S3CloudStorage(AbstractCloudStorage):
                 kwargs[key] = arg_v
 
         session = boto3.Session(**kwargs)
+        # Status checks are part of the control plane, not the data-transfer path, so
+        # they must fail fast when the endpoint is unreachable or misconfigured. Some
+        # network setups return a transport timeout instead of an immediate connection
+        # refusal for a wrong host/port, which can make a simple bucket health probe
+        # hang long enough to block API requests and propagate failures to unrelated
+        # operations. Use a dedicated low-timeout client for head_bucket/head_object,
+        # while the regular resource/client keep the default pool and retry behavior
+        # for real uploads/downloads. Tests with intentionally broken endpoints confirm
+        # that this distinction is required in practice.
+        status_config = Config(
+            proxies=PROXIES_FOR_UNTRUSTED_URLS or {},
+            connect_timeout=2,
+            read_timeout=5,
+            retries={"max_attempts": 1, "mode": "standard"},
+        )
         self._s3 = session.resource(
             "s3",
             endpoint_url=endpoint_url,
@@ -623,10 +643,12 @@ class S3CloudStorage(AbstractCloudStorage):
                 ),
             ),
         )
+        self._status_client = session.client("s3", endpoint_url=endpoint_url, config=status_config)
 
         # anonymous access
         if not any([access_key_id, secret_key, session_token]):
             self._s3.meta.client.meta.events.register("choose-signer.s3.*", disable_signing)
+            self._status_client.meta.events.register("choose-signer.s3.*", disable_signing)
 
         self._client = self._s3.meta.client
         self._bucket = self._s3.Bucket(bucket)
@@ -641,9 +663,14 @@ class S3CloudStorage(AbstractCloudStorage):
         return self._bucket.name
 
     def _head(self):
-        return self._client.head_bucket(Bucket=self.name)
+        # Bucket status belongs to the fast-fail health path. Do not route it through
+        # the main transfer client, otherwise a bad endpoint can delay normal API work.
+        return self._status_client.head_bucket(Bucket=self.name)
 
     def _head_file(self, key: str, /):
+        # Metadata reads are used by normal storage logic as well, not just endpoint
+        # health checks. Keep them on the regular client so they retain normal retry
+        # behavior on slower S3-compatible backends.
         return self._client.head_object(Bucket=self.name, Key=key)
 
     def get_status(self):
@@ -658,7 +685,7 @@ class S3CloudStorage(AbstractCloudStorage):
                 return Status.FORBIDDEN
             else:
                 return Status.NOT_FOUND
-        except EndpointConnectionError:
+        except (ConnectTimeoutError, EndpointConnectionError, ReadTimeoutError):
             slogger.glob.warning(
                 f"CloudStorage S3 {self._client.meta.endpoint_url}, {self.name} not available",
                 exc_info=True,
@@ -675,6 +702,12 @@ class S3CloudStorage(AbstractCloudStorage):
                 return Status.FORBIDDEN
             else:
                 return Status.NOT_FOUND
+        except (ConnectTimeoutError, EndpointConnectionError, ReadTimeoutError):
+            slogger.glob.warning(
+                f"CloudStorage S3 {self._client.meta.endpoint_url}, {self.name}/{key} not available",
+                exc_info=True,
+            )
+            return Status.NOT_FOUND
 
     @validate_file_status
     @validate_bucket_status

--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -685,6 +685,10 @@ class S3CloudStorage(AbstractCloudStorage):
                 return Status.FORBIDDEN
             else:
                 return Status.NOT_FOUND
+        # Only transport-level reachability timeouts belong to the degraded health
+        # path. Keep ClientError handling separate to preserve 403/404 semantics,
+        # and let unexpected SDK/runtime failures propagate instead of masking them
+        # as a storage availability problem.
         except (ConnectTimeoutError, EndpointConnectionError, ReadTimeoutError):
             slogger.glob.warning(
                 f"CloudStorage S3 {self._client.meta.endpoint_url}, {self.name} not available",
@@ -702,6 +706,10 @@ class S3CloudStorage(AbstractCloudStorage):
                 return Status.FORBIDDEN
             else:
                 return Status.NOT_FOUND
+        # Only transport-level reachability timeouts belong to the degraded health
+        # path. Keep ClientError handling separate to preserve 403/404 semantics,
+        # and let unexpected SDK/runtime failures propagate instead of masking them
+        # as a storage availability problem.
         except (ConnectTimeoutError, EndpointConnectionError, ReadTimeoutError):
             slogger.glob.warning(
                 f"CloudStorage S3 {self._client.meta.endpoint_url}, {self.name}/{key} not available",

--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -615,19 +615,15 @@ class S3CloudStorage(AbstractCloudStorage):
 
         session = boto3.Session(**kwargs)
         # Status checks are part of the control plane, not the data-transfer path, so
-        # they must fail fast when the endpoint is unreachable or misconfigured. Some
-        # network setups return a transport timeout instead of an immediate connection
-        # refusal for a wrong host/port, which can make a simple bucket health probe
-        # hang long enough to block API requests and propagate failures to unrelated
-        # operations. Use a dedicated low-timeout client for head_bucket/head_object,
-        # while the regular resource/client keep the default pool and retry behavior
-        # for real uploads/downloads. Tests with intentionally broken endpoints confirm
-        # that this distinction is required in practice.
+        # Bucket status probes should fail fast when the endpoint is unreachable or
+        # misconfigured. Keep a dedicated low-timeout client for head_bucket, while
+        # the regular resource/client retain their standard retry behavior for normal
+        # storage operations.
         status_config = Config(
             proxies=PROXIES_FOR_UNTRUSTED_URLS or {},
             connect_timeout=2,
             read_timeout=5,
-            retries={"max_attempts": 1, "mode": "standard"},
+            retries={"total_max_attempts": 1, "mode": "standard"},
         )
         self._s3 = session.resource(
             "s3",
@@ -663,13 +659,11 @@ class S3CloudStorage(AbstractCloudStorage):
         return self._bucket.name
 
     def _head(self):
-        # Bucket status belongs to the fast-fail health path. Do not route it through
-        # the main transfer client, otherwise a bad endpoint can delay normal API work.
+        # Bucket status checks use the dedicated fast-fail client.
         return self._status_client.head_bucket(Bucket=self.name)
 
     def _head_file(self, key: str, /):
-        # Metadata reads are used by normal storage logic as well, not just endpoint
-        # health checks. Keep them on the regular client so they retain normal retry
+        # File metadata reads stay on the regular client so they retain standard retry
         # behavior on slower S3-compatible backends.
         return self._client.head_object(Bucket=self.name, Key=key)
 
@@ -685,6 +679,8 @@ class S3CloudStorage(AbstractCloudStorage):
                 return Status.FORBIDDEN
             else:
                 return Status.NOT_FOUND
+        # Handle transport-level reachability failures separately from ClientError-
+        # based 403/404 responses.
         except (ConnectTimeoutError, EndpointConnectionError, ReadTimeoutError):
             slogger.glob.warning(
                 f"CloudStorage S3 {self._client.meta.endpoint_url}, {self.name} not available",
@@ -702,6 +698,8 @@ class S3CloudStorage(AbstractCloudStorage):
                 return Status.FORBIDDEN
             else:
                 return Status.NOT_FOUND
+        # Handle transport-level reachability failures separately from ClientError-
+        # based 403/404 responses.
         except (ConnectTimeoutError, EndpointConnectionError, ReadTimeoutError):
             slogger.glob.warning(
                 f"CloudStorage S3 {self._client.meta.endpoint_url}, {self.name}/{key} not available",


### PR DESCRIPTION
## Summary
This is **PR 2** in the split series for the large test-infra branch.

Base PR:
- #10494 `Tests: stabilize local Python and Cypress baselines`

This PR is intentionally small and backend-only. It builds on top of PR 1 because PR 1 contains the baseline test fixes needed to validate the later series reliably.

## What changed
- harden chunk job failure reconstruction in `cvat/apps/engine/cache.py`
  - if rebuilding the original exception from stored type/args fails, raise a stable `ChunkCreationError` instead of masking the real failure with a secondary constructor error
- make S3 cloud-storage status probes fail fast in `cvat/apps/engine/cloud_provider.py`
  - use a dedicated low-timeout client for status checks
  - degrade only transport-level reachability failures (`ConnectTimeoutError`, `EndpointConnectionError`, `ReadTimeoutError`)
  - keep `ClientError` handling separate so existing `403/404` semantics are preserved

## Why this PR exists separately
These changes are independent from the pytest runtime / kube / CI refactor. They are backend robustness fixes and can be reviewed on their own.

## Validation
Local checks completed on this branch:
- `py_compile`
- `black --check --diff`
- `isort --check --diff --resolve-all-configs`
- `pylint`
- `typos` on the changelog fragment
- `remark` on the changelog fragment

## Changelog
- added a dedicated PR fragment for the backend robustness changes
