### PR TITLE
Helm: support release-scoped OPA and secret wiring

### DIFF
--- a/changelog.d/20260418_170500_nmanovic_helm_opa_release_scope.md
+++ b/changelog.d/20260418_170500_nmanovic_helm_opa_release_scope.md
@@ -1,3 +1,5 @@
 ### Fixed
 
-- Helm deployments now support release-scoped OPA and secret wiring by allowing backend pods to target a configurable OPA host, by making OPA probe paths configurable, and by rendering Redis/Kvrocks secret names per release.
+- Helm deployments now support multiple releases in one namespace by rendering
+  OPA, Redis, and Kvrocks wiring with release-scoped service and secret names
+  (<https://github.com/cvat-ai/cvat/pull/10496>)

--- a/changelog.d/20260418_170500_nmanovic_helm_opa_release_scope.md
+++ b/changelog.d/20260418_170500_nmanovic_helm_opa_release_scope.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Helm deployments now support release-scoped OPA and secret wiring by allowing backend pods to target a configurable OPA host, by making OPA probe paths configurable, and by rendering Redis/Kvrocks secret names per release.

--- a/cvat/apps/health/backends.py
+++ b/cvat/apps/health/backends.py
@@ -14,7 +14,7 @@ class OPAHealthCheck(BaseHealthCheckBackend):
     critical_service = True
 
     def check_status(self):
-        opa_health_url = f"{settings.IAM_OPA_HOST}/health?bundles"
+        opa_health_url = f"{settings.IAM_OPA_URL}/health?bundles"
         try:
             with make_requests_session() as session:
                 response = session.get(opa_health_url)

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -233,7 +233,7 @@ IAM_DEFAULT_ROLE = "user"
 IAM_ADMIN_ROLE = "admin"
 # Index in the list below corresponds to the priority (0 has highest priority)
 IAM_ROLES = [IAM_ADMIN_ROLE, "user", "worker"]
-IAM_OPA_HOST = "http://opa:8181"
+IAM_OPA_HOST = os.getenv("CVAT_OPA_HOST", "http://opa:8181")
 IAM_OPA_DATA_URL = f"{IAM_OPA_HOST}/v1/data"
 LOGIN_URL = "rest_login"
 LOGIN_REDIRECT_URL = "/"

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -233,8 +233,8 @@ IAM_DEFAULT_ROLE = "user"
 IAM_ADMIN_ROLE = "admin"
 # Index in the list below corresponds to the priority (0 has highest priority)
 IAM_ROLES = [IAM_ADMIN_ROLE, "user", "worker"]
-IAM_OPA_HOST = os.getenv("CVAT_OPA_HOST", "http://opa:8181")
-IAM_OPA_DATA_URL = f"{IAM_OPA_HOST}/v1/data"
+IAM_OPA_URL = os.getenv("CVAT_OPA_URL", "http://opa:8181")
+IAM_OPA_DATA_URL = f"{IAM_OPA_URL}/v1/data"
 LOGIN_URL = "rest_login"
 LOGIN_REDIRECT_URL = "/"
 

--- a/cvat/settings/development.py
+++ b/cvat/settings/development.py
@@ -37,8 +37,8 @@ INCORRECT_EMAIL_CONFIRMATION_URL = "{}/auth/incorrect-email-confirmation".format
 
 CORS_ORIGIN_WHITELIST = [UI_URL]
 CORS_REPLACE_HTTPS_REFERER = True
-IAM_OPA_HOST = "http://localhost:8181"
-IAM_OPA_DATA_URL = f"{IAM_OPA_HOST}/v1/data"
+IAM_OPA_URL = "http://localhost:8181"
+IAM_OPA_DATA_URL = f"{IAM_OPA_URL}/v1/data"
 
 INSTALLED_APPS += ["silk"]
 

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -119,6 +119,9 @@ The name of the service account to use for backend pods
       name: "{{ tpl (.Values.postgresql.secret.name) . }}"
       key: password
 
+- name: CVAT_OPA_HOST
+  value: {{ if .Values.cvat.opa.composeCompatibleServiceName }}"http://opa:8181"{{ else }}"http://{{ .Release.Name }}-opa-service:8181"{{ end }}
+
 {{- if .Values.analytics.enabled}}
 - name: CVAT_ANALYTICS
   value: "1"

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -119,8 +119,8 @@ The name of the service account to use for backend pods
       name: "{{ tpl (.Values.postgresql.secret.name) . }}"
       key: password
 
-- name: CVAT_OPA_HOST
-  value: {{ if .Values.cvat.opa.composeCompatibleServiceName }}"http://opa:8181"{{ else }}"http://{{ .Release.Name }}-opa-service:8181"{{ end }}
+- name: CVAT_OPA_URL
+  value: "http://{{ .Release.Name }}-opa-service:8181"
 
 {{- if .Values.analytics.enabled}}
 - name: CVAT_ANALYTICS

--- a/helm-chart/templates/cvat_opa/deployment.yml
+++ b/helm-chart/templates/cvat_opa/deployment.yml
@@ -58,14 +58,14 @@ spec:
           readinessProbe:
             httpGet:
               port: 8181
-              path: "/health?bundles"
+              path: {{ .Values.cvat.opa.probePath | quote }}
             {{- toYaml (omit .Values.cvat.opa.readinessProbe "enabled") | nindent 12 }}
           {{- end }}
           {{- if .Values.cvat.opa.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               port: 8181
-              path: "/health?bundles"
+              path: {{ .Values.cvat.opa.probePath | quote }}
             {{- toYaml (omit .Values.cvat.opa.livenessProbe "enabled") | nindent 12 }}
           {{- end }}
           {{- with .Values.cvat.opa.additionalVolumeMounts }}

--- a/helm-chart/templates/cvat_opa/service.yml
+++ b/helm-chart/templates/cvat_opa/service.yml
@@ -1,11 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.cvat.opa.composeCompatibleServiceName }}
-  name: opa
-  {{- else }}
   name: {{ .Release.Name }}-opa-service
-  {{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cvat.labels" . | nindent 4 }}

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -41,7 +41,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: {{ .Release.Name }}-frontend-service
+            name: {{ $.Release.Name }}-frontend-service
             port:
               name: http
 {{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -260,6 +260,11 @@ cvat:
     #     name: tmp
     #     subPath: test
     composeCompatibleServiceName: true # Sets service name to opa in order to be compatible with Docker Compose. Necessary because changing IAM_OPA_DATA_URL via environment variables in current images. Hinders multiple deployment due to duplicate name
+    # Keep the default probe tied to bundle availability in normal deployments.
+    # This makes OPA health reflect whether it has successfully loaded policy data
+    # from the CVAT backend. Test environments may override this to plain `/health`
+    # to avoid false-negative restarts while backend services are still warming up.
+    probePath: /health?bundles
     readinessProbe:
       enabled: true
       periodSeconds: 15
@@ -280,10 +285,10 @@ cvat:
     enabled: true
     external:
       host: kvrocks-external.localdomain
-    existingSecret: "cvat-kvrocks-secret"
+    existingSecret: "{{ .Release.Name }}-kvrocks-secret"
     secret:
       create: true
-      name: cvat-kvrocks-secret
+      name: "{{ .Release.Name }}-kvrocks-secret"
       password: cvat_kvrocks
     image: apache/kvrocks
     tag: 2.12.1
@@ -382,11 +387,11 @@ redis:
     host: 127.0.0.1
   architecture: standalone
   auth:
-    existingSecret: "cvat-redis-secret"
+    existingSecret: "{{ .Release.Name }}-redis-secret"
     existingSecretPasswordKey: password
   secret:
     create: true
-    name: cvat-redis-secret
+    name: "{{ .Release.Name }}-redis-secret"
     password: cvat_redis
   # TODO: persistence options
 

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -259,11 +259,10 @@ cvat:
     # -   mountPath: /tmp
     #     name: tmp
     #     subPath: test
-    composeCompatibleServiceName: true # Sets service name to opa in order to be compatible with Docker Compose. Necessary because changing IAM_OPA_DATA_URL via environment variables in current images. Hinders multiple deployment due to duplicate name
     # Keep the default probe tied to bundle availability in normal deployments.
     # This makes OPA health reflect whether it has successfully loaded policy data
-    # from the CVAT backend. Test environments may override this to plain `/health`
-    # to avoid false-negative restarts while backend services are still warming up.
+    # from the CVAT backend. Deployments may override this to plain `/health`
+    # if they intentionally want process-health-only probes.
     probePath: /health?bundles
     readinessProbe:
       enabled: true

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -260,6 +260,11 @@ cvat:
     #     name: tmp
     #     subPath: test
     composeCompatibleServiceName: true # Sets service name to opa in order to be compatible with Docker Compose. Necessary because changing IAM_OPA_DATA_URL via environment variables in current images. Hinders multiple deployment due to duplicate name
+    # Keep the default probe tied to bundle availability in normal deployments.
+    # This makes OPA health reflect whether it has successfully loaded policy data
+    # from the CVAT backend. Test environments may override this to plain `/health`
+    # to avoid false-negative restarts while backend services are still warming up.
+    probePath: /health?bundles
     readinessProbe:
       enabled: true
       periodSeconds: 15
@@ -280,10 +285,10 @@ cvat:
     enabled: true
     external:
       host: kvrocks-external.localdomain
-    existingSecret: "cvat-kvrocks-secret"
+    existingSecret: "{{ .Release.Name }}-kvrocks-secret"
     secret:
       create: true
-      name: cvat-kvrocks-secret
+      name: "{{ .Release.Name }}-kvrocks-secret"
       password: cvat_kvrocks
     image: apache/kvrocks
     tag: 2.15.0
@@ -382,11 +387,11 @@ redis:
     host: 127.0.0.1
   architecture: standalone
   auth:
-    existingSecret: "cvat-redis-secret"
+    existingSecret: "{{ .Release.Name }}-redis-secret"
     existingSecretPasswordKey: password
   secret:
     create: true
-    name: cvat-redis-secret
+    name: "{{ .Release.Name }}-redis-secret"
     password: cvat_redis
   # TODO: persistence options
 

--- a/site/content/en/docs/administration/community/advanced/k8s_deployment_with_helm.md
+++ b/site/content/en/docs/administration/community/advanced/k8s_deployment_with_helm.md
@@ -159,14 +159,6 @@ Analytics is enabled by default, to disable set `analytics.enabled: false` in yo
 
 Make sure you are using correct kubernetes context. You can check it with `kubectl config current-context`.
 
-{{% alert title="Warning" color="warning" %}}
-The k8s service name of Open Policy Agent is fixed to opa by default.
-This is done to be compatible with CVAT 2.0 but limits this helm chart to a single release per namespace.
-The OPA url currently can´t be set as an environment variable.
-As soon as this is possible you can set cvat.opa.composeCompatibleServiceName
-to false in your value.override.yaml and configure the opa url as additional env.
-{{% /alert %}}
-
 There are two ways to get and install the CVAT Helm chart:
 
 ### Option 1: Install from the CVAT repository


### PR DESCRIPTION
## Summary
This PR makes the Helm chart safer for running multiple CVAT releases in one Kubernetes namespace by release-scoping OPA, Redis, and Kvrocks wiring.

## What changed
- Backend pods now receive `CVAT_OPA_URL` pointing to the release-scoped OPA service.
- The OPA service now always renders as `<release>-opa-service`.
- OPA readiness/liveness probe path is configurable with `cvat.opa.probePath`; the default remains `/health?bundles`.
- Redis and Kvrocks default secret names now include the Helm release name.
- Frontend ingress service lookup now uses the root release context.
- Removed obsolete Helm docs warning about the fixed `opa` service name.

## Validation
- `git diff --check origin/develop...HEAD`
- Helm dependency update and `helm template` with CI-style values
- Helm package with dependency update