### PR TITLE
Tests(py): add runtime profiles and endpoint-aware fixtures

### DIFF
--- a/changelog.d/20260419_190000_nmanovic_runtime_profiles_and_urls.md
+++ b/changelog.d/20260419_190000_nmanovic_runtime_profiles_and_urls.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Local Python tests now support `simple`, `standard`, and `full` runtime profiles, and runtime-aware webhook, cloud storage, and SDK/CLI URLs keep fixture data stable while adapting to the active test environment.

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,6 @@ addopts = --verbose --capture=tee-sys
 timeout = 15
 
 markers =
-    with_external_services: The test requires services external to the minimal local runtime.
     infra_profile(name): Minimum required execution profile: simple, standard, full.
 
 filterwarnings =

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,7 @@ timeout = 15
 
 markers =
     with_external_services: The test requires services external to the minimal local runtime.
+    infra_profile(name): Minimum required execution profile: simple, standard, full.
 
 filterwarnings =
     ignore::DeprecationWarning:cvat_sdk.core

--- a/tests/docker-compose.simple.profile.yml
+++ b/tests/docker-compose.simple.profile.yml
@@ -1,0 +1,67 @@
+services:
+  cvat_server:
+    depends_on: !reset []
+    environment:
+      CVAT_ANALYTICS: 0
+      DJANGO_LOG_SERVER_HOST: 127.0.0.1
+      NUMPROCS: 1
+
+  cvat_ui:
+    profiles:
+      - full
+
+  cvat_grafana:
+    profiles:
+      - full
+
+  cvat_clickhouse:
+    profiles:
+      - full
+
+  cvat_vector:
+    profiles:
+      - full
+
+  cvat_worker_annotation:
+    profiles:
+      - full
+
+  cvat_worker_chunks:
+    profiles:
+      - full
+
+  cvat_worker_consensus:
+    profiles:
+      - full
+
+  cvat_worker_export:
+    profiles:
+      - full
+
+  cvat_worker_import:
+    profiles:
+      - full
+
+  cvat_worker_quality_reports:
+    profiles:
+      - full
+
+  cvat_worker_utils:
+    profiles:
+      - full
+
+  cvat_worker_webhooks:
+    profiles:
+      - full
+
+  mc:
+    profiles:
+      - full
+
+  minio:
+    profiles:
+      - full
+
+  webhook_receiver:
+    profiles:
+      - full

--- a/tests/docker-compose.standard.profile.yml
+++ b/tests/docker-compose.standard.profile.yml
@@ -1,0 +1,62 @@
+services:
+  cvat_server:
+    depends_on: !reset []
+    environment:
+      CVAT_ANALYTICS: 0
+      DJANGO_LOG_SERVER_HOST: 127.0.0.1
+      NUMPROCS: 1
+
+  cvat_ui:
+    profiles:
+      - full
+
+  cvat_grafana:
+    profiles:
+      - full
+
+  cvat_clickhouse:
+    profiles:
+      - full
+
+  cvat_vector:
+    profiles:
+      - full
+
+  cvat_worker_chunks:
+    depends_on: !reset []
+    environment:
+      NUMPROCS: 1
+
+  cvat_worker_annotation:
+    profiles:
+      - full
+
+  cvat_worker_consensus:
+    profiles:
+      - full
+
+  cvat_worker_export:
+    depends_on: !reset []
+    environment:
+      NUMPROCS: 1
+
+  cvat_worker_import:
+    depends_on: !reset []
+    environment:
+      NUMPROCS: 1
+
+  cvat_worker_quality_reports:
+    profiles:
+      - full
+
+  cvat_worker_utils:
+    profiles:
+      - full
+
+  cvat_worker_webhooks:
+    profiles:
+      - full
+
+  webhook_receiver:
+    profiles:
+      - full

--- a/tests/python/cli/test_cli_projects.py
+++ b/tests/python/cli/test_cli_projects.py
@@ -11,6 +11,8 @@ from cvat_sdk.core.proxies.projects import Project
 
 from .util import TestCliBase
 
+pytestmark = [pytest.mark.infra_profile("standard")]
+
 
 class TestCliProjects(TestCliBase):
     @pytest.fixture

--- a/tests/python/cli/test_cli_tasks.py
+++ b/tests/python/cli/test_cli_tasks.py
@@ -16,6 +16,8 @@ from shared.utils.helpers import generate_image_file
 
 from .util import TestCliBase, generate_images
 
+pytestmark = [pytest.mark.infra_profile("standard")]
+
 
 class TestCliTasks(TestCliBase):
     @pytest.fixture

--- a/tests/python/cli/util.py
+++ b/tests/python/cli/util.py
@@ -6,6 +6,7 @@
 import contextlib
 import http.server
 import io
+import os
 import ssl
 import threading
 import unittest
@@ -17,8 +18,12 @@ import pytest
 import requests
 from cvat_sdk import make_client
 
-from shared.utils.config import BASE_URL, USER_PASS
+from shared.utils.config import USER_PASS
 from shared.utils.helpers import generate_image_file
+
+
+def _base_url() -> str:
+    return os.environ.get("CVAT_BASE_URL", "http://localhost:8080")
 
 
 def run_cli(
@@ -82,7 +87,7 @@ class _ProxyHttpRequestHandler(http.server.BaseHTTPRequestHandler):
         headers = {k.lower(): v for k, v in self.headers.items()}
         del headers["host"]
 
-        return {"url": BASE_URL + self.path, "headers": headers, "timeout": 60, "stream": True}
+        return {"url": _base_url() + self.path, "headers": headers, "timeout": 60, "stream": True}
 
     def _translate_response(self, response: requests.Response) -> None:
         self.send_response(response.status_code)
@@ -106,7 +111,7 @@ class TestCliBase:
     ):
         self.tmp_path = tmp_path
         self.stdout = fxt_stdout
-        self.host, self.port = BASE_URL.rsplit(":", maxsplit=1)
+        self.host, self.port = _base_url().rsplit(":", maxsplit=1)
         self.user = admin_user
         self.password = USER_PASS
         self.client = make_client(

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -38,8 +38,20 @@ def pytest_report_header(config):
 
 
 def pytest_runtestloop(session):
+    config = session.config
+    instance = getattr(config, "_cvat_infra_instance", None)
+    if instance is not None and not getattr(config, "_cvat_runtime_started", False):
+        instance.start()
+        setattr(config, "_cvat_runtime_started", True)
+
+        if getattr(config, "_cvat_should_run_version_check", False):
+            run_sanity_version_check(
+                cvat_root_dir=RuntimeInfraConfig.get_cvat_root_dir(),
+                platform=str(config.getoption("--platform")),
+            )
+
     result = None
-    for plugin_class in _selected_plugin_classes(session.config):
+    for plugin_class in _selected_plugin_classes(config):
         hook_result = plugin_class.runtestloop(session)
         if hook_result is not None:
             result = hook_result
@@ -113,6 +125,7 @@ def pytest_sessionstart(session) -> None:
         and not any((cleanup, dumpdb))
         and not bool(config.getoption("--skip-version-check"))
     )
+    setattr(config, "_cvat_should_run_version_check", should_run_version_check)
     if collect_only:
         return
 
@@ -132,9 +145,19 @@ def pytest_sessionstart(session) -> None:
     )
     instance = InfraInstance.create(session, instance_config)
     setattr(config, "_cvat_infra_instance", instance)
-    instance.start()
+    setattr(config, "_cvat_runtime_started", False)
 
-    if should_run_version_check:
+    if infra_mode in {InfraMode.UP, InfraMode.DOWN, InfraMode.RESTORE_DB}:
+        instance.start()
+        setattr(config, "_cvat_runtime_started", True)
+    elif infra_mode == InfraMode.REUSE and platform == "local":
+        # Defer local runtime startup until after collection so profile selection can
+        # choose the correct stack shape without a throwaway initial compose cycle.
+        return
+    elif platform == "local":
+        return
+
+    if should_run_version_check and getattr(config, "_cvat_runtime_started", False):
         run_sanity_version_check(
             cvat_root_dir=RuntimeInfraConfig.get_cvat_root_dir(), platform=platform
         )

--- a/tests/python/infra/config.py
+++ b/tests/python/infra/config.py
@@ -40,7 +40,45 @@ class InfraMode(str, Enum):
         return self.value
 
 
+class InfraProfile(str, Enum):
+    SIMPLE = "simple"
+    STANDARD = "standard"
+    FULL = "full"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 _INFRA_MODES = tuple(str(mode) for mode in InfraMode)
+_DEFAULT_INFRA_PROFILE = str(InfraProfile.SIMPLE)
+_INFRA_PROFILES = tuple(str(profile) for profile in InfraProfile)
+_INFRA_PROFILE_RANK = {
+    str(InfraProfile.SIMPLE): 0,
+    str(InfraProfile.STANDARD): 1,
+    str(InfraProfile.FULL): 2,
+}
+_PROFILE_BASE_DC_FILES = {
+    str(InfraProfile.SIMPLE): [
+        "tests/docker-compose.file_share.yml",
+        "tests/docker-compose.pat_settings.yml",
+    ],
+    str(InfraProfile.STANDARD): [
+        "tests/docker-compose.file_share.yml",
+        "tests/docker-compose.minio.yml",
+        "tests/docker-compose.pat_settings.yml",
+    ],
+    str(InfraProfile.FULL): [
+        "tests/docker-compose.file_share.yml",
+        "tests/docker-compose.minio.yml",
+        "tests/docker-compose.pat_settings.yml",
+        "tests/docker-compose.test_servers.yml",
+    ],
+}
+_PROFILE_DC_FILES = {
+    str(InfraProfile.SIMPLE): ["tests/docker-compose.simple.profile.yml"],
+    str(InfraProfile.STANDARD): ["tests/docker-compose.standard.profile.yml"],
+    str(InfraProfile.FULL): [],
+}
 
 
 def _validate_project_name(name: str) -> str:
@@ -212,8 +250,30 @@ class RuntimeInfraConfig:
         return _DEFAULT_INFRA_MODE
 
     @classmethod
+    def get_default_infra_profile(cls) -> str:
+        return _DEFAULT_INFRA_PROFILE
+
+    @classmethod
     def get_infra_modes(cls) -> tuple[str, ...]:
         return _INFRA_MODES
+
+    @classmethod
+    def get_infra_profiles(cls) -> tuple[str, ...]:
+        return _INFRA_PROFILES
+
+    @classmethod
+    def get_infra_profile_rank(cls, profile: str) -> int:
+        normalized = str(cls.parse_infra_profile(profile))
+        return _INFRA_PROFILE_RANK[normalized]
+
+    @classmethod
+    def get_base_dc_files(cls, profile: str) -> list[str]:
+        normalized = str(cls.parse_infra_profile(profile))
+        return list(_PROFILE_BASE_DC_FILES[normalized])
+
+    @classmethod
+    def get_profile_dc_files(cls) -> dict[str, list[str]]:
+        return {profile: list(files) for profile, files in _PROFILE_DC_FILES.items()}
 
     @classmethod
     def get_clickhouse_init_script(cls) -> str:
@@ -227,6 +287,20 @@ class RuntimeInfraConfig:
             raise pytest.UsageError(
                 f"Unknown infra mode {value!r}. Allowed: {', '.join(_INFRA_MODES)}"
             ) from ex
+
+    @classmethod
+    def parse_infra_profile(cls, value: str) -> InfraProfile:
+        try:
+            return InfraProfile(value)
+        except ValueError as ex:
+            raise pytest.UsageError(
+                f"Unknown infra profile {value!r}. Allowed: {', '.join(_INFRA_PROFILES)}"
+            ) from ex
+
+    @classmethod
+    def get_infra_profile(cls) -> str:
+        profile = os.environ.get("CVAT_TEST_INFRA_PROFILE", _DEFAULT_INFRA_PROFILE)
+        return str(cls.parse_infra_profile(profile))
 
     @classmethod
     def get_server_url(cls, endpoint: str, **kwargs) -> str:

--- a/tests/python/infra/instances/local_instance.py
+++ b/tests/python/infra/instances/local_instance.py
@@ -6,6 +6,7 @@ import http.client
 import json
 import logging
 import os
+import shlex
 import socket
 from pathlib import Path
 from subprocess import CalledProcessError, run
@@ -43,6 +44,17 @@ _BACKGROUND_JOB_QUEUES = (
     "cleaning",
     "notifications",
 )
+
+
+def _has_explicit_infra_profile(config) -> bool:
+    option_sources = [
+        *(str(arg) for arg in config.invocation_params.args),
+        *shlex.split(os.environ.get("PYTEST_ADDOPTS", "")),
+        *shlex.split(str(config.getini("addopts") or "")),
+    ]
+    return any(
+        arg == "--infra-profile" or arg.startswith("--infra-profile=") for arg in option_sources
+    )
 
 
 def _configure_runtime_env(
@@ -955,11 +967,7 @@ class LocalPlugin(InfraPlugin):
             ) > RuntimeInfraConfig.get_infra_profile_rank(required_profile):
                 required_profile = item_profile
 
-        invocation_args = tuple(str(arg) for arg in config.invocation_params.args)
-        explicit_profile_requested = any(
-            arg == "--infra-profile" or arg.startswith("--infra-profile=")
-            for arg in invocation_args
-        )
+        explicit_profile_requested = _has_explicit_infra_profile(config)
         requested_profile = str(config.getoption("--infra-profile") or "").strip()
         if explicit_profile_requested:
             selected_profile = str(RuntimeInfraConfig.parse_infra_profile(requested_profile))

--- a/tests/python/infra/instances/local_instance.py
+++ b/tests/python/infra/instances/local_instance.py
@@ -13,7 +13,7 @@ from time import sleep
 
 import pytest
 import yaml
-from infra.config import InfraMode, RuntimeInfraConfig
+from infra.config import InfraMode, InfraProfile, RuntimeInfraConfig
 from infra.db_restore import PsycopgDatabaseRestorer
 from infra.instances.base_instance import InfraInstance, InfraPlugin
 from infra.redis_restore import RedisStateRestorer
@@ -32,12 +32,6 @@ _COVERED_CONTAINERS = (
     "cvat_worker_utils",
 )
 _FAILURE_LOG_CONTAINERS = _COVERED_CONTAINERS + ("cvat_opa", "traefik")
-_LOCAL_DC_FILES = (
-    "tests/docker-compose.file_share.yml",
-    "tests/docker-compose.minio.yml",
-    "tests/docker-compose.pat_settings.yml",
-    "tests/docker-compose.test_servers.yml",
-)
 _BACKGROUND_JOB_QUEUES = (
     "import",
     "export",
@@ -87,6 +81,9 @@ def preconfigure_local_runtime_env(config) -> None:
     """
     project_name = RuntimeInfraConfig.get_run_prefix_from_config(config)
     infra_mode = RuntimeInfraConfig.parse_infra_mode(config.getoption("--infra"))
+    os.environ["CVAT_TEST_INFRA_PROFILE"] = str(
+        RuntimeInfraConfig.parse_infra_profile(config.getoption("--infra-profile"))
+    )
 
     if config.getoption("--platform") != "local":
         return
@@ -115,6 +112,7 @@ def resolve_local_project_context(session) -> tuple[str, dict]:
     project_cfg.save_state(
         {
             "project_name": project_name,
+            "infra_profile": RuntimeInfraConfig.get_infra_profile(),
             **port_config,
             "base_url": os.environ["CVAT_BASE_URL"],
             "minio_endpoint_url": os.environ["CVAT_MINIO_ENDPOINT_URL"],
@@ -191,10 +189,13 @@ def project_containers_running(project_name: str) -> bool:
 def project_stack_compatible(
     project_name: str,
     *,
+    profile: str,
     expected_db_port: int,
     expected_redis_inmem_port: int,
     expected_redis_ondisk_port: int,
 ) -> tuple[bool, str]:
+    if not profile_services_ready(project_name, profile):
+        return False, f"missing required services for profile '{profile}'"
     if not project_db_port_ready(project_name, expected_db_port):
         return False, "PostgreSQL host port mapping is missing or outdated"
     if not project_redis_ports_ready(
@@ -204,6 +205,44 @@ def project_stack_compatible(
     ):
         return False, "Redis host port mapping is missing or outdated"
     return True, ""
+
+
+def _profile_required_services(profile: str) -> set[str]:
+    normalized = str(RuntimeInfraConfig.parse_infra_profile(profile))
+    if normalized == str(InfraProfile.SIMPLE):
+        return set()
+    if normalized == str(InfraProfile.STANDARD):
+        return {
+            "minio",
+            "cvat_worker_chunks",
+            "cvat_worker_export",
+            "cvat_worker_import",
+        }
+    return {
+        "cvat_clickhouse",
+        "minio",
+        "webhook_receiver",
+        "cvat_ui",
+        "cvat_grafana",
+        "cvat_vector",
+        "cvat_worker_annotation",
+        "cvat_worker_chunks",
+        "cvat_worker_consensus",
+        "cvat_worker_export",
+        "cvat_worker_import",
+        "cvat_worker_quality_reports",
+        "cvat_worker_webhooks",
+        "cvat_worker_utils",
+    }
+
+
+def profile_services_ready(project_name: str, profile: str) -> bool:
+    required = _profile_required_services(profile)
+    if not required:
+        return True
+
+    containers = set(running_containers())
+    return all(f"{project_name}_{service}_1" in containers for service in required)
 
 
 def project_db_port_ready(project_name: str, expected_host_port: int) -> bool:
@@ -463,7 +502,19 @@ def _delete_compose_files(container_name_files: list[Path]):
 
 def stop_project_services_best_effort(*, project_name: str) -> None:
     project_cfg = RuntimeInfraConfig.get_project_config(project_name)
-    dc_files = project_cfg.dc_files + [project_cfg.cvat_root_dir / f for f in _LOCAL_DC_FILES]
+    saved_state = project_cfg.load_state() or {}
+    saved_profile = str(
+        RuntimeInfraConfig.parse_infra_profile(
+            saved_state.get("infra_profile", RuntimeInfraConfig.get_default_infra_profile())
+        )
+    )
+    dc_files = project_cfg.dc_files + [
+        project_cfg.cvat_root_dir / f for f in RuntimeInfraConfig.get_base_dc_files(saved_profile)
+    ]
+    dc_files += [
+        project_cfg.cvat_root_dir / f
+        for f in RuntimeInfraConfig.get_profile_dc_files().get(saved_profile, [])
+    ]
 
     try:
         stop_services(
@@ -536,6 +587,10 @@ class LocalInstance(InfraInstance):
         self._redis_restorer = None
         self._background_job_cleaner = None
 
+    def _reset_runtime_restore_caches(self) -> None:
+        self._cvat_data_archive_host = None
+        self._cvat_data_template_host = None
+
     def _get_db_restorer(self) -> PsycopgDatabaseRestorer:
         if self._db_restorer is None:
             project_cfg = RuntimeInfraConfig.get_project_config()
@@ -589,8 +644,14 @@ class LocalInstance(InfraInstance):
         return cls.can_handle_config(session.config)
 
     def _build_local_dc_files(self, project_cfg) -> list[Path]:
+        active_profile = RuntimeInfraConfig.get_infra_profile()
         dc_files = project_cfg.generated_compose_files + [
-            project_cfg.cvat_root_dir / f for f in _LOCAL_DC_FILES
+            project_cfg.cvat_root_dir / f
+            for f in RuntimeInfraConfig.get_base_dc_files(active_profile)
+        ]
+        dc_files += [
+            project_cfg.cvat_root_dir / f
+            for f in RuntimeInfraConfig.get_profile_dc_files().get(active_profile, [])
         ]
         if self.deps.extra_dc_files is not None:
             dc_files += self.deps.extra_dc_files
@@ -646,6 +707,7 @@ class LocalInstance(InfraInstance):
                 )
             stack_ok, reason = project_stack_compatible(
                 project_name,
+                profile=RuntimeInfraConfig.get_infra_profile(),
                 expected_db_port=project_cfg.host_db_port,
                 expected_redis_inmem_port=project_cfg.host_redis_inmem_port,
                 expected_redis_ondisk_port=project_cfg.host_redis_ondisk_port,
@@ -667,6 +729,7 @@ class LocalInstance(InfraInstance):
         )
 
         if infra_mode == InfraMode.DOWN:
+            self._reset_runtime_restore_caches()
             self._close_db_restorer()
             self._close_redis_restorer()
             stop_services(
@@ -679,6 +742,7 @@ class LocalInstance(InfraInstance):
 
         stack_ok, incompatibility_reason = project_stack_compatible(
             project_name,
+            profile=RuntimeInfraConfig.get_infra_profile(),
             expected_db_port=project_cfg.host_db_port,
             expected_redis_inmem_port=project_cfg.host_redis_inmem_port,
             expected_redis_ondisk_port=project_cfg.host_redis_ondisk_port,
@@ -691,6 +755,7 @@ class LocalInstance(InfraInstance):
                 project_name,
                 incompatibility_reason,
             )
+            self._reset_runtime_restore_caches()
             self._close_db_restorer()
             self._close_redis_restorer()
             stop_services(
@@ -752,11 +817,22 @@ class LocalInstance(InfraInstance):
             RuntimeInfraConfig.write_context_for_project(project_name)
             resolve_local_project_context(self.session)
 
+        setattr(self.config, "_cvat_started_infra_profile", RuntimeInfraConfig.get_infra_profile())
         self._run_local_lifecycle(
             infra_mode=infra_mode,
             dumpdb=config.getoption("--dumpdb"),
             cleanup=config.getoption("--cleanup"),
         )
+        setattr(self.config, "_cvat_started_infra_profile", RuntimeInfraConfig.get_infra_profile())
+
+    def reconcile_runtime_profile(self) -> None:
+        infra_mode = getattr(self.config, "_cvat_infra_mode", InfraMode.AUTO)
+        if infra_mode not in {InfraMode.AUTO, InfraMode.REUSE}:
+            return
+
+        resolve_local_project_context(self.session)
+        self._run_local_lifecycle(infra_mode=infra_mode, dumpdb=False, cleanup=False)
+        setattr(self.config, "_cvat_started_infra_profile", RuntimeInfraConfig.get_infra_profile())
 
     def finish(self) -> None:
         if self.config.getoption("--platform") != "local":
@@ -860,6 +936,67 @@ class LocalPlugin(InfraPlugin):
     @classmethod
     def configure(cls, config) -> None:
         preconfigure_local_runtime_env(config)
+
+    @classmethod
+    def collection_modifyitems(cls, config, items) -> None:
+        if config.getoption("--platform") != "local":
+            return
+
+        required_profile = str(InfraProfile.SIMPLE)
+        for item in items:
+            marker = item.get_closest_marker("infra_profile")
+            if marker and marker.args:
+                item_profile = str(RuntimeInfraConfig.parse_infra_profile(marker.args[0]))
+            else:
+                item_profile = str(InfraProfile.SIMPLE)
+
+            if RuntimeInfraConfig.get_infra_profile_rank(
+                item_profile
+            ) > RuntimeInfraConfig.get_infra_profile_rank(required_profile):
+                required_profile = item_profile
+
+        invocation_args = tuple(str(arg) for arg in config.invocation_params.args)
+        explicit_profile_requested = any(
+            arg == "--infra-profile" or arg.startswith("--infra-profile=")
+            for arg in invocation_args
+        )
+        requested_profile = str(config.getoption("--infra-profile") or "").strip()
+        if explicit_profile_requested:
+            selected_profile = str(RuntimeInfraConfig.parse_infra_profile(requested_profile))
+            if RuntimeInfraConfig.get_infra_profile_rank(
+                selected_profile
+            ) < RuntimeInfraConfig.get_infra_profile_rank(required_profile):
+                raise pytest.UsageError(
+                    f"--infra-profile={selected_profile!r} is too small for the collected test set; "
+                    f"required profile is {required_profile!r}"
+                )
+        else:
+            selected_profile = required_profile
+
+        setattr(config, "_cvat_selected_infra_profile", selected_profile)
+        os.environ["CVAT_TEST_INFRA_PROFILE"] = selected_profile
+
+    @classmethod
+    def runtestloop(cls, session):
+        config = session.config
+        if config.getoption("--platform") != "local" or config.getoption("--collect-only"):
+            return None
+
+        selected_profile = getattr(config, "_cvat_selected_infra_profile", None)
+        if not selected_profile:
+            return None
+
+        started_profile = getattr(
+            config, "_cvat_started_infra_profile", RuntimeInfraConfig.get_infra_profile()
+        )
+        if str(started_profile) == str(selected_profile):
+            return None
+
+        os.environ["CVAT_TEST_INFRA_PROFILE"] = str(selected_profile)
+        instance = getattr(config, "_cvat_infra_instance", None)
+        if instance is not None:
+            instance.reconcile_runtime_profile()
+        return None
 
     @classmethod
     def can_handle_config(cls, config) -> bool:

--- a/tests/python/infra/instances/local_instance.py
+++ b/tests/python/infra/instances/local_instance.py
@@ -6,7 +6,6 @@ import http.client
 import json
 import logging
 import os
-import shlex
 import socket
 from pathlib import Path
 from subprocess import CalledProcessError, run
@@ -46,17 +45,6 @@ _BACKGROUND_JOB_QUEUES = (
 )
 
 
-def _has_explicit_infra_profile(config) -> bool:
-    option_sources = [
-        *(str(arg) for arg in config.invocation_params.args),
-        *shlex.split(os.environ.get("PYTEST_ADDOPTS", "")),
-        *shlex.split(str(config.getini("addopts") or "")),
-    ]
-    return any(
-        arg == "--infra-profile" or arg.startswith("--infra-profile=") for arg in option_sources
-    )
-
-
 def _configure_runtime_env(
     project_name: str,
     port_config: dict,
@@ -93,8 +81,11 @@ def preconfigure_local_runtime_env(config) -> None:
     """
     project_name = RuntimeInfraConfig.get_run_prefix_from_config(config)
     infra_mode = RuntimeInfraConfig.parse_infra_mode(config.getoption("--infra"))
+    requested_profile = config.getoption("--infra-profile")
     os.environ["CVAT_TEST_INFRA_PROFILE"] = str(
-        RuntimeInfraConfig.parse_infra_profile(config.getoption("--infra-profile"))
+        RuntimeInfraConfig.parse_infra_profile(
+            requested_profile or RuntimeInfraConfig.get_default_infra_profile()
+        )
     )
 
     if config.getoption("--platform") != "local":
@@ -967,9 +958,8 @@ class LocalPlugin(InfraPlugin):
             ) > RuntimeInfraConfig.get_infra_profile_rank(required_profile):
                 required_profile = item_profile
 
-        explicit_profile_requested = _has_explicit_infra_profile(config)
-        requested_profile = str(config.getoption("--infra-profile") or "").strip()
-        if explicit_profile_requested:
+        requested_profile = config.getoption("--infra-profile")
+        if requested_profile is not None:
             selected_profile = str(RuntimeInfraConfig.parse_infra_profile(requested_profile))
             if RuntimeInfraConfig.get_infra_profile_rank(
                 selected_profile

--- a/tests/python/infra/options.py
+++ b/tests/python/infra/options.py
@@ -49,6 +49,17 @@ def add_infra_options(parser):
         ),
     )
     group._addoption(
+        "--infra-profile",
+        action="store",
+        default=RuntimeInfraConfig.get_default_infra_profile(),
+        choices=RuntimeInfraConfig.get_infra_profiles(),
+        help=(
+            "Local runtime profile selection. "
+            "Use simple, standard, or full; default auto-selection starts from %(default)s "
+            "and may reconcile upward after collection."
+        ),
+    )
+    group._addoption(
         "--skip-version-check",
         action="store_true",
         default=False,

--- a/tests/python/infra/options.py
+++ b/tests/python/infra/options.py
@@ -51,12 +51,12 @@ def add_infra_options(parser):
     group._addoption(
         "--infra-profile",
         action="store",
-        default=RuntimeInfraConfig.get_default_infra_profile(),
+        default=None,
         choices=RuntimeInfraConfig.get_infra_profiles(),
         help=(
             "Local runtime profile selection. "
-            "Use simple, standard, or full; default auto-selection starts from %(default)s "
-            "and may reconcile upward after collection."
+            "Use simple, standard, or full; if omitted, pytest auto-selects the smallest "
+            "sufficient profile after collection."
         ),
     )
     group._addoption(

--- a/tests/python/rest_api/_test_base.py
+++ b/tests/python/rest_api/_test_base.py
@@ -293,7 +293,7 @@ class TestTasksBase:
     @fixture(scope="class")
     @parametrize(
         "cloud_storage_id",
-        [pytest.param(2, marks=[pytest.mark.with_external_services, pytest.mark.timeout(60)])],
+        [pytest.param(2, marks=[pytest.mark.infra_profile("standard"), pytest.mark.timeout(60)])],
     )
     def fxt_cloud_images_task_with_honeypots_and_changed_real_frames(
         self, request: pytest.FixtureRequest, cloud_storages, cloud_storage_id: int
@@ -397,7 +397,7 @@ class TestTasksBase:
     @fixture(scope="class")
     @parametrize(
         "cloud_storage_id",
-        [pytest.param(2, marks=[pytest.mark.with_external_services, pytest.mark.timeout(60)])],
+        [pytest.param(2, marks=[pytest.mark.infra_profile("standard"), pytest.mark.timeout(60)])],
     )
     def fxt_cloud_images_task_with_related_images(
         self, request: pytest.FixtureRequest, cloud_storages, cloud_storage_id: int
@@ -449,7 +449,7 @@ class TestTasksBase:
     @fixture(scope="class")
     @parametrize(
         "cloud_storage_id",
-        [pytest.param(1, marks=[pytest.mark.with_external_services, pytest.mark.timeout(60)])],
+        [pytest.param(1, marks=[pytest.mark.infra_profile("standard"), pytest.mark.timeout(60)])],
     )
     def fxt_cloud_pcd_task_with_related_images(
         self, request: pytest.FixtureRequest, cloud_storages, cloud_storage_id: int
@@ -550,7 +550,7 @@ class TestTasksBase:
     @fixture(scope="class")
     @parametrize(
         "cloud_storage_id",
-        [pytest.param(5, marks=[pytest.mark.with_external_services])],
+        [pytest.param(5, marks=[pytest.mark.infra_profile("standard")])],
     )
     def fxt_backing_cs_images_task_with_related_images(
         self, request: pytest.FixtureRequest, cloud_storage_id: int

--- a/tests/python/rest_api/test_analytics.py
+++ b/tests/python/rest_api/test_analytics.py
@@ -21,6 +21,8 @@ from shared.utils.helpers import generate_image_files
 
 from .utils import create_task, export_events
 
+pytestmark = [pytest.mark.infra_profile("full")]
+
 
 class TestGetAnalytics:
     endpoint = "analytics"
@@ -295,7 +297,6 @@ class TestGetAuditEvents:
         assert event_count["delete:task"] == 2
         assert event_count["delete:job"] == 4
 
-    @pytest.mark.with_external_services
     @pytest.mark.parametrize("api_version, allowed", [(1, False), (2, True)])
     @pytest.mark.parametrize("cloud_storage_id", [3])  # import/export bucket
     def test_export_to_cloud(

--- a/tests/python/rest_api/test_cache_policy.py
+++ b/tests/python/rest_api/test_cache_policy.py
@@ -6,7 +6,11 @@
 import re
 from http import HTTPStatus
 
+import pytest
+
 from shared.utils.config import server_get
+
+pytestmark = [pytest.mark.infra_profile("full")]
 
 
 class TestCachePolicy:

--- a/tests/python/rest_api/test_cloud_storages.py
+++ b/tests/python/rest_api/test_cloud_storages.py
@@ -16,13 +16,13 @@ from cvat_sdk.api_client.model.file_info import FileInfo
 from deepdiff import DeepDiff
 from PIL import Image
 
-from shared.utils.config import get_method, make_api_client
+from shared.utils.config import get_method, get_runtime_cloud_storage_endpoint_url, make_api_client
 from shared.utils.s3 import make_client as make_s3_client
 
 from .utils import CollectionSimpleFilterTestBase
 
 # https://docs.pytest.org/en/7.1.x/example/markers.html#marking-whole-classes-or-modules
-pytestmark = [pytest.mark.with_external_services]
+pytestmark = [pytest.mark.infra_profile("standard")]
 
 
 @pytest.mark.usefixtures("restore_db_per_class")
@@ -154,7 +154,7 @@ class TestPostCloudStorage:
         "credentials_type": "KEY_SECRET_KEY_PAIR",
         "key": "minio_access_key",
         "secret_key": "minio_secret_key",
-        "specific_attributes": "endpoint_url=http://minio:9000",
+        "specific_attributes": f"endpoint_url={get_runtime_cloud_storage_endpoint_url()}",
         "description": "Some description",
         "manifests": ["images_with_manifest/manifest.jsonl"],
     }

--- a/tests/python/rest_api/test_consensus.py
+++ b/tests/python/rest_api/test_consensus.py
@@ -26,6 +26,8 @@ from .utils import (
     wait_background_request,
 )
 
+pytestmark = [pytest.mark.infra_profile("full")]
+
 
 class _PermissionTestBase:
     def merge(

--- a/tests/python/rest_api/test_quality_control.py
+++ b/tests/python/rest_api/test_quality_control.py
@@ -29,6 +29,8 @@ from .utils import (
     wait_background_request,
 )
 
+pytestmark = [pytest.mark.infra_profile("full")]
+
 
 class _PermissionTestBase:
     def create_quality_report(

--- a/tests/python/rest_api/test_requests.py
+++ b/tests/python/rest_api/test_requests.py
@@ -33,6 +33,8 @@ from .utils import (
     wait_background_request,
 )
 
+pytestmark = [pytest.mark.infra_profile("standard")]
+
 
 @pytest.mark.usefixtures("restore_db_per_class")
 @pytest.mark.usefixtures("restore_redis_inmem_per_function")

--- a/tests/python/rest_api/test_resource_import_export.py
+++ b/tests/python/rest_api/test_resource_import_export.py
@@ -27,6 +27,8 @@ from shared.utils.s3 import make_client as make_s3_client
 
 from .utils import create_task
 
+pytestmark = [pytest.mark.infra_profile("standard")]
+
 
 class _S3ResourceTest(_CloudStorageResourceTest):
     @staticmethod
@@ -34,7 +36,6 @@ class _S3ResourceTest(_CloudStorageResourceTest):
         return make_s3_client()
 
 
-@pytest.mark.with_external_services
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestExportResourceToS3(_S3ResourceTest):
     @pytest.mark.usefixtures("restore_redis_inmem_per_function")
@@ -179,7 +180,6 @@ class TestExportResourceToS3(_S3ResourceTest):
         )
 
 
-@pytest.mark.with_external_services
 @pytest.mark.usefixtures("restore_db_per_function")
 @pytest.mark.usefixtures("restore_cvat_data_per_function")
 class TestImportResourceFromS3(_S3ResourceTest):

--- a/tests/python/rest_api/test_task_data.py
+++ b/tests/python/rest_api/test_task_data.py
@@ -43,6 +43,8 @@ from shared.utils.helpers import (
     read_video_file,
 )
 
+pytestmark = [pytest.mark.infra_profile("standard")]
+
 
 @pytest.mark.usefixtures("restore_db_per_function")
 @pytest.mark.usefixtures("restore_cvat_data_per_function")
@@ -483,7 +485,6 @@ class TestPostTaskData:
         response = get_method(self._USERNAME, f"jobs/{job_id}/annotations")
         assert response.status_code == HTTPStatus.OK
 
-    @pytest.mark.with_external_services
     @pytest.mark.parametrize(
         "use_cache, cloud_storage_id, manifest, use_bucket_content",
         [
@@ -643,7 +644,6 @@ class TestPostTaskData:
 
         return create_task(self._USERNAME, task_spec, data_spec, org=org)
 
-    @pytest.mark.with_external_services
     @pytest.mark.parametrize("cloud_storage_id", [2])
     @pytest.mark.parametrize(
         "use_cache, use_manifest, server_files, server_files_exclude, task_size",
@@ -688,7 +688,6 @@ class TestPostTaskData:
             assert response.status == HTTPStatus.OK
             assert task.size == task_size
 
-    @pytest.mark.with_external_services
     @pytest.mark.parametrize("cloud_storage_id", [2])
     @pytest.mark.parametrize("use_manifest", [True, False])
     @pytest.mark.parametrize(
@@ -731,7 +730,6 @@ class TestPostTaskData:
             data_meta, _ = api_client.tasks_api.retrieve_data_meta(task_id)
             assert expected_result == [x.name for x in data_meta.frames]
 
-    @pytest.mark.with_external_services
     @pytest.mark.parametrize(
         "storage_id, manifest",
         [
@@ -788,7 +786,6 @@ class TestPostTaskData:
 
         assert capture.value.status == HTTPStatus.FORBIDDEN
 
-    @pytest.mark.with_external_services
     @pytest.mark.parametrize("cloud_storage_id", [1])
     @pytest.mark.parametrize(
         "manifest, filename_pattern, sub_dir, task_size, expected_error",
@@ -889,7 +886,6 @@ class TestPostTaskData:
             rq_job_details = self._test_cannot_create_task(self._USERNAME, task_spec, data_spec)
             assert expected_error and expected_error in rq_job_details.message
 
-    @pytest.mark.with_external_services
     @pytest.mark.parametrize("use_manifest", [True, False])
     @pytest.mark.parametrize("use_cache", [True, False])
     @pytest.mark.parametrize(
@@ -929,7 +925,6 @@ class TestPostTaskData:
             )
             assert response.status == HTTPStatus.OK
 
-    @pytest.mark.with_external_services
     @pytest.mark.parametrize(
         "filenames, sorting_method",
         [
@@ -972,7 +967,6 @@ class TestPostTaskData:
             for image_name, frame in zip(filenames, data_meta.frames):
                 assert frame.name.rsplit("/", maxsplit=1)[1] == image_name
 
-    @pytest.mark.with_external_services
     @pytest.mark.parametrize(
         "cloud_storage_id, org",
         [
@@ -1078,7 +1072,6 @@ class TestPostTaskData:
         response = get_method(self._USERNAME, "tasks")
         assert response.status_code == HTTPStatus.OK
 
-    @pytest.mark.with_external_services
     @pytest.mark.parametrize("cloud_storage_id", [2])
     @pytest.mark.parametrize("use_manifest", [True, False])
     @pytest.mark.parametrize("server_files", [["test/"]])
@@ -1571,7 +1564,6 @@ class TestPostTaskData:
         else:
             assert len(validation_frames) == validation_frames_count
 
-    @pytest.mark.with_external_services
     @pytest.mark.parametrize("cloud_storage_id", [2])
     @pytest.mark.parametrize(
         "validation_mode",

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -1322,7 +1322,7 @@ class TestPatchTaskLabel:
 class TestWorkWithTask:
     _USERNAME = "admin1"
 
-    @pytest.mark.with_external_services
+    @pytest.mark.infra_profile("standard")
     @pytest.mark.parametrize(
         "cloud_storage_id, manifest",
         [(1, "images_with_manifest/manifest.jsonl")],  # public bucket
@@ -1421,7 +1421,7 @@ class TestTaskBackups:
 
         assert "Backup of a task without data is not allowed" in str(capture.value.body)
 
-    @pytest.mark.with_external_services
+    @pytest.mark.infra_profile("standard")
     def test_can_export_and_import_backup_task_with_mounted_share(self):
         task_spec = {
             "name": "Task with files from mounted share",
@@ -1450,7 +1450,7 @@ class TestTaskBackups:
 
         self._test_can_restore_task_from_backup(task_id)
 
-    @pytest.mark.with_external_services
+    @pytest.mark.infra_profile("standard")
     @pytest.mark.parametrize("lightweight_backup", [True, False])
     def test_can_export_and_import_backup_task_with_cloud_storage(self, lightweight_backup):
         task_spec = {
@@ -1567,7 +1567,7 @@ class TestTaskBackups:
 
         self._test_can_restore_task_from_backup(task["id"])
 
-    @pytest.mark.with_external_services
+    @pytest.mark.infra_profile("standard")
     def test_can_export_and_import_backup_with_backing_cs(self, request, cloud_storages):
         cloud_storage_id = next(cs["id"] for cs in cloud_storages if cs["resource"] == "backingcs")
 
@@ -2799,7 +2799,7 @@ class TestPatchTask:
         assert response.status_code == HTTPStatus.OK
         assert compare_annotations(annotations, response.json(), ignore_spec_ids=True) == {}
 
-    @pytest.mark.with_external_services
+    @pytest.mark.infra_profile("standard")
     @pytest.mark.parametrize(
         "storage_id",
         [
@@ -3189,8 +3189,15 @@ class TestImportTaskAnnotations:
             required_time = ceil(time() - start_time) * 2
             self._delete_annotations(task_id)
 
+            # The SDK uploader accepts an optional logger callback even though pylint
+            # does not see it in the generated signature here.
+            # pylint: disable-next=unexpected-keyword-arg
             response = uploader.upload_file(
-                url, filename, meta=params, query_params=params, logger=self.client.logger.debug
+                url,
+                filename,
+                meta=params,
+                query_params=params,
+                logger=self.client.logger.debug,
             )
             rq_id = json.loads(response.data)["rq_id"]
             assert rq_id

--- a/tests/python/rest_api/test_tus_uploads.py
+++ b/tests/python/rest_api/test_tus_uploads.py
@@ -10,6 +10,8 @@ import pytest
 from shared.utils.config import BASE_URL, make_api_client
 from shared.utils.helpers import generate_image_file
 
+pytestmark = [pytest.mark.infra_profile("standard")]
+
 
 @pytest.mark.usefixtures("restore_db_per_function")
 @pytest.mark.usefixtures("restore_cvat_data_per_function")

--- a/tests/python/rest_api/test_webhooks_sender.py
+++ b/tests/python/rest_api/test_webhooks_sender.py
@@ -3,13 +3,14 @@
 # SPDX-License-Identifier: MIT
 
 import json
+import os
 from http import HTTPStatus
 from time import sleep, time
 
 import pytest
 from deepdiff import DeepDiff
+from infra.config import RuntimeInfraConfig
 
-from shared.fixtures.init import CVAT_ROOT_DIR
 from shared.utils.config import delete_method, get_method, patch_method, post_method
 
 # Testing webhook functionality:
@@ -21,12 +22,17 @@ from shared.utils.config import delete_method, get_method, patch_method, post_me
 #  2) check that webhook is sent by checking value of `response` field for the last delivery of this webhook
 
 # https://docs.pytest.org/en/7.1.x/example/markers.html#marking-whole-classes-or-modules
-pytestmark = [pytest.mark.with_external_services]
+pytestmark = [pytest.mark.infra_profile("full")]
 
 
 def target_url():
+    if webhook_receiver_url := os.environ.get("CVAT_TEST_WEBHOOK_RECEIVER_URL"):
+        return webhook_receiver_url
+
     env_data = {}
-    with open(CVAT_ROOT_DIR / "tests/python/webhook_receiver/.env", "r") as f:
+    with open(
+        RuntimeInfraConfig.get_cvat_root_dir() / "tests/python/webhook_receiver/.env", "r"
+    ) as f:
         for line in f:
             name, value = tuple(line.strip().split("="))
             env_data[name] = value

--- a/tests/python/sdk/common.py
+++ b/tests/python/sdk/common.py
@@ -86,7 +86,9 @@ class TestDatasetExport:
                 "resource"
             ]
             s3_client = make_s3_client(bucket=bucket)
-            request.addfinalizer(lambda: s3_client.remove_file(filename=str(file_path)))
+            request.addfinalizer(
+                lambda: s3_client.remove_file(filename=str(file_path), ignore_clock_skew=True)
+            )
             self._test_export_to_cloud_storage(
                 resource,
                 format_name=format_name,

--- a/tests/python/sdk/test_jobs.py
+++ b/tests/python/sdk/test_jobs.py
@@ -19,6 +19,8 @@ from shared.fixtures.data import CloudStorageAssets
 from .common import TestDatasetExport
 from .util import make_pbar
 
+pytestmark = [pytest.mark.infra_profile("standard")]
+
 
 class TestJobUsecases(TestDatasetExport):
     @pytest.fixture(autouse=True)
@@ -103,28 +105,10 @@ class TestJobUsecases(TestDatasetExport):
         [
             (fixture_ref("fxt_new_task"), None),
             (fixture_ref("fxt_new_task"), Location.LOCAL),
-            (
-                pytest.param(
-                    fixture_ref("fxt_new_task"),
-                    Location.CLOUD_STORAGE,
-                    marks=pytest.mark.with_external_services,
-                )
-            ),
-            (
-                pytest.param(
-                    fixture_ref("fxt_new_task_with_target_storage"),
-                    None,
-                    marks=pytest.mark.with_external_services,
-                )
-            ),
+            (fixture_ref("fxt_new_task"), Location.CLOUD_STORAGE),
+            (fixture_ref("fxt_new_task_with_target_storage"), None),
             (fixture_ref("fxt_new_task_with_target_storage"), Location.LOCAL),
-            (
-                pytest.param(
-                    fixture_ref("fxt_new_task_with_target_storage"),
-                    Location.CLOUD_STORAGE,
-                    marks=pytest.mark.with_external_services,
-                )
-            ),
+            (fixture_ref("fxt_new_task_with_target_storage"), Location.CLOUD_STORAGE),
         ],
     )
     def test_can_export_dataset(

--- a/tests/python/sdk/test_projects.py
+++ b/tests/python/sdk/test_projects.py
@@ -22,6 +22,8 @@ from shared.utils.config import IMPORT_EXPORT_BUCKET_ID
 from .common import TestDatasetExport
 from .util import make_pbar
 
+pytestmark = [pytest.mark.infra_profile("standard")]
+
 
 class TestProjectUsecases(TestDatasetExport):
     @pytest.fixture(autouse=True)
@@ -258,28 +260,10 @@ class TestProjectUsecases(TestDatasetExport):
         [
             (fixture_ref("fxt_new_project"), None),
             (fixture_ref("fxt_new_project"), Location.LOCAL),
-            (
-                pytest.param(
-                    fixture_ref("fxt_new_project"),
-                    Location.CLOUD_STORAGE,
-                    marks=pytest.mark.with_external_services,
-                )
-            ),
-            (
-                pytest.param(
-                    fixture_ref("fxt_new_project_with_target_storage"),
-                    None,
-                    marks=pytest.mark.with_external_services,
-                )
-            ),
+            (fixture_ref("fxt_new_project"), Location.CLOUD_STORAGE),
+            (fixture_ref("fxt_new_project_with_target_storage"), None),
             (fixture_ref("fxt_new_project_with_target_storage"), Location.LOCAL),
-            (
-                pytest.param(
-                    fixture_ref("fxt_new_project_with_target_storage"),
-                    Location.CLOUD_STORAGE,
-                    marks=pytest.mark.with_external_services,
-                )
-            ),
+            (fixture_ref("fxt_new_project_with_target_storage"), Location.CLOUD_STORAGE),
         ],
     )
     def test_can_export_dataset(

--- a/tests/python/sdk/test_tasks.py
+++ b/tests/python/sdk/test_tasks.py
@@ -24,6 +24,8 @@ from shared.utils.helpers import generate_image_files
 from .common import TestDatasetExport
 from .util import make_pbar
 
+pytestmark = [pytest.mark.infra_profile("standard")]
+
 
 class TestTaskUsecases(TestDatasetExport):
     @pytest.fixture(autouse=True)
@@ -244,28 +246,10 @@ class TestTaskUsecases(TestDatasetExport):
         [
             (fixture_ref("fxt_new_task"), None),
             (fixture_ref("fxt_new_task"), Location.LOCAL),
-            (
-                pytest.param(
-                    fixture_ref("fxt_new_task"),
-                    Location.CLOUD_STORAGE,
-                    marks=pytest.mark.with_external_services,
-                )
-            ),
-            (
-                pytest.param(
-                    fixture_ref("fxt_new_task_with_target_storage"),
-                    None,
-                    marks=pytest.mark.with_external_services,
-                )
-            ),
+            (fixture_ref("fxt_new_task"), Location.CLOUD_STORAGE),
+            (fixture_ref("fxt_new_task_with_target_storage"), None),
             (fixture_ref("fxt_new_task_with_target_storage"), Location.LOCAL),
-            (
-                pytest.param(
-                    fixture_ref("fxt_new_task_with_target_storage"),
-                    Location.CLOUD_STORAGE,
-                    marks=pytest.mark.with_external_services,
-                )
-            ),
+            (fixture_ref("fxt_new_task_with_target_storage"), Location.CLOUD_STORAGE),
         ],
     )
     def test_can_export_dataset(

--- a/tests/python/shared/fixtures/data.py
+++ b/tests/python/shared/fixtures/data.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 
 import pytest
 
-from shared.utils.config import ASSETS_DIR
+from shared.utils.config import ASSETS_DIR, normalize_runtime_asset_urls
 
 
 class Container:
@@ -38,28 +38,34 @@ class Container:
         return self.map_data[key]
 
 
+def _load_asset(filename: str, root_key: str = "results"):
+    with open(ASSETS_DIR / filename) as f:
+        data = json.load(f)
+
+    if root_key is None:
+        return normalize_runtime_asset_urls(data)
+
+    return normalize_runtime_asset_urls(data[root_key])
+
+
 @pytest.fixture(scope="session")
 def users():
-    with open(ASSETS_DIR / "users.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("users.json"))
 
 
 @pytest.fixture(scope="session")
 def organizations():
-    with open(ASSETS_DIR / "organizations.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("organizations.json"))
 
 
 @pytest.fixture(scope="session")
 def memberships():
-    with open(ASSETS_DIR / "memberships.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("memberships.json"))
 
 
 @pytest.fixture(scope="session")
 def tasks():
-    with open(ASSETS_DIR / "tasks.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("tasks.json"))
 
 
 def filter_assets(resources: Iterable, **kwargs):
@@ -141,8 +147,7 @@ def tasks_wlc(labels, tasks):  # tasks with labels count
 
 @pytest.fixture(scope="session")
 def projects():
-    with open(ASSETS_DIR / "projects.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("projects.json"))
 
 
 @pytest.fixture(scope="session")
@@ -161,8 +166,7 @@ def projects_wlc(projects, labels):  # projects with labels count
 
 @pytest.fixture(scope="session")
 def jobs():
-    with open(ASSETS_DIR / "jobs.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("jobs.json"))
 
 
 @pytest.fixture(scope="session")
@@ -176,14 +180,12 @@ def jobs_wlc(jobs, tasks_wlc):  # jobs with labels count
 
 @pytest.fixture(scope="session")
 def invitations():
-    with open(ASSETS_DIR / "invitations.json") as f:
-        return Container(json.load(f)["results"], key="key")
+    return Container(_load_asset("invitations.json"), key="key")
 
 
 @pytest.fixture(scope="session")
 def annotations():
-    with open(ASSETS_DIR / "annotations.json") as f:
-        return json.load(f)
+    return _load_asset("annotations.json", root_key=None)
 
 
 CloudStorageAssets = Container
@@ -191,56 +193,47 @@ CloudStorageAssets = Container
 
 @pytest.fixture(scope="session")
 def cloud_storages() -> CloudStorageAssets:
-    with open(ASSETS_DIR / "cloudstorages.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("cloudstorages.json"))
 
 
 @pytest.fixture(scope="session")
 def issues():
-    with open(ASSETS_DIR / "issues.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("issues.json"))
 
 
 @pytest.fixture(scope="session")
 def comments():
-    with open(ASSETS_DIR / "comments.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("comments.json"))
 
 
 @pytest.fixture(scope="session")
 def webhooks():
-    with open(ASSETS_DIR / "webhooks.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("webhooks.json"))
 
 
 @pytest.fixture(scope="session")
 def labels():
-    with open(ASSETS_DIR / "labels.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("labels.json"))
 
 
 @pytest.fixture(scope="session")
 def quality_reports():
-    with open(ASSETS_DIR / "quality_reports.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("quality_reports.json"))
 
 
 @pytest.fixture(scope="session")
 def quality_conflicts():
-    with open(ASSETS_DIR / "quality_conflicts.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("quality_conflicts.json"))
 
 
 @pytest.fixture(scope="session")
 def quality_settings():
-    with open(ASSETS_DIR / "quality_settings.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("quality_settings.json"))
 
 
 @pytest.fixture(scope="session")
 def consensus_settings():
-    with open(ASSETS_DIR / "consensus_settings.json") as f:
-        return Container(json.load(f)["results"])
+    return Container(_load_asset("consensus_settings.json"))
 
 
 @pytest.fixture(scope="session")
@@ -590,8 +583,7 @@ def access_tokens(access_tokens_by_username):
 
 @pytest.fixture(scope="session")
 def raw_access_tokens_by_username():
-    with open(ASSETS_DIR / "access_tokens.json") as f:
-        return json.load(f)["user"]
+    return _load_asset("access_tokens.json", root_key="user")
 
 
 @pytest.fixture(scope="session")

--- a/tests/python/shared/utils/config.py
+++ b/tests/python/shared/utils/config.py
@@ -5,9 +5,11 @@
 # Generic test request helpers intentionally rely on pytest/runtime-level timeouts.
 # pylint: disable=missing-timeout
 
+import os
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
+from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit, urlunsplit
 
 import requests
 from cvat_sdk.api_client import ApiClient, Configuration
@@ -19,14 +21,126 @@ ASSETS_DIR = (ROOT_DIR / "assets").resolve()
 USER_PASS = "!Q@W#E$R"  # nosec
 ADMIN_USER = "admin1"
 ADMIN_PASS = USER_PASS
-BASE_URL = "http://localhost:8080"
+BASE_URL = os.environ.get("CVAT_BASE_URL", "http://localhost:8080")
 API_URL = BASE_URL + "/api/"
+LEGACY_BASE_URL = "http://localhost:8080"
 
 # MiniIO settings
 MINIO_KEY = "minio_access_key"
 MINIO_SECRET_KEY = "minio_secret_key"  # nosec
-MINIO_ENDPOINT_URL = "http://localhost:9000"
+MINIO_ENDPOINT_URL = os.environ.get("CVAT_MINIO_ENDPOINT_URL", "http://localhost:9000")
 IMPORT_EXPORT_BUCKET_ID = 3
+
+
+def get_runtime_webhook_target_url() -> str:
+    return os.environ.get(
+        "CVAT_TEST_DB_WEBHOOK_RECEIVER_URL",
+        os.environ.get("CVAT_TEST_WEBHOOK_RECEIVER_URL", "http://webhooks.internal"),
+    )
+
+
+def get_runtime_cloud_storage_endpoint_url() -> str:
+    return os.environ.get("CVAT_TEST_DB_MINIO_ENDPOINT_URL", "http://minio:9000")
+
+
+def normalize_runtime_asset_urls(
+    value,
+    *,
+    base_url: str | None = None,
+    webhook_url: str | None = None,
+    minio_url: str | None = None,
+):
+    # Repo-tracked fixtures keep stable localhost/internal URLs. Rewrite them at
+    # load time so the same fixture data works for the active runtime endpoints.
+    base_url = base_url or os.environ.get("CVAT_BASE_URL", LEGACY_BASE_URL)
+    webhook_url = (
+        webhook_url
+        or os.environ.get("CVAT_TEST_DB_WEBHOOK_RECEIVER_URL")
+        or os.environ.get("CVAT_TEST_WEBHOOK_RECEIVER_URL")
+    )
+    # DB-backed fixture payloads already carry the legacy internal webhook/MinIO
+    # URLs used by local tests. Only rewrite them when the runtime provides an
+    # explicit override, otherwise preserve the stored values exactly.
+    minio_url = minio_url or os.environ.get("CVAT_TEST_DB_MINIO_ENDPOINT_URL")
+
+    if isinstance(value, str):
+        value = value.replace(LEGACY_BASE_URL, base_url)
+        value = _rewrite_webhook_url(value, webhook_url=webhook_url)
+        value = _rewrite_cloud_storage_attributes(value, minio_url=minio_url)
+        return value
+
+    if isinstance(value, list):
+        return [
+            normalize_runtime_asset_urls(
+                item, base_url=base_url, webhook_url=webhook_url, minio_url=minio_url
+            )
+            for item in value
+        ]
+
+    if isinstance(value, dict):
+        return {
+            key: normalize_runtime_asset_urls(
+                item, base_url=base_url, webhook_url=webhook_url, minio_url=minio_url
+            )
+            for key, item in value.items()
+        }
+
+    return value
+
+
+def _rewrite_webhook_url(value: str, *, webhook_url: str) -> str:
+    if not webhook_url:
+        return value
+
+    current = urlsplit(value)
+    if current.hostname != "webhooks.internal":
+        return value
+
+    runtime = urlsplit(webhook_url)
+    path = current.path or runtime.path or "/"
+    query = current.query or runtime.query
+    fragment = current.fragment or runtime.fragment
+    return urlunsplit((runtime.scheme, runtime.netloc, path, query, fragment))
+
+
+def _rewrite_cloud_storage_attributes(value: str, *, minio_url: str) -> str:
+    if "endpoint_url=" not in value or not minio_url:
+        return value
+
+    parsed = []
+    runtime = urlsplit(minio_url)
+    for key, attr_value in parse_qsl(value, keep_blank_values=True):
+        if key != "endpoint_url":
+            parsed.append((key, attr_value))
+            continue
+
+        current = urlsplit(unquote(attr_value))
+        if current.hostname != "minio":
+            parsed.append((key, attr_value))
+            continue
+
+        netloc = runtime.hostname or current.hostname or ""
+        if runtime.port:
+            netloc = f"{netloc}:{runtime.port}"
+        elif current.port:
+            netloc = f"{netloc}:{current.port}"
+
+        parsed.append(
+            (
+                key,
+                urlunsplit(
+                    (
+                        runtime.scheme or current.scheme,
+                        netloc,
+                        current.path,
+                        current.query,
+                        current.fragment,
+                    )
+                ),
+            )
+        )
+
+    return urlencode(parsed, doseq=True, quote_via=quote)
 
 
 def _to_query_params(**kwargs):
@@ -41,8 +155,10 @@ def get_api_url(endpoint, **kwargs):
     return API_URL + endpoint + "?" + _to_query_params(**kwargs)
 
 
-def get_method(username, endpoint, **kwargs):
-    return requests.get(get_api_url(endpoint, **kwargs), auth=(username, USER_PASS))
+def get_method(username, endpoint, *, timeout=None, **kwargs):
+    return requests.get(
+        get_api_url(endpoint, **kwargs), auth=(username, USER_PASS), timeout=timeout
+    )
 
 
 def options_method(username, endpoint, **kwargs):

--- a/tests/python/shared/utils/resource_import_export.py
+++ b/tests/python/shared/utils/resource_import_export.py
@@ -7,6 +7,7 @@ from time import sleep
 from typing import Any, TypeVar
 
 import pytest
+import requests
 
 T = TypeVar("T")
 
@@ -61,16 +62,26 @@ def _wait_request(
     sleep_interval: float = 0.1,
     number_of_checks: int = 100,
 ):
+    last_request_details: dict[str, Any] | None = None
     for _ in range(number_of_checks):
         sleep(sleep_interval)
-        response = get_method(user, f"requests/{request_id}")
+        try:
+            response = get_method(user, f"requests/{request_id}", timeout=5)
+        except (requests.Timeout, requests.ConnectionError):
+            continue
         assert response.status_code == HTTPStatus.OK
 
         request_details = json.loads(response.content)
+        last_request_details = request_details
         status = request_details["status"]
         assert status in {"started", "queued", "finished", "failed"}
         if status in {"finished", "failed"}:
-            return
+            return request_details
+
+    raise AssertionError(
+        f"Timed out waiting for request {request_id!r} to finish; "
+        f"last payload: {last_request_details!r}"
+    )
 
 
 class _CloudStorageResourceTest(ABC):
@@ -96,10 +107,12 @@ class _CloudStorageResourceTest(ABC):
             # check that file doesn't exist on the bucket
             assert not self.client.file_exists(bucket=bucket, filename=filename)
 
-            func(*args, **kwargs)
+            request_details = func(*args, **kwargs)
 
-            # check that file exists on the bucket
-            assert self.client.file_exists(bucket=bucket, filename=filename)
+            assert self.client.file_exists(bucket=bucket, filename=filename), (
+                f"Exported object {filename!r} was not found in bucket {bucket!r} after request "
+                f"{request_details.get('id')!r} finished with payload: {request_details!r}"
+            )
 
         return wrapper
 
@@ -129,7 +142,12 @@ class _CloudStorageResourceTest(ABC):
         rq_id = json.loads(response.content).get("rq_id")
         assert rq_id, "The rq_id was not found in server request"
 
-        _wait_request(user, rq_id)
+        request_details = _wait_request(user, rq_id)
+        assert request_details["status"] == "finished", (
+            f"Export request {rq_id!r} for {obj}/{obj_id}/{resource!r} ended with unexpected "
+            f"payload: {request_details!r}"
+        )
+        return request_details
 
     def _import_resource_from_cloud_storage(
         self, url: str, *, user: str, _expect_status: HTTPStatus = HTTPStatus.ACCEPTED, **kwargs
@@ -144,7 +162,11 @@ class _CloudStorageResourceTest(ABC):
         rq_id = response.json().get("rq_id")
         assert rq_id, "The rq_id parameter was not found in the server response"
 
-        _wait_request(user, rq_id)
+        request_details = _wait_request(user, rq_id)
+        assert request_details["status"] == "finished", (
+            f"Import request {rq_id!r} for {url!r} ended with unexpected payload: "
+            f"{request_details!r}"
+        )
 
     def _import_annotations_from_cloud_storage(
         self,

--- a/tests/python/shared/utils/s3.py
+++ b/tests/python/shared/utils/s3.py
@@ -2,18 +2,26 @@
 #
 # SPDX-License-Identifier: MIT
 
+import time
+from collections.abc import Callable
 from io import BytesIO
+from typing import BinaryIO, TypeVar
 
 import boto3
 from botocore.exceptions import ClientError
 
 from shared.utils.config import MINIO_ENDPOINT_URL, MINIO_KEY, MINIO_SECRET_KEY
 
+T = TypeVar("T")
+
 
 class S3Client:
     def __init__(
         self, endpoint_url: str, *, access_key: str, secret_key: str, bucket: str | None = None
     ) -> None:
+        self.endpoint_url = endpoint_url
+        self.access_key = access_key
+        self.secret_key = secret_key
         self.client = self._make_boto_client(
             endpoint_url=endpoint_url, access_key=access_key, secret_key=secret_key
         )
@@ -29,21 +37,64 @@ class S3Client:
         )
         return s3.meta.client
 
-    def create_file(self, filename: str, data: bytes = b"", *, bucket: str | None = None):
-        bucket = bucket or self.bucket
-        assert bucket
-        self.client.put_object(Body=data, Bucket=bucket, Key=filename)
+    @staticmethod
+    def _is_clock_skew_error(error: ClientError) -> bool:
+        code = error.response.get("Error", {}).get("Code")
+        return code in {"RequestTimeTooSkewed", "RequestExpired"}
 
-    def remove_file(self, filename: str, *, bucket: str | None = None):
+    def _refresh_client(self) -> None:
+        self.client = self._make_boto_client(
+            endpoint_url=self.endpoint_url,
+            access_key=self.access_key,
+            secret_key=self.secret_key,
+        )
+
+    def _call_with_retry(self, callback: Callable[[], T]) -> T:
+        max_retries = 4
+        for attempt in range(max_retries + 1):
+            try:
+                return callback()
+            except ClientError as error:
+                if not self._is_clock_skew_error(error) or attempt == max_retries:
+                    raise
+
+                self._refresh_client()
+                time.sleep(0.5 * (2**attempt))
+
+    def create_file(
+        self, filename: str, data: bytes | BinaryIO = b"", *, bucket: str | None = None
+    ):
         bucket = bucket or self.bucket
         assert bucket
-        self.client.delete_object(Bucket=bucket, Key=filename)
+
+        def _put_object():
+            if hasattr(data, "seek"):
+                data.seek(0)
+            self.client.put_object(Body=data, Bucket=bucket, Key=filename)
+
+        self._call_with_retry(_put_object)
+
+    def remove_file(
+        self,
+        filename: str,
+        *,
+        bucket: str | None = None,
+        ignore_clock_skew: bool = False,
+    ):
+        bucket = bucket or self.bucket
+        assert bucket
+        try:
+            self._call_with_retry(lambda: self.client.delete_object(Bucket=bucket, Key=filename))
+        except ClientError as error:
+            if ignore_clock_skew and self._is_clock_skew_error(error):
+                return
+            raise
 
     def file_exists(self, filename: str, *, bucket: str | None = None) -> bool:
         bucket = bucket or self.bucket
         assert bucket
         try:
-            self.client.head_object(Bucket=bucket, Key=filename)
+            self._call_with_retry(lambda: self.client.head_object(Bucket=bucket, Key=filename))
             return True
         except ClientError as e:
             if e.response["Error"]["Code"] == "404":
@@ -55,7 +106,9 @@ class S3Client:
         bucket = bucket or self.bucket
         assert bucket
         with BytesIO() as data:
-            self.client.download_fileobj(Bucket=bucket, Key=key, Fileobj=data)
+            self._call_with_retry(
+                lambda: self.client.download_fileobj(Bucket=bucket, Key=key, Fileobj=data)
+            )
             return data.getvalue()
 
 


### PR DESCRIPTION
## Summary

This is the next stacked PR after `v3-pr4b-fast-restore`.

It introduces explicit local runtime profiles and runtime-aware endpoint handling for Python tests.

Scope:
- add `simple`, `standard`, and `full` local runtime profiles
- select the required local profile from explicit `@pytest.mark.infra_profile(...)` markers in test files
- fail early when an explicit `--infra-profile` is too small
- make fixture-backed webhook / cloud-storage / SDK / CLI URLs adapt to the active runtime
- keep repo-tracked fixture JSON stable by normalizing URLs in memory at load time

Out of scope:
- dynamic local ports
- parallel runtime
- kube runtime replacement
- profiler
- CI workflow changes

## Why

After the runtime foundation and fast restore PRs, the remaining local-runtime gap was test selection and endpoint assumptions.

Some Python tests need a heavier local stack than others:
- MinIO-backed cloud storage
- webhook receiver / test servers
- full analytics-related services

At the same time, some fixture-backed payloads still assumed fixed legacy internal URLs.

This PR makes those requirements explicit and keeps the runtime/test data aligned without introducing dynamic ports yet.

## What changed

### Local runtime profiles
Added 3 local profiles:
- `simple`
- `standard`
- `full`

Selection rules:
- unmarked tests implicitly require `simple`
- tests that need more services use explicit `@pytest.mark.infra_profile("standard")` or `@pytest.mark.infra_profile("full")`
- if `--infra-profile` is not explicitly provided, the local runtime selects the smallest sufficient profile for the collected test set
- if `--infra-profile` is explicitly too small, pytest fails before starting the stack

### Compose layering
Added only valid local profile overlays:
- `tests/docker-compose.simple.profile.yml`
- `tests/docker-compose.standard.profile.yml`

Important:
- this PR does **not** reintroduce the outdated:
  - `tests/docker-compose.core.profile.yml`
  - `tests/docker-compose.extended.profile.yml`

The `full` profile is assembled from valid existing compose inputs only.

### Runtime-aware endpoints
Added shared helper support so runtime-facing URLs adapt without changing committed fixture assets:
- `CVAT_BASE_URL` for SDK / CLI / shared helpers
- runtime-aware webhook target handling
- runtime-aware cloud-storage endpoint handling
- in-memory normalization of fixture JSON at load time

This keeps repo-tracked fixtures stable while still matching the active runtime.

### Test classification cleanup
- migrated Python test requirements to explicit `infra_profile(...)` markers
- removed the legacy `with_external_services` marker usage from `tests/python`
- removed the now-dead marker registration

## Validation

Static checks:
- `py_compile`
- `black --check`
- `isort --check --diff --resolve-all-configs`
- `pylint`
- `typos`
- `remark`

Profile selection checks:
- `simple` local smoke: passed
- `standard` local smoke: passed
- `full` local smoke: passed
- explicit too-small profile fails early as intended

Targeted profile-sensitive suites:
- `tests/python/rest_api/test_cloud_storages.py`
  - `52 passed`
- `tests/python/rest_api/test_webhooks.py`
  - `94 passed, 1 skipped`

Full local Python suite:
- `pytest tests/python --platform=local`
- result: `2178 passed, 20 skipped, 1 xfailed`

CI-like Django unit tests:
- `docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.ci.yml run --rm cvat_ci python manage.py test cvat/apps -v 2`
- result: `412 tests`, `OK (skipped=58)`

## Review notes

- This PR keeps profile requirements in test files only.
- Infra code reads `infra_profile(...)` markers but does not create a second synthetic marker system.
- Dynamic local ports are intentionally deferred to the next PR.
- Kube remains on the legacy path until the dedicated kube PR.
