### PR TITLE
Improve usability of the backing cloud storage migration commands

### DIFF
--- a/changelog.d/20260420_141212_roman_backing_cs_migration_usability.md
+++ b/changelog.d/20260420_141212_roman_backing_cs_migration_usability.md
@@ -1,0 +1,20 @@
+### Added
+
+- The `movetasktobackingcs` and `movetasktobackingcs` commands can now load
+  a list of tasks to migrate from a file
+  (<https://github.com/cvat-ai/cvat/pull/10504>)
+
+- The `movetasktobackingcs` and `movetasktobackingcs` commands now print
+  statistics about the transfer
+  (<https://github.com/cvat-ai/cvat/pull/10504>)
+
+### Changed
+
+- The `movetasktobackingcs` and `movetasktobackingcs` no longer exit with a
+  failure status when the given task already has the expected backing CS
+  (<https://github.com/cvat-ai/cvat/pull/10504>)
+
+### Fixed
+
+- Tasks without manifests can now use backing cloud storage
+  (<https://github.com/cvat-ai/cvat/pull/10504>)

--- a/cvat/apps/engine/management/commands/movetaskfrombackingcs.py
+++ b/cvat/apps/engine/management/commands/movetaskfrombackingcs.py
@@ -57,6 +57,11 @@ class Command(BaseCommand):
             raise CommandError(f"Task #{task_id} does not support backing cloud storage")
 
         if not data.local_storage_backing_cs_id:
-            raise CommandError(f"Task #{task_id} has no backing cloud storage")
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Task #{task_id} already has no backing cloud storage"
+                )
+            )
+            return
 
         data.move_from_backing_cs()

--- a/cvat/apps/engine/management/commands/movetaskfrombackingcs.py
+++ b/cvat/apps/engine/management/commands/movetaskfrombackingcs.py
@@ -6,7 +6,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 from cvat.apps.engine.models import Task
 
-from ..utils import parse_task_ids, process_tasks
+from ..utils import move_multiple_tasks, parse_task_ids
 
 
 class Command(BaseCommand):
@@ -22,12 +22,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         task_ids: list[int] = options["task_ids"]
 
-        process_tasks(self, task_ids, self._handle_one_task)
+        move_multiple_tasks(self, task_ids, self._handle_one_task)
 
     def _handle_one_task(self, task: Task) -> bool:
-        data = task.data
-        if not data:
-            raise CommandError(f"Task #{task.id} has no attached data")
+        data = task.require_data()
 
         if not data.supports_backing_cs():
             raise CommandError(f"Task #{task.id} does not support backing cloud storage")

--- a/cvat/apps/engine/management/commands/movetaskfrombackingcs.py
+++ b/cvat/apps/engine/management/commands/movetaskfrombackingcs.py
@@ -2,12 +2,11 @@
 #
 # SPDX-License-Identifier: MIT
 
-import traceback
-
 from django.core.management.base import BaseCommand, CommandError
 
 from cvat.apps.engine.models import Task
-from ..utils import parse_task_ids
+
+from ..utils import parse_task_ids, process_tasks
 
 
 class Command(BaseCommand):
@@ -23,45 +22,21 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         task_ids: list[int] = options["task_ids"]
 
-        succeeded = failed = 0
+        process_tasks(self, task_ids, self._handle_one_task)
 
-        for task_id in task_ids:
-            try:
-                self._handle_one_task(task_id)
-            except Exception:
-                failed += 1
-                self.stderr.write(self.style.ERROR(f"Task #{task_id}: failure"))
-                self.stderr.write(traceback.format_exc(), ending="")
-            else:
-                succeeded += 1
-                self.stdout.write(self.style.SUCCESS(f"Task #{task_id}: success"))
-
-        self.stdout.write(
-            f"Processed {len(task_ids)} task(s): {succeeded} succeeded, {failed} failed"
-        )
-
-        if failed:
-            raise CommandError("Failed to move some task(s)")
-
-    def _handle_one_task(self, task_id: int) -> None:
-        try:
-            task = Task.objects.get(id=task_id)
-        except Task.DoesNotExist as ex:
-            raise CommandError(f"Task #{task_id} does not exist") from ex
-
+    def _handle_one_task(self, task: Task) -> bool:
         data = task.data
         if not data:
-            raise CommandError(f"Task #{task_id} has no attached data")
+            raise CommandError(f"Task #{task.id} has no attached data")
 
         if not data.supports_backing_cs():
-            raise CommandError(f"Task #{task_id} does not support backing cloud storage")
+            raise CommandError(f"Task #{task.id} does not support backing cloud storage")
 
         if not data.local_storage_backing_cs_id:
             self.stdout.write(
-                self.style.WARNING(
-                    f"Task #{task_id} already has no backing cloud storage"
-                )
+                self.style.WARNING(f"Task #{task.id} already has no backing cloud storage")
             )
-            return
+            return False
 
         data.move_from_backing_cs()
+        return True

--- a/cvat/apps/engine/management/commands/movetaskfrombackingcs.py
+++ b/cvat/apps/engine/management/commands/movetaskfrombackingcs.py
@@ -2,24 +2,52 @@
 #
 # SPDX-License-Identifier: MIT
 
+import traceback
+
 from django.core.management.base import BaseCommand, CommandError
 
 from cvat.apps.engine.models import Task
+from ..utils import parse_task_ids
 
 
 class Command(BaseCommand):
     help = "Moves data of a given task from backing cloud storage back to the filesystem"
 
     def add_arguments(self, parser):
-        parser.add_argument("task_id", type=int, help="ID of the task to move data of")
+        parser.add_argument(
+            "task_ids",
+            type=parse_task_ids,
+            help="ID of the task to move data of, or @<path> to a file with one ID per line",
+        )
 
     def handle(self, *args, **options):
-        task_id: int = options["task_id"]
+        task_ids: list[int] = options["task_ids"]
 
+        succeeded = failed = 0
+
+        for task_id in task_ids:
+            try:
+                self._handle_one_task(task_id)
+            except Exception:
+                failed += 1
+                self.stderr.write(self.style.ERROR(f"Task #{task_id}: failure"))
+                self.stderr.write(traceback.format_exc(), ending="")
+            else:
+                succeeded += 1
+                self.stdout.write(self.style.SUCCESS(f"Task #{task_id}: success"))
+
+        self.stdout.write(
+            f"Processed {len(task_ids)} task(s): {succeeded} succeeded, {failed} failed"
+        )
+
+        if failed:
+            raise CommandError("Failed to move some task(s)")
+
+    def _handle_one_task(self, task_id: int) -> None:
         try:
             task = Task.objects.get(id=task_id)
-        except Task.DoesNotExist:
-            raise CommandError(f"Task #{task_id} does not exist")
+        except Task.DoesNotExist as ex:
+            raise CommandError(f"Task #{task_id} does not exist") from ex
 
         data = task.data
         if not data:

--- a/cvat/apps/engine/management/commands/movetasktobackingcs.py
+++ b/cvat/apps/engine/management/commands/movetasktobackingcs.py
@@ -2,16 +2,23 @@
 #
 # SPDX-License-Identifier: MIT
 
+import traceback
+
 from django.core.management.base import BaseCommand, CommandError
 
 from cvat.apps.engine.models import CloudStorage, Task
+from ..utils import parse_task_ids
 
 
 class Command(BaseCommand):
     help = "Moves data of a given task to a backing cloud storage"
 
     def add_arguments(self, parser):
-        parser.add_argument("task_id", type=int, help="ID of the task to move data of")
+        parser.add_argument(
+            "task_ids",
+            type=parse_task_ids,
+            help="ID of the task to move data of, or @<path> to a file with one ID per line",
+        )
         parser.add_argument(
             "backing_cs_id",
             type=int,
@@ -19,13 +26,39 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        task_id: int = options["task_id"]
+        task_ids: list[int] = options["task_ids"]
         backing_cs_id: int = options["backing_cs_id"]
 
         try:
+            backing_cs = CloudStorage.objects.get(id=backing_cs_id)
+        except CloudStorage.DoesNotExist:
+            raise CommandError(f"Cloud storage #{backing_cs_id} does not exist")
+
+        succeeded = failed = 0
+
+        for task_id in task_ids:
+            try:
+                self._handle_one_task(task_id, backing_cs)
+            except Exception:
+                failed += 1
+                self.stderr.write(self.style.ERROR(f"Task #{task_id}: failure"))
+                self.stderr.write(traceback.format_exc(), ending="")
+            else:
+                succeeded += 1
+                self.stdout.write(self.style.SUCCESS(f"Task #{task_id}: success"))
+
+        self.stdout.write(
+            f"Processed {len(task_ids)} task(s): {succeeded} succeeded, {failed} failed"
+        )
+
+        if failed:
+            raise CommandError(f"Failed to move some task(s)")
+
+    def _handle_one_task(self, task_id: int, backing_cs: CloudStorage) -> None:
+        try:
             task = Task.objects.get(id=task_id)
-        except Task.DoesNotExist:
-            raise CommandError(f"Task #{task_id} does not exist")
+        except Task.DoesNotExist as ex:
+            raise CommandError(f"Task #{task_id} does not exist") from ex
 
         data = task.data
         if not data:
@@ -39,10 +72,5 @@ class Command(BaseCommand):
                 f"Task #{task_id} already has a backing cloud storage"
                 f" (#{data.local_storage_backing_cs_id})"
             )
-
-        try:
-            backing_cs = CloudStorage.objects.get(id=backing_cs_id)
-        except CloudStorage.DoesNotExist:
-            raise CommandError(f"Cloud storage #{backing_cs_id} does not exist")
 
         data.move_to_backing_cs(backing_cs)

--- a/cvat/apps/engine/management/commands/movetasktobackingcs.py
+++ b/cvat/apps/engine/management/commands/movetasktobackingcs.py
@@ -67,6 +67,14 @@ class Command(BaseCommand):
         if not data.supports_backing_cs():
             raise CommandError(f"Task #{task_id} does not support backing cloud storage")
 
+        if data.local_storage_backing_cs_id == backing_cs.id:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Task #{task_id} is already backed by cloud storage #{backing_cs.id}"
+                )
+            )
+            return
+
         if data.local_storage_backing_cs_id:
             raise CommandError(
                 f"Task #{task_id} already has a backing cloud storage"

--- a/cvat/apps/engine/management/commands/movetasktobackingcs.py
+++ b/cvat/apps/engine/management/commands/movetasktobackingcs.py
@@ -2,12 +2,11 @@
 #
 # SPDX-License-Identifier: MIT
 
-import traceback
-
 from django.core.management.base import BaseCommand, CommandError
 
 from cvat.apps.engine.models import CloudStorage, Task
-from ..utils import parse_task_ids
+
+from ..utils import parse_task_ids, process_tasks
 
 
 class Command(BaseCommand):
@@ -34,51 +33,29 @@ class Command(BaseCommand):
         except CloudStorage.DoesNotExist:
             raise CommandError(f"Cloud storage #{backing_cs_id} does not exist")
 
-        succeeded = failed = 0
+        process_tasks(self, task_ids, lambda task: self._handle_one_task(task, backing_cs))
 
-        for task_id in task_ids:
-            try:
-                self._handle_one_task(task_id, backing_cs)
-            except Exception:
-                failed += 1
-                self.stderr.write(self.style.ERROR(f"Task #{task_id}: failure"))
-                self.stderr.write(traceback.format_exc(), ending="")
-            else:
-                succeeded += 1
-                self.stdout.write(self.style.SUCCESS(f"Task #{task_id}: success"))
-
-        self.stdout.write(
-            f"Processed {len(task_ids)} task(s): {succeeded} succeeded, {failed} failed"
-        )
-
-        if failed:
-            raise CommandError(f"Failed to move some task(s)")
-
-    def _handle_one_task(self, task_id: int, backing_cs: CloudStorage) -> None:
-        try:
-            task = Task.objects.get(id=task_id)
-        except Task.DoesNotExist as ex:
-            raise CommandError(f"Task #{task_id} does not exist") from ex
-
+    def _handle_one_task(self, task: Task, backing_cs: CloudStorage) -> bool:
         data = task.data
         if not data:
-            raise CommandError(f"Task #{task_id} has no attached data")
+            raise CommandError(f"Task #{task.id} has no attached data")
 
         if not data.supports_backing_cs():
-            raise CommandError(f"Task #{task_id} does not support backing cloud storage")
+            raise CommandError(f"Task #{task.id} does not support backing cloud storage")
 
         if data.local_storage_backing_cs_id == backing_cs.id:
             self.stdout.write(
                 self.style.WARNING(
-                    f"Task #{task_id} is already backed by cloud storage #{backing_cs.id}"
+                    f"Task #{task.id} is already backed by cloud storage #{backing_cs.id}"
                 )
             )
-            return
+            return False
 
         if data.local_storage_backing_cs_id:
             raise CommandError(
-                f"Task #{task_id} already has a backing cloud storage"
+                f"Task #{task.id} already has a backing cloud storage"
                 f" (#{data.local_storage_backing_cs_id})"
             )
 
         data.move_to_backing_cs(backing_cs)
+        return True

--- a/cvat/apps/engine/management/commands/movetasktobackingcs.py
+++ b/cvat/apps/engine/management/commands/movetasktobackingcs.py
@@ -6,7 +6,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 from cvat.apps.engine.models import CloudStorage, Task
 
-from ..utils import parse_task_ids, process_tasks
+from ..utils import move_multiple_tasks, parse_task_ids
 
 
 class Command(BaseCommand):
@@ -33,12 +33,10 @@ class Command(BaseCommand):
         except CloudStorage.DoesNotExist:
             raise CommandError(f"Cloud storage #{backing_cs_id} does not exist")
 
-        process_tasks(self, task_ids, lambda task: self._handle_one_task(task, backing_cs))
+        move_multiple_tasks(self, task_ids, lambda task: self._handle_one_task(task, backing_cs))
 
     def _handle_one_task(self, task: Task, backing_cs: CloudStorage) -> bool:
-        data = task.data
-        if not data:
-            raise CommandError(f"Task #{task.id} has no attached data")
+        data = task.require_data()
 
         if not data.supports_backing_cs():
             raise CommandError(f"Task #{task.id} does not support backing cloud storage")

--- a/cvat/apps/engine/management/utils.py
+++ b/cvat/apps/engine/management/utils.py
@@ -1,0 +1,30 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import argparse
+
+
+def parse_task_ids(value: str) -> list[int]:
+    task_ids = []
+
+    if value.startswith("@"):
+        task_ids_path = value[1:]
+
+        with open(task_ids_path) as task_ids_file:
+            for line_num, line in enumerate(task_ids_file):
+                line = line.strip()
+                if not line:
+                    continue
+
+                try:
+                    task_ids.append(int(line))
+                except ValueError as ex:
+                    raise RuntimeError(f"{task_ids_path}:{line_num + 1}: Invalid task ID") from ex
+    else:
+        try:
+            task_ids.append(int(value))
+        except ValueError as ex:
+            raise argparse.ArgumentTypeError(f"Invalid task ID: {value!r}") from ex
+
+    return task_ids

--- a/cvat/apps/engine/management/utils.py
+++ b/cvat/apps/engine/management/utils.py
@@ -3,6 +3,12 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import traceback
+from collections.abc import Callable, Iterable
+
+from django.core.management.base import BaseCommand, CommandError
+
+from ..models import Task
 
 
 def parse_task_ids(value: str) -> list[int]:
@@ -28,3 +34,38 @@ def parse_task_ids(value: str) -> list[int]:
             raise argparse.ArgumentTypeError(f"Invalid task ID: {value!r}") from ex
 
     return task_ids
+
+
+def process_tasks(
+    command: BaseCommand, task_ids: Iterable[int], process_one: Callable[[Task], bool]
+) -> None:
+    succeeded = failed = ignored = 0
+
+    for task_id in task_ids:
+        try:
+            try:
+                task = Task.objects.get(id=task_id)
+            except Task.DoesNotExist as ex:
+                raise CommandError(f"Task #{task_id} does not exist") from ex
+
+            action_taken = process_one(task)
+        except Exception:
+            failed += 1
+            command.stderr.write(command.style.ERROR(f"Task #{task_id}: failure"))
+            command.stderr.write(traceback.format_exc(), ending="")
+        else:
+            if action_taken:
+                succeeded += 1
+                command.stdout.write(command.style.SUCCESS(f"Task #{task_id}: success"))
+            else:
+                ignored += 1
+                # We're relying on process_one to log the reason for ignoring.
+
+    processed = succeeded + failed + ignored
+
+    command.stdout.write(
+        f"Processed {processed} task(s): {succeeded} succeeded, {failed} failed, {ignored} ignored"
+    )
+
+    if failed:
+        raise CommandError("Failed to move some task(s)")

--- a/cvat/apps/engine/management/utils.py
+++ b/cvat/apps/engine/management/utils.py
@@ -39,7 +39,7 @@ def parse_task_ids(value: str) -> list[int]:
 
 
 def move_multiple_tasks(
-    command: BaseCommand, task_ids: Iterable[int], process_one: Callable[[Task], bool]
+    command: BaseCommand, task_ids: Iterable[int], move_one: Callable[[Task], bool]
 ) -> None:
     succeeded = failed = ignored = 0
 
@@ -56,13 +56,13 @@ def move_multiple_tasks(
             if not data:
                 raise CommandError(f"Task #{task_id} has no attached data")
 
-            action_taken = process_one(task)
+            action_was_taken = move_one(task)
         except Exception:
             failed += 1
             command.stderr.write(command.style.ERROR(f"Task #{task_id}: failure"))
             command.stderr.write(traceback.format_exc(), ending="")
         else:
-            if action_taken:
+            if action_was_taken:
                 succeeded += 1
                 time_taken = time_after - time_before
                 mb_moved = (data.content_size or math.nan) / (1024 * 1024)
@@ -76,7 +76,7 @@ def move_multiple_tasks(
                 )
             else:
                 ignored += 1
-                # We're relying on process_one to log the reason for ignoring.
+                # We're relying on move_one to log the reason for ignoring.
 
     processed = succeeded + failed + ignored
 

--- a/cvat/apps/engine/management/utils.py
+++ b/cvat/apps/engine/management/utils.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import math
+import time
 import traceback
 from collections.abc import Callable, Iterable
 
@@ -36,7 +38,7 @@ def parse_task_ids(value: str) -> list[int]:
     return task_ids
 
 
-def process_tasks(
+def move_multiple_tasks(
     command: BaseCommand, task_ids: Iterable[int], process_one: Callable[[Task], bool]
 ) -> None:
     succeeded = failed = ignored = 0
@@ -44,9 +46,15 @@ def process_tasks(
     for task_id in task_ids:
         try:
             try:
+                time_before = time.perf_counter()
                 task = Task.objects.get(id=task_id)
+                time_after = time.perf_counter()
             except Task.DoesNotExist as ex:
                 raise CommandError(f"Task #{task_id} does not exist") from ex
+
+            data = task.data
+            if not data:
+                raise CommandError(f"Task #{task_id} has no attached data")
 
             action_taken = process_one(task)
         except Exception:
@@ -56,7 +64,16 @@ def process_tasks(
         else:
             if action_taken:
                 succeeded += 1
-                command.stdout.write(command.style.SUCCESS(f"Task #{task_id}: success"))
+                time_taken = time_after - time_before
+                mb_moved = (data.content_size or math.nan) / (1024 * 1024)
+                throughput = mb_moved / time_taken if time_taken > 0 else math.inf
+                command.stdout.write(
+                    command.style.SUCCESS(
+                        f"Task #{task_id}: success;"
+                        f" taken {time_taken:.3f} s for {mb_moved:.3f} MiB"
+                        f" ({throughput:.3f} MiB/s)"
+                    )
+                )
             else:
                 ignored += 1
                 # We're relying on process_one to log the reason for ignoring.

--- a/cvat/apps/engine/management/utils.py
+++ b/cvat/apps/engine/management/utils.py
@@ -42,7 +42,9 @@ def move_multiple_tasks(
     command: BaseCommand, task_ids: Iterable[int], move_one: Callable[[Task], bool]
 ) -> None:
     succeeded = failed = ignored = 0
+    total_content_size = 0
 
+    time_before_all = time.perf_counter()
     for task_id in task_ids:
         try:
             try:
@@ -67,21 +69,33 @@ def move_multiple_tasks(
                 time_taken = time_after - time_before
                 mb_moved = (data.content_size or math.nan) / (1024 * 1024)
                 throughput = mb_moved / time_taken if time_taken > 0 else math.inf
+
                 command.stdout.write(
                     command.style.SUCCESS(
                         f"Task #{task_id}: success;"
-                        f" taken {time_taken:.3f} s for {mb_moved:.3f} MiB"
-                        f" ({throughput:.3f} MiB/s)"
+                        f" taken {time_taken:.3f} s for {mb_moved:.3f} MiB ({throughput:.3f} MiB/s)"
                     )
                 )
+
+                # Not using NaN here, since it would make the total useless.
+                total_content_size += data.content_size or 0
             else:
                 ignored += 1
                 # We're relying on move_one to log the reason for ignoring.
+
+    time_after_all = time.perf_counter()
+    total_time_taken = time_after_all - time_before_all
+    total_mb_moved = total_content_size / (1024 * 1024)
+    total_throughput = total_mb_moved / total_time_taken if total_time_taken > 0 else math.inf
 
     processed = succeeded + failed + ignored
 
     command.stdout.write(
         f"Processed {processed} task(s): {succeeded} succeeded, {failed} failed, {ignored} ignored"
+    )
+    command.stdout.write(
+        f"Total time taken: {total_time_taken:.3f} s"
+        f" for {total_mb_moved:.3f} MiB ({total_throughput:.3f} MiB/s)"
     )
 
     if failed:

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -586,7 +586,6 @@ class Data(models.Model):
         assert cloud_storage_instance
 
         upload_dir = self.get_upload_dirname()
-        assert (upload_dir / self.MANIFEST_FILENAME).is_file()
 
         rel_paths_to_move = self.get_all_media_rel_paths()
 

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -36,6 +36,7 @@ from azure.core.exceptions import HttpResponseError, ServiceRequestError
 from botocore.exceptions import ClientError, EndpointConnectionError
 from django.conf import settings
 from django.contrib.auth.models import Group, User
+from django.core.management import CommandError, call_command
 from django.http import FileResponse, HttpResponse
 from django.test import SimpleTestCase, override_settings
 from pdf2image import convert_from_bytes
@@ -8015,6 +8016,59 @@ class TaskBackingCloudStorageTestCase(_CloudStorageTestBase):
 
         for p in self._IMAGE_PATHS:
             self.assertFalse(self.mock_aws.file_exists(cloud_key(p)))
+
+    def test_move_to_backing_cs_with_cli(self):
+        task = self._create_local_task()
+        task_id = task["id"]
+
+        call_command("movetasktobackingcs", str(task_id), str(self.cloud_storage_id))
+
+        data = Data.objects.get(task__id=task_id)
+        assert data.local_storage_backing_cs_id == self.cloud_storage_id
+
+    def test_move_to_backing_cs_with_cli_multiple(self):
+        task = self._create_local_task()
+        task_id = task["id"]
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            task_ids_path = Path(tmp_dir, "task_ids.txt")
+            task_ids_path.write_text(f"-1\n{task_id}\n")
+
+            with self.assertRaises(CommandError):
+                call_command("movetasktobackingcs", f"@{task_ids_path}", str(self.cloud_storage_id))
+
+        # The command fails due to an invalid task ID, but the valid task should still be moved.
+        data = Data.objects.get(task__id=task_id)
+        assert data.local_storage_backing_cs_id == self.cloud_storage_id
+
+    def test_move_from_backing_cs_with_cli(self):
+        task = self._create_local_task()
+        task_id = task["id"]
+
+        data = Data.objects.get(task__id=task_id)
+        data.move_to_backing_cs(CloudStorage.objects.get(id=self.cloud_storage_id))
+
+        call_command("movetaskfrombackingcs", str(task_id))
+
+        data.refresh_from_db()
+        assert data.local_storage_backing_cs_id is None
+
+    def test_move_from_backing_cs_with_cli_multiple(self):
+        task = self._create_local_task()
+        task_id = task["id"]
+
+        data = Data.objects.get(task__id=task_id)
+        data.move_to_backing_cs(CloudStorage.objects.get(id=self.cloud_storage_id))
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            task_ids_path = Path(tmp_dir, "task_ids.txt")
+            task_ids_path.write_text(f"-1\n{task_id}\n")
+
+            with self.assertRaises(CommandError):
+                call_command("movetaskfrombackingcs", f"@{task_ids_path}")
+
+        data.refresh_from_db()
+        assert data.local_storage_backing_cs_id is None
 
 
 class TaskJobLimitAPITestCase(ApiTestBase):

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -8026,6 +8026,14 @@ class TaskBackingCloudStorageTestCase(_CloudStorageTestBase):
         data = Data.objects.get(task__id=task_id)
         assert data.local_storage_backing_cs_id == self.cloud_storage_id
 
+    def test_move_to_backing_cs_with_cli_redundant(self):
+        task = self._create_local_task()
+        task_id = task["id"]
+
+        data = Data.objects.get(task__id=task_id)
+        data.move_to_backing_cs(CloudStorage.objects.get(id=self.cloud_storage_id))
+        call_command("movetasktobackingcs", str(task_id), str(self.cloud_storage_id))
+
     def test_move_to_backing_cs_with_cli_multiple(self):
         task = self._create_local_task()
         task_id = task["id"]
@@ -8052,6 +8060,12 @@ class TaskBackingCloudStorageTestCase(_CloudStorageTestBase):
 
         data.refresh_from_db()
         assert data.local_storage_backing_cs_id is None
+
+    def test_move_from_backing_cs_with_cli_redundant(self):
+        task = self._create_local_task()
+        task_id = task["id"]
+
+        call_command("movetaskfrombackingcs", str(task_id))
 
     def test_move_from_backing_cs_with_cli_multiple(self):
         task = self._create_local_task()


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This contains several changes aimed at making backing cloud storage migration easier:

* Support tasks without manifests (most necessary changes have already been made in #10429, this just removes a useless assert).
* Support migrating multiple tasks at once by reading IDs from a file (this helps mitigate the Django initialization overhead).
* Don't fail if a task already has the specified backing CS (for `movetasktobackingcs`) or no backing CS (for `movetaskfrombackingcs`).
* Print statistics about the transfer of each individual task and of the total.

In addition, I factored out the common outer loop from the two commands.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
