### PR TITLE
Tweak backing cloud storage eligibility rules

### DIFF
--- a/changelog.d/20260422_174312_roman.md
+++ b/changelog.d/20260422_174312_roman.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Prevented half-created tasks from being moved to backing cloud storage
+  (<https://github.com/cvat-ai/cvat/pull/10513>)

--- a/cvat/apps/engine/management/commands/movetaskfrombackingcs.py
+++ b/cvat/apps/engine/management/commands/movetaskfrombackingcs.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from cvat.apps.engine.models import Task
 
@@ -26,9 +26,6 @@ class Command(BaseCommand):
 
     def _handle_one_task(self, task: Task) -> bool:
         data = task.require_data()
-
-        if not data.supports_backing_cs():
-            raise CommandError(f"Task #{task.id} does not support backing cloud storage")
 
         if not data.local_storage_backing_cs_id:
             self.stdout.write(

--- a/cvat/apps/engine/management/commands/movetasktobackingcs.py
+++ b/cvat/apps/engine/management/commands/movetasktobackingcs.py
@@ -38,9 +38,6 @@ class Command(BaseCommand):
     def _handle_one_task(self, task: Task, backing_cs: CloudStorage) -> bool:
         data = task.require_data()
 
-        if not data.supports_backing_cs():
-            raise CommandError(f"Task #{task.id} does not support backing cloud storage")
-
         if data.local_storage_backing_cs_id == backing_cs.id:
             self.stdout.write(
                 self.style.WARNING(
@@ -54,6 +51,9 @@ class Command(BaseCommand):
                 f"Task #{task.id} already has a backing cloud storage"
                 f" (#{data.local_storage_backing_cs_id})"
             )
+
+        if not data.supports_backing_cs():
+            raise CommandError(f"Task #{task.id} does not support backing cloud storage")
 
         data.move_to_backing_cs(backing_cs)
         return True

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -573,7 +573,7 @@ class Data(models.Model):
         return (
             self.storage == StorageChoice.LOCAL
             and self.storage_method == StorageMethodChoice.CACHE
-            and not hasattr(self, "video")
+            and self.images.exists()
         )
 
     def move_to_backing_cs(self, backing_cs: CloudStorage) -> None:
@@ -612,7 +612,6 @@ class Data(models.Model):
         transaction.on_commit(clear_original_files, robust=True)
 
     def move_from_backing_cs(self) -> None:
-        assert self.supports_backing_cs()
         assert self.local_storage_backing_cs_id
 
         cloud_storage_instance = self.get_cloud_storage_instance()


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
* When moving _to_ backing CS, check that the data actually has attached images (rather than not having videos). If a data object has neither images nor videos, then the task has not yet been fully created, so we shouldn't touch it.

* When moving _from_ backing CS, don't check backing CS support, only that the data is already in CS. This way, if we tighten the eligibility rules (like I just did), tasks that had already been moved can be moved back.

Also, reorder checks in `movetasktobackingcs` so that a more sensible message is printed if the user attempts to move a formerly-eligible task to the CS it's already in.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
