### PR TITLE
Allow configuring a default backing cloud storage

### DIFF
--- a/changelog.d/20260422_203254_roman_default_backing_cs.md
+++ b/changelog.d/20260422_203254_roman_default_backing_cs.md
@@ -1,0 +1,5 @@
+### Added
+
+- The server can now be configured to store all new eligible tasks on a
+  particular backing cloud storage
+  (<https://github.com/cvat-ai/cvat/pull/10514>)

--- a/cvat/apps/engine/default_settings.py
+++ b/cvat/apps/engine/default_settings.py
@@ -110,3 +110,13 @@ DEFAULT_DB_BULK_CREATE_BATCH_SIZE = int(os.getenv("CVAT_DEFAULT_DB_BULK_CREATE_B
 DEFAULT_DB_ANNO_CHUNK_SIZE = int(os.getenv("CVAT_DEFAULT_DB_ANNO_CHUNK_SIZE", 2000))
 
 MAX_JOBS_PER_TASK = int(os.getenv("CVAT_MAX_JOBS_PER_TASK", 5_000))
+
+DEFAULT_BACKING_CS_ID = os.getenv("CVAT_DEFAULT_BACKING_CS_ID")
+"""
+ID of the default backing cloud storage for local tasks.
+If not set or blank, tasks will be stored on the filesystem.
+"""
+if DEFAULT_BACKING_CS_ID:
+    DEFAULT_BACKING_CS_ID = int(DEFAULT_BACKING_CS_ID)
+else:
+    DEFAULT_BACKING_CS_ID = None

--- a/cvat/apps/engine/management/commands/movetasktobackingcs.py
+++ b/cvat/apps/engine/management/commands/movetasktobackingcs.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
 from cvat.apps.engine.models import CloudStorage, Task
@@ -21,12 +22,17 @@ class Command(BaseCommand):
         parser.add_argument(
             "backing_cs_id",
             type=int,
-            help="ID of the backing cloud storage to move data to",
+            help="ID of the backing cloud storage to move data to (default: %(default)s)",
+            nargs="?",
+            default=settings.DEFAULT_BACKING_CS_ID,
         )
 
     def handle(self, *args, **options):
         task_ids: list[int] = options["task_ids"]
         backing_cs_id: int = options["backing_cs_id"]
+
+        if backing_cs_id is None:
+            raise CommandError("No cloud storage ID was specified, and no default is configured")
 
         try:
             backing_cs = CloudStorage.objects.get(id=backing_cs_id)

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -1725,6 +1725,8 @@ def create_thread(
     if not (is_data_in_cloud and is_backup_restore):
         TaskFrameProvider(db_task=db_task).get_preview()
 
+    _move_to_backing_cs_if_configured(db_data)
+
 
 def _create_static_chunks(
     db_task: models.Task, *, media_extractor: IMediaReader, upload_dir: Path
@@ -1879,3 +1881,16 @@ def _create_static_chunks(
                     save_chunks(executor, db_segment, chunk_idx, chunk_frame_ids)
 
                 progress_updater.update_progress(segment_idx / len(db_segments))
+
+
+def _move_to_backing_cs_if_configured(db_data):
+    backing_cs_id = settings.DEFAULT_BACKING_CS_ID
+    if backing_cs_id is not None and db_data.supports_backing_cs():
+        try:
+            backing_cs = models.CloudStorage.objects.get(pk=backing_cs_id)
+        except models.CloudStorage.DoesNotExist:
+            slogger.glob.warning(
+                f"Cloud storage #{backing_cs_id} (configured as default backing CS) does not exist"
+            )
+        else:
+            db_data.move_to_backing_cs(backing_cs)

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -7993,6 +7993,23 @@ class TaskBackingCloudStorageTestCase(_CloudStorageTestBase):
             self.assertEqual(local_path(image_rel_path).read_bytes(), image_bytes)
             self.assertFalse(self.mock_aws.file_exists(cloud_key(image_rel_path)))
 
+    def test_creation_with_default_backing_cs(self):
+        with (
+            self.captureOnCommitCallbacks(execute=True),
+            self.settings(DEFAULT_BACKING_CS_ID=self.cloud_storage_id),
+        ):
+            task = self._create_local_task()
+
+        task_id = task["id"]
+
+        data = Data.objects.get(task__id=task_id)
+
+        self.assertEqual(data.local_storage_backing_cs_id, self.cloud_storage_id)
+
+        image_path = self._IMAGE_PATHS[0]
+        self.assertFalse((data.get_upload_dirname() / image_path).exists())
+        self.assertTrue(self.mock_aws.file_exists(f"data/{data.id}/raw/{image_path}"))
+
     def test_deletion_with_backing_cs(self):
         task = self._create_local_task()
         task_id = task["id"]
@@ -8046,6 +8063,20 @@ class TaskBackingCloudStorageTestCase(_CloudStorageTestBase):
                 call_command("movetasktobackingcs", f"@{task_ids_path}", str(self.cloud_storage_id))
 
         # The command fails due to an invalid task ID, but the valid task should still be moved.
+        data = Data.objects.get(task__id=task_id)
+        assert data.local_storage_backing_cs_id == self.cloud_storage_id
+
+    def test_move_to_backing_cs_with_cli_default(self):
+        task = self._create_local_task()
+        task_id = task["id"]
+
+        with self.settings(DEFAULT_BACKING_CS_ID=None):
+            with self.assertRaises(CommandError):
+                call_command("movetasktobackingcs", str(task_id))
+
+        with self.settings(DEFAULT_BACKING_CS_ID=self.cloud_storage_id):
+            call_command("movetasktobackingcs", str(task_id))
+
         data = Data.objects.get(task__id=task_id)
         assert data.local_storage_backing_cs_id == self.cloud_storage_id
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-backend-env: &backend-env
   CVAT_REDIS_ONDISK_PORT: 6666
   CVAT_LOG_IMPORT_ERRORS: 'true'
   CVAT_ALLOW_STATIC_CACHE: '${CVAT_ALLOW_STATIC_CACHE:-no}'
+  CVAT_DEFAULT_BACKING_CS_ID:
   DJANGO_LOG_SERVER_HOST: vector
   DJANGO_LOG_SERVER_PORT: 8282
   no_proxy: clickhouse,grafana,vector,nuclio,opa,${no_proxy:-}


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
If this is set, all new tasks will be automatically migrated to this CS. It will also be used as the default CS in the `movetasktobackingcs` command. This will allow CVAT to use cloud storage as the main media storage location.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Unit tests + some manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
