### PR TITLE
Remove list chunks

### DIFF
--- a/changelog.d/20260424_175237_mzhiltsov_remove_list_chunk.md
+++ b/changelog.d/20260424_175237_mzhiltsov_remove_list_chunk.md
@@ -1,0 +1,4 @@
+### Removed
+
+- The unused `list` chunk type. This change is not expected to affect anyone.
+  (<https://github.com/cvat-ai/cvat/pull/10524>)

--- a/cvat/apps/engine/migrations/0099_remove_chunk_type_list.py
+++ b/cvat/apps/engine/migrations/0099_remove_chunk_type_list.py
@@ -1,0 +1,57 @@
+from django.db import migrations, models
+
+import cvat.apps.engine.models
+
+
+def check_list_chunks(apps, schema_editor):
+    Data = apps.get_model("engine", "Data")
+
+    CHUNK_TYPE = "list"
+
+    related_rows = (
+        Data.objects.filter(
+            models.Q(compressed_chunk_type=CHUNK_TYPE) | models.Q(original_chunk_type=CHUNK_TYPE)
+        )
+        .order_by("-id")
+        .values_list("id", flat=True)[:10]
+    )
+
+    if related_rows:
+        raise Exception(
+            "Some '{}' table rows have their compressed or original chunk type = '{}'. "
+            "Please review the related tasks and remove them, if possible. "
+            "Example Data ids: {}".format(
+                Data._meta.db_table,
+                CHUNK_TYPE,
+                ", ".join(f"{v}" for v in related_rows),
+            )
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("engine", "0098_data_local_storage_backing_cs"),
+    ]
+
+    operations = [
+        migrations.RunPython(check_list_chunks, reverse_code=migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="data",
+            name="compressed_chunk_type",
+            field=models.CharField(
+                choices=[("video", "VIDEO"), ("imageset", "IMAGESET")],
+                default=cvat.apps.engine.models.DataChoice["IMAGESET"],
+                max_length=32,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="data",
+            name="original_chunk_type",
+            field=models.CharField(
+                choices=[("video", "VIDEO"), ("imageset", "IMAGESET")],
+                default=cvat.apps.engine.models.DataChoice["IMAGESET"],
+                max_length=32,
+            ),
+        ),
+    ]

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -128,7 +128,6 @@ class StateChoice(str, Enum):
 class DataChoice(str, Enum):
     VIDEO = 'video'
     IMAGESET = 'imageset'
-    LIST = 'list'
 
     @classmethod
     def choices(cls):

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -503,7 +503,7 @@ class Data(models.Model):
         elif chunk_type == DataChoice.IMAGESET:
             ext = 'zip'
         else:
-            ext = 'list'
+            assert False, f"Unexpected chunk type '{chunk_type}'"
 
         return 'segment_{}-{}.{}'.format(segment_id, chunk_number, ext)
 

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -7244,12 +7244,10 @@ components:
       enum:
       - video
       - imageset
-      - list
       type: string
       description: |-
         * `video` - VIDEO
         * `imageset` - IMAGESET
-        * `list` - LIST
     ClientEvents:
       type: object
       properties:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

If I understand correctly, this chunk type has never been used. This change is not expected to affect anyone, but there's an extra safety check in the DB migration.

- Removed the `list` chunk type

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
