### PR TITLE
use lower case in the label atrtibute checkbox's value names

### DIFF
--- a/changelog.d/20260427_134619_oleg.valiulin_fix_checkbox_values_font.md
+++ b/changelog.d/20260427_134619_oleg.valiulin_fix_checkbox_values_font.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Change case of 'Checkbox' var names in label editor to lower case
+  (<https://github.com/cvat-ai/cvat/pull/10535>)

--- a/cvat-ui/src/components/labels-editor/label-form.tsx
+++ b/cvat-ui/src/components/labels-editor/label-form.tsx
@@ -322,8 +322,8 @@ export default class LabelForm extends React.Component<Props> {
                     name={[key, 'values']}
                 >
                     <Select className='cvat-attribute-values-input'>
-                        <Select.Option value='false'>False</Select.Option>
-                        <Select.Option value='true'>True</Select.Option>
+                        <Select.Option value='false'>false</Select.Option>
+                        <Select.Option value='true'>true</Select.Option>
                     </Select>
                 </Form.Item>
             </CVATTooltip>

--- a/tests/cypress/e2e/actions_tasks3/case_18_filters_functionality.js
+++ b/tests/cypress/e2e/actions_tasks3/case_18_filters_functionality.js
@@ -13,12 +13,12 @@ context('Filters functionality.', () => {
     const additionalAttrsLabelShape = [
         { name: 'type', values: 'shape', type: 'Text' },
         { name: 'count points', values: '3', type: 'Text' },
-        { name: 'polygon', values: 'True', type: 'Checkbox' },
+        { name: 'polygon', values: 'true', type: 'Checkbox' },
     ];
     const labelTrack = 'track 4 points';
     const additionalAttrsLabelTrack = [
         { name: 'type', values: 'track', type: 'Text' },
-        { name: 'polygon', values: 'True', type: 'Checkbox' },
+        { name: 'polygon', values: 'true', type: 'Checkbox' },
         { name: 'count points', values: '4', type: 'Text' },
     ];
 

--- a/tests/cypress/e2e/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/e2e/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -6,6 +6,7 @@
 /// <reference types="cypress" />
 
 import { taskName } from '../../support/const';
+import { fullMatch } from '../../support/utils';
 
 context('Changing a default value for an attribute.', () => {
     const caseId = '44';
@@ -13,7 +14,7 @@ context('Changing a default value for an attribute.', () => {
     const additionalAttrsLabel = [
         { name: 'type', values: '', type: 'Text' },
         { name: 'count', values: '0;5;1', type: 'Number' }, // Check issue 2968
-        { name: 'shape', values: 'False', type: 'Checkbox' },
+        { name: 'shape', values: 'false', type: 'Checkbox' },
     ];
     const rectangleShape2Points = {
         points: 'By 2 Points',
@@ -25,7 +26,7 @@ context('Changing a default value for an attribute.', () => {
         secondY: 200,
     };
     const newTextValue = `${additionalLabel} text`;
-    const newCheckboxValue = 'True';
+    const newCheckboxValue = 'true';
     const wrapperId = [];
 
     before(() => {
@@ -44,8 +45,7 @@ context('Changing a default value for an attribute.', () => {
         it('Open label editor. Change default values for text & checkbox attributes, press Done.', () => {
             cy.intercept('PATCH', '/api/labels/**').as('patchLabel');
             cy.get('.cvat-constructor-viewer').within(() => {
-                // eslint-disable-next-line security/detect-non-literal-regexp
-                cy.contains(new RegExp(`^${additionalLabel}$`))
+                cy.contains(fullMatch(additionalLabel))
                     .parents('.cvat-constructor-viewer-item')
                     .should('be.visible')
                     .find('[aria-label="edit"]')
@@ -64,10 +64,8 @@ context('Changing a default value for an attribute.', () => {
                     cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click();
                 });
             });
-            cy.get('.ant-select-dropdown').not('.ant-select-dropdown-hidden').within(() => {
-                // eslint-disable-next-line security/detect-non-literal-regexp
-                cy.contains(new RegExp(`^${newCheckboxValue}$`)).click();
-            });
+            cy.get('.cvat-attribute-values-input.ant-select-open').should('exist');
+            cy.contains('.ant-select-item', fullMatch(newCheckboxValue)).should('exist').and('be.visible').click();
             cy.contains('[type="submit"]', 'Done').click();
             cy.wait('@patchLabel').its('response.statusCode').should('equal', 200);
             cy.get('.cvat-constructor-viewer').should('exist').and('be.visible');
@@ -82,8 +80,7 @@ context('Changing a default value for an attribute.', () => {
                 [additionalAttrsLabel[1].name, additionalAttrsLabel[1].values.split(';')[0]],
                 [additionalAttrsLabel[2].name, newCheckboxValue.toLowerCase()],
             ].forEach(([attrName, attrValue]) => {
-                // eslint-disable-next-line security/detect-non-literal-regexp
-                cy.contains(new RegExp(`^${attrName}: ${attrValue}$`)).should('be.visible');
+                cy.contains(fullMatch(`${attrName}: ${attrValue}`));
             });
         });
     });


### PR DESCRIPTION
### Motivation and context

Label attribute with value type Checkbox displays `True`/`False` which does not match the case on the canvas. The PR uses lowercase in label editor

Before:
<img width="1660" height="472" alt="image" src="https://github.com/user-attachments/assets/38454d2b-b5b4-49dd-a94a-52584cbf77a5" />
<img width="1480" height="1120" alt="image" src="https://github.com/user-attachments/assets/3e200079-16df-4fe2-b591-6b6f38e66984" />

After:
<img width="832" height="287" alt="image" src="https://github.com/user-attachments/assets/bc653e36-8be6-459f-9688-74ff9927d6a0" />



### How has this been tested?

### Checklist

- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
