### PR TITLE
As/fix create data 500 server files

### DIFF
--- a/changelog.d/20260504_110758_alekseyysosov_fix_remote_files_500.md
+++ b/changelog.d/20260504_110758_alekseyysosov_fix_remote_files_500.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Task creation with `remote_files` now returns a readable validation error
+  when a URL is unreachable or uses an unsupported scheme, instead of a 500
+  with a raw traceback
+  (<https://github.com/cvat-ai/cvat/pull/10554>)

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -21,6 +21,7 @@ from inspect import isclass
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, cast
+from urllib.parse import urlparse
 
 import django_rq
 from django.conf import settings
@@ -2361,6 +2362,19 @@ class DataSerializer(serializers.ModelSerializer):
 
                 existing_files.add(filename)
 
+        return value
+
+    def validate_remote_files(self, value: list[dict[str, str]]) -> list[dict[str, str]]:
+        errors: list[str] = []
+        for entry in value:
+            url = entry["file"]
+            parsed = urlparse(url)
+            if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                errors.append(
+                    f"{url!r}: remote_files entries must be http(s) URLs."
+                )
+        if errors:
+            raise serializers.ValidationError(errors)
         return value
 
     # pylint: disable=no-self-use

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -19,6 +19,7 @@ from urllib import request as urlrequest
 
 import attrs
 import av
+import requests
 import rq
 from django.conf import settings
 from django.db import transaction
@@ -48,7 +49,11 @@ from cvat.apps.engine.rq import ImportRQMeta
 from cvat.apps.engine.task_validation import HoneypotFrameSelector
 from cvat.apps.engine.utils import av_scan_paths, format_list, get_path_size, take_by
 from cvat.utils.http import PROXIES_FOR_UNTRUSTED_URLS, make_requests_session
-from utils.dataset_manifest import ImageManifestManager, VideoManifestManager, is_manifest
+from utils.dataset_manifest import (
+    ImageManifestManager,
+    VideoManifestManager,
+    is_manifest,
+)
 from utils.dataset_manifest.core import VideoManifestValidator, is_dataset_manifest
 from utils.dataset_manifest.utils import find_related_images
 
@@ -458,24 +463,43 @@ def _validate_scheme(url):
         )
 
 
+class _FailedToDownloadFileError(Exception):
+    pass
+
+
 def _download_data(
     urls: Iterable[str],
     upload_dir: str,
     *,
     update_status_callback: Callable[[str], None],
-):
+    timeout: tuple[int, int] | None = (10, 60),
+) -> list[str]:
     local_files = {}
 
     with make_requests_session() as session:
         for url in urls:
             name = os.path.basename(urlrequest.url2pathname(urlparse.urlparse(url).path))
             if name in local_files:
-                raise Exception("filename collision: {}".format(name))
+                raise _FailedToDownloadFileError("filename collision: {}".format(name))
+
             _validate_scheme(url)
+
             slogger.glob.info("Downloading: {}".format(url))
+
             update_status_callback("{} is being downloaded..".format(url))
 
-            response = session.get(url, stream=True, proxies=PROXIES_FOR_UNTRUSTED_URLS)
+            try:
+                response = session.get(
+                    url,
+                    stream=True,
+                    proxies=PROXIES_FOR_UNTRUSTED_URLS,
+                    timeout=timeout,
+                )
+            except requests.exceptions.RequestException as e:
+                raise _FailedToDownloadFileError(
+                    f"Failed to download {url}: {e.__class__.__name__}: {e}"
+                ) from e
+
             if response.status_code == 200:
                 response.raw.decode_content = True
                 with open(os.path.join(upload_dir, name), "wb") as output_file:
@@ -490,7 +514,7 @@ def _download_data(
                 elif response.status_code:
                     error_message += f"; HTTP error {response.status_code}"
 
-                raise Exception(error_message)
+                raise _FailedToDownloadFileError(error_message)
 
             local_files[name] = True
 
@@ -574,11 +598,13 @@ def _create_task_manifest_based_on_cloud_storage_manifest(
         content = list(map(_add_prefix, raw_content))
     else:
         sequence, content = cloud_storage_manifest.get_subset(sorted_media)
+
     if not content:
         raise ValidationError(
             "There is no intersection of the files specified"
             "in the request with the contents of the bucket"
         )
+
     sorted_content = (i[1] for i in sorted(zip(sequence, content)))
     manifest.create(sorted_content)
 
@@ -1163,9 +1189,12 @@ def create_thread(
     is_data_in_cloud = db_data.storage == models.StorageChoice.CLOUD_STORAGE
 
     if data["remote_files"]:
-        data["remote_files"] = _download_data(
-            data["remote_files"], upload_dir, update_status_callback=update_status
-        )
+        try:
+            data["remote_files"] = _download_data(
+                data["remote_files"], upload_dir, update_status_callback=update_status
+            )
+        except _FailedToDownloadFileError as e:
+            raise ValidationError(str(e)) from e
 
     # find and validate manifest file
     manifest_files = _find_manifest_files(data)
@@ -1268,14 +1297,18 @@ def create_thread(
                 if not is_backup_restore:
                     # Define task manifest content based on cloud storage manifest content and uploaded files
                     _create_task_manifest_based_on_cloud_storage_manifest(
-                        sorted_media,
-                        cloud_storage_manifest_prefix,
-                        cloud_storage_manifest,
-                        manifest,
+                        sorted_media=sorted_media,
+                        cloud_storage_manifest_prefix=cloud_storage_manifest_prefix,
+                        cloud_storage_manifest=cloud_storage_manifest,
+                        manifest=manifest,
                     )
             else:  # without manifest file but with use_cache option
                 # Define task manifest content based on list with uploaded files
-                _create_task_manifest_from_cloud_data(db_data.cloud_storage, sorted_media, manifest)
+                _create_task_manifest_from_cloud_data(
+                    db_storage=db_data.cloud_storage,
+                    sorted_media=sorted_media,
+                    manifest=manifest,
+                )
 
     av_scan_paths(upload_dir)
 

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -1194,6 +1194,7 @@ def create_thread(
                 data["remote_files"], upload_dir, update_status_callback=update_status
             )
         except _FailedToDownloadFileError as e:
+            slogger.glob.exception("Failed to download remote files")
             raise ValidationError(str(e)) from e
 
     # find and validate manifest file

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -233,7 +233,7 @@ IAM_DEFAULT_ROLE = "user"
 IAM_ADMIN_ROLE = "admin"
 # Index in the list below corresponds to the priority (0 has highest priority)
 IAM_ROLES = [IAM_ADMIN_ROLE, "user", "worker"]
-IAM_OPA_HOST = "http://opa:8181"
+IAM_OPA_HOST = os.getenv("IAM_OPA_HOST", "http://opa:8181")
 IAM_OPA_DATA_URL = f"{IAM_OPA_HOST}/v1/data"
 LOGIN_URL = "rest_login"
 LOGIN_REDIRECT_URL = "/"
@@ -756,7 +756,7 @@ ASSET_SUPPORTED_TYPES = ("image/jpeg", "image/png", "image/webp", "image/gif", "
 ASSET_MAX_IMAGE_SIZE = 1920
 ASSET_MAX_COUNT_PER_GUIDE = 150
 
-SMOKESCREEN_ENABLED = True
+SMOKESCREEN_ENABLED = to_bool(os.getenv("SMOKESCREEN_ENABLED", True))
 
 # By default, email backend is django.core.mail.backends.smtp.EmailBackend
 # But it won't work without additional configuration, so we set it to None

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -233,7 +233,7 @@ IAM_DEFAULT_ROLE = "user"
 IAM_ADMIN_ROLE = "admin"
 # Index in the list below corresponds to the priority (0 has highest priority)
 IAM_ROLES = [IAM_ADMIN_ROLE, "user", "worker"]
-IAM_OPA_HOST = os.getenv("IAM_OPA_HOST", "http://opa:8181")
+IAM_OPA_HOST = "http://opa:8181"
 IAM_OPA_DATA_URL = f"{IAM_OPA_HOST}/v1/data"
 LOGIN_URL = "rest_login"
 LOGIN_REDIRECT_URL = "/"

--- a/cvat/settings/development.py
+++ b/cvat/settings/development.py
@@ -37,7 +37,7 @@ INCORRECT_EMAIL_CONFIRMATION_URL = "{}/auth/incorrect-email-confirmation".format
 
 CORS_ORIGIN_WHITELIST = [UI_URL]
 CORS_REPLACE_HTTPS_REFERER = True
-IAM_OPA_HOST = "http://localhost:8181"
+IAM_OPA_HOST = os.getenv("IAM_OPA_HOST", "http://localhost:8181")
 IAM_OPA_DATA_URL = f"{IAM_OPA_HOST}/v1/data"
 
 INSTALLED_APPS += ["silk"]

--- a/cvat/settings/development.py
+++ b/cvat/settings/development.py
@@ -37,7 +37,7 @@ INCORRECT_EMAIL_CONFIRMATION_URL = "{}/auth/incorrect-email-confirmation".format
 
 CORS_ORIGIN_WHITELIST = [UI_URL]
 CORS_REPLACE_HTTPS_REFERER = True
-IAM_OPA_HOST = os.getenv("IAM_OPA_HOST", "http://localhost:8181")
+IAM_OPA_HOST = "http://localhost:8181"
 IAM_OPA_DATA_URL = f"{IAM_OPA_HOST}/v1/data"
 
 INSTALLED_APPS += ["silk"]

--- a/tests/python/rest_api/test_remote_url.py
+++ b/tests/python/rest_api/test_remote_url.py
@@ -70,7 +70,7 @@ class TestCreateFromRemote:
 
         self._test_can_create(user, self.task_id, remote_resources)
 
-    def test_remote_files_when_downloading_them_fails(self, find_users):
+    def test_cannot_create_task_when_remote_file_download_fails(self, find_users):
         user = find_users(privilege="admin")[0]["username"]
         url = "http://invalid.invalid/x.png"
 

--- a/tests/python/rest_api/test_remote_url.py
+++ b/tests/python/rest_api/test_remote_url.py
@@ -58,24 +58,18 @@ class TestCreateFromRemote:
         assert response_json["status"] == "failed"
         return response_json
 
-    def test_cannot_create(self, find_users):
+    def test_can_report_failed_remote_file_download(self, find_users):
         user = find_users(privilege="admin")[0]["username"]
         remote_resources = ["http://localhost/favicon.ico"]
 
-        self._test_cannot_create(user, self.task_id, remote_resources)
+        response_json = self._test_cannot_create(user, self.task_id, remote_resources)
+
+        message = response_json["message"]
+        assert "rest_framework.exceptions.ValidationError" in message, message
+        assert f"Failed to download {remote_resources[0]}" in message, message
 
     def test_can_create(self, find_users):
         user = find_users(privilege="admin")[0]["username"]
         remote_resources = ["https://docs.cvat.ai/favicons/favicon-32x32.png"]
 
         self._test_can_create(user, self.task_id, remote_resources)
-
-    def test_cannot_create_task_when_remote_file_download_fails(self, find_users):
-        user = find_users(privilege="admin")[0]["username"]
-        url = "http://invalid.invalid/x.png"
-
-        response_json = self._test_cannot_create(user, self.task_id, [url])
-
-        message = response_json["message"]
-        assert "rest_framework.exceptions.ValidationError" in message, message
-        assert f"Failed to download {url}" in message, message

--- a/tests/python/rest_api/test_remote_url.py
+++ b/tests/python/rest_api/test_remote_url.py
@@ -56,6 +56,7 @@ class TestCreateFromRemote:
 
         response_json = _wait_until_task_is_created(user, rq_id)
         assert response_json["status"] == "failed"
+        return response_json
 
     def test_cannot_create(self, find_users):
         user = find_users(privilege="admin")[0]["username"]
@@ -68,3 +69,13 @@ class TestCreateFromRemote:
         remote_resources = ["https://docs.cvat.ai/favicons/favicon-32x32.png"]
 
         self._test_can_create(user, self.task_id, remote_resources)
+
+    def test_remote_files_when_downloading_them_fails(self, find_users):
+        user = find_users(privilege="admin")[0]["username"]
+        url = "http://invalid.invalid/x.png"
+
+        response_json = self._test_cannot_create(user, self.task_id, [url])
+
+        message = response_json["message"]
+        assert "rest_framework.exceptions.ValidationError" in message, message
+        assert f"Failed to download {url}" in message, message

--- a/tests/python/rest_api/test_task_data.py
+++ b/tests/python/rest_api/test_task_data.py
@@ -544,6 +544,97 @@ class TestPostTaskData:
         kwargs = {"org_id": org_id} if org_id else {}
         create_task(self._USERNAME, task_spec, data_spec, **kwargs)
 
+    @pytest.mark.with_external_services
+    @pytest.mark.timeout(60)
+    def test_cannot_create_task_with_cloud_storage_without_cache_when_server_file_is_missing(
+        self, cloud_storages
+    ):
+        cloud_storage = cloud_storages[1]
+        missing_key = "this_file_does_not_exist_for_full_download.png"
+
+        task_spec = {"name": "missing key, no cache", "labels": [{"name": "car"}]}
+        data_spec = {
+            "image_quality": 75,
+            "use_cache": False,
+            "cloud_storage_id": cloud_storage["id"],
+            "server_files": [missing_key],
+        }
+
+        request_details = self._test_cannot_create_task(self._USERNAME, task_spec, data_spec)
+
+        message = request_details.message
+        assert "rest_framework.exceptions.NotFound" in message, message
+        assert f"The file '{missing_key}' not found" in message, message
+
+    @pytest.mark.with_external_services
+    @pytest.mark.timeout(60)
+    def test_can_create_task_with_cloud_storage_and_manifest_when_manifest_references_missing_file(
+        self, request, cloud_storages
+    ):
+        cloud_storage = cloud_storages[1]
+        s3_client = s3.make_client(bucket=cloud_storage["resource"])
+
+        prefix = "test_lying_manifest"
+        present_name = "01_present.png"
+        ghost_name = "02_ghost.png"
+        present_image = generate_image_file(filename=present_name)
+        present_image.seek(0)
+        s3_client.create_file(filename=f"{prefix}/{present_name}", data=present_image.getvalue())
+        request.addfinalizer(partial(s3_client.remove_file, filename=f"{prefix}/{present_name}"))
+
+        manifest_body = (
+            '{"version":"1.0"}\n'
+            '{"type":"images"}\n'
+            '{"name":"01_present","extension":".png","width":100,"height":50,'
+            '"checksum":"00000000000000000000000000000000"}\n'
+            '{"name":"02_ghost","extension":".png","width":100,"height":50,'
+            '"checksum":"00000000000000000000000000000000"}\n'
+        ).encode()
+        s3_client.create_file(filename=f"{prefix}/manifest.jsonl", data=manifest_body)
+        request.addfinalizer(partial(s3_client.remove_file, filename=f"{prefix}/manifest.jsonl"))
+
+        task_spec = {"name": "manifest lies", "labels": [{"name": "car"}]}
+        data_spec = {
+            "image_quality": 75,
+            "use_cache": True,
+            "cloud_storage_id": cloud_storage["id"],
+            "chunk_size": 1,
+            "server_files": [
+                f"{prefix}/{present_name}",
+                f"{prefix}/{ghost_name}",
+                f"{prefix}/manifest.jsonl",
+            ],
+        }
+
+        task_id, _ = create_task(self._USERNAME, task_spec, data_spec)
+
+        with make_api_client(self._USERNAME) as api_client:
+            task, _ = api_client.tasks_api.retrieve(task_id)
+
+        assert task.size == 2, task.size
+
+    @pytest.mark.with_external_services
+    @pytest.mark.timeout(60)
+    def test_cannot_create_task_with_cloud_storage_without_manifest_when_server_file_is_missing(
+        self, cloud_storages
+    ):
+        cloud_storage = cloud_storages[1]
+        missing_key = "this_file_does_not_exist_for_header_download.png"
+
+        task_spec = {"name": "missing key, cache, no manifest", "labels": [{"name": "car"}]}
+        data_spec = {
+            "image_quality": 75,
+            "use_cache": True,
+            "cloud_storage_id": cloud_storage["id"],
+            "server_files": [missing_key],
+        }
+
+        request_details = self._test_cannot_create_task(self._USERNAME, task_spec, data_spec)
+
+        message = request_details.message
+        assert "rest_framework.exceptions.NotFound" in message, message
+        assert f"The file '{missing_key}' not found" in message, message
+
     def _create_task_with_cloud_data(
         self,
         request,

--- a/tests/python/rest_api/test_task_data.py
+++ b/tests/python/rest_api/test_task_data.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import numpy as np
 import pytest
+from attrs.converters import to_bool
 from cvat_sdk import exceptions
 from cvat_sdk.api_client import models
 from cvat_sdk.core.helpers import get_paginated_collection
@@ -546,6 +547,10 @@ class TestPostTaskData:
 
     @pytest.mark.with_external_services
     @pytest.mark.timeout(60)
+    @pytest.mark.skipif(
+        to_bool(os.getenv("CVAT_ALLOW_STATIC_CACHE", False)) is False,
+        reason="requires CVAT_ALLOW_STATIC_CACHE=true on the worker",
+    )
     def test_cannot_create_task_with_cloud_storage_without_cache_when_server_file_is_missing(
         self, cloud_storages
     ):
@@ -585,10 +590,8 @@ class TestPostTaskData:
         manifest_body = (
             '{"version":"1.0"}\n'
             '{"type":"images"}\n'
-            '{"name":"01_present","extension":".png","width":100,"height":50,'
-            '"checksum":"00000000000000000000000000000000"}\n'
-            '{"name":"02_ghost","extension":".png","width":100,"height":50,'
-            '"checksum":"00000000000000000000000000000000"}\n'
+            '{"name":"01_present","extension":".png","width":100,"height":50}\n'
+            '{"name":"02_ghost","extension":".png","width":100,"height":50}\n'
         ).encode()
         s3_client.create_file(filename=f"{prefix}/manifest.jsonl", data=manifest_body)
         request.addfinalizer(partial(s3_client.remove_file, filename=f"{prefix}/manifest.jsonl"))

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -533,6 +533,35 @@ class TestPostTasks:
 
             assert labels.count == 0
 
+    def test_cannot_create_data_with_non_http_remote_files(self, admin_user):
+        """Regression test for https://github.com/cvat-ai/cvat/issues/9647.
+
+        `remote_files` entries are direct download URLs and must use the
+        http(s) scheme. Anything else is rejected synchronously by the
+        DataSerializer with HTTP 400, instead of being enqueued and failing
+        deep in the worker.
+        """
+        bad_url = "not-a-url/foo.jpg"
+
+        with make_api_client(admin_user) as api_client:
+            task, _ = api_client.tasks_api.create({"name": "task with bad remote_files"})
+
+            _, response = api_client.tasks_api.create_data(
+                task.id,
+                data_request=models.DataRequest(
+                    image_quality=70,
+                    remote_files=[bad_url],
+                ),
+                upload_start=True,
+                upload_finish=True,
+                _parse_response=False,
+                _check_status=False,
+            )
+
+            assert response.status == HTTPStatus.BAD_REQUEST
+            assert b"remote_files" in response.data
+            assert bad_url.encode() in response.data
+
 
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestGetData:

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -90,6 +90,13 @@ def pytest_addoption(parser):
     )
 
     group._addoption(
+        "--no-services",
+        action="store_true",
+        help=("""Don't start, stop, or seed any containers — assume the user runs
+            the test stack externally"""),
+    )
+
+    group._addoption(
         "--platform",
         action="store",
         default="local",
@@ -432,6 +439,12 @@ def session_start(
             raise Exception("""--collect-only is not compatible with any of the other options:
                 --stop-services --start-services --rebuild --cleanup --dumpdb""")
         return  # don't need to start the services to collect tests
+
+    if session.config.getoption("--no-services"):
+        # User manages the stack and the server externally — pytest does
+        # nothing on session start. Per-test restore fixtures still docker-exec
+        # into the user's containers (which must be named test_<service>_1).
+        return
 
     platform = session.config.getoption("--platform")
 


### PR DESCRIPTION
### Title
[DEV-857] Fix #9647: validate and surface remote_files download errors

### Body
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

`POST /api/tasks/{id}/data` accepted any URL string in `remote_files` and any failure during the per-URL download in the import worker reached the client as a 500 with a raw traceback in `request.message`. Two fixes:

- `DataSerializer.validate_remote_files` rejects non-`http(s)` URLs synchronously, so unsupported schemes (`ftp://`, `file://`, …) are 400 at request time instead of failing the background job.
- `_download_data` now raises a typed `_FailedToDownloadFileError` for every failure mode (HTTP non-200, `requests.exceptions.RequestException`, filename collision). `create_thread` catches it at the call site and re-raises as DRF `ValidationError`, so the requests API surfaces a single readable line via `formatted_exception`. A connect/read timeout was added to `session.get` so a hung URL no longer pins an `import` worker for the queue's 4h job timeout.

Tests cover the four media-source surfaces of `create_thread`:
- `remote_files` failure path (case 1).
- Cloud storage with `use_cache=False` and a missing key (case A) — surfaces DRF `NotFound`.
- Cloud storage with `use_cache=True` and a manifest that references a key missing in the bucket (case C) — task creation is expected to succeed; the manifest is deliberately trusted at create time. This locks in the team-lead-approved trade-off.
- Cloud storage with `use_cache=True` and no manifest (case D) — `HeaderFirstMediaDownloader`'s per-file partial GET surfaces DRF `NotFound`.

Case C does not validate manifest keys against the bucket up front. A stale manifest still surfaces only when the affected frame is requested (chunk endpoint returns 404 via the existing `@validate_file_status` decorator). Adding eager validation was discussed and intentionally deferred.

Also bundled (separate commit, test infra): a `--no-services` pytest flag for running the suite against a stack the developer manages outside the harness — used by the host-based dev loop in `docker-compose.sosov.pytest.yaml`.

Fixes #9647.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.