### PR TITLE
Fix auto simplify automatically initialized

### DIFF
--- a/changelog.d/20260507_150604_klakhov_fix_auto_simplify_init.md
+++ b/changelog.d/20260507_150604_klakhov_fix_auto_simplify_init.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed polygon/polyline auto simplification switch state is shared
+  (<https://github.com/cvat-ai/cvat/pull/10568>)

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -172,7 +172,7 @@ function DrawShapePopoverComponent(props: Props): JSX.Element {
                                         checked={simplifyPoly}
                                         disabled={simplifyDisabled}
                                         onChange={onChangeSimplifyPoly}
-                                        className='cvat-draw-shape-popover-simplify-checkbox'
+                                        className={`cvat-draw-${shapeType}-popover-simplify-switch`}
                                     />
                                 </Col>
                             </Row>

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -38,7 +38,6 @@ interface StateToProps {
     shapeType: ShapeType;
     labels: any[];
     jobInstance: any;
-    activeSimplifyPoly?: boolean;
 }
 
 function mapDispatchToProps(dispatch: any): DispatchToProps {
@@ -72,7 +71,6 @@ function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
         annotation: {
             canvas: { instance: canvasInstance },
             job: { labels, instance: jobInstance },
-            drawing: { activeSimplifyPoly },
         },
         shortcuts: { normalizedKeyMap },
     } = state;
@@ -83,7 +81,6 @@ function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
         labels,
         normalizedKeyMap,
         jobInstance,
-        activeSimplifyPoly,
     };
 }
 
@@ -106,7 +103,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props);
 
-        const { shapeType, activeSimplifyPoly } = props;
+        const { shapeType } = props;
         this.isPolyShape = [ShapeType.POLYGON, ShapeType.POLYLINE].includes(shapeType);
         this.satisfiedLabels = props.labels.filter((label: Label) => {
             if (shapeType === ShapeType.SKELETON) {
@@ -123,7 +120,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
             selectedLabelID: defaultLabelID,
             rectDrawingMethod: shapeType === ShapeType.RECTANGLE ? defaultRectDrawingMethod : undefined,
             cuboidDrawingMethod: shapeType === ShapeType.CUBOID ? defaultCuboidDrawingMethod : undefined,
-            simplifyPoly: activeSimplifyPoly || false,
+            simplifyPoly: false,
         };
 
         if (shapeType === ShapeType.POLYGON) {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

The pr fixes the bug when auto simplify is automatically enabled for polygon/polyline. That happens if we:
1. Enable auto-simplify for polygon
2. Draw polygon and auto simplify
3. Open polyline popover, see that its auto simplify is enabled

The problem is that this switch should be initialized by default as false and ignore the repeatDrawState in redux

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
