### PR TITLE
Optimize metadata endpoints

### DIFF
--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -3218,7 +3218,8 @@ class DataMetaReadSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         serialized = super().to_representation(instance)
 
-        if hasattr(instance, 'audio'):
+        if (task := self._context.get("task")) and task.media_type == models.MediaType.AUDIO:
+            # Can also be checked via hasattr(instance, 'audio'), but it results in extra requests
             # TODO: deprecated for 3d, remove later
             serialized.pop('image_quality', None) # not relevant for audio
 

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -70,6 +70,7 @@ from cvat.apps.engine.models import (
     StorageChoice,
     StorageMethodChoice,
     Task,
+    TaskMode,
 )
 from cvat.apps.engine.tests.utils import (
     ApiTestBase,
@@ -211,6 +212,7 @@ def create_dummy_db_tasks(obj, project=None):
         "size": 100,
         "project": project,
         "media_type": MediaType.IMAGE,
+        "mode": TaskMode.ANNOTATION,
     }
     db_task = create_db_task(data)
     tasks.append(db_task)
@@ -224,6 +226,7 @@ def create_dummy_db_tasks(obj, project=None):
         "size": 200,
         "project": project,
         "media_type": MediaType.IMAGE,
+        "mode": TaskMode.ANNOTATION,
     }
     db_task = create_db_task(data)
     tasks.append(db_task)
@@ -238,6 +241,7 @@ def create_dummy_db_tasks(obj, project=None):
         "size": 100,
         "project": project,
         "media_type": MediaType.POINT_CLOUD,
+        "mode": TaskMode.ANNOTATION,
     }
     db_task = create_db_task(data)
     tasks.append(db_task)
@@ -251,6 +255,7 @@ def create_dummy_db_tasks(obj, project=None):
         "size": 50,
         "project": project,
         "media_type": MediaType.IMAGE,
+        "mode": TaskMode.INTERPOLATION,
     }
     db_task = create_db_task(data)
     tasks.append(db_task)

--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -1502,25 +1502,32 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         if db_data is None:
             raise ValidationError("Data is not uploaded for the task yet")
 
-        if hasattr(db_data, 'audio'):
+        if (
+            db_task.media_type == models.MediaType.AUDIO
+            and db_task.mode == models.TaskMode.INTERPOLATION
+        ):
             media = [db_data.audio]
             chapters = None
 
             def serialize_media_item(item: models.Audio) -> dict[str, Any]:
                 return {}
-        else:
-            if hasattr(db_data, 'video'):
+        elif db_task.media_type in (models.MediaType.IMAGE, models.MediaType.POINT_CLOUD):
+            if db_task.mode == models.TaskMode.INTERPOLATION:
                 media = [db_data.video]
                 chapters = get_video_chapters(db_data.get_manifest_path())
-            else:
+            elif db_task.mode == models.TaskMode.ANNOTATION:
                 media = list(db_data.images.all())
                 chapters = None
+            else:
+                assert False, f"Unknown mode '{db_task.mode}'"
 
             def serialize_media_item(item: models.Video | models.Image) -> dict[str, Any]:
                 return {
                     'width': item.width,
                     'height': item.height,
                 }
+        elif db_task.media_type:
+            assert False, f"Unknown media type '{db_task.media_type}'"
 
         frame_meta = [
             {
@@ -1537,7 +1544,7 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         db_data.chunks_updated_date = db_task.get_chunks_updated_date()
         db_data.chapters = chapters
 
-        serializer = DataMetaReadSerializer(db_data)
+        serializer = DataMetaReadSerializer(db_data, context={"task": db_task})
         return Response(serializer.data)
 
     @extend_schema(exclude=True)
@@ -2059,7 +2066,7 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
             deleted_frames.update(db_data.validation_layout.disabled_frames)
 
         # Keep only frames from the job segment
-        if hasattr(db_data, 'audio'):
+        if db_task.media_type == models.MediaType.AUDIO:
             assert not deleted_frames
         else:
             task_media_provider = TaskFrameProvider(db_task)
@@ -2074,20 +2081,23 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
         db_data.included_frames = db_segment.frames or None
         db_data.chunks_updated_date = db_segment.chunks_updated_date
 
-        if hasattr(db_data, 'audio'):
+        if (
+            db_task.media_type == models.MediaType.AUDIO
+            and db_task.mode == models.TaskMode.INTERPOLATION
+        ):
             media = [db_data.audio]
             chapters = None
 
             def serialize_media_item(item: models.Audio) -> dict[str, Any]:
                 return {}
-        else:
-            if hasattr(db_data, 'video'):
+        elif db_task.media_type in (models.MediaType.IMAGE, models.MediaType.POINT_CLOUD):
+            if db_task.mode == models.TaskMode.INTERPOLATION:
                 media = [db_data.video]
                 chapters = get_video_chapters(
                     db_task.data.get_manifest_path(),
                     segment=(data_start_frame, data_stop_frame)
                 )
-            else:
+            elif db_task.mode == models.TaskMode.ANNOTATION:
                 media = [
                     # Insert placeholders if frames are skipped
                     # TODO: remove placeholders, UI supports chunks without placeholders already
@@ -2099,12 +2109,16 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
                     if f.frame in range(data_start_frame, data_stop_frame + frame_step, frame_step)
                 ]
                 chapters = None
+            else:
+                assert False, f"Unknown mode '{db_task.mode}'"
 
             def serialize_media_item(item: models.Video | models.Image) -> dict[str, Any]:
                 return {
                     'width': item.width,
                     'height': item.height,
                 }
+        elif db_task.media_type:
+            assert False, f"Unknown media type '{db_task.media_type}'"
 
         frame_meta = [
             {
@@ -2120,7 +2134,7 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
         db_data.frames = frame_meta
         db_data.chapters = chapters
 
-        serializer = DataMetaReadSerializer(db_data)
+        serializer = DataMetaReadSerializer(db_data, context={"task": db_task})
         return Response(serializer.data)
 
     @extend_schema(summary='Get a preview image for a job',

--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -1453,25 +1453,37 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         db_task = self.get_object() #force to call check_object_permissions
 
         def prefetch():
-            data_queryset = (
-                models.Data.objects
-                .select_related("validation_layout", "video")
-                .prefetch_related(
-                    Prefetch(
-                        'images',
-                        queryset=(
-                            models.Image.objects
-                            .prefetch_related('related_files')
-                            .order_by('frame')
-                        )
-                    )
-                )
-            )
+            data_queryset = models.Data.objects.select_related("validation_layout")
+            extra_prefetches = []
+
+            match (db_task.media_type, db_task.mode):
+                case (models.MediaType.AUDIO, models.TaskMode.INTERPOLATION):
+                    data_queryset = data_queryset.select_related("audio")
+                case (models.MediaType.IMAGE, models.TaskMode.INTERPOLATION):
+                    data_queryset = data_queryset.select_related("video")
+                case (
+                    models.MediaType.IMAGE | models.MediaType.POINT_CLOUD,
+                    models.TaskMode.ANNOTATION,
+                ):
+                    # Could also be done via data_qs.prefetch_related(),
+                    # but it results in more requests
+                    extra_prefetches += [
+                        Prefetch(
+                            "data__images",
+                            queryset=models.Image.objects.order_by('frame'),
+                        ),
+                        "data__images__related_files"
+                    ]
+                case ("", ""):
+                    pass # noop, nothing to load
+                case (media_type, mode):
+                    assert False, f"Unknown media type '{media_type}' with mode '{mode}'"
 
             prefetch_related_objects(
                 [db_task],
                 "segment_set",
-                Prefetch("data", queryset=data_queryset)
+                Prefetch("data", queryset=data_queryset),
+                *extra_prefetches,
             )
 
         prefetch()
@@ -1986,24 +1998,38 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
         db_job = self.get_object() # force call of check_object_permissions()
 
         def prefetch():
-            data_queryset = (
-                models.Data.objects
-                .select_related("validation_layout", "video")
-                .prefetch_related(
-                    Prefetch(
-                        'images',
-                        queryset=(
-                            models.Image.objects
-                            .prefetch_related('related_files')
-                            .order_by('frame')
-                        )
-                    )
-                )
-            )
+            db_task = db_job.segment.task
+
+            data_queryset = models.Data.objects.select_related("validation_layout")
+            extra_prefetches = []
+
+            match (db_task.media_type, db_task.mode):
+                case (models.MediaType.AUDIO, models.TaskMode.INTERPOLATION):
+                    data_queryset = data_queryset.select_related("audio")
+                case (models.MediaType.IMAGE, models.TaskMode.INTERPOLATION):
+                    data_queryset = data_queryset.select_related("video")
+                case (
+                    models.MediaType.IMAGE | models.MediaType.POINT_CLOUD,
+                    models.TaskMode.ANNOTATION,
+                ):
+                    # Could also be done via data_qs.prefetch_related(),
+                    # but it results in more requests
+                    extra_prefetches += [
+                        Prefetch(
+                            "segment__task__data__images",
+                            queryset=models.Image.objects.order_by('frame'),
+                        ),
+                        "segment__task__data__images__related_files"
+                    ]
+                case ("", ""):
+                    pass # noop, nothing to load
+                case (media_type, mode):
+                    assert False, f"Unknown media type '{media_type}' with mode '{mode}'"
 
             prefetch_related_objects(
                 [db_job],
-                Prefetch("segment__task__data", queryset=data_queryset)
+                Prefetch("segment__task__data", queryset=data_queryset),
+                *extra_prefetches,
             )
 
         prefetch()


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Depends on #10551

As the number of possible media types grows, the prefetches in the metadata endpoints require a redesign.

- Optimized metadata requests

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Benchmarked against a seeded Postgres DB (10k tasks, 50k jobs, 700k images, 150k videos, 150k audios; per-task media counts drawn from a geometric distribution). Each row is the minimum over 7 repeats after a warm-up call, averaged across 3 sample tasks per bucket. Query counts captured via `django.test.utils.CaptureQueriesContext`.

**`/api/tasks/{id}/data/meta`**

| case                  | size      | queries (develop → PR) | time (develop → PR)              |
| --------------------- | --------- | ---------------------- | -------------------------------- |
| image+annotation S    | 8-26      | 12 → 10 (-2)           | 12.97 → 10.89 ms (-16.0%)        |
| image+annotation M    | 39-105    | 12 → 10 (-2)           | 16.13 → 13.95 ms (-13.5%)        |
| image+annotation L    | 323-498   | 12 → 10 (-2)           | 35.71 → 30.06 ms (-15.8%)        |
| image+interpolation   | 12-58     | 10 → 8  (-2)           |  9.61 →  8.70 ms ( -9.4%)        |
| audio+interpolation   | 1         | 10 → 8  (-2)           | 10.44 →  8.63 ms (-17.3%)        |

**`/api/jobs/{id}/data/meta`**

| case                  | queries (develop → PR) | time (develop → PR)              |
| --------------------- | ---------------------- | -------------------------------- |
| image+annotation S    | 10 → 8 (-2)            | 13.21 → 11.29 ms (-14.5%)        |
| image+annotation M    | 10 → 8 (-2)            | 16.54 → 13.17 ms (-20.4%)        |
| image+annotation L    | 10 → 8 (-2)            | 32.56 → 26.87 ms (-17.5%)        |
| image+interpolation   |  8 → 6 (-2)            | 10.76 →  9.26 ms (-13.9%)        |
| audio+interpolation   |  8 → 6 (-2)            | 11.50 →  9.73 ms (-15.4%)        |

Each endpoint saves exactly 2 SQL queries:
- Image-annotation tasks: drop the two `hasattr(db_data, 'audio')` reverse-OneToOne probes (view + serializer) and video prefetch.
- Video / audio tasks: drop the always-issued `images` and `related_files` prefetches that returned 0 rows.

Wall-time improvement is 9-20% depending on case; the largest absolute gain (-5.7 ms) is on large image-annotation tasks where the per-query roundtrip and image-table scan dominate. SQL inspection on the PR build confirms no unexpected new queries are introduced: `select_related` joins to `validation_layout` plus the appropriate media table only.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
