### PR TITLE
Removed unsafe and unused SOURCE_MAPS_TOKEN

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -27,12 +27,10 @@ COPY cvat-canvas/ /tmp/cvat-canvas/
 COPY cvat-ui/ /tmp/cvat-ui/
 
 ARG CLIENT_PLUGINS
-ARG DISABLE_SOURCE_MAPS
-ARG SOURCE_MAPS_TOKEN
+ARG SOURCE_MAPS_ENABLED=false
 
 RUN CLIENT_PLUGINS="${CLIENT_PLUGINS}" \
-DISABLE_SOURCE_MAPS="${DISABLE_SOURCE_MAPS}" \
-SOURCE_MAPS_TOKEN="${SOURCE_MAPS_TOKEN}" yarn run build:cvat-ui
+SOURCE_MAPS_ENABLED="${SOURCE_MAPS_ENABLED}" yarn run build:cvat-ui
 
 FROM nginxinc/nginx-unprivileged:1.29.5-alpine3.23-slim
 

--- a/cvat-ui/webpack.config.js
+++ b/cvat-ui/webpack.config.js
@@ -5,15 +5,15 @@
 
 const fs = require('fs');
 const path = require('path');
-const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const Dotenv = require('dotenv-webpack');
 const CopyPlugin = require('copy-webpack-plugin');
 const ExecScriptsPlugin = require('./exec-scripts-webpack-plugin.cjs');
 
-module.exports = (env) => {
-    const sourceMapsDisabled = (process.env.DISABLE_SOURCE_MAPS || 'false').toLocaleLowerCase() === 'true';
-    const sourceMapsToken = process.env.SOURCE_MAPS_TOKEN || '';
+module.exports = (env, argv = {}) => {
+    const isDevMode = argv.mode === 'development' || process.env.WEBPACK_SERVE === 'true';
+    const sourceMapsEnabled = isDevMode ||
+        (process.env.SOURCE_MAPS_ENABLED || 'false').toLocaleLowerCase() === 'true';
 
     const defaultPlugins = ['plugins/sam'];
     const plugins = process.env.CLIENT_PLUGINS ? [...defaultPlugins, ...process.env.CLIENT_PLUGINS.split(':')]
@@ -35,7 +35,7 @@ module.exports = (env) => {
         return true;
     });
 
-    console.log('Source maps: ', sourceMapsDisabled ? 'disabled' : 'enabled');
+    console.log('Source maps: ', sourceMapsEnabled ? 'enabled' : 'disabled');
     console.log('Plugins:');
     for (const { entrypoint } of pluginPaths) {
         console.log(`- ${entrypoint}`);
@@ -45,8 +45,8 @@ module.exports = (env) => {
     const port = process.env.CVAT_UI_PORT ?? 3000;
     return {
         target: 'web',
-        mode: 'production',
-        devtool: sourceMapsDisabled ? false : 'source-map',
+        mode: isDevMode ? 'development' : 'production',
+        devtool: sourceMapsEnabled ? 'source-map' : false,
         entry: {
             'cvat-ui': './src/index.tsx',
             ...pluginPaths.reduce((acc, { entrypoint }, index) => ({
@@ -224,10 +224,6 @@ module.exports = (env) => {
                     },
                 ],
             }),
-            ...(!sourceMapsDisabled && sourceMapsToken ? [new webpack.SourceMapDevToolPlugin({
-                append: '\n',
-                filename: `${sourceMapsToken}/[file].map`,
-            })] : []),
         ],
     }
 };


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context

This PR removes the unsafe `SOURCE_MAPS_TOKEN` mechanism from the CVAT UI build and switches source map generation to an explicit allow-list model.

Source maps are now disabled by default for production Docker builds and are generated only when running in development mode or when `SOURCE_MAPS_ENABLED=true` is explicitly provided.


- Removed `SOURCE_MAPS_TOKEN` and the tokenized `SourceMapDevToolPlugin` configuration.
- Replaced `DISABLE_SOURCE_MAPS` with `SOURCE_MAPS_ENABLED=false` as a safer Docker build default.
- Updated webpack source map logic:
  - enabled automatically in development mode / webpack dev server;
  - enabled in production only with `SOURCE_MAPS_ENABLED=true`;
  - disabled by default otherwise.
- Removed the unused `webpack` import from `cvat-ui/webpack.config.js`.


Keeping a token in the Docker image is not a safe way to protect source maps. The safer default is to avoid shipping source maps in production images unless they are explicitly requested for a controlled build.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
