### PR TITLE
Audio task GT job creation

### DIFF
--- a/changelog.d/20260511_193000_mzhiltsov_audio_gt_job_creation.md
+++ b/changelog.d/20260511_193000_mzhiltsov_audio_gt_job_creation.md
@@ -1,0 +1,4 @@
+### Added
+
+- \[Server API\] Ground truth jobs can now be created in audio tasks
+  (<https://github.com/cvat-ai/cvat/pull/10582>)

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1235,8 +1235,6 @@ class JobWriteSerializer(WriteOnceMixin, serializers.ModelSerializer):
             raise serializers.ValidationError(
                 "This task has no data attached yet. Please set up task data and try again"
             )
-        if task.dimension != models.DimensionType.DIM_2D:
-            raise serializers.ValidationError("Ground Truth jobs can only be added in 2d tasks")
 
         if task.data.validation_mode in (models.ValidationMode.GT_POOL, models.ValidationMode.GT):
             raise serializers.ValidationError(
@@ -1244,98 +1242,105 @@ class JobWriteSerializer(WriteOnceMixin, serializers.ModelSerializer):
                 "cannot have more than 1 GT job"
             )
 
-        task_size = task.data.size
-        valid_frame_ids = task.data.get_valid_frame_indices()
+        if task.media_type == models.MediaType.AUDIO:
+            frames = []
+        elif task.media_type == models.MediaType.IMAGE:
+            task_size = task.data.size
+            valid_frame_ids = task.data.get_valid_frame_indices()
 
-        frame_selection_method = validated_data.pop("frame_selection_method")
-        if frame_selection_method == models.JobFrameSelectionMethod.RANDOM_UNIFORM:
-            if frame_count := validated_data.pop("frame_count", None):
-                if task_size < frame_count:
+            frame_selection_method = validated_data.pop("frame_selection_method")
+            if frame_selection_method == models.JobFrameSelectionMethod.RANDOM_UNIFORM:
+                if frame_count := validated_data.pop("frame_count", None):
+                    if task_size < frame_count:
+                        raise serializers.ValidationError(
+                            f"The number of frames requested ({frame_count}) "
+                            f"must not be greater than the number of the task frames ({task_size})"
+                        )
+                elif frame_share := validated_data.pop("frame_share", None):
+                    frame_count = max(1, int(frame_share * task_size))
+                else:
                     raise serializers.ValidationError(
-                        f"The number of frames requested ({frame_count}) "
-                        f"must not be greater than the number of the task frames ({task_size})"
+                        "The number of validation frames is not specified"
                     )
-            elif frame_share := validated_data.pop("frame_share", None):
-                frame_count = max(1, int(frame_share * task_size))
+
+                seed = validated_data.pop("random_seed", None)
+
+                # The RNG backend must not change to yield reproducible results,
+                # so here we specify it explicitly
+                rng = random.Generator(random.MT19937(seed=seed))
+
+                frames = rng.choice(
+                    list(valid_frame_ids), size=frame_count, shuffle=False, replace=False
+                ).tolist()
+            elif frame_selection_method == models.JobFrameSelectionMethod.RANDOM_PER_JOB:
+                if frame_count := validated_data.pop("frames_per_job_count", None):
+                    if task_size < frame_count:
+                        raise serializers.ValidationError(
+                            f"The number of frames requested ({frame_count}) "
+                            f"must be not be greater than the segment size ({task.segment_size})"
+                        )
+                elif frame_share := validated_data.pop("frames_per_job_share", None):
+                    frame_count = min(max(1, int(frame_share * task.segment_size)), task_size)
+                else:
+                    raise serializers.ValidationError(
+                        "The number of validation frames is not specified"
+                    )
+
+                task_frame_provider = TaskFrameProvider(task)
+                seed = validated_data.pop("random_seed", None)
+
+                # The RNG backend must not change to yield reproducible results,
+                # so here we specify it explicitly
+                rng = random.Generator(random.MT19937(seed=seed))
+
+                frames: list[int] = []
+                overlap = task.overlap
+                for segment in task.segment_set.all():
+                    segment_frames = set(
+                        map(task_frame_provider.get_rel_frame_number, segment.frame_set)
+                    )
+                    selected_frames = segment_frames.intersection(frames)
+                    selected_count = len(selected_frames)
+
+                    missing_count = min(len(segment_frames), frame_count) - selected_count
+                    if missing_count <= 0:
+                        continue
+
+                    selectable_segment_frames = set(
+                        sorted(segment_frames)[overlap * (segment.start_frame != 0) :]
+                    ).difference(selected_frames)
+
+                    frames.extend(
+                        rng.choice(
+                            tuple(selectable_segment_frames), size=missing_count, replace=False
+                        ).tolist()
+                    )
+
+                frames = list(map(task_frame_provider.get_abs_frame_number, frames))
+            elif frame_selection_method == models.JobFrameSelectionMethod.MANUAL:
+                frames = validated_data.pop("frames")
+
+                unique_frames = set(frames)
+                if len(unique_frames) != len(frames):
+                    raise serializers.ValidationError("Frames must not repeat")
+
+                invalid_ids = unique_frames.difference(range(task_size))
+                if invalid_ids:
+                    raise serializers.ValidationError(
+                        "The following frames do not exist in the task: {}".format(
+                            format_list(tuple(map(str, sorted(invalid_ids))))
+                        )
+                    )
+
+                task_frame_provider = TaskFrameProvider(task)
+                frames = list(map(task_frame_provider.get_abs_frame_number, frames))
             else:
                 raise serializers.ValidationError(
-                    "The number of validation frames is not specified"
+                    f"Unexpected frame selection method '{frame_selection_method}'"
                 )
-
-            seed = validated_data.pop("random_seed", None)
-
-            # The RNG backend must not change to yield reproducible results,
-            # so here we specify it explicitly
-            rng = random.Generator(random.MT19937(seed=seed))
-
-            frames = rng.choice(
-                list(valid_frame_ids), size=frame_count, shuffle=False, replace=False
-            ).tolist()
-        elif frame_selection_method == models.JobFrameSelectionMethod.RANDOM_PER_JOB:
-            if frame_count := validated_data.pop("frames_per_job_count", None):
-                if task_size < frame_count:
-                    raise serializers.ValidationError(
-                        f"The number of frames requested ({frame_count}) "
-                        f"must be not be greater than the segment size ({task.segment_size})"
-                    )
-            elif frame_share := validated_data.pop("frames_per_job_share", None):
-                frame_count = min(max(1, int(frame_share * task.segment_size)), task_size)
-            else:
-                raise serializers.ValidationError(
-                    "The number of validation frames is not specified"
-                )
-
-            task_frame_provider = TaskFrameProvider(task)
-            seed = validated_data.pop("random_seed", None)
-
-            # The RNG backend must not change to yield reproducible results,
-            # so here we specify it explicitly
-            rng = random.Generator(random.MT19937(seed=seed))
-
-            frames: list[int] = []
-            overlap = task.overlap
-            for segment in task.segment_set.all():
-                segment_frames = set(
-                    map(task_frame_provider.get_rel_frame_number, segment.frame_set)
-                )
-                selected_frames = segment_frames.intersection(frames)
-                selected_count = len(selected_frames)
-
-                missing_count = min(len(segment_frames), frame_count) - selected_count
-                if missing_count <= 0:
-                    continue
-
-                selectable_segment_frames = set(
-                    sorted(segment_frames)[overlap * (segment.start_frame != 0) :]
-                ).difference(selected_frames)
-
-                frames.extend(
-                    rng.choice(
-                        tuple(selectable_segment_frames), size=missing_count, replace=False
-                    ).tolist()
-                )
-
-            frames = list(map(task_frame_provider.get_abs_frame_number, frames))
-        elif frame_selection_method == models.JobFrameSelectionMethod.MANUAL:
-            frames = validated_data.pop("frames")
-
-            unique_frames = set(frames)
-            if len(unique_frames) != len(frames):
-                raise serializers.ValidationError(f"Frames must not repeat")
-
-            invalid_ids = unique_frames.difference(range(task_size))
-            if invalid_ids:
-                raise serializers.ValidationError(
-                    "The following frames do not exist in the task: {}".format(
-                        format_list(tuple(map(str, sorted(invalid_ids))))
-                    )
-                )
-
-            task_frame_provider = TaskFrameProvider(task)
-            frames = list(map(task_frame_provider.get_abs_frame_number, frames))
         else:
             raise serializers.ValidationError(
-                f"Unexpected frame selection method '{frame_selection_method}'"
+                f"Ground Truth jobs are not available for the '{task.media_type}' media type"
             )
 
         # Save the new job
@@ -1344,18 +1349,28 @@ class JobWriteSerializer(WriteOnceMixin, serializers.ModelSerializer):
             stop_frame=task.data.size - 1,
             frames=frames,
             task=task,
-            type=models.SegmentType.SPECIFIC_FRAMES,
+            type=models.SegmentType.SPECIFIC_FRAMES if frames else models.SegmentType.RANGE,
         )
 
-        validated_data["segment"] = segment
-        validated_data["assignee_id"] = validated_data.pop("assignee", None)
+        job_params = {
+            "type": validated_data.pop("type"),
+            "segment": segment,
+            "assignee_id": validated_data.pop("assignee", None),
+        }
+
+        if validated_data:
+            raise serializers.ValidationError(
+                "Fields {} specified, but not used.".format(
+                    ", ".join(f'"{k}"' for k in validated_data)
+                )
+            )
 
         try:
-            job = super().create(validated_data)
+            job = super().create(job_params)
         except models.TaskGroundTruthJobsLimitError as ex:
             raise serializers.ValidationError(ex.message) from ex
 
-        if validated_data.get("assignee_id"):
+        if job_params.get("assignee_id"):
             job.assignee_updated_date = job.updated_date
             job.save(update_fields=["assignee_updated_date"])
 
@@ -2319,12 +2334,13 @@ class JobFileMapping(serializers.ListField):
 class ValidationParamsSerializer(serializers.ModelSerializer):
     mode = serializers.ChoiceField(choices=models.ValidationMode.choices(), required=True)
     frame_selection_method = serializers.ChoiceField(
-        choices=models.JobFrameSelectionMethod.choices(), required=True
+        choices=models.JobFrameSelectionMethod.choices(), required=False
     )
     frames = serializers.ListField(
         write_only=True,
         child=serializers.CharField(max_length=MAX_FILENAME_LENGTH),
         required=False,
+        allow_empty=False,
         help_text=textwrap.dedent("""\
             The list of file names to be included in the validation set.
             Applicable only to the "{}" frame selection method.
@@ -2389,15 +2405,16 @@ class ValidationParamsSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         if attrs["mode"] == models.ValidationMode.GT:
-            field_validation.require_one_of_values(
-                attrs,
-                "frame_selection_method",
-                [
-                    models.JobFrameSelectionMethod.MANUAL,
-                    models.JobFrameSelectionMethod.RANDOM_UNIFORM,
-                    models.JobFrameSelectionMethod.RANDOM_PER_JOB,
-                ],
-            )
+            if "frame_selection_method" in attrs:
+                field_validation.require_one_of_values(
+                    attrs,
+                    "frame_selection_method",
+                    [
+                        models.JobFrameSelectionMethod.MANUAL,
+                        models.JobFrameSelectionMethod.RANDOM_UNIFORM,
+                        models.JobFrameSelectionMethod.RANDOM_PER_JOB,
+                    ],
+                )
         elif attrs["mode"] == models.ValidationMode.GT_POOL:
             field_validation.require_one_of_values(
                 attrs,
@@ -2412,6 +2429,9 @@ class ValidationParamsSerializer(serializers.ModelSerializer):
             )
         else:
             assert False, f"Unknown validation mode {attrs['mode']}"
+
+        if "frame_selection_method" not in attrs:
+            return super().validate(attrs)
 
         if attrs["frame_selection_method"] == models.JobFrameSelectionMethod.RANDOM_UNIFORM:
             field_validation.require_one_of_fields(attrs, ["frame_count", "frame_share"])

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -26,7 +26,7 @@ from django.db import transaction
 from django.forms.models import model_to_dict
 from rest_framework.serializers import ValidationError
 
-from cvat.apps.engine import models
+from cvat.apps.engine import field_validation, models
 from cvat.apps.engine.log import ServerLogManager
 from cvat.apps.engine.media_extractors import (
     MEDIA_TYPES,
@@ -399,7 +399,7 @@ def _validate_validation_params(
 
     if (
         params["mode"] == models.ValidationMode.GT
-        and params["frame_selection_method"] == models.JobFrameSelectionMethod.RANDOM_PER_JOB
+        and params.get("frame_selection_method") == models.JobFrameSelectionMethod.RANDOM_PER_JOB
         and (frames_per_job := params.get("frames_per_job_count"))
         and db_task.segment_size <= frames_per_job
     ):
@@ -902,104 +902,138 @@ def _create_validation_jobs(
 ) -> None:
     db_data = db_task.require_data()
 
-    if db_task.media_type == models.MediaType.AUDIO and validation_params:
+    if db_task.media_type == models.MediaType.AUDIO and (
+        validation_params and validation_params["mode"] != models.ValidationMode.GT
+    ):
         raise ValidationError(
-            f"Quality control is not available for '{models.MediaType.AUDIO}' media type"
+            "Only the '{}' validation mode is available in '{}' tasks.".format(
+                models.ValidationMode.GT, models.MediaType.AUDIO
+            )
         )
+
+    if db_task.media_type == models.MediaType.POINT_CLOUD and (
+        validation_params and validation_params["mode"]
+    ):
+        raise ValidationError(f"Validation is not available in '{db_task.media_type}' tasks.")
 
     if validation_params and validation_params["mode"] == models.ValidationMode.GT:
 
         def _to_rel_frame(abs_frame: int) -> int:
             return (abs_frame - db_data.start_frame) // db_data.get_frame_step()
 
-        # The RNG backend must not change to yield reproducible frame picks,
-        # so here we specify it explicitly
-        from numpy import random
+        if db_task.media_type == models.MediaType.AUDIO:
+            if "frame_selection_method" in validation_params:
+                field_validation.require_one_of_values(
+                    validation_params, "frame_selection_method", ["random_uniform"]
+                )
+                validation_params.pop("frame_selection_method")
 
-        seed = validation_params.get("random_seed")
-        rng = random.Generator(random.MT19937(seed=seed))
+            if "frames" in validation_params:
+                if not validation_params["frames"]:
+                    validation_params.pop("frames")
 
-        match validation_params["frame_selection_method"]:
-            case models.JobFrameSelectionMethod.RANDOM_UNIFORM:
-                all_frames = range(db_data.size)
+            if extra_params := set(validation_params.keys()) - {"mode"}:
+                raise ValidationError(
+                    "Validation parameters {} are not applicable to the '{}' media type.".format(
+                        ", ".join(f"'{v}'" for v in extra_params),
+                        db_task.media_type,
+                    )
+                )
 
-                if frame_count := validation_params.get("frame_count"):
-                    if db_data.size < frame_count:
+            validation_frames = []
+        else:
+            field_validation.require_field(validation_params, "frame_selection_method")
+
+            # The RNG backend must not change to yield reproducible frame picks,
+            # so here we specify it explicitly
+            from numpy import random
+
+            seed = validation_params.get("random_seed")
+            rng = random.Generator(random.MT19937(seed=seed))
+
+            match validation_params["frame_selection_method"]:
+                case models.JobFrameSelectionMethod.RANDOM_UNIFORM:
+                    all_frames = range(db_data.size)
+
+                    if frame_count := validation_params.get("frame_count"):
+                        if db_data.size < frame_count:
+                            raise ValidationError(
+                                f"The number of validation frames requested ({frame_count}) "
+                                f"is greater that the number of task frames ({db_data.size})"
+                            )
+                    elif frame_share := validation_params.get("frame_share"):
+                        frame_count = max(1, int(frame_share * len(all_frames)))
+                    else:
+                        raise ValidationError("The number of validation frames is not specified")
+
+                    validation_frames = rng.choice(
+                        all_frames, size=frame_count, shuffle=False, replace=False
+                    ).tolist()
+                case models.JobFrameSelectionMethod.RANDOM_PER_JOB:
+                    if frame_count := validation_params.get("frames_per_job_count"):
+                        if db_task.segment_size < frame_count:
+                            raise ValidationError(
+                                "The requested number of GT frames per job must be less "
+                                f"than task segment size ({db_task.segment_size})"
+                            )
+                    elif frame_share := validation_params.get("frames_per_job_share"):
+                        frame_count = min(
+                            max(1, int(frame_share * db_task.segment_size)), db_data.size
+                        )
+                    else:
+                        raise ValidationError("The number of validation frames is not specified")
+
+                    validation_frames: list[int] = []
+                    overlap = db_task.overlap
+                    for segment in db_task.segment_set.all():
+                        segment_frames = set(map(_to_rel_frame, segment.frame_set))
+                        selected_frames = segment_frames.intersection(validation_frames)
+                        selected_count = len(selected_frames)
+
+                        missing_count = min(len(segment_frames), frame_count) - selected_count
+                        if missing_count <= 0:
+                            continue
+
+                        selectable_segment_frames = set(
+                            sorted(segment_frames)[overlap * (segment.start_frame != 0) :]
+                        ).difference(selected_frames)
+
+                        validation_frames.extend(
+                            rng.choice(
+                                tuple(selectable_segment_frames), size=missing_count, replace=False
+                            ).tolist()
+                        )
+                case models.JobFrameSelectionMethod.MANUAL:
+                    if not images:
                         raise ValidationError(
-                            f"The number of validation frames requested ({frame_count}) "
-                            f"is greater that the number of task frames ({db_data.size})"
+                            "{} validation frame selection method at task creation "
+                            "is only available for image-based tasks. "
+                            "Please create the GT job after the task is created.".format(
+                                models.JobFrameSelectionMethod.MANUAL
+                            )
                         )
-                elif frame_share := validation_params.get("frame_share"):
-                    frame_count = max(1, int(frame_share * len(all_frames)))
-                else:
-                    raise ValidationError("The number of validation frames is not specified")
 
-                validation_frames = rng.choice(
-                    all_frames, size=frame_count, shuffle=False, replace=False
-                ).tolist()
-            case models.JobFrameSelectionMethod.RANDOM_PER_JOB:
-                if frame_count := validation_params.get("frames_per_job_count"):
-                    if db_task.segment_size < frame_count:
+                    validation_frames: list[int] = []
+                    known_frame_names = {frame.path: _to_rel_frame(frame.frame) for frame in images}
+                    unknown_requested_frames = []
+                    for frame_filename in validation_params["frames"]:
+                        frame_id = known_frame_names.get(frame_filename)
+                        if frame_id is None:
+                            unknown_requested_frames.append(frame_filename)
+                            continue
+
+                        validation_frames.append(frame_id)
+
+                    if unknown_requested_frames:
                         raise ValidationError(
-                            "The requested number of GT frames per job must be less "
-                            f"than task segment size ({db_task.segment_size})"
+                            "Unknown validation frames requested: {}".format(
+                                format_list(sorted(unknown_requested_frames))
+                            )
                         )
-                elif frame_share := validation_params.get("frames_per_job_share"):
-                    frame_count = min(max(1, int(frame_share * db_task.segment_size)), db_data.size)
-                else:
-                    raise ValidationError("The number of validation frames is not specified")
-
-                validation_frames: list[int] = []
-                overlap = db_task.overlap
-                for segment in db_task.segment_set.all():
-                    segment_frames = set(map(_to_rel_frame, segment.frame_set))
-                    selected_frames = segment_frames.intersection(validation_frames)
-                    selected_count = len(selected_frames)
-
-                    missing_count = min(len(segment_frames), frame_count) - selected_count
-                    if missing_count <= 0:
-                        continue
-
-                    selectable_segment_frames = set(
-                        sorted(segment_frames)[overlap * (segment.start_frame != 0) :]
-                    ).difference(selected_frames)
-
-                    validation_frames.extend(
-                        rng.choice(
-                            tuple(selectable_segment_frames), size=missing_count, replace=False
-                        ).tolist()
-                    )
-            case models.JobFrameSelectionMethod.MANUAL:
-                if not images:
-                    raise ValidationError(
-                        "{} validation frame selection method at task creation "
-                        "is only available for image-based tasks. "
-                        "Please create the GT job after the task is created.".format(
-                            models.JobFrameSelectionMethod.MANUAL
-                        )
-                    )
-
-                validation_frames: list[int] = []
-                known_frame_names = {frame.path: _to_rel_frame(frame.frame) for frame in images}
-                unknown_requested_frames = []
-                for frame_filename in validation_params["frames"]:
-                    frame_id = known_frame_names.get(frame_filename)
-                    if frame_id is None:
-                        unknown_requested_frames.append(frame_filename)
-                        continue
-
-                    validation_frames.append(frame_id)
-
-                if unknown_requested_frames:
-                    raise ValidationError(
-                        "Unknown validation frames requested: {}".format(
-                            format_list(sorted(unknown_requested_frames))
-                        )
-                    )
-            case _:
-                assert (
-                    False
-                ), f'Unknown frame selection method {validation_params["frame_selection_method"]}'
+                case _:
+                    assert (
+                        False
+                    ), f'Unknown frame selection method {validation_params["frame_selection_method"]}'
 
         db_data.update_validation_layout(
             models.ValidationLayout(
@@ -1019,7 +1053,11 @@ def _create_validation_jobs(
                 start_frame=0,
                 stop_frame=db_data.size - 1,
                 frames=list(map(_to_abs_frame, db_data.validation_layout.frames)),
-                type=models.SegmentType.SPECIFIC_FRAMES,
+                type=(
+                    models.SegmentType.SPECIFIC_FRAMES
+                    if db_data.validation_layout.frames
+                    else models.SegmentType.RANGE
+                ),
             )
         elif db_data.validation_layout.mode == models.ValidationMode.GT_POOL:
             db_gt_segment = models.Segment(

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -11688,7 +11688,6 @@ components:
             The share of frames to be included in the validation set from each annotation job.
             Applicable only to the "random_per_job" frame selection method
       required:
-      - frame_selection_method
       - mode
     WebhookContentType:
       enum:

--- a/tests/python/rest_api/test_audio_support.py
+++ b/tests/python/rest_api/test_audio_support.py
@@ -9,7 +9,7 @@ from itertools import product
 from pathlib import Path, PurePosixPath
 
 import pytest
-from cvat_sdk import exceptions, models
+from cvat_sdk import models
 from cvat_sdk.core.exceptions import BackgroundRequestException
 from cvat_sdk.core.proxies.tasks import ResourceType, Task
 from PIL import Image
@@ -241,29 +241,25 @@ class TestAudioTasks:
             assert chunk_audio.shape[0] / sampling_rate >= job_meta.size / 1000
 
     @parametrize("task", [fixture_ref(fxt_audio_task_from_uploaded_data)])
-    def test_cant_create_gt_job(self, task: Task):
-        with pytest.raises(exceptions.ApiException) as capture:
-            self.client.jobs.api.create(
-                job_write_request=models.JobWriteRequest(type="ground_truth", task_id=task.id)
-            )
+    def test_can_create_gt_job(self, task: Task):
+        gt_job = self.client.jobs.api.create(
+            job_write_request=models.JobWriteRequest(type="ground_truth", task_id=task.id)
+        )[0]
 
-        assert "can only be added in 2d tasks" in str(capture.value)
+        assert gt_job.type == "ground_truth"
+        assert gt_job.frame_count == task.size
 
     @parametrize("source_filename", [fixture_ref("fxt_local_audio_file_path")])
-    def test_cant_create_task_with_gt_job(self, fxt_test_name: str, source_filename: Path):
-        with pytest.raises(BackgroundRequestException) as capture:
-            self.client.tasks.create_from_data(
-                spec={
-                    "name": fxt_test_name,
-                },
-                resources=[source_filename],
-                data_params={
-                    "validation_params": {
-                        "mode": "gt",
-                        "frame_selection_method": "manual",
-                        "frames": [0],
-                    }
-                },
-            )
+    def test_can_create_task_with_gt_job(self, fxt_test_name: str, source_filename: Path):
+        task = self.client.tasks.create_from_data(
+            spec={
+                "name": fxt_test_name,
+            },
+            resources=[source_filename],
+            data_params={"validation_params": {"mode": "gt"}},
+        )
 
-        assert "not available" in str(capture.value)
+        gt_job = next(j for j in task.get_jobs() if j.type == "ground_truth")
+
+        assert gt_job.type == "ground_truth"
+        assert gt_job.frame_count == task.size


### PR DESCRIPTION
Depends on #10551, #10560.

Adds ground truth job creation support for audio tasks.

- Allow GT job creation on audio tasks

### Stack

```
develop
└── #10551 zm/audio-task-creation
    └── #10560 zm/audio-media-access
        └── this PR (zm/audio-gt-job-creation)
            └── zm/audio-intervals-backup-tsv (next PR)
                └── zm/audio-quality (final PR)
```

### How has this been tested?

Unit tests in `tests/python/rest_api/test_audio_support.py` (TestAudioTasks GT-job cases).
