### PR TITLE
Make use of Django 5.2's query-related parameter support

### DIFF
--- a/cvat/apps/dataset_manager/tests/test_formats.py
+++ b/cvat/apps/dataset_manager/tests/test_formats.py
@@ -81,7 +81,9 @@ class _DbTestBase(ApiTestBase):
             if 200 <= response.status_code < 400:
                 labels_response = list(
                     get_paginated_collection(
-                        lambda page: self.client.get("/api/labels?task_id=%s&page=%s" % (tid, page))
+                        lambda page: self.client.get(
+                            "/api/labels", query_params={"task_id": tid, "page": page}
+                        )
                     )
                 )
                 response.data["labels"] = labels_response
@@ -480,7 +482,7 @@ class TaskExportTest(_DbTestBase):
         with ForceLogin(self.user, self.client):
             return get_paginated_collection(
                 lambda page: self.client.get(
-                    "/api/jobs?task_id=%s&page=%s" % (tid, page), format="json"
+                    "/api/jobs", query_params={"task_id": tid, "page": page}, format="json"
                 )
             )
 

--- a/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
+++ b/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
@@ -230,7 +230,9 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
             if 200 <= response.status_code < 400:
                 labels_response = list(
                     get_paginated_collection(
-                        lambda page: self.client.get("/api/labels?task_id=%s&page=%s" % (tid, page))
+                        lambda page: self.client.get(
+                            "/api/labels", query_params={"task_id": tid, "page": page}
+                        )
                     )
                 )
                 response.data["labels"] = labels_response
@@ -250,7 +252,9 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
     def _get_jobs(self, task_id):
         with ForceLogin(self.admin, self.client):
             values = get_paginated_collection(
-                lambda page: self.client.get("/api/jobs?task_id={}&page={}".format(task_id, page))
+                lambda page: self.client.get(
+                    "/api/jobs", query_params={"task_id": task_id, "page": page}
+                )
             )
         return values
 
@@ -258,7 +262,7 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
         with ForceLogin(self.admin, self.client):
             values = get_paginated_collection(
                 lambda page: self.client.get(
-                    "/api/tasks", data={"project_id": project_id, "page": page}
+                    "/api/tasks", query_params={"project_id": project_id, "page": page}
                 )
             )
         return values

--- a/cvat/apps/dataset_manager/tests/test_streaming_efficiency.py
+++ b/cvat/apps/dataset_manager/tests/test_streaming_efficiency.py
@@ -385,7 +385,9 @@ class TestImporters(ApiTestBase):
             if 200 <= response.status_code < 400:
                 labels_response = list(
                     get_paginated_collection(
-                        lambda page: self.client.get("/api/labels?task_id=%s&page=%s" % (tid, page))
+                        lambda page: self.client.get(
+                            "/api/labels", query_params={"task_id": tid, "page": page}
+                        )
                     )
                 )
                 response.data["labels"] = labels_response
@@ -398,7 +400,7 @@ class TestImporters(ApiTestBase):
         with ForceLogin(self.user, self.client):
             return get_paginated_collection(
                 lambda page: self.client.get(
-                    "/api/jobs?task_id=%s&page=%s" % (tid, page), format="json"
+                    "/api/jobs", query_params={"task_id": tid, "page": page}, format="json"
                 )
             )
 

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -35,6 +35,7 @@ from drf_spectacular.utils import OpenApiExample, extend_schema_field, extend_sc
 from numpy import random
 from PIL import Image
 from rest_framework import exceptions, serializers
+from rest_framework.reverse import reverse
 
 from cvat.apps.dataset_manager.formats.utils import get_label_color
 from cvat.apps.engine import field_validation, models
@@ -60,7 +61,6 @@ from cvat.apps.engine.utils import (
     get_path_size,
     grouped,
     parse_specific_attributes,
-    reverse,
     take_by,
 )
 from cvat.apps.iam.permissions import get_iam_context
@@ -143,11 +143,14 @@ class HyperlinkedEndpointSerializer(serializers.Serializer):
             return None
 
         return serializers.Hyperlink(
-            reverse(self.view_name, request=request,
-                query_params=build_field_filter_params(
+            reverse(
+                self.view_name,
+                request=request,
+                query=build_field_filter_params(
                     self.filter_key, getattr(instance, self.key_field)
-            )),
-            instance
+                ),
+            ),
+            instance,
         )
 
 
@@ -203,8 +206,7 @@ class LabelsSummarySerializer(serializers.Serializer):
 
     def get_url(self, request, instance):
         filter_key = instance.__class__.__name__.lower() + '_id'
-        return reverse('label-list', request=request,
-            query_params={ filter_key: instance.id })
+        return reverse('label-list', request=request, query={filter_key: instance.id})
 
     def to_representation(self, instance):
         request = self.context.get('request')
@@ -220,8 +222,7 @@ class IssuesSummarySerializer(serializers.Serializer):
     count = serializers.IntegerField(read_only=True)
 
     def get_url(self, request, instance):
-        return reverse('issue-list', request=request,
-            query_params={ 'job_id': instance.id })
+        return reverse('issue-list', request=request, query={'job_id': instance.id})
 
     def get_count(self, instance):
         return getattr(instance, 'issue__count', 0)

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -912,9 +912,9 @@ class ProjectListAPITestCase(ApiTestBase):
         create_db_users(cls)
         cls.projects = create_dummy_db_projects(cls)
 
-    def _run_api_v2_projects(self, user, params=""):
+    def _run_api_v2_projects(self, user):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/projects{}".format(params))
+            response = self.client.get("/api/projects")
 
         return response
 
@@ -1068,7 +1068,8 @@ class ProjectCreateAPITestCase(ApiTestBase):
                 labels_response = list(
                     get_paginated_collection(
                         lambda page: self.client.get(
-                            "/api/labels?project_id=%s&page=%s" % (response.data["id"], page)
+                            "/api/labels",
+                            query_params={"project_id": response.data["id"], "page": page},
                         )
                     )
                 )
@@ -1161,7 +1162,7 @@ class ProjectPartialUpdateAPITestCase(ApiTestBase):
                 labels_response = list(
                     get_paginated_collection(
                         lambda page: self.client.get(
-                            "/api/labels?project_id=%s&page=%s" % (pid, page)
+                            "/api/labels", query_params={"project_id": pid, "page": page}
                         )
                     )
                 )
@@ -1312,7 +1313,7 @@ class ProjectUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
                 labels_response = list(
                     get_paginated_collection(
                         lambda page: self.client.get(
-                            "/api/labels?project_id=%s&page=%s" % (pid, page)
+                            "/api/labels", query_params={"project_id": pid, "page": page}
                         )
                     )
                 )
@@ -1355,7 +1356,7 @@ class ProjectListOfTasksAPITestCase(ApiTestBase):
 
     def _run_api_v2_projects_id_tasks(self, user, pid):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/tasks?project_id={}".format(pid))
+            response = self.client.get("/api/tasks", query_params={"project_id": pid})
 
         return response
 
@@ -1735,7 +1736,7 @@ class ProjectBackupAPITestCase(ExportApiTestBase, ImportApiTestBase):
 
     def _get_tasks_for_project(self, user, pid):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/tasks?project_id={}".format(pid))
+            response = self.client.get("/api/tasks", query_params={"project_id": pid})
 
         return sorted(response.data["results"], key=lambda task: task["name"])
 
@@ -2256,9 +2257,9 @@ class TaskListAPITestCase(ApiTestBase):
         create_db_users(cls)
         cls.tasks = create_dummy_db_tasks(cls)
 
-    def _run_api_v2_tasks(self, user, params=""):
+    def _run_api_v2_tasks(self, user):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/tasks{}".format(params))
+            response = self.client.get("/api/tasks")
 
         return response
 
@@ -2301,7 +2302,9 @@ class TaskGetAPITestCase(ApiTestBase):
             if 200 <= response.status_code < 400:
                 labels_response = list(
                     get_paginated_collection(
-                        lambda page: self.client.get("/api/labels?task_id=%s&page=%s" % (tid, page))
+                        lambda page: self.client.get(
+                            "/api/labels", query_params={"task_id": tid, "page": page}
+                        )
                     )
                 )
                 response.data["labels"] = labels_response
@@ -2479,7 +2482,9 @@ class TaskPartialUpdateAPITestCase(ApiTestBase):
             if 200 <= response.status_code < 400:
                 labels_response = list(
                     get_paginated_collection(
-                        lambda page: self.client.get("/api/labels?task_id=%s&page=%s" % (tid, page))
+                        lambda page: self.client.get(
+                            "/api/labels", query_params={"task_id": tid, "page": page}
+                        )
                     )
                 )
                 response.data["labels"] = labels_response
@@ -2680,7 +2685,9 @@ class TaskUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
             if 200 <= response.status_code < 400:
                 labels_response = list(
                     get_paginated_collection(
-                        lambda page: self.client.get("/api/labels?task_id=%s&page=%s" % (tid, page))
+                        lambda page: self.client.get(
+                            "/api/labels", query_params={"task_id": tid, "page": page}
+                        )
                     )
                 )
                 response.data["labels"] = labels_response
@@ -2935,7 +2942,8 @@ class TaskCreateAPITestCase(ApiTestBase):
                 labels_response = list(
                     get_paginated_collection(
                         lambda page: self.client.get(
-                            "/api/labels?task_id=%s&page=%s" % (response.data["id"], page)
+                            "/api/labels",
+                            query_params={"task_id": response.data["id"], "page": page},
                         )
                     )
                 )
@@ -3858,13 +3866,13 @@ class TaskDataAPITestCase(ApiTestBase):
     def _run_api_v2_task_id_data_get(
         self, tid, user, data_type, data_quality=None, data_number=None
     ):
-        url = "/api/tasks/{}/data?type={}".format(tid, data_type)
+        query_params = {"type": data_type}
         if data_quality is not None:
-            url += "&quality={}".format(data_quality)
+            query_params["quality"] = data_quality
         if data_number is not None:
-            url += "&number={}".format(data_number)
+            query_params["number"] = data_number
         with ForceLogin(user, self.client):
-            return self.client.get(url)
+            return self.client.get("/api/tasks/{}/data".format(tid), query_params=query_params)
 
     def _get_preview(self, tid, user):
         url = "/api/tasks/{}/preview".format(tid)
@@ -5669,14 +5677,17 @@ class JobAnnotationAPITestCase(ApiTestBase):
                 labels_response = list(
                     get_paginated_collection(
                         lambda page: self.client.get(
-                            "/api/labels?task_id=%s&page=%s" % (response.data["id"], page)
+                            "/api/labels",
+                            query_params={"task_id": response.data["id"], "page": page},
                         )
                     )
                 )
                 response.data["labels"] = labels_response
 
             jobs = get_paginated_collection(
-                lambda page: self.client.get("/api/jobs?task_id={}&page={}".format(tid, page))
+                lambda page: self.client.get(
+                    "/api/jobs", query_params={"task_id": tid, "page": page}
+                )
             )
 
         return (task, jobs)
@@ -5725,7 +5736,10 @@ class JobAnnotationAPITestCase(ApiTestBase):
     def _patch_api_v2_jobs_id_data(self, jid, user, action, data):
         with ForceLogin(user, self.client):
             response = self.client.patch(
-                "/api/jobs/{}/annotations?action={}".format(jid, action), data=data, format="json"
+                "/api/jobs/{}/annotations".format(jid),
+                query_params={"action": action},
+                data=data,
+                format="json",
             )
 
         return response
@@ -6167,7 +6181,10 @@ class TaskAnnotationAPITestCase(ExportApiTestBase, ImportApiTestBase, JobAnnotat
     def _patch_api_v2_tasks_id_annotations(self, pk, user, action, data):
         with ForceLogin(user, self.client):
             response = self.client.patch(
-                "/api/tasks/{}/annotations?action={}".format(pk, action), data=data, format="json"
+                "/api/tasks/{}/annotations".format(pk),
+                query_params={"action": action},
+                data=data,
+                format="json",
             )
 
         return response
@@ -7557,7 +7574,7 @@ class ServerShareAPITestCase(ApiTestBase):
 
     def _run_api_v2_server_share(self, user, directory):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/server/share?directory={}".format(directory))
+            response = self.client.get("/api/server/share", query_params={"directory": directory})
 
         return response
 
@@ -7659,7 +7676,7 @@ class ServerShareDifferentTypesAPITestCase(ApiTestBase):
 
     def _run_api_v2_server_share(self, directory):
         with ForceLogin(self.user, self.client):
-            response = self.client.get("/api/server/share?directory={}".format(directory))
+            response = self.client.get("/api/server/share", query_params={"directory": directory})
 
         return response
 
@@ -7864,8 +7881,10 @@ class TaskChangeCloudStorageTestCase(_CloudStorageTestBase):
             self.client.get(f"/api/tasks/{task_id}/preview")
             for quality in ["compressed", "original"]:
                 for frame in range(task["size"]):
-                    url = f"/api/tasks/{task_id}/data?type=frame&quality={quality}&number={frame}"
-                    self.client.get(url)
+                    self.client.get(
+                        f"/api/tasks/{task_id}/data",
+                        query_params={"type": "frame", "quality": quality, "number": frame},
+                    )
 
             self.assertGreater(len(get_cache_keys()), 0)
 

--- a/cvat/apps/engine/tests/test_rest_api_3D.py
+++ b/cvat/apps/engine/tests/test_rest_api_3D.py
@@ -68,7 +68,10 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
     def _patch_api_v2_task_id_annotations(self, tid, data, action, user):
         with ForceLogin(user, self.client):
             response = self.client.patch(
-                "/api/tasks/{}/annotations?action={}".format(tid, action), data=data, format="json"
+                "/api/tasks/{}/annotations".format(tid),
+                query_params={"action": action},
+                data=data,
+                format="json",
             )
 
         return response
@@ -76,7 +79,10 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
     def _patch_api_v2_job_id_annotations(self, jid, data, action, user):
         with ForceLogin(user, self.client):
             response = self.client.patch(
-                "/api/jobs/{}/annotations?action={}".format(jid, action), data=data, format="json"
+                "/api/jobs/{}/annotations".format(jid),
+                query_params={"action": action},
+                data=data,
+                format="json",
             )
 
         return response
@@ -100,7 +106,9 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
             if 200 <= response.status_code < 400:
                 labels_response = list(
                     get_paginated_collection(
-                        lambda page: self.client.get("/api/labels?task_id=%s&page=%s" % (tid, page))
+                        lambda page: self.client.get(
+                            "/api/labels", query_params={"task_id": tid, "page": page}
+                        )
                     )
                 )
                 response.data["labels"] = labels_response
@@ -146,7 +154,9 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
     def _get_jobs(self, task_id):
         with ForceLogin(self.admin, self.client):
             values = get_paginated_collection(
-                lambda page: self.client.get("/api/jobs?task_id={}&page={}".format(task_id, page))
+                lambda page: self.client.get(
+                    "/api/jobs", query_params={"task_id": task_id, "page": page}
+                )
             )
         return values
 

--- a/cvat/apps/engine/tests/utils.py
+++ b/cvat/apps/engine/tests/utils.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from pprint import pformat
 from typing import Any, NoReturn, Protocol, TypeVar
 from unittest import TestCase
-from urllib.parse import urlencode
 
 import av
 import django.test
@@ -144,7 +143,7 @@ class ApiTestBase(APITestCase):
         self, path: str, user: User, *, query_params: dict[str, Any] | None = None
     ) -> Response:
         with ForceLogin(user, self.client):
-            response = self.client.get(path, data=query_params)
+            response = self.client.get(path, query_params=query_params)
         return response
 
     def _delete_request(self, path: str, user: User):
@@ -158,16 +157,11 @@ class ApiTestBase(APITestCase):
         user: User,
         *,
         format: str = "json",  # pylint: disable=redefined-builtin
-        query_params: dict[str, Any] = None,
+        query_params: dict[str, Any] | None = None,
         data: dict[str, Any] | None = None,
     ):
-        if query_params:
-            # Note: once we upgrade to Django 5.1+, this should be changed to pass query_params
-            # directly to self.client.
-            assert "?" not in path
-            path += "?" + urlencode(query_params)
         with ForceLogin(user, self.client):
-            response = self.client.post(path, data=data, format=format)
+            response = self.client.post(path, data=data, format=format, query_params=query_params)
         return response
 
     def _patch_request(self, path: str, user: str, *, data: dict[str, Any] | None = None):

--- a/cvat/apps/engine/utils.py
+++ b/cvat/apps/engine/utils.py
@@ -30,12 +30,10 @@ from datumaro.util.os_util import walk
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import connection, transaction
-from django.utils.http import urlencode
 from django_rq.queues import DjangoRQ
 from django_sendfile import sendfile as _sendfile
 from PIL import Image
 from redis.lock import Lock
-from rest_framework.reverse import reverse as _reverse
 from rq.job import Job as RQJob
 
 from cvat.apps.engine.types import ExtendedRequest
@@ -198,28 +196,6 @@ def get_rq_lock_for_job(
         timeout=timeout,
         blocking_timeout=blocking_timeout,
     )
-
-
-def reverse(
-    viewname,
-    *,
-    args=None,
-    kwargs=None,
-    query_params: dict[str, str] | None = None,
-    request: ExtendedRequest | None = None,
-) -> str:
-    """
-    The same as rest_framework's reverse(), but adds custom query params support.
-    The original request can be passed in the 'request' parameter to
-    return absolute URLs.
-    """
-
-    url = _reverse(viewname, args, kwargs, request)
-
-    if query_params:
-        return f"{url}?{urlencode(query_params)}"
-
-    return url
 
 
 def build_field_filter_params(field: str, value: Any) -> dict[str, str]:

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -1265,13 +1265,17 @@ class TestComplexFrameSetupCases(_LambdaTestCaseBase):
 
         self.labels = get_paginated_collection(
             lambda page: self._get_request(
-                f"/api/labels?task_id={self.task['id']}&page={page}&sort=id", self.admin
+                "/api/labels",
+                self.admin,
+                query_params={"task_id": self.task["id"], "page": page, "sort": "id"},
             )
         )
 
         self.jobs = get_paginated_collection(
             lambda page: self._get_request(
-                f"/api/jobs?task_id={self.task['id']}&page={page}", self.admin
+                "/api/jobs",
+                self.admin,
+                query_params={"task_id": self.task["id"], "page": page},
             )
         )
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
* Remove `cvat.apps.engine.utils.reverse`, which is now unnecessary.

* Use `query_string` in tests instead of string formatting to ensure correct escaping.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
