### PR TITLE
Fixed task backup export for tasks with media stored in cloud storage

### DIFF
--- a/changelog.d/20260512_131155_sekachev.bs.md
+++ b/changelog.d/20260512_131155_sekachev.bs.md
@@ -1,4 +1,5 @@
 ### Fixed
 
-- Fixed task backup export for tasks with media stored in backing cloud storage when image database rows are returned out of frame order
+- Fixed task backup export for tasks with media stored in backing cloud storage
+  when image database rows are returned out of frame order
   (<https://github.com/cvat-ai/cvat/pull/10589>)

--- a/changelog.d/20260512_131155_sekachev.bs.md
+++ b/changelog.d/20260512_131155_sekachev.bs.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - Fixed task backup export for tasks with media stored in backing cloud storage when image database rows are returned out of frame order
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/10589>)

--- a/changelog.d/20260512_131155_sekachev.bs.md
+++ b/changelog.d/20260512_131155_sekachev.bs.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed task backup export for tasks with media stored in backing cloud storage when image database rows are returned out of frame order
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/changelog.d/20260512_131155_sekachev.bs.md
+++ b/changelog.d/20260512_131155_sekachev.bs.md
@@ -1,5 +1,5 @@
 ### Fixed
 
-- Fixed task backup export for tasks with media stored in backing cloud storage
+- Fixed task backup export for tasks with media stored in cloud storage
   when image database rows are returned out of frame order
   (<https://github.com/cvat-ai/cvat/pull/10589>)

--- a/cvat/apps/engine/backup.py
+++ b/cvat/apps/engine/backup.py
@@ -502,7 +502,7 @@ class TaskExporter(_ExporterBase, _TaskBackupBase):
 
         frame_ids_to_download = []
         frame_names_to_download = []
-        for media_file in self._db_data.images.all():
+        for media_file in self._db_data.images.order_by("frame").all():
             media_path = media_file.path
 
             local_path = os.path.join(data_dir, media_path)


### PR DESCRIPTION

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
This PR fixes backup export for tasks whose media is stored in backing cloud storage. The backup path collected image frame ids from engine_image without ordering them, but the downstream raw-image reader expects ascending frame ids. When PostgreSQL returned rows in physical order instead of frame order, export could fail with a misleading AssertionError: frame #0 is missing from DB even though frame 0 existed. Ordering images by frame before download makes the backup path deterministic and matches the reader contract.



### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
