### PR TITLE
Refactor redis_handler migration tests

### DIFF
--- a/cvat/apps/redis_handler/tests/test_redis_migrations.py
+++ b/cvat/apps/redis_handler/tests/test_redis_migrations.py
@@ -2,82 +2,66 @@
 #
 # SPDX-License-Identifier: MIT
 
+import contextlib
 import io
-import os
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
 import fakeredis
+from django.apps import apps
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from cvat.apps.redis_handler.migration_loader import AppliedMigration, LoaderError, MigrationLoader
-from cvat.apps.redis_handler.utils import get_class_from_module
-
-from .utils import path_to_module
-
-WORKDIR = Path("cvat/apps")
-
-MIGRATION_DIR = MigrationLoader.REDIS_MIGRATIONS_DIR_NAME
-MIGRATION_CLASS_NAME = MigrationLoader.REDIS_MIGRATION_CLASS_NAME
-MIGRATION_NAME_FORMAT = "{:03}_{}.py"
-BAD_MIGRATION_FILE = """\
-class Migration:
-    @classmethod
-    def run(cls): ...
-
-"""
+from cvat.apps.redis_handler import migration_loader as ml_module
+from cvat.apps.redis_handler.migration_loader import (
+    AppliedMigration,
+    LoaderError,
+    MigrationLoader,
+)
 
 
-def _write_migration_file(app_name: str, filename: str) -> Path:
-    migration_dir = WORKDIR / app_name / MIGRATION_DIR
-    migration_dir.mkdir(exist_ok=True)
-    path = migration_dir / filename
-    path.write_text(BAD_MIGRATION_FILE)
-    return path
+@contextlib.contextmanager
+def _extra_migrations(*extra_filenames: str):
+    """Yield real ``iter_migration_files()`` entries plus virtual
+    ``(app_config, Path)`` pairs for the redis_handler app, without writing to disk."""
+    app_config = apps.get_app_config("redis_handler")
+    real_entries = list(MigrationLoader.iter_migration_files())
+
+    def fake_iter():
+        yield from real_entries
+        for name in extra_filenames:
+            yield app_config, Path(name)
+
+    with patch.object(MigrationLoader, "iter_migration_files", staticmethod(fake_iter)):
+        yield
+
+
+class TestCheckRedisMigrationsCommand(TestCase):
+    def test_rejects_bad_filename(self):
+        with _extra_migrations("1_bad.py"):
+            err = io.StringIO()
+            with self.assertRaises(CommandError):
+                call_command("checkredismigrations", stderr=err)
+
+            self.assertIn("1_bad.py", err.getvalue())
+
+    def test_rejects_duplicate_prefix(self):
+        with _extra_migrations("000_dup_a.py", "000_dup_b.py"):
+            err = io.StringIO()
+            with self.assertRaises(CommandError):
+                call_command("checkredismigrations", stderr=err)
+
+            self.assertIn("redis_handler", err.getvalue())
+            self.assertIn("'000'", err.getvalue())
 
 
 @patch(
-    f"cvat.apps.redis_handler.management.commands.migrateredis.Redis",
+    "cvat.apps.redis_handler.management.commands.migrateredis.Redis",
     return_value=fakeredis.FakeRedis(),
 )
-class TestRedisMigrations(TestCase):
-    class BadMigration:
-
-        def __init__(self, app_name: str, migration_name: str):
-            self.app_name = app_name
-            self.app_path = WORKDIR / app_name
-            assert self.app_path.exists()
-            self.migration_name = migration_name
-            self.number = 0
-
-            self.migration_file_path = self.generate_migration_file()
-            mock_migration_module_path = path_to_module(self.migration_file_path)
-
-            self.test_class = get_class_from_module(
-                mock_migration_module_path, MIGRATION_CLASS_NAME
-            )
-            assert self.test_class is not None
-
-        def make_migration_name(self):
-            return MIGRATION_NAME_FORMAT.format(self.number, self.migration_name)
-
-        def generate_migration_file(self) -> Path:
-            migration_dir = self.app_path / MIGRATION_DIR
-            if not os.path.exists(migration_dir):
-                os.mkdir(migration_dir)
-            filename = self.make_migration_name()
-            migration_file_path = migration_dir / filename
-            with open(migration_file_path, "w") as file:
-                file.write(BAD_MIGRATION_FILE)
-            return migration_file_path
-
-        def cleanup(self):
-            os.remove(self.migration_file_path)
-
+class TestMigrateRedisCommand(TestCase):
     def test_migration_added_and_applied(self, redis):
-
         # Keys are not added yet
         with self.assertRaises(SystemExit):
             call_command("migrateredis", check=True)
@@ -88,7 +72,6 @@ class TestRedisMigrations(TestCase):
         # Keys are added
         self.assertIsNone(call_command("migrateredis", check=True))
 
-        # Check keys added
         expected_migrations = {
             f"{app_config.label}.{f.stem}".encode()
             for app_config, f in MigrationLoader.iter_migration_files()
@@ -100,47 +83,35 @@ class TestRedisMigrations(TestCase):
             self.assertEqual(expected_migrations, applied_migrations)
 
     def test_migration_bad(self, _):
-        self.test_migration = self.BadMigration("redis_handler", "bad")
-        self.addCleanup(self.test_migration.cleanup)
+        class NotABaseMigration:
+            @classmethod
+            def run(cls): ...
 
-        with patch.object(self.test_migration.test_class, "run") as mock_run:
+        original_get_class_from_module = ml_module.get_class_from_module
+
+        def fake_get_class_from_module(module_path, class_name):
+            if module_path.endswith(".000_bad"):
+                return NotABaseMigration
+            return original_get_class_from_module(module_path, class_name)
+
+        with (
+            _extra_migrations("000_bad.py"),
+            patch.object(ml_module, "get_class_from_module", fake_get_class_from_module),
+            patch.object(NotABaseMigration, "run") as mock_run,
+        ):
             with self.assertRaises(LoaderError):
                 call_command("migrateredis")
             mock_run.assert_not_called()
 
-    def test_checkredismigrations_rejects_bad_filename(self, _):
-        path = _write_migration_file("redis_handler", "1_bad.py")
-        self.addCleanup(path.unlink)
+    def test_aborts_on_bad_filename(self, redis):
+        with _extra_migrations("1_bad.py"):
+            with redis() as conn:
+                applied_before = set(conn.smembers(AppliedMigration.SET_KEY))
 
-        err = io.StringIO()
-        with self.assertRaises(CommandError):
-            call_command("checkredismigrations", stderr=err)
-        self.assertIn("1_bad.py", err.getvalue())
+            err = io.StringIO()
+            with self.assertRaises(CommandError):
+                call_command("migrateredis", stderr=err)
+            self.assertIn("1_bad.py", err.getvalue())
 
-    def test_checkredismigrations_rejects_duplicate_prefix(self, _):
-        path_a = _write_migration_file("redis_handler", "000_dup_a.py")
-        self.addCleanup(path_a.unlink)
-        path_b = _write_migration_file("redis_handler", "000_dup_b.py")
-        self.addCleanup(path_b.unlink)
-
-        err = io.StringIO()
-        with self.assertRaises(CommandError):
-            call_command("checkredismigrations", stderr=err)
-
-        self.assertIn("redis_handler", err.getvalue())
-        self.assertIn("'000'", err.getvalue())
-
-    def test_migrateredis_aborts_on_bad_filename(self, redis):
-        path = _write_migration_file("redis_handler", "1_bad.py")
-        self.addCleanup(path.unlink)
-
-        with redis() as conn:
-            applied_before = set(conn.smembers(AppliedMigration.SET_KEY))
-
-        err = io.StringIO()
-        with self.assertRaises(CommandError):
-            call_command("migrateredis", stderr=err)
-        self.assertIn("1_bad.py", err.getvalue())
-
-        with redis() as conn:
-            self.assertEqual(set(conn.smembers(AppliedMigration.SET_KEY)), applied_before)
+            with redis() as conn:
+                self.assertEqual(set(conn.smembers(AppliedMigration.SET_KEY)), applied_before)

--- a/cvat/apps/redis_handler/tests/utils.py
+++ b/cvat/apps/redis_handler/tests/utils.py
@@ -1,5 +1,0 @@
-from pathlib import Path
-
-
-def path_to_module(path: Path) -> str:
-    return str(path).removesuffix(".py").replace("/", ".")


### PR DESCRIPTION
## Summary

Redis migration tests previously wrote real `.py` files into installed apps' on-disk `redis_migrations/` dirs and relied on cleanup callbacks; a crash between create and cleanup left stray files behind.

- Updated migration tests to avoid writing to the real migration dirs
- For the bad-class case, also patch `get_class_from_module` so the loader never tries to import a non-existent module.
- Split the suite into one class per Django management command (`checkredismigrations`, `migrateredis`).

## Test plan
- [x] `python -m django test cvat.apps.redis_handler.tests.test_redis_migrations` — 5/5 pass
- [x] Verify `cvat/apps/*/redis_migrations/` dirs untouched after run

🤖 Generated with [Claude Code](https://claude.com/claude-code)