### PR TITLE
Add shared tsconfig base for mounted UI plugins

### DIFF
--- a/cvat-ui/plugins/tsconfig.plugin.base.json
+++ b/cvat-ui/plugins/tsconfig.plugin.base.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "baseUrl": "../src",
+    "paths": {
+      "@modules/react": ["../../node_modules/@types/react"],
+      "@modules/react-dom": ["../../node_modules/@types/react-dom"],
+      "@modules/react-dom/*": ["../../node_modules/@types/react-dom/*"],
+      "@modules/*": ["../../node_modules/*"],
+      "@types/*": ["../../node_modules/*"],
+      "@root/*": ["*"]
+    },
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "react"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `cvat-ui/plugins/tsconfig.plugin.base.json` for plugins copied or linked into the CVAT UI plugin directory.
- Keep plugin `../tsconfig.plugin.base.json` extends valid after plugins are mounted under `cvat-ui/plugins`.

## Validation
- Parsed the mounted plugin base config with TypeScript.
- Verified aliases resolve to CVAT UI source and CVAT node modules from the mounted plugin location.
