### PR TITLE
Apply isort to serverless functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,6 @@ profile = "black"
 forced_separate = ["tests"]
 line_length = 100
 skip_gitignore = true # align tool behavior with Black
-extend_skip=[
-    # Correctly ordering the imports in serverless functions would
-    # require a pyproject.toml in every function; don't bother with it for now.
-    "serverless",
-]
 
 [tool.black]
 line-length = 100

--- a/serverless/openvino/omz/intel/face-detection-0205/nuclio/main.py
+++ b/serverless/openvino/omz/intel/face-detection-0205/nuclio/main.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
-import json
 import base64
-from PIL import Image
 import io
-from model_handler import FaceDetectorHandler, AttributesExtractorHandler
+import json
+
+from model_handler import AttributesExtractorHandler, FaceDetectorHandler
+from PIL import Image
 
 
 def init_context(context):

--- a/serverless/openvino/omz/intel/face-detection-0205/nuclio/model_handler.py
+++ b/serverless/openvino/omz/intel/face-detection-0205/nuclio/model_handler.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import os
+
 import numpy as np
 from model_loader import ModelLoader
 

--- a/serverless/openvino/omz/public/mask_rcnn_inception_resnet_v2_atrous_coco/nuclio/main.py
+++ b/serverless/openvino/omz/public/mask_rcnn_inception_resnet_v2_atrous_coco/nuclio/main.py
@@ -1,9 +1,10 @@
-import json
 import base64
-from PIL import Image
 import io
-from model_handler import ModelHandler
+import json
+
 import yaml
+from model_handler import ModelHandler
+from PIL import Image
 
 
 def init_context(context):

--- a/serverless/openvino/omz/public/mask_rcnn_inception_resnet_v2_atrous_coco/nuclio/model_handler.py
+++ b/serverless/openvino/omz/public/mask_rcnn_inception_resnet_v2_atrous_coco/nuclio/model_handler.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 import os
+
 import cv2
 import numpy as np
 from model_loader import ModelLoader

--- a/serverless/pytorch/facebookresearch/detectron2/retinanet_r101/nuclio/main.py
+++ b/serverless/pytorch/facebookresearch/detectron2/retinanet_r101/nuclio/main.py
@@ -1,13 +1,13 @@
-import json
 import base64
 import io
-from PIL import Image
+import json
 
 import torch
-from detectron2.model_zoo import get_config
+from detectron2.data.datasets.builtin_meta import COCO_CATEGORIES
 from detectron2.data.detection_utils import convert_PIL_to_numpy
 from detectron2.engine.defaults import DefaultPredictor
-from detectron2.data.datasets.builtin_meta import COCO_CATEGORIES
+from detectron2.model_zoo import get_config
+from PIL import Image
 
 CONFIG_OPTS = ["MODEL.WEIGHTS", "model_final_971ab9.pkl"]
 CONFIDENCE_THRESHOLD = 0.5

--- a/serverless/pytorch/facebookresearch/sam/nuclio/main.py
+++ b/serverless/pytorch/facebookresearch/sam/nuclio/main.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
-import json
 import base64
-from PIL import Image
 import io
+import json
+
 from model_handler import ModelHandler
+from PIL import Image
 
 
 def init_context(context):

--- a/serverless/pytorch/facebookresearch/sam/nuclio/model_handler.py
+++ b/serverless/pytorch/facebookresearch/sam/nuclio/model_handler.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 import torch
-from segment_anything import sam_model_registry, SamPredictor
+from segment_anything import SamPredictor, sam_model_registry
 
 
 class ModelHandler:

--- a/serverless/pytorch/mmpose/hrnet32/nuclio/main.py
+++ b/serverless/pytorch/mmpose/hrnet32/nuclio/main.py
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-import json
 import base64
 import io
-import yaml
-import numpy as np
-from PIL import Image
+import json
 
+import numpy as np
+import yaml
 from mmpose.apis import MMPoseInferencer
+from PIL import Image
 
 
 def init_context(context):

--- a/serverless/pytorch/shiyinzhang/iog/nuclio/main.py
+++ b/serverless/pytorch/shiyinzhang/iog/nuclio/main.py
@@ -3,12 +3,13 @@
 #
 # SPDX-License-Identifier: MIT
 
-import json
 import base64
-from PIL import Image
 import io
+import json
+
 import numpy as np
 from model_handler import ModelHandler
+from PIL import Image
 
 
 def init_context(context):

--- a/serverless/pytorch/shiyinzhang/iog/nuclio/model_handler.py
+++ b/serverless/pytorch/shiyinzhang/iog/nuclio/model_handler.py
@@ -3,12 +3,13 @@
 #
 # SPDX-License-Identifier: MIT
 
-import numpy as np
 import os
+
 import cv2
+import numpy as np
 import torch
-from networks.mainnetwork import Network
 from dataloaders import helpers
+from networks.mainnetwork import Network
 
 
 def mask_to_rle(mask):

--- a/serverless/tensorflow/faster_rcnn_inception_v2_coco/nuclio/main.py
+++ b/serverless/tensorflow/faster_rcnn_inception_v2_coco/nuclio/main.py
@@ -1,9 +1,10 @@
-import json
 import base64
 import io
-from PIL import Image
+import json
+
 import yaml
 from model_loader import ModelLoader
+from PIL import Image
 
 
 def init_context(context):

--- a/serverless/tensorflow/faster_rcnn_inception_v2_coco/nuclio/model_loader.py
+++ b/serverless/tensorflow/faster_rcnn_inception_v2_coco/nuclio/model_loader.py
@@ -1,6 +1,6 @@
 import numpy as np
-from PIL import Image
 import tensorflow.compat.v1 as tf
+from PIL import Image
 
 tf.disable_v2_behavior()
 


### PR DESCRIPTION
### Motivation and context

Continuing to remove formatting exceptions from `pyproject.toml`.

Removes the `extend_skip = ["serverless"]` entry from the isort config and applies `isort` to the affected files.

### How has this been tested?

Ran `dev/format_python_code.sh` (isort portion) on `serverless/`.

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have updated the documentation accordingly (n/a)
- [x] I have added tests to cover my changes (n/a — formatting only)
- [x] I have linked related issues (see CVAT-AI/cvat#... — none)

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.

> [!IMPORTANT]
> Make sure to merge without squashing.
