### PR TITLE
Blacken `engine/models.py`

### DIFF
--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -44,14 +44,14 @@ class SafeCharField(models.CharField):
     def get_prep_value(self, value):
         value = super().get_prep_value(value)
         if value:
-            return value[:self.max_length]
+            return value[: self.max_length]
         return value
 
 
 class DimensionType(str, Enum):
-    DIM_1D = '1d'
-    DIM_2D = '2d'
-    DIM_3D = '3d'
+    DIM_1D = "1d"
+    DIM_2D = "2d"
+    DIM_3D = "3d"
 
     @classmethod
     def choices(cls):
@@ -59,13 +59,14 @@ class DimensionType(str, Enum):
 
     def __str__(self):
         return self.value
+
 
 class StatusChoice(str, Enum):
     """Deprecated. Use StageChoice and StateChoice instead"""
 
-    ANNOTATION = 'annotation'
-    VALIDATION = 'validation'
-    COMPLETED = 'completed'
+    ANNOTATION = "annotation"
+    VALIDATION = "validation"
+    COMPLETED = "completed"
 
     @classmethod
     def choices(cls):
@@ -77,18 +78,19 @@ class StatusChoice(str, Enum):
 
     def __str__(self):
         return self.value
+
 
 class LabelType(str, Enum):
-    ANY = 'any'
-    CUBOID = 'cuboid'
-    ELLIPSE = 'ellipse'
-    MASK = 'mask'
-    POINTS = 'points'
-    POLYGON = 'polygon'
-    POLYLINE = 'polyline'
-    RECTANGLE = 'rectangle'
-    SKELETON = 'skeleton'
-    TAG = 'tag'
+    ANY = "any"
+    CUBOID = "cuboid"
+    ELLIPSE = "ellipse"
+    MASK = "mask"
+    POINTS = "points"
+    POLYGON = "polygon"
+    POLYLINE = "polyline"
+    RECTANGLE = "rectangle"
+    SKELETON = "skeleton"
+    TAG = "tag"
 
     @classmethod
     def choices(cls):
@@ -101,10 +103,11 @@ class LabelType(str, Enum):
     def __str__(self):
         return self.value
 
+
 class StageChoice(str, Enum):
-    ANNOTATION = 'annotation'
-    VALIDATION = 'validation'
-    ACCEPTANCE = 'acceptance'
+    ANNOTATION = "annotation"
+    VALIDATION = "validation"
+    ACCEPTANCE = "acceptance"
 
     @classmethod
     def choices(cls):
@@ -112,12 +115,13 @@ class StageChoice(str, Enum):
 
     def __str__(self):
         return self.value
+
 
 class StateChoice(str, Enum):
-    NEW = 'new'
-    IN_PROGRESS = 'in progress'
-    COMPLETED = 'completed'
-    REJECTED = 'rejected'
+    NEW = "new"
+    IN_PROGRESS = "in progress"
+    COMPLETED = "completed"
+    REJECTED = "rejected"
 
     @classmethod
     def choices(cls):
@@ -125,10 +129,11 @@ class StateChoice(str, Enum):
 
     def __str__(self):
         return self.value
+
 
 class DataChoice(str, Enum):
-    VIDEO = 'video'
-    IMAGESET = 'imageset'
+    VIDEO = "video"
+    IMAGESET = "imageset"
 
     @classmethod
     def choices(cls):
@@ -136,10 +141,11 @@ class DataChoice(str, Enum):
 
     def __str__(self):
         return self.value
+
 
 class StorageMethodChoice(str, Enum):
-    CACHE = 'cache'
-    FILE_SYSTEM = 'file_system'
+    CACHE = "cache"
+    FILE_SYSTEM = "file_system"
 
     @classmethod
     def choices(cls):
@@ -147,11 +153,12 @@ class StorageMethodChoice(str, Enum):
 
     def __str__(self):
         return self.value
+
 
 class StorageChoice(str, Enum):
-    CLOUD_STORAGE = 'cloud_storage'
-    LOCAL = 'local'
-    SHARE = 'share'
+    CLOUD_STORAGE = "cloud_storage"
+    LOCAL = "local"
+    SHARE = "share"
 
     @classmethod
     def choices(cls):
@@ -159,12 +166,13 @@ class StorageChoice(str, Enum):
 
     def __str__(self):
         return self.value
+
 
 class SortingMethod(str, Enum):
-    LEXICOGRAPHICAL = 'lexicographical'
-    NATURAL = 'natural'
-    PREDEFINED = 'predefined'
-    RANDOM = 'random'
+    LEXICOGRAPHICAL = "lexicographical"
+    NATURAL = "natural"
+    PREDEFINED = "predefined"
+    RANDOM = "random"
 
     @classmethod
     def choices(cls):
@@ -172,11 +180,12 @@ class SortingMethod(str, Enum):
 
     def __str__(self):
         return self.value
+
 
 class JobType(str, Enum):
-    ANNOTATION = 'annotation'
-    GROUND_TRUTH = 'ground_truth'
-    CONSENSUS_REPLICA = 'consensus_replica'
+    ANNOTATION = "annotation"
+    GROUND_TRUTH = "ground_truth"
+    CONSENSUS_REPLICA = "consensus_replica"
 
     @classmethod
     def choices(cls):
@@ -185,10 +194,11 @@ class JobType(str, Enum):
     def __str__(self):
         return self.value
 
+
 class JobFrameSelectionMethod(str, Enum):
-    RANDOM_UNIFORM = 'random_uniform'
-    RANDOM_PER_JOB = 'random_per_job'
-    MANUAL = 'manual'
+    RANDOM_UNIFORM = "random_uniform"
+    RANDOM_PER_JOB = "random_per_job"
+    MANUAL = "manual"
 
     @classmethod
     def choices(cls):
@@ -207,7 +217,7 @@ class AbstractArrayField(models.TextField):
     ):
         self._store_sorted = store_sorted
         self._unique_values = unique_values
-        super().__init__(*args,**{'default': '', **kwargs})
+        super().__init__(*args, **{"default": "", **kwargs})
 
     def from_db_value(self, value, expression, connection):
         if not value:
@@ -230,8 +240,10 @@ class AbstractArrayField(models.TextField):
             value = sorted(value)
         return self.separator.join(map(str, value))
 
+
 class FloatArrayField(AbstractArrayField):
     converter = float
+
 
 class IntArrayField(AbstractArrayField):
     converter = int
@@ -256,8 +268,8 @@ class CloudProviderChoice(TextChoices):
 
 class CredentialsTypeChoice(str, Enum):
     # ignore bandit issues because false positives
-    KEY_SECRET_KEY_PAIR = "KEY_SECRET_KEY_PAIR" # nosec
-    ACCOUNT_NAME_TOKEN_PAIR = "ACCOUNT_NAME_TOKEN_PAIR" # nosec
+    KEY_SECRET_KEY_PAIR = "KEY_SECRET_KEY_PAIR"  # nosec
+    ACCOUNT_NAME_TOKEN_PAIR = "ACCOUNT_NAME_TOKEN_PAIR"  # nosec
     KEY_FILE_PATH = "KEY_FILE_PATH"
     ANONYMOUS_ACCESS = "ANONYMOUS_ACCESS"
     CONNECTION_STRING = "CONNECTION_STRING"
@@ -290,16 +302,28 @@ class CloudStorage(TimestampedModel):
     provider_type = models.CharField(max_length=20, choices=CloudProviderChoice.choices)
     resource = models.CharField(max_length=222)
     display_name = models.CharField(max_length=63)
-    owner = models.ForeignKey(User, null=True, blank=True,
-        on_delete=models.SET_NULL, related_name="cloud_storages", related_query_name="cloud_storage"
+    owner = models.ForeignKey(
+        User,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="cloud_storages",
+        related_query_name="cloud_storage",
     )
     credentials = models.CharField(max_length=1024, null=True, blank=True)
-    credentials_type = models.CharField(max_length=29, choices=CredentialsTypeChoice.choices())#auth_type
+    credentials_type = models.CharField(
+        max_length=29, choices=CredentialsTypeChoice.choices()
+    )  # auth_type
     specific_attributes = models.CharField(max_length=1024, blank=True)
     description = models.TextField(blank=True)
-    organization = models.ForeignKey("organizations.Organization", null=True, default=None,
-        blank=True, on_delete=models.SET_NULL,
-        related_name="cloud_storages", related_query_name="cloud_storage",
+    organization = models.ForeignKey(
+        "organizations.Organization",
+        null=True,
+        default=None,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="cloud_storages",
+        related_query_name="cloud_storage",
     )
 
     class Meta:
@@ -366,9 +390,10 @@ class ValidationMode(str, Enum):
     def __str__(self):
         return self.value
 
+
 class ValidationParams(models.Model):
     task_data = models.OneToOneField(
-        'Data', on_delete=models.CASCADE, related_name="validation_params"
+        "Data", on_delete=models.CASCADE, related_name="validation_params"
     )
 
     mode = models.CharField(max_length=32, choices=ValidationMode.choices())
@@ -384,18 +409,22 @@ class ValidationParams(models.Model):
     frames_per_job_count = models.IntegerField(null=True)
     frames_per_job_share = models.FloatField(null=True)
 
+
 class ValidationFrame(models.Model):
     validation_params = models.ForeignKey(
-        ValidationParams, on_delete=models.CASCADE,
-        related_name="frames", related_query_name="frame",
+        ValidationParams,
+        on_delete=models.CASCADE,
+        related_name="frames",
+        related_query_name="frame",
     )
-    path = models.CharField(max_length=1024, default='')
+    path = models.CharField(max_length=1024, default="")
+
 
 class ValidationLayout(models.Model):
     "Represents validation configuration in a task"
 
     task_data = models.OneToOneField(
-        'Data', on_delete=models.CASCADE, related_name="validation_layout"
+        "Data", on_delete=models.CASCADE, related_name="validation_layout"
     )
 
     mode = models.CharField(max_length=32, choices=ValidationMode.choices())
@@ -420,7 +449,7 @@ class FrameQuality(IntEnum):
 
 
 class Data(models.Model):
-    MANIFEST_FILENAME: ClassVar[str] = 'manifest.jsonl'
+    MANIFEST_FILENAME: ClassVar[str] = "manifest.jsonl"
 
     # Content descriptors
     content_size = models.PositiveBigIntegerField(null=True)
@@ -440,20 +469,34 @@ class Data(models.Model):
     # Cache descriptors
     chunk_size = models.PositiveIntegerField(null=True)
     image_quality = models.PositiveSmallIntegerField(default=0)
-    compressed_chunk_type = models.CharField(max_length=32, choices=DataChoice.choices(),
-        blank=True, default="")
-    original_chunk_type = models.CharField(max_length=32, choices=DataChoice.choices(),
-        blank=True, default="")
+    compressed_chunk_type = models.CharField(
+        max_length=32, choices=DataChoice.choices(), blank=True, default=""
+    )
+    original_chunk_type = models.CharField(
+        max_length=32, choices=DataChoice.choices(), blank=True, default=""
+    )
 
     # Storage descriptors
-    storage_method = models.CharField(max_length=15, choices=StorageMethodChoice.choices(), default=StorageMethodChoice.FILE_SYSTEM)
-    storage = models.CharField(max_length=15, choices=StorageChoice.choices(), default=StorageChoice.LOCAL)
-    local_storage_backing_cs = models.ForeignKey(CloudStorage, on_delete=models.PROTECT, null=True, related_name="+")
+    storage_method = models.CharField(
+        max_length=15,
+        choices=StorageMethodChoice.choices(),
+        default=StorageMethodChoice.FILE_SYSTEM,
+    )
+    storage = models.CharField(
+        max_length=15, choices=StorageChoice.choices(), default=StorageChoice.LOCAL
+    )
+    local_storage_backing_cs = models.ForeignKey(
+        CloudStorage, on_delete=models.PROTECT, null=True, related_name="+"
+    )
     local_storage_backing_cs_id: int | None
-    cloud_storage = models.ForeignKey(CloudStorage, on_delete=models.SET_NULL, null=True, related_name='data')
+    cloud_storage = models.ForeignKey(
+        CloudStorage, on_delete=models.SET_NULL, null=True, related_name="data"
+    )
 
     # Task creation parameters
-    sorting_method = models.CharField(max_length=15, choices=SortingMethod.choices(), default=SortingMethod.LEXICOGRAPHICAL)
+    sorting_method = models.CharField(
+        max_length=15, choices=SortingMethod.choices(), default=SortingMethod.LEXICOGRAPHICAL
+    )
     client_files: models.manager.RelatedManager[ClientFile]
     server_files: models.manager.RelatedManager[ServerFile]
     remote_files: models.manager.RelatedManager[RemoteFile]
@@ -501,13 +544,13 @@ class Data(models.Model):
     @staticmethod
     def _get_chunk_name(segment_id: int, chunk_number: int, chunk_type: DataChoice | str) -> str:
         if chunk_type == DataChoice.VIDEO:
-            ext = 'mp4'
+            ext = "mp4"
         elif chunk_type == DataChoice.IMAGESET:
-            ext = 'zip'
+            ext = "zip"
         else:
             assert False, f"Unexpected chunk type '{chunk_type}'"
 
-        return 'segment_{}-{}.{}'.format(segment_id, chunk_number, ext)
+        return "segment_{}-{}.{}".format(segment_id, chunk_number, ext)
 
     def get_static_segment_chunk_path(
         self, chunk_number: int, segment_id: int, quality: FrameQuality
@@ -543,16 +586,15 @@ class Data(models.Model):
 
     @property
     def validation_mode(self) -> ValidationMode | None:
-        return getattr(getattr(self, 'validation_layout', None), 'mode', None)
+        return getattr(getattr(self, "validation_layout", None), "mode", None)
 
     def get_all_media_rel_paths(self) -> list[PurePath]:
         if video := getattr(self, "video", None):
             return [PurePath(video.path)]
         else:
-            return (
-                [PurePath(image.path) for image in self.images.filter(is_placeholder=False)]
-                + [PurePath(f.path) for f in self.related_files.all()]
-            )
+            return [PurePath(image.path) for image in self.images.filter(is_placeholder=False)] + [
+                PurePath(f.path) for f in self.related_files.all()
+            ]
 
     def get_cloud_storage_instance(self) -> AbstractCloudStorage | None:
         from .cloud_provider import SubdirectoryCloudStorage, db_storage_to_storage_instance
@@ -635,7 +677,7 @@ class Data(models.Model):
 
 class Video(models.Model):
     data = models.OneToOneField(Data, on_delete=models.CASCADE, related_name="video", null=True)
-    path = models.CharField(max_length=1024, default='')
+    path = models.CharField(max_length=1024, default="")
     width = models.PositiveIntegerField()
     height = models.PositiveIntegerField()
 
@@ -654,7 +696,7 @@ class Image(models.Model):
     data = models.ForeignKey(
         Data, on_delete=models.CASCADE, related_name="images", related_query_name="image", null=True
     )
-    path = models.CharField(max_length=1024, default='')
+    path = models.CharField(max_length=1024, default="")
     frame = models.PositiveIntegerField()
     width = models.PositiveIntegerField()
     height = models.PositiveIntegerField()
@@ -665,10 +707,15 @@ class Image(models.Model):
     class Meta:
         default_permissions = ()
 
+
 class AssignableModel(models.Model):
     assignee = models.ForeignKey(
-        User, null=True, blank=True, on_delete=models.SET_NULL,
-        related_name="assigned_%(class)ss", related_query_name="assigned_%(class)s"
+        User,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="assigned_%(class)ss",
+        related_query_name="assigned_%(class)s",
     )
     assignee_updated_date = models.DateTimeField(null=True, blank=True, default=None)
 
@@ -693,10 +740,10 @@ class AssignableModel(models.Model):
 class ABCModelMeta(ABCMeta, ModelBase):
     pass
 
+
 class FileSystemRelatedModel(metaclass=ABCModelMeta):
     @abstractmethod
-    def get_dirname(self) -> Path:
-        ...
+    def get_dirname(self) -> Path: ...
 
     def get_tmp_dirname(self) -> Path:
         """
@@ -746,28 +793,44 @@ def clear_annotations_on_frames_in_honeypot_task(db_task: Task, frames: Sequence
             frame__in=frames_batch,
         ).delete()
 
+
 class Project(TimestampedModel, AssignableModel, FileSystemRelatedModel):
     name = SafeCharField(max_length=256)
-    owner = models.ForeignKey(User, null=True, blank=True,
-                              on_delete=models.SET_NULL, related_name="+")
+    owner = models.ForeignKey(
+        User, null=True, blank=True, on_delete=models.SET_NULL, related_name="+"
+    )
 
     bug_tracker = models.CharField(max_length=2000, blank=True, default="")
-    status = models.CharField(max_length=32, choices=StatusChoice.choices(),
-                              default=StatusChoice.ANNOTATION)
-    organization = models.ForeignKey('organizations.Organization', null=True, default=None,
-        blank=True, on_delete=models.SET_NULL, related_name="projects")
-    source_storage = models.ForeignKey(Storage, null=True, default=None,
-        blank=True, on_delete=models.SET_NULL, related_name='+')
-    target_storage = models.ForeignKey(Storage, null=True, default=None,
-        blank=True, on_delete=models.SET_NULL, related_name='+')
+    status = models.CharField(
+        max_length=32, choices=StatusChoice.choices(), default=StatusChoice.ANNOTATION
+    )
+    organization = models.ForeignKey(
+        "organizations.Organization",
+        null=True,
+        default=None,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="projects",
+    )
+    source_storage = models.ForeignKey(
+        Storage, null=True, default=None, blank=True, on_delete=models.SET_NULL, related_name="+"
+    )
+    target_storage = models.ForeignKey(
+        Storage, null=True, default=None, blank=True, on_delete=models.SET_NULL, related_name="+"
+    )
 
     tasks: models.manager.RelatedManager[Task]
 
     def get_labels(self, prefetch=False):
-        queryset = self.label_set.filter(parent__isnull=True).select_related('skeleton')
-        return queryset.prefetch_related(
-            'attributespec_set', 'sublabels__attributespec_set',
-        ) if prefetch else queryset
+        queryset = self.label_set.filter(parent__isnull=True).select_related("skeleton")
+        return (
+            queryset.prefetch_related(
+                "attributespec_set",
+                "sublabels__attributespec_set",
+            )
+            if prefetch
+            else queryset
+        )
 
     def get_dirname(self) -> Path:
         return settings.PROJECTS_ROOT / str(self.id)
@@ -779,9 +842,12 @@ class Project(TimestampedModel, AssignableModel, FileSystemRelatedModel):
         if self.assignee == user_id:
             return True
 
-        return self.tasks.prefetch_related('segment_set', 'segment_set__job_set').filter(
-            Q(owner=user_id) | Q(assignee=user_id) | Q(segment__job__assignee=user_id)
-        ).count() > 0
+        return (
+            self.tasks.prefetch_related("segment_set", "segment_set__job_set")
+            .filter(Q(owner=user_id) | Q(assignee=user_id) | Q(segment__job__assignee=user_id))
+            .count()
+            > 0
+        )
 
     @cache_deleted
     @transaction.atomic(savepoint=False)
@@ -802,6 +868,7 @@ class Project(TimestampedModel, AssignableModel, FileSystemRelatedModel):
     def __str__(self):
         return self.name
 
+
 class TaskQuerySet(models.QuerySet):
     class JobSummaryFields(str, Enum):
         total_jobs_count = "total_jobs_count"
@@ -812,15 +879,15 @@ class TaskQuerySet(models.QuerySet):
         Fields = self.JobSummaryFields
         return self.annotate(
             **{
-                Fields.total_jobs_count.value: models.Count('segment__job', distinct=True),
+                Fields.total_jobs_count.value: models.Count("segment__job", distinct=True),
                 Fields.completed_jobs_count.value: models.Count(
-                    'segment__job',
-                    filter=models.Q(segment__job__state=StateChoice.COMPLETED.value) &
-                        models.Q(segment__job__stage=StageChoice.ACCEPTANCE.value),
+                    "segment__job",
+                    filter=models.Q(segment__job__state=StateChoice.COMPLETED.value)
+                    & models.Q(segment__job__stage=StageChoice.ACCEPTANCE.value),
                     distinct=True,
                 ),
                 Fields.validation_jobs_count.value: models.Count(
-                    'segment__job',
+                    "segment__job",
                     filter=models.Q(segment__job__stage=StageChoice.VALIDATION.value),
                     distinct=True,
                 ),
@@ -845,15 +912,27 @@ class MediaType(TextChoices):
 class Task(TimestampedModel, AssignableModel, FileSystemRelatedModel):
     objects = TaskQuerySet.as_manager()
 
-    project = models.ForeignKey(Project, on_delete=models.CASCADE,
-        null=True, blank=True, related_name="tasks",
-        related_query_name="task")
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="tasks",
+        related_query_name="task",
+    )
     name = SafeCharField(max_length=256)
-    owner = models.ForeignKey(User, null=True, blank=True,
-        on_delete=models.SET_NULL, related_name="tasks", related_query_name="task")
+    owner = models.ForeignKey(
+        User,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="tasks",
+        related_query_name="task",
+    )
     bug_tracker = models.CharField(max_length=2000, blank=True, default="")
-    status = models.CharField(max_length=32, choices=StatusChoice.choices(),
-                              default=StatusChoice.ANNOTATION)
+    status = models.CharField(
+        max_length=32, choices=StatusChoice.choices(), default=StatusChoice.ANNOTATION
+    )
 
     overlap = models.PositiveIntegerField(null=True)
 
@@ -865,17 +944,28 @@ class Task(TimestampedModel, AssignableModel, FileSystemRelatedModel):
     data = models.ForeignKey(
         Data, on_delete=models.CASCADE, null=True, related_name="tasks", related_query_name="task"
     )
-    dimension = models.CharField(max_length=2, choices=DimensionType.choices(), default="", blank=True)
+    dimension = models.CharField(
+        max_length=2, choices=DimensionType.choices(), default="", blank=True
+    )
     mode = models.CharField(max_length=32, choices=TaskMode.choices, default="", blank=True)
     media_type = models.CharField(max_length=32, choices=MediaType.choices, default="", blank=True)
 
     subset = models.CharField(max_length=64, blank=True, default="")
-    organization = models.ForeignKey('organizations.Organization', null=True, default=None,
-        blank=True, on_delete=models.SET_NULL, related_name="tasks", related_query_name="task")
-    source_storage = models.ForeignKey(Storage, null=True, default=None,
-        blank=True, on_delete=models.SET_NULL, related_name='+')
-    target_storage = models.ForeignKey(Storage, null=True, default=None,
-        blank=True, on_delete=models.SET_NULL, related_name='+')
+    organization = models.ForeignKey(
+        "organizations.Organization",
+        null=True,
+        default=None,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="tasks",
+        related_query_name="task",
+    )
+    source_storage = models.ForeignKey(
+        Storage, null=True, default=None, blank=True, on_delete=models.SET_NULL, related_name="+"
+    )
+    target_storage = models.ForeignKey(
+        Storage, null=True, default=None, blank=True, on_delete=models.SET_NULL, related_name="+"
+    )
     consensus_replicas = models.IntegerField(default=0)
     "Per job consensus replica count"
 
@@ -893,10 +983,15 @@ class Task(TimestampedModel, AssignableModel, FileSystemRelatedModel):
         if project:
             return project.get_labels(prefetch)
 
-        queryset = self.label_set.filter(parent__isnull=True).select_related('skeleton')
-        return queryset.prefetch_related(
-            'attributespec_set', 'sublabels__attributespec_set',
-        ) if prefetch else queryset
+        queryset = self.label_set.filter(parent__isnull=True).select_related("skeleton")
+        return (
+            queryset.prefetch_related(
+                "attributespec_set",
+                "sublabels__attributespec_set",
+            )
+            if prefetch
+            else queryset
+        )
 
     def get_dirname(self) -> Path:
         return settings.TASKS_ROOT / str(self.id)
@@ -906,7 +1001,9 @@ class Task(TimestampedModel, AssignableModel, FileSystemRelatedModel):
             return True
         if self.assignee == user_id:
             return True
-        return self.segment_set.prefetch_related('job_set').filter(job__assignee=user_id).count() > 0
+        return (
+            self.segment_set.prefetch_related("job_set").filter(job__assignee=user_id).count() > 0
+        )
 
     def require_data(self) -> Data:
         assert self.data is not None
@@ -948,14 +1045,15 @@ class Task(TimestampedModel, AssignableModel, FileSystemRelatedModel):
                 self.label_set.exclude(parent=None).delete()
             self.label_set.filter(parent=None).delete()
         else:
-            job_ids = list(self.segment_set.values_list('job__id', flat=True))
+            job_ids = list(self.segment_set.values_list("job__id", flat=True))
             clear_annotations_in_jobs(job_ids)
         super().delete(using, keep_parents)
 
     def get_chunks_updated_date(self) -> datetime.datetime:
-        return self.segment_set.aggregate(
-            chunks_updated_date=models.Max('chunks_updated_date')
-        )['chunks_updated_date']
+        return self.segment_set.aggregate(chunks_updated_date=models.Max("chunks_updated_date"))[
+            "chunks_updated_date"
+        ]
+
 
 # Redefined a couple of operation for FileSystemStorage to avoid renaming
 # or other side effects.
@@ -965,21 +1063,27 @@ class MyFileSystemStorage(FileSystemStorage):
 
     def get_available_name(self, name, max_length=None):
         if self.exists(name) or (max_length and len(name) > max_length):
-            raise IOError('`{}` file already exists or its name is too long'.format(name))
+            raise IOError("`{}` file already exists or its name is too long".format(name))
         return name
+
 
 def upload_path_handler(instance: ClientFile, filename: str) -> Path:
     # relative path is required since Django 3.1.11
     return instance.data.get_upload_dirname().relative_to(settings.BASE_DIR) / filename
 
+
 # For client files which the user is uploaded
 class ClientFile(models.Model):
     data = models.ForeignKey(
-        Data, on_delete=models.CASCADE, null=True,
-        related_name='client_files', related_query_name='client_file',
+        Data,
+        on_delete=models.CASCADE,
+        null=True,
+        related_name="client_files",
+        related_query_name="client_file",
     )
-    file = models.FileField(upload_to=upload_path_handler,
-        max_length=1024, storage=MyFileSystemStorage())
+    file = models.FileField(
+        upload_to=upload_path_handler, max_length=1024, storage=MyFileSystemStorage()
+    )
 
     class Meta:
         default_permissions = ()
@@ -987,13 +1091,17 @@ class ClientFile(models.Model):
 
         # Some DBs can shuffle the rows. Here we restore the insertion order.
         # https://github.com/cvat-ai/cvat/pull/5083#discussion_r1038032715
-        ordering = ('id', )
+        ordering = ("id",)
+
 
 # For server files on the mounted share
 class ServerFile(models.Model):
     data = models.ForeignKey(
-        Data, on_delete=models.CASCADE, null=True,
-        related_name='server_files', related_query_name='server_file',
+        Data,
+        on_delete=models.CASCADE,
+        null=True,
+        related_name="server_files",
+        related_query_name="server_file",
     )
     file = models.CharField(max_length=1024)
 
@@ -1003,13 +1111,17 @@ class ServerFile(models.Model):
 
         # Some DBs can shuffle the rows. Here we restore the insertion order.
         # https://github.com/cvat-ai/cvat/pull/5083#discussion_r1038032715
-        ordering = ('id', )
+        ordering = ("id",)
+
 
 # For URLs
 class RemoteFile(models.Model):
     data = models.ForeignKey(
-        Data, on_delete=models.CASCADE, null=True,
-        related_name='remote_files', related_query_name='remote_file',
+        Data,
+        on_delete=models.CASCADE,
+        null=True,
+        related_name="remote_files",
+        related_query_name="remote_file",
     )
     file = models.CharField(max_length=1024)
 
@@ -1019,14 +1131,17 @@ class RemoteFile(models.Model):
 
         # Some DBs can shuffle the rows. Here we restore the insertion order.
         # https://github.com/cvat-ai/cvat/pull/5083#discussion_r1038032715
-        ordering = ('id', )
+        ordering = ("id",)
 
 
 class RelatedFile(models.Model):
     data = models.ForeignKey(
-        Data, on_delete=models.CASCADE,
-        related_name="related_files", related_query_name="related_file",
-        default=1, null=True,
+        Data,
+        on_delete=models.CASCADE,
+        related_name="related_files",
+        related_query_name="related_file",
+        default=1,
+        null=True,
     )
     path = models.CharField(max_length=1024)
     images = models.ManyToManyField(
@@ -1039,12 +1154,12 @@ class RelatedFile(models.Model):
 
         # Some DBs can shuffle the rows. Here we restore the insertion order.
         # https://github.com/cvat-ai/cvat/pull/5083#discussion_r1038032715
-        ordering = ('id', )
+        ordering = ("id",)
 
 
 class SegmentType(str, Enum):
-    RANGE = 'range'
-    SPECIFIC_FRAMES = 'specific_frames'
+    RANGE = "range"
+    SPECIFIC_FRAMES = "specific_frames"
 
     @classmethod
     def choices(cls):
@@ -1056,14 +1171,14 @@ class SegmentType(str, Enum):
 
 class Segment(models.Model):
     # Common fields
-    task = models.ForeignKey(Task, on_delete=models.CASCADE) # TODO: add related name
+    task = models.ForeignKey(Task, on_delete=models.CASCADE)  # TODO: add related name
     start_frame = models.IntegerField()
     stop_frame = models.IntegerField()
     chunks_updated_date = models.DateTimeField(null=False, auto_now_add=True)
     type = models.CharField(choices=SegmentType.choices(), default=SegmentType.RANGE, max_length=32)
 
     # SegmentType.SPECIFIC_FRAMES fields
-    frames = IntArrayField(store_sorted=True, unique_values=True, default='', blank=True)
+    frames = IntArrayField(store_sorted=True, unique_values=True, default="", blank=True)
 
     job_set: models.manager.RelatedManager[Job]
 
@@ -1083,7 +1198,7 @@ class Segment(models.Model):
         frame_range = range(
             data_start_frame + self.start_frame * step,
             min(data_start_frame + self.stop_frame * step, data_stop_frame) + step,
-            step
+            step,
         )
 
         if self.type == SegmentType.RANGE:
@@ -1116,11 +1231,9 @@ class Segment(models.Model):
         default_permissions = ()
 
 
-
 class TaskGroundTruthJobsLimitError(ValidationError):
     def __init__(self) -> None:
         super().__init__("A task can have only 1 ground truth job")
-
 
 
 class JobQuerySet(models.QuerySet):
@@ -1149,21 +1262,25 @@ class JobQuerySet(models.QuerySet):
         return super().update_or_create(*args, **kwargs)
 
     def _validate_constraints(self, obj: dict[str, Any]):
-        if 'type' not in obj:
+        if "type" not in obj:
             return
 
         # Constraints can't be set on the related model fields
         # This method requires the save operation to be called as a transaction
-        if obj['type'] == JobType.GROUND_TRUTH and self.filter(
-            segment__task=obj['segment'].task, type=JobType.GROUND_TRUTH.value
-        ).count() != 0:
+        if (
+            obj["type"] == JobType.GROUND_TRUTH
+            and self.filter(
+                segment__task=obj["segment"].task, type=JobType.GROUND_TRUTH.value
+            ).count()
+            != 0
+        ):
             raise TaskGroundTruthJobsLimitError()
 
     def with_issue_counts(self):
-        return self.annotate(issue__count=models.Count('issue'))
+        return self.annotate(issue__count=models.Count("issue"))
 
     def with_child_jobs_counts(self):
-        return self.annotate(child_jobs__count=models.Count('child_job'))
+        return self.annotate(child_jobs__count=models.Count("child_job"))
 
 
 class Job(TimestampedModel, AssignableModel, FileSystemRelatedModel):
@@ -1175,17 +1292,21 @@ class Job(TimestampedModel, AssignableModel, FileSystemRelatedModel):
     # The stage field cannot be changed by an assignee, but state field can be. For
     # now status is read only and it will be updated by (stage, state). Thus we don't
     # need to update Task and Project (all should work as previously).
-    status = models.CharField(max_length=32, choices=StatusChoice.choices(),
-        default=StatusChoice.ANNOTATION)
-    stage = models.CharField(max_length=32, choices=StageChoice.choices(),
-        default=StageChoice.ANNOTATION)
-    state = models.CharField(max_length=32, choices=StateChoice.choices(),
-        default=StateChoice.NEW)
-    type = models.CharField(max_length=32, choices=JobType.choices(),
-        default=JobType.ANNOTATION)
+    status = models.CharField(
+        max_length=32, choices=StatusChoice.choices(), default=StatusChoice.ANNOTATION
+    )
+    stage = models.CharField(
+        max_length=32, choices=StageChoice.choices(), default=StageChoice.ANNOTATION
+    )
+    state = models.CharField(max_length=32, choices=StateChoice.choices(), default=StateChoice.NEW)
+    type = models.CharField(max_length=32, choices=JobType.choices(), default=JobType.ANNOTATION)
     parent_job = models.ForeignKey(
-        'self', on_delete=models.CASCADE, null=True, blank=True,
-        related_name='child_jobs', related_query_name="child_job"
+        "self",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="child_jobs",
+        related_query_name="child_job",
     )
 
     labeledimage_set: models.manager.RelatedManager[LabeledImage]
@@ -1224,7 +1345,7 @@ class Job(TimestampedModel, AssignableModel, FileSystemRelatedModel):
         source = self.segment.task.project
         if not source:
             source = self.segment.task
-        if hasattr(source, 'annotation_guide'):
+        if hasattr(source, "annotation_guide"):
             return source.annotation_guide.id
         return None
 
@@ -1246,7 +1367,7 @@ class Job(TimestampedModel, AssignableModel, FileSystemRelatedModel):
     def get_bug_tracker(self):
         task = self.segment.task
         project = task.project
-        return task.bug_tracker or getattr(project, 'bug_tracker', None)
+        return task.bug_tracker or getattr(project, "bug_tracker", None)
 
     def get_labels(self, prefetch=False):
         task = self.segment.task
@@ -1275,15 +1396,20 @@ class Job(TimestampedModel, AssignableModel, FileSystemRelatedModel):
 class InvalidLabel(ValueError):
     pass
 
+
 class Label(models.Model):
     task = models.ForeignKey(Task, null=True, blank=True, on_delete=models.CASCADE)
     project = models.ForeignKey(Project, null=True, blank=True, on_delete=models.CASCADE)
     name = SafeCharField(max_length=64)
-    color = models.CharField(default='', max_length=8)
+    color = models.CharField(default="", max_length=8)
     type = models.CharField(max_length=32, choices=LabelType.choices(), default=LabelType.ANY)
     parent = models.ForeignKey(
-        'self', on_delete=models.CASCADE, null=True, blank=True,
-        related_name='sublabels', related_query_name='sublabel',
+        "self",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="sublabels",
+        related_query_name="sublabel",
     )
 
     def __str__(self):
@@ -1317,26 +1443,27 @@ class Label(models.Model):
         default_permissions = ()
         constraints = [
             models.UniqueConstraint(
-                name='project_name_unique',
-                fields=('project', 'name'),
-                condition=models.Q(task__isnull=True, parent__isnull=True)
+                name="project_name_unique",
+                fields=("project", "name"),
+                condition=models.Q(task__isnull=True, parent__isnull=True),
             ),
             models.UniqueConstraint(
-                name='task_name_unique',
-                fields=('task', 'name'),
-                condition=models.Q(project__isnull=True, parent__isnull=True)
+                name="task_name_unique",
+                fields=("task", "name"),
+                condition=models.Q(project__isnull=True, parent__isnull=True),
             ),
             models.UniqueConstraint(
-                name='project_name_parent_unique',
-                fields=('project', 'name', 'parent'),
-                condition=models.Q(task__isnull=True)
+                name="project_name_parent_unique",
+                fields=("project", "name", "parent"),
+                condition=models.Q(task__isnull=True),
             ),
             models.UniqueConstraint(
-                name='task_name_parent_unique',
-                fields=('task', 'name', 'parent'),
-                condition=models.Q(project__isnull=True)
-            )
+                name="task_name_parent_unique",
+                fields=("task", "name", "parent"),
+                condition=models.Q(project__isnull=True),
+            ),
         ]
+
 
 class Skeleton(models.Model):
     root = models.OneToOneField(Label, on_delete=models.CASCADE)
@@ -1344,14 +1471,15 @@ class Skeleton(models.Model):
 
     class Meta:
         default_permissions = ()
-        unique_together = ('root',)
+        unique_together = ("root",)
+
 
 class AttributeType(str, Enum):
-    CHECKBOX = 'checkbox'
-    RADIO = 'radio'
-    NUMBER = 'number'
-    TEXT = 'text'
-    SELECT = 'select'
+    CHECKBOX = "checkbox"
+    RADIO = "radio"
+    NUMBER = "number"
+    TEXT = "text"
+    SELECT = "select"
 
     @classmethod
     def choices(cls):
@@ -1360,21 +1488,22 @@ class AttributeType(str, Enum):
     def __str__(self):
         return self.value
 
+
 class AttributeSpec(models.Model):
     label = models.ForeignKey(Label, on_delete=models.CASCADE)
     name = models.CharField(max_length=64)
     mutable = models.BooleanField()
-    input_type = models.CharField(max_length=16,
-        choices=AttributeType.choices())
+    input_type = models.CharField(max_length=16, choices=AttributeType.choices())
     default_value = models.CharField(blank=True, max_length=128)
     values = models.CharField(blank=True, max_length=4096)
 
     class Meta:
         default_permissions = ()
-        unique_together = ('label', 'name')
+        unique_together = ("label", "name")
 
     def __str__(self):
         return self.name
+
 
 class AttributeVal(models.Model):
     # TODO: add a validator here to be sure that it corresponds to self.label
@@ -1387,15 +1516,16 @@ class AttributeVal(models.Model):
         abstract = True
         default_permissions = ()
 
+
 class ShapeType(str, Enum):
-    RECTANGLE = 'rectangle' # (x0, y0, x1, y1)
-    POLYGON = 'polygon'     # (x0, y0, ..., xn, yn)
-    POLYLINE = 'polyline'   # (x0, y0, ..., xn, yn)
-    POINTS = 'points'       # (x0, y0, ..., xn, yn)
-    ELLIPSE = 'ellipse'     # (cx, cy, rx, ty)
-    CUBOID = 'cuboid'       # (x0, y0, ..., x7, y7)
-    MASK = 'mask'           # (rle mask, left, top, right, bottom)
-    SKELETON = 'skeleton'
+    RECTANGLE = "rectangle"  # (x0, y0, x1, y1)
+    POLYGON = "polygon"  # (x0, y0, ..., xn, yn)
+    POLYLINE = "polyline"  # (x0, y0, ..., xn, yn)
+    POINTS = "points"  # (x0, y0, ..., xn, yn)
+    ELLIPSE = "ellipse"  # (cx, cy, rx, ty)
+    CUBOID = "cuboid"  # (x0, y0, ..., x7, y7)
+    MASK = "mask"  # (rle mask, left, top, right, bottom)
+    SKELETON = "skeleton"
 
     @classmethod
     def choices(cls):
@@ -1403,13 +1533,14 @@ class ShapeType(str, Enum):
 
     def __str__(self):
         return self.value
+
 
 class SourceType(str, Enum):
-    AUTO = 'auto'
-    SEMI_AUTO = 'semi-auto'
-    MANUAL = 'manual'
-    FILE = 'file'
-    CONSENSUS = 'consensus'
+    AUTO = "auto"
+    SEMI_AUTO = "semi-auto"
+    MANUAL = "manual"
+    FILE = "file"
+    CONSENSUS = "consensus"
 
     @classmethod
     def choices(cls):
@@ -1417,6 +1548,7 @@ class SourceType(str, Enum):
 
     def __str__(self):
         return self.value
+
 
 class Annotation(models.Model):
     id = models.BigAutoField(primary_key=True)
@@ -1430,17 +1562,20 @@ class Annotation(models.Model):
         # - it results in a long migration, that's undesirable if done alone.
         null=True
     )
-    source = models.CharField(max_length=16, choices=SourceType.choices(),
-        default=str(SourceType.MANUAL), null=True)
+    source = models.CharField(
+        max_length=16, choices=SourceType.choices(), default=str(SourceType.MANUAL), null=True
+    )
 
     class Meta:
         abstract = True
+
 
 class FrameAnnotationMixin(models.Model):
     frame = models.PositiveIntegerField()
 
     class Meta:
         abstract = True
+
 
 class ShapeAnnotationMixin(models.Model):
     type = models.CharField(max_length=16, choices=ShapeType.choices())
@@ -1464,32 +1599,60 @@ class ScoredAnnotationMixin(models.Model):
 class LabeledImage(Annotation, FrameAnnotationMixin):
     pass
 
+
 class LabeledImageAttributeVal(AttributeVal):
-    image = models.ForeignKey(LabeledImage, on_delete=models.DO_NOTHING,
-        related_name='attributes', related_query_name='attribute')
+    image = models.ForeignKey(
+        LabeledImage,
+        on_delete=models.DO_NOTHING,
+        related_name="attributes",
+        related_query_name="attribute",
+    )
+
 
 class LabeledShape(Annotation, FrameAnnotationMixin, ShapeAnnotationMixin, ScoredAnnotationMixin):
-    parent = models.ForeignKey('self', on_delete=models.DO_NOTHING, null=True, related_name='elements')
+    parent = models.ForeignKey(
+        "self", on_delete=models.DO_NOTHING, null=True, related_name="elements"
+    )
+
 
 class LabeledShapeAttributeVal(AttributeVal):
-    shape = models.ForeignKey(LabeledShape, on_delete=models.DO_NOTHING,
-        related_name='attributes', related_query_name='attribute')
+    shape = models.ForeignKey(
+        LabeledShape,
+        on_delete=models.DO_NOTHING,
+        related_name="attributes",
+        related_query_name="attribute",
+    )
+
 
 class LabeledTrack(Annotation, FrameAnnotationMixin):
-    parent = models.ForeignKey('self', on_delete=models.DO_NOTHING, null=True, related_name='elements')
+    parent = models.ForeignKey(
+        "self", on_delete=models.DO_NOTHING, null=True, related_name="elements"
+    )
+
 
 class LabeledTrackAttributeVal(AttributeVal):
-    track = models.ForeignKey(LabeledTrack, on_delete=models.DO_NOTHING,
-        related_name='attributes', related_query_name='attribute')
+    track = models.ForeignKey(
+        LabeledTrack,
+        on_delete=models.DO_NOTHING,
+        related_name="attributes",
+        related_query_name="attribute",
+    )
+
 
 class TrackedShape(FrameAnnotationMixin, ShapeAnnotationMixin):
     id = models.BigAutoField(primary_key=True)
-    track = models.ForeignKey(LabeledTrack, on_delete=models.CASCADE,
-        related_name='shapes', related_query_name='shape')
+    track = models.ForeignKey(
+        LabeledTrack, on_delete=models.CASCADE, related_name="shapes", related_query_name="shape"
+    )
+
 
 class TrackedShapeAttributeVal(AttributeVal):
-    shape = models.ForeignKey(TrackedShape, on_delete=models.DO_NOTHING,
-        related_name='attributes', related_query_name='attribute')
+    shape = models.ForeignKey(
+        TrackedShape,
+        on_delete=models.DO_NOTHING,
+        related_name="attributes",
+        related_query_name="attribute",
+    )
 
 
 class Profile(models.Model):
@@ -1509,8 +1672,9 @@ class Issue(TimestampedModel, AssignableModel):
     job = models.ForeignKey(
         Job, related_name="issues", related_query_name="issue", on_delete=models.CASCADE
     )
-    owner = models.ForeignKey(User, null=True, blank=True, related_name='+',
-        on_delete=models.SET_NULL)
+    owner = models.ForeignKey(
+        User, null=True, blank=True, related_name="+", on_delete=models.SET_NULL
+    )
     resolved = models.BooleanField(default=False)
 
     def get_project_id(self):
@@ -1535,7 +1699,7 @@ class Comment(TimestampedModel):
         Issue, related_name="comments", related_query_name="comment", on_delete=models.CASCADE
     )
     owner = models.ForeignKey(User, null=True, blank=True, on_delete=models.SET_NULL)
-    message = models.TextField(default='')
+    message = models.TextField(default="")
 
     def get_project_id(self):
         return self.issue.get_project_id()
@@ -1553,27 +1717,35 @@ class Comment(TimestampedModel):
     def get_job_id(self):
         return self.issue.get_job_id()
 
+
 class Manifest(models.Model):
-    filename = models.CharField(max_length=1024, default='manifest.jsonl')
+    filename = models.CharField(max_length=1024, default="manifest.jsonl")
     cloud_storage = models.ForeignKey(
-        CloudStorage, on_delete=models.CASCADE, null=True,
-        related_name='manifests', related_query_name='manifest',
+        CloudStorage,
+        on_delete=models.CASCADE,
+        null=True,
+        related_name="manifests",
+        related_query_name="manifest",
     )
 
     def __str__(self):
-        return '{}'.format(self.filename)
+        return "{}".format(self.filename)
 
 
 class AnnotationGuide(TimestampedModel):
-    task = models.OneToOneField(Task, null=True, blank=True, on_delete=models.CASCADE, related_name="annotation_guide")
-    project = models.OneToOneField(Project, null=True, blank=True, on_delete=models.CASCADE, related_name="annotation_guide")
-    markdown = models.TextField(blank=True, default='')
+    task = models.OneToOneField(
+        Task, null=True, blank=True, on_delete=models.CASCADE, related_name="annotation_guide"
+    )
+    project = models.OneToOneField(
+        Project, null=True, blank=True, on_delete=models.CASCADE, related_name="annotation_guide"
+    )
+    markdown = models.TextField(blank=True, default="")
     is_public = models.BooleanField(default=False)
 
     @property
     def target(self) -> Task | Project:
         target = self.project or self.task
-        assert target # one of the fields must be set
+        assert target  # one of the fields must be set
         return target
 
     @property
@@ -1585,13 +1757,18 @@ class AnnotationGuide(TimestampedModel):
         pattern = r"\(/api/assets/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\)"
         return set(re.findall(pattern, markdown))
 
+
 class Asset(models.Model):
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     filename = models.CharField(max_length=1024)
     created_date = models.DateTimeField(auto_now_add=True)
     owner = models.ForeignKey(
-        User, null=True, blank=True, on_delete=models.SET_NULL,
-        related_name="assets", related_query_name="asset",
+        User,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="assets",
+        related_query_name="asset",
     )
     guide = models.ForeignKey(
         AnnotationGuide, on_delete=models.CASCADE, related_name="assets", related_query_name="asset"
@@ -1605,16 +1782,19 @@ class Asset(models.Model):
     def get_asset_dir(self) -> Path:
         return settings.ASSETS_ROOT / str(self.uuid)
 
+
 class RequestAction(TextChoices):
     AUTOANNOTATE = "autoannotate"
     CREATE = "create"
     IMPORT = "import"
     EXPORT = "export"
 
+
 class RequestTarget(TextChoices):
     PROJECT = "project"
     TASK = "task"
     JOB = "job"
+
 
 class RequestSubresource(TextChoices):
     ANNOTATIONS = "annotations"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ target-version = ['py310']
 extend-exclude = """
 # TODO: get rid of these
 ^/cvat/apps/engine/(
-    models.py
-    |serializers.py
+    serializers.py
 )
 """


### PR DESCRIPTION
### Motivation and context

Continuing to remove black exceptions from `pyproject.toml`.

Removes `cvat/apps/engine/models.py` from the `[tool.black]` `extend-exclude` and applies `black` to it.

### How has this been tested?

Ran `black cvat/apps/engine/models.py`.

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have updated the documentation accordingly (n/a)
- [x] I have added tests to cover my changes (n/a — formatting only)

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
