### PR TITLE
Blacken `engine/views.py`

### DIFF
--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -161,12 +161,12 @@ slogger = ServerLogManager(__name__)
 
 _UPLOAD_PARSER_CLASSES = api_settings.DEFAULT_PARSER_CLASSES + [MultiPartParser]
 
-_DATA_CHECKSUM_HEADER_NAME = 'X-Checksum'
-_DATA_UPDATED_DATE_HEADER_NAME = 'X-Updated-Date'
+_DATA_CHECKSUM_HEADER_NAME = "X-Checksum"
+_DATA_UPDATED_DATE_HEADER_NAME = "X-Updated-Date"
 _RETRY_AFTER_TIMEOUT = 10
 
 
-@extend_schema(tags=['server'])
+@extend_schema(tags=["server"])
 class ServerViewSet(viewsets.ViewSet):
     serializer_class = None
     iam_supports_organization_params = False
@@ -178,27 +178,35 @@ class ServerViewSet(viewsets.ViewSet):
         pass
 
     @staticmethod
-    @extend_schema(summary='Get basic CVAT information',
+    @extend_schema(
+        summary="Get basic CVAT information",
         responses={
-            '200': AboutSerializer,
-        })
-    @action(detail=False, methods=['GET'], serializer_class=AboutSerializer,
-        permission_classes=[] # This endpoint is available for everyone
+            "200": AboutSerializer,
+        },
+    )
+    @action(
+        detail=False,
+        methods=["GET"],
+        serializer_class=AboutSerializer,
+        permission_classes=[],  # This endpoint is available for everyone
     )
     def about(request: ExtendedRequest):
         from cvat import __version__ as cvat_version
+
         about = {
             "name": "Computer Vision Annotation Tool",
             "subtitle": settings.ABOUT_INFO["subtitle"],
-            "description": "CVAT is completely re-designed and re-implemented " +
-                "version of Video Annotation Tool from Irvine, California " +
-                "tool. It is free, online, interactive video and image annotation " +
-                "tool for computer vision. It is being used by our team to " +
-                "annotate million of objects with different properties. Many UI " +
-                "and UX decisions are based on feedbacks from professional data " +
-                "annotation team.",
+            "description": "CVAT is completely re-designed and re-implemented "
+            + "version of Video Annotation Tool from Irvine, California "
+            + "tool. It is free, online, interactive video and image annotation "
+            + "tool for computer vision. It is being used by our team to "
+            + "annotate million of objects with different properties. Many UI "
+            + "and UX decisions are based on feedbacks from professional data "
+            + "annotation team.",
             "version": cvat_version,
-            "logo_url": request.build_absolute_uri(storages["staticfiles"].url(settings.LOGO_FILENAME)),
+            "logo_url": request.build_absolute_uri(
+                storages["staticfiles"].url(settings.LOGO_FILENAME)
+            ),
         }
         serializer = AboutSerializer(data=about)
         if serializer.is_valid(raise_exception=True):
@@ -206,20 +214,27 @@ class ServerViewSet(viewsets.ViewSet):
 
     @staticmethod
     @extend_schema(
-        summary='List files/directories in the mounted share',
+        summary="List files/directories in the mounted share",
         parameters=[
-            OpenApiParameter('directory', description='Directory to browse',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR),
-            OpenApiParameter('search', description='Search for specific files',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR)
+            OpenApiParameter(
+                "directory",
+                description="Directory to browse",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+            ),
+            OpenApiParameter(
+                "search",
+                description="Search for specific files",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+            ),
         ],
-        responses={
-            '200' : FileInfoSerializer(many=True)
-        })
-    @action(detail=False, methods=['GET'], serializer_class=FileInfoSerializer)
+        responses={"200": FileInfoSerializer(many=True)},
+    )
+    @action(detail=False, methods=["GET"], serializer_class=FileInfoSerializer)
     def share(request: ExtendedRequest):
-        directory_param = request.query_params.get('directory', '/')
-        search_param = request.query_params.get('search', '')
+        directory_param = request.query_params.get("directory", "/")
+        search_param = request.query_params.get("search", "")
 
         if directory_param.startswith("/"):
             directory_param = directory_param[1:]
@@ -228,106 +243,137 @@ class ServerViewSet(viewsets.ViewSet):
 
         if directory.is_relative_to(settings.SHARE_ROOT) and directory.is_dir():
             data = []
-            generator = directory.iterdir() if not search_param else (f for f in directory.iterdir() if f.name.startswith(search_param))
+            generator = (
+                directory.iterdir()
+                if not search_param
+                else (f for f in directory.iterdir() if f.name.startswith(search_param))
+            )
 
             for entry in generator:
                 entry_type, entry_mime_type = None, None
                 if entry.is_file():
                     entry_type = "REG"
                     entry_mime_type = get_mime(entry)
-                    if entry_mime_type == 'zip':
-                        entry_mime_type = 'archive'
+                    if entry_mime_type == "zip":
+                        entry_mime_type = "archive"
                 elif entry.is_dir():
                     entry_type = entry_mime_type = "DIR"
 
                 if entry_type:
-                    data.append({
-                        "name": entry.name,
-                        "type": entry_type,
-                        "mime_type": entry_mime_type,
-                    })
+                    data.append(
+                        {
+                            "name": entry.name,
+                            "type": entry_type,
+                            "mime_type": entry_mime_type,
+                        }
+                    )
 
             # return directories at the top of the list
-            serializer = FileInfoSerializer(many=True, data=sorted(data, key=lambda x: (x['type'], x['name'])))
+            serializer = FileInfoSerializer(
+                many=True, data=sorted(data, key=lambda x: (x["type"], x["name"]))
+            )
             if serializer.is_valid(raise_exception=True):
                 return Response(serializer.data)
         else:
-            return Response("{} is an invalid directory".format(directory_param),
-                status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                "{} is an invalid directory".format(directory_param),
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
     @staticmethod
     @extend_schema(
-        summary='Get supported annotation formats',
+        summary="Get supported annotation formats",
         responses={
-            '200': DatasetFormatsSerializer,
-        })
-    @action(detail=False, methods=['GET'], url_path='annotation/formats')
+            "200": DatasetFormatsSerializer,
+        },
+    )
+    @action(detail=False, methods=["GET"], url_path="annotation/formats")
     def annotation_formats(request: ExtendedRequest):
         data = dm.views.get_all_formats()
         return Response(DatasetFormatsSerializer(data).data)
 
     @staticmethod
     @extend_schema(
-        summary='Get enabled plugins',
+        summary="Get enabled plugins",
         responses={
-            '200': PluginsSerializer,
-        })
-    @action(detail=False, methods=['GET'], url_path='plugins', serializer_class=PluginsSerializer)
+            "200": PluginsSerializer,
+        },
+    )
+    @action(detail=False, methods=["GET"], url_path="plugins", serializer_class=PluginsSerializer)
     def plugins(request: ExtendedRequest):
         data = {
-            'ANALYTICS': settings.ANALYTICS_ENABLED,
-            'MODELS': to_bool(os.environ.get("CVAT_SERVERLESS", False)), # not used anymore, remove later
+            "ANALYTICS": settings.ANALYTICS_ENABLED,
+            "MODELS": to_bool(
+                os.environ.get("CVAT_SERVERLESS", False)
+            ),  # not used anymore, remove later
         }
         return Response(PluginsSerializer(data).data)
 
-@extend_schema(tags=['projects'])
+
+@extend_schema(tags=["projects"])
 @extend_schema_view(
     list=extend_schema(
-        summary='List projects',
+        summary="List projects",
         responses={
-            '200': ProjectReadSerializer(many=True),
-        }),
+            "200": ProjectReadSerializer(many=True),
+        },
+    ),
     create=extend_schema(
-        summary='Create a project',
+        summary="Create a project",
         request=ProjectWriteSerializer,
         parameters=ORGANIZATION_OPEN_API_PARAMETERS,
         responses={
-            '201': ProjectReadSerializer, # check ProjectWriteSerializer.to_representation
-        }),
+            "201": ProjectReadSerializer,  # check ProjectWriteSerializer.to_representation
+        },
+    ),
     retrieve=extend_schema(
-        summary='Get project details',
+        summary="Get project details",
         responses={
-            '200': ProjectReadSerializer,
-        }),
+            "200": ProjectReadSerializer,
+        },
+    ),
     destroy=extend_schema(
-        summary='Delete a project',
+        summary="Delete a project",
         responses={
-            '204': OpenApiResponse(description='The project has been deleted'),
-        }),
+            "204": OpenApiResponse(description="The project has been deleted"),
+        },
+    ),
     partial_update=extend_schema(
-        summary='Update a project',
+        summary="Update a project",
         request=ProjectWriteSerializer(partial=True),
         responses={
-            '200': ProjectReadSerializer, # check ProjectWriteSerializer.to_representation
-        })
+            "200": ProjectReadSerializer,  # check ProjectWriteSerializer.to_representation
+        },
+    ),
 )
-class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
-    mixins.RetrieveModelMixin, mixins.CreateModelMixin, mixins.DestroyModelMixin,
-    PartialUpdateModelMixin, UploadMixin, DatasetMixin, BackupMixin
+class ProjectViewSet(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    PartialUpdateModelMixin,
+    UploadMixin,
+    DatasetMixin,
+    BackupMixin,
 ):
     # NOTE: The search_fields attribute should be a list of names of text
     # type fields on the model,such as CharField or TextField
     queryset = models.Project.objects.select_related(
-        'owner', 'assignee', 'organization',
-        'annotation_guide', 'source_storage', 'target_storage',
+        "owner",
+        "assignee",
+        "organization",
+        "annotation_guide",
+        "source_storage",
+        "target_storage",
     )
 
-    search_fields = ('name', 'owner', 'assignee')
-    simple_filters = (*search_fields, 'status')
-    filter_fields = (*simple_filters, 'id', 'updated_date')
+    search_fields = ("name", "owner", "assignee")
+    simple_filters = (*search_fields, "status")
+    filter_fields = (*simple_filters, "id", "updated_date")
     ordering_fields = list(filter_fields)
     ordering = "-id"
-    lookup_fields = {'owner': 'owner__username', 'assignee': 'assignee__username'}
+    lookup_fields = {"owner": "owner__username", "assignee": "assignee__username"}
     iam_supports_organization_params = True
     iam_permission_class = ProjectPermission
 
@@ -339,10 +385,10 @@ class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
 
     def get_queryset(self):
         queryset = super().get_queryset()
-        if self.action in ('list', 'retrieve', 'partial_update', 'update') :
-            queryset = queryset.prefetch_related('tasks')
+        if self.action in ("list", "retrieve", "partial_update", "update"):
+            queryset = queryset.prefetch_related("tasks")
 
-            if self.action == 'list':
+            if self.action == "list":
                 perm = ProjectPermission.create_scope_list(self.request)
                 return perm.filter(queryset)
 
@@ -351,44 +397,69 @@ class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
     @transaction.atomic
     def perform_create(self, serializer, **kwargs):
         serializer.save(
-            owner=self.request.user,
-            organization=self.request.iam_context['organization']
+            owner=self.request.user, organization=self.request.iam_context["organization"]
         )
 
         # Required for the extra summary information added in the queryset
         serializer.instance = self.get_queryset().get(pk=serializer.instance.pk)
 
-    @extend_schema(methods=['GET'], exclude=True)
-    @extend_schema(methods=['POST'],
-        summary='Import a dataset into a project',
+    @extend_schema(methods=["GET"], exclude=True)
+    @extend_schema(
+        methods=["POST"],
+        summary="Import a dataset into a project",
         description=textwrap.dedent("""
             The request POST /api/projects/id/dataset initiates a background process to import dataset into a project.
             Please, use the GET /api/requests/<rq_id> endpoint for checking status of the process.
             The `rq_id` parameter can be found in the response on initiating request.
         """),
         parameters=[
-            OpenApiParameter('format', description='Desired dataset format name\n'
-                'You can get the list of supported formats at:\n/server/annotation/formats',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False),
-            OpenApiParameter('location', description='Where to import the dataset from',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False,
-                enum=Location.list()),
-            OpenApiParameter('cloud_storage_id', description='Storage id',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.INT, required=False),
-            OpenApiParameter('filename', description='Dataset file name',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False),
+            OpenApiParameter(
+                "format",
+                description="Desired dataset format name\n"
+                "You can get the list of supported formats at:\n/server/annotation/formats",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+            ),
+            OpenApiParameter(
+                "location",
+                description="Where to import the dataset from",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+                enum=Location.list(),
+            ),
+            OpenApiParameter(
+                "cloud_storage_id",
+                description="Storage id",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.INT,
+                required=False,
+            ),
+            OpenApiParameter(
+                "filename",
+                description="Dataset file name",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+            ),
         ],
         request=DatasetFileSerializer(required=False),
         responses={
-            '202': OpenApiResponse(RqIdSerializer, description='Importing has been started'),
-            '400': OpenApiResponse(description='Failed to import dataset'),
-            '405': OpenApiResponse(description='Format is not available'),
-        })
-    @action(detail=True, methods=['GET', 'POST', 'OPTIONS'], serializer_class=None,
-        url_path=r'dataset/?$', parser_classes=_UPLOAD_PARSER_CLASSES,
+            "202": OpenApiResponse(RqIdSerializer, description="Importing has been started"),
+            "400": OpenApiResponse(description="Failed to import dataset"),
+            "405": OpenApiResponse(description="Format is not available"),
+        },
+    )
+    @action(
+        detail=True,
+        methods=["GET", "POST", "OPTIONS"],
+        serializer_class=None,
+        url_path=r"dataset/?$",
+        parser_classes=_UPLOAD_PARSER_CLASSES,
     )
     def dataset(self, request: ExtendedRequest, pk: int):
-        self._object = self.get_object() # force call of check_object_permissions()
+        self._object = self.get_object()  # force call of check_object_permissions()
 
         if request.method == "GET":
             if request.query_params.get("action") == "import_status":
@@ -402,10 +473,11 @@ class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
 
             # we cannot redirect to the new API here since this endpoint used not only to check the status
             # of exporting process|download a result file, but also to initiate export process
-            return get_410_response_for_export_api("/api/projects/id/dataset/export?save_images=True")
+            return get_410_response_for_export_api(
+                "/api/projects/id/dataset/export?save_images=True"
+            )
 
         return self.upload_data(request, append_url_name="append-dataset-chunk")
-
 
     @tus_chunk_action(detail=True, suffix_base="dataset")
     def append_dataset_chunk(self, request: ExtendedRequest, pk: int, file_id: str):
@@ -413,35 +485,36 @@ class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         return self.append_tus_chunk(request, file_id)
 
     def get_upload_dir(self):
-        if 'dataset' in self.action:
+        if "dataset" in self.action:
             return self._object.get_tmp_dirname()
-        elif 'backup' in self.action:
+        elif "backup" in self.action:
             return backup.get_backup_dirname()
         assert False
 
     def upload_finished(self, request: ExtendedRequest):
-        if self.action == 'dataset':
+        if self.action == "dataset":
             importer = DatasetImporter(request=request, db_instance=self._object)
             return importer.enqueue_job()
 
-        elif self.action == 'import_backup':
+        elif self.action == "import_backup":
             importer = BackupImporter(request=request, target=RequestTarget.PROJECT)
             return importer.enqueue_job()
 
-        return Response(data='Unknown upload was finished',
-                        status=status.HTTP_400_BAD_REQUEST)
+        return Response(data="Unknown upload was finished", status=status.HTTP_400_BAD_REQUEST)
 
     @extend_schema(exclude=True)
-    @action(detail=True, methods=['GET'])
+    @action(detail=True, methods=["GET"])
     def annotations(self, request: ExtendedRequest, pk: int):
         return get_410_response_for_export_api("/api/projects/id/dataset/export?save_images=False")
 
     @extend_schema(exclude=True)
-    @action(methods=['GET'], detail=True, url_path='backup')
+    @action(methods=["GET"], detail=True, url_path="backup")
     def export_backup(self, request: ExtendedRequest, pk: int):
         return get_410_response_for_export_api("/api/projects/id/backup/export")
 
-    @extend_schema(methods=['POST'], summary='Recreate a project from a backup',
+    @extend_schema(
+        methods=["POST"],
+        summary="Recreate a project from a backup",
         description=textwrap.dedent("""
             The backup import process is as follows:
 
@@ -456,21 +529,44 @@ class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         """),
         parameters=[
             *ORGANIZATION_OPEN_API_PARAMETERS,
-            OpenApiParameter('location', description='Where to import the backup file from',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False,
-                enum=Location.list(), default=Location.LOCAL),
-            OpenApiParameter('cloud_storage_id', description='Storage id',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.INT, required=False),
-            OpenApiParameter('filename', description='Backup file name',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False),
+            OpenApiParameter(
+                "location",
+                description="Where to import the backup file from",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+                enum=Location.list(),
+                default=Location.LOCAL,
+            ),
+            OpenApiParameter(
+                "cloud_storage_id",
+                description="Storage id",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.INT,
+                required=False,
+            ),
+            OpenApiParameter(
+                "filename",
+                description="Backup file name",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+            ),
         ],
         request=ProjectFileSerializer(required=False),
         responses={
-            '202': OpenApiResponse(RqIdSerializer, description='Import of the backup file has started'),
-        })
-    @action(detail=False, methods=['OPTIONS', 'POST'], url_path=r'backup/?$',
+            "202": OpenApiResponse(
+                RqIdSerializer, description="Import of the backup file has started"
+            ),
+        },
+    )
+    @action(
+        detail=False,
+        methods=["OPTIONS", "POST"],
+        url_path=r"backup/?$",
         serializer_class=None,
-        parser_classes=_UPLOAD_PARSER_CLASSES)
+        parser_classes=_UPLOAD_PARSER_CLASSES,
+    )
     def import_backup(self, request: ExtendedRequest):
         if "rq_id" in request.query_params:
             return get_410_response_when_checking_process_status("import")
@@ -481,24 +577,25 @@ class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
     def append_backup_chunk(self, request: ExtendedRequest, file_id: str):
         return self.append_tus_chunk(request, file_id)
 
-    @extend_schema(summary='Get a preview image for a project',
+    @extend_schema(
+        summary="Get a preview image for a project",
         responses={
-            '200': OpenApiResponse(description='Project image preview'),
-            '404': OpenApiResponse(description='Project image preview not found'),
-
-        })
-    @action(detail=True, methods=['GET'], url_path='preview')
+            "200": OpenApiResponse(description="Project image preview"),
+            "404": OpenApiResponse(description="Project image preview not found"),
+        },
+    )
+    @action(detail=True, methods=["GET"], url_path="preview")
     def preview(self, request: ExtendedRequest, pk: int):
-        self._object = self.get_object() # call check_object_permissions as well
+        self._object = self.get_object()  # call check_object_permissions as well
 
-        first_task: models.Task | None = self._object.tasks.order_by('-id').first()
+        first_task: models.Task | None = self._object.tasks.order_by("-id").first()
         if not first_task:
-            return HttpResponseNotFound('Project image preview not found')
+            return HttpResponseNotFound("Project image preview not found")
 
         data_getter = _TaskDataGetter(
             db_task=first_task,
-            data_type='preview',
-            data_quality='compressed',
+            data_type="preview",
+            data_quality="compressed",
         )
 
         return data_getter()
@@ -510,37 +607,37 @@ class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         rq_job_meta = ImportRQMeta.for_job(job)
         response = {}
         if job is None or job.is_finished:
-            response = { "state": "Finished" }
+            response = {"state": "Finished"}
         elif job.is_queued or job.is_deferred:
-            response = { "state": "Queued" }
+            response = {"state": "Queued"}
         elif job.is_failed:
-            response = { "state": "Failed", "message": job.exc_info }
+            response = {"state": "Failed", "message": job.exc_info}
         else:
-            response = { "state": "Started" }
-            response['message'] = rq_job_meta.status or ""
-            response['progress'] = rq_job_meta.progress or 0.
+            response = {"state": "Started"}
+            response["message"] = rq_job_meta.status or ""
+            response["progress"] = rq_job_meta.progress or 0.0
 
         return response
 
+
 class _DataGetter(metaclass=ABCMeta):
-    def __init__(
-        self, data_type: str, data_num: str | int | None, data_quality: str
-    ) -> None:
-        possible_data_type_values = ('chunk', 'frame', 'preview', 'context_image')
-        possible_quality_values = ('compressed', 'original')
+    def __init__(self, data_type: str, data_num: str | int | None, data_quality: str) -> None:
+        possible_data_type_values = ("chunk", "frame", "preview", "context_image")
+        possible_quality_values = ("compressed", "original")
 
         if not data_type or data_type not in possible_data_type_values:
-            raise ValidationError('Data type not specified or has wrong value')
-        elif data_type == 'chunk' or data_type == 'frame' or data_type == 'preview':
-            if data_num is None and data_type != 'preview':
-                raise ValidationError('Number is not specified')
+            raise ValidationError("Data type not specified or has wrong value")
+        elif data_type == "chunk" or data_type == "frame" or data_type == "preview":
+            if data_num is None and data_type != "preview":
+                raise ValidationError("Number is not specified")
             elif data_quality not in possible_quality_values:
-                raise ValidationError('Wrong quality value')
+                raise ValidationError("Wrong quality value")
 
         self.type = data_type
         self.number = int(data_num) if data_num is not None else None
-        self.quality = FrameQuality.COMPRESSED \
-            if data_quality == 'compressed' else FrameQuality.ORIGINAL
+        self.quality = (
+            FrameQuality.COMPRESSED if data_quality == "compressed" else FrameQuality.ORIGINAL
+        )
 
     @abstractmethod
     def _get_frame_provider(self) -> IFrameProvider: ...
@@ -548,40 +645,44 @@ class _DataGetter(metaclass=ABCMeta):
     def _get_data_response(self) -> HttpResponse:
         frame_provider = self._get_frame_provider()
 
-        if self.type == 'chunk':
+        if self.type == "chunk":
             data = frame_provider.get_chunk(self.number, quality=self.quality)
             return HttpResponse(
                 data.data.getvalue(),
                 content_type=data.mime,
                 headers=self._get_chunk_response_headers(data),
             )
-        elif self.type == 'frame':
+        elif self.type == "frame":
             data = frame_provider.get_frame(self.number, quality=self.quality)
             return HttpResponse(data.data.getvalue(), content_type=data.mime)
-        elif self.type == 'preview':
+        elif self.type == "preview":
             data = frame_provider.get_preview()
             return HttpResponse(data.data.getvalue(), content_type=data.mime)
-        elif self.type == 'context_image':
+        elif self.type == "context_image":
             data = frame_provider.get_frame_context_images_chunk(self.number)
             if not data:
                 return HttpResponseNotFound()
 
             return HttpResponse(data.data, content_type=data.mime)
         else:
-            return Response(data='unknown data type {}.'.format(self.type),
-                status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                data="unknown data type {}.".format(self.type), status=status.HTTP_400_BAD_REQUEST
+            )
 
     def __call__(self):
         try:
             return self._get_data_response()
         except (ValidationError, PermissionDenied, NotFound) as ex:
-            msg = str(ex) if not isinstance(ex, ValidationError) else \
-                '\n'.join([str(d) for d in ex.detail])
+            msg = (
+                str(ex)
+                if not isinstance(ex, ValidationError)
+                else "\n".join([str(d) for d in ex.detail])
+            )
             return Response(data=msg, status=ex.status_code)
         except (TimeoutError, CvatChunkTimestampMismatchError, LockError):
             return Response(
                 status=status.HTTP_429_TOO_MANY_REQUESTS,
-                headers={'Retry-After': _RETRY_AFTER_TIMEOUT},
+                headers={"Retry-After": _RETRY_AFTER_TIMEOUT},
             )
         except CacheTooLargeDataError as ex:
             return Response(
@@ -603,13 +704,16 @@ class _DataGetter(metaclass=ABCMeta):
     def _get_chunk_checksum(self, chunk_data: DataWithMeta) -> str:
         data = chunk_data.data.getbuffer()
         size_checksum = zlib.crc32(str(len(data)).encode())
-        return str(zlib.crc32(data[:self._CHUNK_HEADER_BYTES_LENGTH], size_checksum))
+        return str(zlib.crc32(data[: self._CHUNK_HEADER_BYTES_LENGTH], size_checksum))
 
     def _make_chunk_response_headers(self, checksum: str, updated_date: datetime) -> dict[str, str]:
         return {
-            _DATA_CHECKSUM_HEADER_NAME: str(checksum or ''),
-            _DATA_UPDATED_DATE_HEADER_NAME: serializers.DateTimeField().to_representation(updated_date),
+            _DATA_CHECKSUM_HEADER_NAME: str(checksum or ""),
+            _DATA_UPDATED_DATE_HEADER_NAME: serializers.DateTimeField().to_representation(
+                updated_date
+            ),
         }
+
 
 class _TaskDataGetter(_DataGetter):
     def __init__(
@@ -631,7 +735,8 @@ class _TaskDataGetter(_DataGetter):
 
     def _get_chunk_response_headers(self, chunk_data: DataWithMeta) -> dict[str, str]:
         return self._make_chunk_response_headers(
-            self._get_chunk_checksum(chunk_data), self._db_task.get_chunks_updated_date(),
+            self._get_chunk_checksum(chunk_data),
+            self._db_task.get_chunks_updated_date(),
         )
 
 
@@ -645,29 +750,30 @@ class _JobDataGetter(_DataGetter):
         data_num: str | int | None = None,
         data_index: str | int | None = None,
     ) -> None:
-        possible_data_type_values = ('chunk', 'frame', 'preview', 'context_image')
-        possible_quality_values = ('compressed', 'original')
+        possible_data_type_values = ("chunk", "frame", "preview", "context_image")
+        possible_quality_values = ("compressed", "original")
 
         if not data_type or data_type not in possible_data_type_values:
-            raise ValidationError('Data type not specified or has wrong value')
-        elif data_type == 'chunk' or data_type == 'frame' or data_type == 'preview':
-            if data_type == 'chunk':
+            raise ValidationError("Data type not specified or has wrong value")
+        elif data_type == "chunk" or data_type == "frame" or data_type == "preview":
+            if data_type == "chunk":
                 if data_num is None and data_index is None:
-                    raise ValidationError('Number or Index is not specified')
+                    raise ValidationError("Number or Index is not specified")
                 if data_num is not None and data_index is not None:
-                    raise ValidationError('Number and Index cannot be used together')
-            elif data_num is None and data_type != 'preview':
-                raise ValidationError('Number is not specified')
+                    raise ValidationError("Number and Index cannot be used together")
+            elif data_num is None and data_type != "preview":
+                raise ValidationError("Number is not specified")
             elif data_quality not in possible_quality_values:
-                raise ValidationError('Wrong quality value')
+                raise ValidationError("Wrong quality value")
 
         self.type = data_type
 
         self.index = int(data_index) if data_index is not None else None
         self.number = int(data_num) if data_num is not None else None
 
-        self.quality = FrameQuality.COMPRESSED \
-            if data_quality == 'compressed' else FrameQuality.ORIGINAL
+        self.quality = (
+            FrameQuality.COMPRESSED if data_quality == "compressed" else FrameQuality.ORIGINAL
+        )
 
         self._db_job = db_job
 
@@ -678,7 +784,7 @@ class _JobDataGetter(_DataGetter):
         return JobFrameProvider(self._db_job)
 
     def _get_data_response(self):
-        if self.type == 'chunk':
+        if self.type == "chunk":
             # Reproduce the task chunk indexing
             frame_provider = self._get_frame_provider()
 
@@ -701,20 +807,20 @@ class _JobDataGetter(_DataGetter):
 
     def _get_chunk_response_headers(self, chunk_data: DataWithMeta) -> dict[str, str]:
         return self._make_chunk_response_headers(
-            self._get_chunk_checksum(chunk_data),
-            self._db_job.segment.chunks_updated_date
+            self._get_chunk_checksum(chunk_data), self._db_job.segment.chunks_updated_date
         )
 
 
-@extend_schema(tags=['tasks'])
+@extend_schema(tags=["tasks"])
 @extend_schema_view(
     list=extend_schema(
-        summary='List tasks',
+        summary="List tasks",
         responses={
-            '200': TaskReadSerializer(many=True),
-        }),
+            "200": TaskReadSerializer(many=True),
+        },
+    ),
     create=extend_schema(
-        summary='Create a task',
+        summary="Create a task",
         description=textwrap.dedent("""\
             The new task will not have any attached images or videos.
             To attach them, use the /api/tasks/<id>/data endpoint.
@@ -722,21 +828,19 @@ class _JobDataGetter(_DataGetter):
         request=TaskWriteSerializer,
         parameters=ORGANIZATION_OPEN_API_PARAMETERS,
         responses={
-            '201': TaskReadSerializer, # check TaskWriteSerializer.to_representation
-        }),
-    retrieve=extend_schema(
-        summary='Get task details',
-        responses={
-            '200': TaskReadSerializer
-        }),
+            "201": TaskReadSerializer,  # check TaskWriteSerializer.to_representation
+        },
+    ),
+    retrieve=extend_schema(summary="Get task details", responses={"200": TaskReadSerializer}),
     destroy=extend_schema(
-        summary='Delete a task',
-        description='All attached jobs, annotations and data will be deleted as well.',
+        summary="Delete a task",
+        description="All attached jobs, annotations and data will be deleted as well.",
         responses={
-            '204': OpenApiResponse(description='The task has been deleted'),
-        }),
+            "204": OpenApiResponse(description="The task has been deleted"),
+        },
+    ),
     partial_update=extend_schema(
-        summary='Update a task',
+        summary="Update a task",
         examples=[
             OpenApiExample(
                 "Update task properties",
@@ -746,14 +850,8 @@ class _JobDataGetter(_DataGetter):
                     "assignee_id": 0,
                     "bug_tracker": "string",
                     "subset": "string",
-                    "target_storage": {
-                        "location": "cloud_storage",
-                        "cloud_storage_id": 0
-                    },
-                    "source_storage": {
-                        "location": "cloud_storage",
-                        "cloud_storage_id": 0
-                    }
+                    "target_storage": {"location": "cloud_storage", "cloud_storage_id": 0},
+                    "source_storage": {"location": "cloud_storage", "cloud_storage_id": 0},
                 },
                 request_only=True,
             ),
@@ -768,13 +866,15 @@ class _JobDataGetter(_DataGetter):
                             "deleted": False,
                             "type": "any",
                             "svg": "string",
-                            "sublabels": [{
-                                "name": "string",
-                                "color": "string",
-                                "attributes": [],
-                                "type": "any",
-                                "has_parent": True
-                            }],
+                            "sublabels": [
+                                {
+                                    "name": "string",
+                                    "color": "string",
+                                    "attributes": [],
+                                    "type": "any",
+                                    "has_parent": True,
+                                }
+                            ],
                         }
                     ],
                 },
@@ -815,35 +915,52 @@ class _JobDataGetter(_DataGetter):
                     },
                 },
                 request_only=True,
-            )
+            ),
         ],
         request=TaskWriteSerializer(partial=True),
         responses={
-            '200': TaskReadSerializer, # check TaskWriteSerializer.to_representation
-        })
+            "200": TaskReadSerializer,  # check TaskWriteSerializer.to_representation
+        },
+    ),
 )
-
-class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
-    mixins.RetrieveModelMixin, mixins.CreateModelMixin, mixins.DestroyModelMixin,
-    PartialUpdateModelMixin, UploadMixin, DatasetMixin, BackupMixin
+class TaskViewSet(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    PartialUpdateModelMixin,
+    UploadMixin,
+    DatasetMixin,
+    BackupMixin,
 ):
     queryset = Task.objects
 
     lookup_fields = {
-        'project_name': 'project__name',
-        'owner': 'owner__username',
-        'assignee': 'assignee__username',
-        'tracker_link': 'bug_tracker',
-        'validation_mode': 'data__validation_layout__mode',
+        "project_name": "project__name",
+        "owner": "owner__username",
+        "assignee": "assignee__username",
+        "tracker_link": "bug_tracker",
+        "validation_mode": "data__validation_layout__mode",
     }
     search_fields = (
-        'project_name', 'name', 'owner', 'assignee', 'subset', 'tracker_link',
+        "project_name",
+        "name",
+        "owner",
+        "assignee",
+        "subset",
+        "tracker_link",
     )
     simple_filters = (
         *search_fields,
-        'project_id', 'status', 'media_type', 'mode', 'dimension', 'validation_mode',
+        "project_id",
+        "status",
+        "media_type",
+        "mode",
+        "dimension",
+        "validation_mode",
     )
-    filter_fields = (*simple_filters, 'id', 'updated_date')
+    filter_fields = (*simple_filters, "id", "updated_date")
     filter_description = textwrap.dedent("""
 
         There are few examples for complex filtering tasks:\n
@@ -864,29 +981,30 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
     def get_queryset(self):
         queryset = super().get_queryset()
 
-        if self.action == 'list':
+        if self.action == "list":
             perm = TaskPermission.create_scope_list(self.request)
             queryset = perm.filter(queryset)
-            queryset = queryset.select_related('assignee', 'owner')
+            queryset = queryset.select_related("assignee", "owner")
             # with_job_summary() is optimized in the serializer
-        elif self.action == 'validation_layout':
-            queryset = Task.objects.select_related('data', 'data__validation_layout')
-        elif self.action not in ('metadata', 'annotations'):
-            queryset = queryset.select_related('data')
+        elif self.action == "validation_layout":
+            queryset = Task.objects.select_related("data", "data__validation_layout")
+        elif self.action not in ("metadata", "annotations"):
+            queryset = queryset.select_related("data")
 
-            if self.action in ('create', 'retrieve', 'update', 'partial_update', 'destroy'):
+            if self.action in ("create", "retrieve", "update", "partial_update", "destroy"):
                 queryset = queryset.select_related(
-                    'target_storage',
-                    'source_storage',
-                    'annotation_guide',
-                    'assignee',
-                    'owner',
+                    "target_storage",
+                    "source_storage",
+                    "annotation_guide",
+                    "assignee",
+                    "owner",
                 )
                 queryset = queryset.with_job_summary()
 
         return queryset
 
-    @extend_schema(summary='Recreate a task from a backup',
+    @extend_schema(
+        summary="Recreate a task from a backup",
         description=textwrap.dedent("""
             The backup import process is as follows:
 
@@ -901,22 +1019,44 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         """),
         parameters=[
             *ORGANIZATION_OPEN_API_PARAMETERS,
-            OpenApiParameter('location', description='Where to import the backup file from',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False,
-                enum=Location.list(), default=Location.LOCAL),
-            OpenApiParameter('cloud_storage_id', description='Storage id',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.INT, required=False),
-            OpenApiParameter('filename', description='Backup file name',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False),
+            OpenApiParameter(
+                "location",
+                description="Where to import the backup file from",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+                enum=Location.list(),
+                default=Location.LOCAL,
+            ),
+            OpenApiParameter(
+                "cloud_storage_id",
+                description="Storage id",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.INT,
+                required=False,
+            ),
+            OpenApiParameter(
+                "filename",
+                description="Backup file name",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+            ),
         ],
         request=TaskFileSerializer(required=False),
         responses={
-            '202': OpenApiResponse(RqIdSerializer, description='Import of the backup file has started'),
-        })
-
-    @action(detail=False, methods=['OPTIONS', 'POST'], url_path=r'backup/?$',
+            "202": OpenApiResponse(
+                RqIdSerializer, description="Import of the backup file has started"
+            ),
+        },
+    )
+    @action(
+        detail=False,
+        methods=["OPTIONS", "POST"],
+        url_path=r"backup/?$",
         serializer_class=None,
-        parser_classes=_UPLOAD_PARSER_CLASSES)
+        parser_classes=_UPLOAD_PARSER_CLASSES,
+    )
     def import_backup(self, request: ExtendedRequest):
         if "rq_id" in request.query_params:
             return get_410_response_when_checking_process_status("import")
@@ -928,7 +1068,7 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         return self.append_tus_chunk(request, file_id)
 
     @extend_schema(exclude=True)
-    @action(methods=['GET'], detail=True, url_path='backup')
+    @action(methods=["GET"], detail=True, url_path="backup")
     def export_backup(self, request: ExtendedRequest, pk: int):
         return get_410_response_for_export_api("/api/tasks/id/backup/export")
 
@@ -948,8 +1088,7 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
     @transaction.atomic
     def perform_create(self, serializer, **kwargs):
         serializer.save(
-            owner=self.request.user,
-            organization=self.request.iam_context['organization']
+            owner=self.request.user, organization=self.request.iam_context["organization"]
         )
 
         if db_project := serializer.instance.project:
@@ -960,15 +1099,15 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         serializer.instance = self.get_queryset().get(pk=serializer.instance.pk)
 
     def _is_data_uploading(self) -> bool:
-        return 'data' in self.action
+        return "data" in self.action
 
     # UploadMixin method
     def get_upload_dir(self):
-        if 'annotations' in self.action:
+        if "annotations" in self.action:
             return self._object.get_tmp_dirname()
         elif self._is_data_uploading():
             return self._object.data.get_upload_dirname()
-        elif 'backup' in self.action:
+        elif "backup" in self.action:
             return backup.get_backup_dirname()
 
         assert False
@@ -990,9 +1129,9 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         bulk_create(
             ClientFile,
             [
-                ClientFile(file=self._prepare_upload_info_entry(cf['file'].name), data=task_data)
+                ClientFile(file=self._prepare_upload_info_entry(cf["file"].name), data=task_data)
                 for cf in client_files
-            ]
+            ],
         )
 
     def _sort_uploaded_files(self, uploaded_files: list[str], ordering: list[str]) -> list[str]:
@@ -1016,11 +1155,10 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             raise ValidationError(
                 "Uploaded files do not match the '{}' field contents. "
                 "Please check the uploaded data and the list of uploaded files. "
-                "Mismatching files: {}{}"
-                .format(
+                "Mismatching files: {}{}".format(
                     self._UPLOAD_FILE_ORDER_FIELD,
                     ", ".join(mismatching_display),
-                    f" (and {remaining_count} more). " if 0 < remaining_count else ""
+                    f" (and {remaining_count} more). " if 0 < remaining_count else "",
                 )
             )
 
@@ -1058,9 +1196,9 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 serializer.is_valid(raise_exception=True)
 
                 # Append new files to the previous ones
-                if uploaded_files := serializer.validated_data.get('client_files', None):
+                if uploaded_files := serializer.validated_data.get("client_files", None):
                     self.append_files(request)
-                    serializer.validated_data['client_files'] = [] # avoid file info duplication
+                    serializer.validated_data["client_files"] = []  # avoid file info duplication
 
                 # Refresh the db value with the updated file list and other request parameters
                 db_data = serializer.save()
@@ -1070,46 +1208,54 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 # Create a temporary copy of the parameters we will try to create the task with
                 data = copy(serializer.data)
 
-                for optional_field in ['job_file_mapping', 'server_files_exclude', 'validation_params']:
+                for optional_field in [
+                    "job_file_mapping",
+                    "server_files_exclude",
+                    "validation_params",
+                ]:
                     if optional_field in serializer.validated_data:
                         data[optional_field] = serializer.validated_data[optional_field]
 
-                if validation_params := getattr(db_data, 'validation_params', None):
-                    data['validation_params']['frames'] = set(itertools.chain(
-                        data['validation_params'].get('frames', []),
-                        validation_params.frames.values_list('path', flat=True).all()
-                    ))
+                if validation_params := getattr(db_data, "validation_params", None):
+                    data["validation_params"]["frames"] = set(
+                        itertools.chain(
+                            data["validation_params"].get("frames", []),
+                            validation_params.frames.values_list("path", flat=True).all(),
+                        )
+                    )
 
                 if (
-                    data['sorting_method'] == models.SortingMethod.PREDEFINED
-                    and (uploaded_files := data['client_files'])
+                    data["sorting_method"] == models.SortingMethod.PREDEFINED
+                    and (uploaded_files := data["client_files"])
                     and (
-                        uploaded_file_order := serializer.validated_data[self._UPLOAD_FILE_ORDER_FIELD]
+                        uploaded_file_order := serializer.validated_data[
+                            self._UPLOAD_FILE_ORDER_FIELD
+                        ]
                     )
                 ):
                     # In the case of predefined sorting and custom file ordering,
                     # the requested order must be applied
-                    data['client_files'] = self._sort_uploaded_files(
+                    data["client_files"] = self._sort_uploaded_files(
                         uploaded_files, uploaded_file_order
                     )
 
-                data['use_zip_chunks'] = serializer.validated_data['use_zip_chunks']
-                data['use_cache'] = serializer.validated_data['use_cache']
-                data['copy_data'] = serializer.validated_data['copy_data']
+                data["use_zip_chunks"] = serializer.validated_data["use_zip_chunks"]
+                data["use_cache"] = serializer.validated_data["use_cache"]
+                data["copy_data"] = serializer.validated_data["copy_data"]
 
-                if data['use_cache']:
+                if data["use_cache"]:
                     self._object.data.storage_method = StorageMethodChoice.CACHE
-                    self._object.data.save(update_fields=['storage_method'])
-                if data['server_files'] and not data.get('copy_data'):
+                    self._object.data.save(update_fields=["storage_method"])
+                if data["server_files"] and not data.get("copy_data"):
                     self._object.data.storage = StorageChoice.SHARE
-                    self._object.data.save(update_fields=['storage'])
+                    self._object.data.save(update_fields=["storage"])
                 if db_data.cloud_storage:
                     self._object.data.storage = StorageChoice.CLOUD_STORAGE
-                    self._object.data.save(update_fields=['storage'])
-                if 'stop_frame' not in serializer.validated_data:
+                    self._object.data.save(update_fields=["storage"])
+                if "stop_frame" not in serializer.validated_data:
                     # if the value of stop_frame is 0, then inside the function we cannot know
                     # the value specified by the user or it's default value from the database
-                    data['stop_frame'] = None
+                    data["stop_frame"] = None
 
             # Need to process task data when the transaction is committed
             creator = TaskCreator(request=request, db_instance=self._object, db_data=data)
@@ -1120,20 +1266,20 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             importer = BackupImporter(request=request, target=RequestTarget.TASK)
             return importer.enqueue_job()
 
-        if self.action == 'annotations':
+        if self.action == "annotations":
             return _handle_upload_annotations(request)
-        elif self.action == 'data':
+        elif self.action == "data":
             return _handle_upload_data(request)
-        elif self.action == 'import_backup':
+        elif self.action == "import_backup":
             return _handle_upload_backup(request)
 
-        return Response(data='Unknown upload was finished',
-                        status=status.HTTP_400_BAD_REQUEST)
+        return Response(data="Unknown upload was finished", status=status.HTTP_400_BAD_REQUEST)
 
-    _UPLOAD_FILE_ORDER_FIELD = 'upload_file_order'
+    _UPLOAD_FILE_ORDER_FIELD = "upload_file_order"
     assert _UPLOAD_FILE_ORDER_FIELD in DataSerializer().fields
 
-    @extend_schema(methods=['POST'],
+    @extend_schema(
+        methods=["POST"],
         summary="Attach data to a task",
         description=textwrap.dedent("""\
             Allows to upload data (images, video, etc.) to a task.
@@ -1187,65 +1333,100 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             the `GET /api/requests/<rq_id>`, where **rq_id** is request ID returned for this request.
 
             Once data is attached to a task, it cannot be detached or replaced.
-        """.format(
-            upload_file_order_field=_UPLOAD_FILE_ORDER_FIELD
-        )),
+        """.format(upload_file_order_field=_UPLOAD_FILE_ORDER_FIELD)),
         # TODO: add a tutorial on this endpoint in the REST API docs
         request=DataSerializer(required=False),
         parameters=[
-            OpenApiParameter('Upload-Start', location=OpenApiParameter.HEADER, type=OpenApiTypes.BOOL,
-                description='Initializes data upload. Optionally, can include upload metadata in the request body.'),
-            OpenApiParameter('Upload-Multiple', location=OpenApiParameter.HEADER, type=OpenApiTypes.BOOL,
-                description='Indicates that data with this request are single or multiple files that should be attached to a task'),
-            OpenApiParameter('Upload-Finish', location=OpenApiParameter.HEADER, type=OpenApiTypes.BOOL,
-                description='Finishes data upload. Can be combined with Upload-Start header to create task data with one request'),
+            OpenApiParameter(
+                "Upload-Start",
+                location=OpenApiParameter.HEADER,
+                type=OpenApiTypes.BOOL,
+                description="Initializes data upload. Optionally, can include upload metadata in the request body.",
+            ),
+            OpenApiParameter(
+                "Upload-Multiple",
+                location=OpenApiParameter.HEADER,
+                type=OpenApiTypes.BOOL,
+                description="Indicates that data with this request are single or multiple files that should be attached to a task",
+            ),
+            OpenApiParameter(
+                "Upload-Finish",
+                location=OpenApiParameter.HEADER,
+                type=OpenApiTypes.BOOL,
+                description="Finishes data upload. Can be combined with Upload-Start header to create task data with one request",
+            ),
         ],
         responses={
-            '202': OpenApiResponse(
+            "202": OpenApiResponse(
                 response=PolymorphicProxySerializer(
-                    component_name='DataResponse',
+                    component_name="DataResponse",
                     # FUTURE-FIXME: endpoint should return RqIdSerializer or OpenApiTypes.NONE
                     # but SDK generated from a schema with nullable RqIdSerializer
                     # throws an error when tried to convert empty response to a specific type
                     serializers=[RqIdSerializer, OpenApiTypes.BINARY],
-                    resource_type_field_name=None
+                    resource_type_field_name=None,
                 ),
-
-                description='Request to attach a data to a task has been accepted'
+                description="Request to attach a data to a task has been accepted",
             ),
-        })
-    @extend_schema(methods=['GET'],
-        summary='Get data of a task',
+        },
+    )
+    @extend_schema(
+        methods=["GET"],
+        summary="Get data of a task",
         parameters=[
-            OpenApiParameter('type', location=OpenApiParameter.QUERY, required=True,
-                type=OpenApiTypes.STR, enum=['chunk', 'frame', 'context_image'],
-                description='Specifies the type of the requested data'),
-            OpenApiParameter('quality', location=OpenApiParameter.QUERY, required=False,
-                type=OpenApiTypes.STR, enum=['compressed', 'original'],
-                description="Specifies the quality level of the requested data"),
-            OpenApiParameter('number', location=OpenApiParameter.QUERY, required=False, type=OpenApiTypes.INT,
-                description="A unique number value identifying chunk or frame"),
+            OpenApiParameter(
+                "type",
+                location=OpenApiParameter.QUERY,
+                required=True,
+                type=OpenApiTypes.STR,
+                enum=["chunk", "frame", "context_image"],
+                description="Specifies the type of the requested data",
+            ),
+            OpenApiParameter(
+                "quality",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=OpenApiTypes.STR,
+                enum=["compressed", "original"],
+                description="Specifies the quality level of the requested data",
+            ),
+            OpenApiParameter(
+                "number",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=OpenApiTypes.INT,
+                description="A unique number value identifying chunk or frame",
+            ),
             OpenApiParameter(
                 _DATA_CHECKSUM_HEADER_NAME,
-                location=OpenApiParameter.HEADER, type=OpenApiTypes.STR, required=False,
+                location=OpenApiParameter.HEADER,
+                type=OpenApiTypes.STR,
+                required=False,
                 response=[200],
                 description="Data checksum, applicable for chunks only",
             ),
             OpenApiParameter(
                 _DATA_UPDATED_DATE_HEADER_NAME,
-                location=OpenApiParameter.HEADER, type=OpenApiTypes.DATETIME, required=False,
+                location=OpenApiParameter.HEADER,
+                type=OpenApiTypes.DATETIME,
+                required=False,
                 response=[200],
                 description="Data update date, applicable for chunks only",
-            )
+            ),
         ],
         responses={
-            '200': OpenApiResponse(description='Data of a specific type'),
-        })
-    @action(detail=True, methods=['OPTIONS', 'POST', 'GET'], url_path=r'data/?$',
-        parser_classes=_UPLOAD_PARSER_CLASSES)
+            "200": OpenApiResponse(description="Data of a specific type"),
+        },
+    )
+    @action(
+        detail=True,
+        methods=["OPTIONS", "POST", "GET"],
+        url_path=r"data/?$",
+        parser_classes=_UPLOAD_PARSER_CLASSES,
+    )
     def data(self, request: ExtendedRequest, pk: int):
-        self._object = self.get_object() # call check_object_permissions as well
-        if request.method == 'POST' or request.method == 'OPTIONS':
+        self._object = self.get_object()  # call check_object_permissions as well
+        if request.method == "POST" or request.method == "OPTIONS":
             with transaction.atomic():
                 # Need to make sure that only one Data object can be attached to the task,
                 # otherwise this can lead to many problems such as Data objects without a task,
@@ -1262,13 +1443,14 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                     self._object.data = task_data
                     locked_instance.save()
                 elif task_data.size != 0:
-                    return Response(data='Adding more data is not supported',
-                        status=status.HTTP_400_BAD_REQUEST)
+                    return Response(
+                        data="Adding more data is not supported", status=status.HTTP_400_BAD_REQUEST
+                    )
                 return self.upload_data(request, append_url_name="append-data-chunk")
         else:
-            data_type = request.query_params.get('type', None)
-            data_num = request.query_params.get('number', None)
-            data_quality = request.query_params.get('quality', 'compressed')
+            data_type = request.query_params.get("type", None)
+            data_num = request.query_params.get("number", None)
+            data_quality = request.query_params.get("quality", "compressed")
 
             data_getter = _TaskDataGetter(
                 self._object, data_type=data_type, data_num=data_num, data_quality=data_quality
@@ -1280,14 +1462,17 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         self._object = self.get_object()
         return self.append_tus_chunk(request, file_id)
 
-    @extend_schema(methods=['GET'], summary='Get task annotations',
+    @extend_schema(
+        methods=["GET"],
+        summary="Get task annotations",
         responses={
-            '200': OpenApiResponse(LabeledDataSerializer),
-            '400': OpenApiResponse(description="Exporting without data is not allowed"),
-            '410': OpenApiResponse(description="API endpoint no longer handles exporting process"),
-        })
-
-    @extend_schema(methods=['POST'],
+            "200": OpenApiResponse(LabeledDataSerializer),
+            "400": OpenApiResponse(description="Exporting without data is not allowed"),
+            "410": OpenApiResponse(description="API endpoint no longer handles exporting process"),
+        },
+    )
+    @extend_schema(
+        methods=["POST"],
         summary="Import annotations into a task",
         description=textwrap.dedent("""
             The request POST /api/tasks/id/annotations initiates a background process to import annotations into a task.
@@ -1295,68 +1480,126 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             The `rq_id` parameter can be found in the response on initiating request.
         """),
         parameters=[
-            OpenApiParameter('format', location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False,
-                description='Input format name\nYou can get the list of supported formats at:\n/server/annotation/formats'),
-            OpenApiParameter('location', description='where to import the annotation from',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False,
-                enum=Location.list()),
-            OpenApiParameter('cloud_storage_id', description='Storage id',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.INT, required=False),
-            OpenApiParameter('use_default_location', description='Use the location that was configured in task to import annotations',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.BOOL, required=False,
-                default=True, deprecated=True),
-            OpenApiParameter('filename', description='Annotation file name',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False),
-            OpenApiParameter('import_mode', description='How to import annotations',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False,
+            OpenApiParameter(
+                "format",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+                description="Input format name\nYou can get the list of supported formats at:\n/server/annotation/formats",
+            ),
+            OpenApiParameter(
+                "location",
+                description="where to import the annotation from",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+                enum=Location.list(),
+            ),
+            OpenApiParameter(
+                "cloud_storage_id",
+                description="Storage id",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.INT,
+                required=False,
+            ),
+            OpenApiParameter(
+                "use_default_location",
+                description="Use the location that was configured in task to import annotations",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.BOOL,
+                required=False,
+                default=True,
+                deprecated=True,
+            ),
+            OpenApiParameter(
+                "filename",
+                description="Annotation file name",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+            ),
+            OpenApiParameter(
+                "import_mode",
+                description="How to import annotations",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
                 enum=dm.task.AnnotationImportMode.values(),
-                default=dm.task.AnnotationImportMode.REPLACE),
+                default=dm.task.AnnotationImportMode.REPLACE,
+            ),
         ],
         request=AnnotationFileSerializer(required=False),
         responses={
-            '201': OpenApiResponse(description='Uploading has finished'),
-            '202': OpenApiResponse(RqIdSerializer, description='Uploading has been started'),
-            '405': OpenApiResponse(description='Format is not available'),
-        })
-    @extend_schema(methods=['PUT'], summary='Replace task annotations',
+            "201": OpenApiResponse(description="Uploading has finished"),
+            "202": OpenApiResponse(RqIdSerializer, description="Uploading has been started"),
+            "405": OpenApiResponse(description="Format is not available"),
+        },
+    )
+    @extend_schema(
+        methods=["PUT"],
+        summary="Replace task annotations",
         request=LabeledDataSerializer,
         responses={
-            '200': OpenApiResponse(description='Annotations have been replaced'),
-        })
-    @extend_schema(methods=['PATCH'], summary='Update task annotations',
+            "200": OpenApiResponse(description="Annotations have been replaced"),
+        },
+    )
+    @extend_schema(
+        methods=["PATCH"],
+        summary="Update task annotations",
         parameters=[
-            OpenApiParameter('action', location=OpenApiParameter.QUERY, required=True,
-                type=OpenApiTypes.STR, enum=['create', 'update', 'delete']),
+            OpenApiParameter(
+                "action",
+                location=OpenApiParameter.QUERY,
+                required=True,
+                type=OpenApiTypes.STR,
+                enum=["create", "update", "delete"],
+            ),
         ],
         request=LabeledDataSerializer,
         responses={
-            '200': LabeledDataSerializer,
-        })
-    @extend_schema(methods=['DELETE'], summary='Delete task annotations',
+            "200": LabeledDataSerializer,
+        },
+    )
+    @extend_schema(
+        methods=["DELETE"],
+        summary="Delete task annotations",
         responses={
-            '204': OpenApiResponse(description='The annotation has been deleted'),
-        })
-    @action(detail=True, methods=['GET', 'DELETE', 'PUT', 'PATCH', 'POST', 'OPTIONS'], url_path=r'annotations/?$',
-        serializer_class=None, parser_classes=_UPLOAD_PARSER_CLASSES)
+            "204": OpenApiResponse(description="The annotation has been deleted"),
+        },
+    )
+    @action(
+        detail=True,
+        methods=["GET", "DELETE", "PUT", "PATCH", "POST", "OPTIONS"],
+        url_path=r"annotations/?$",
+        serializer_class=None,
+        parser_classes=_UPLOAD_PARSER_CLASSES,
+    )
     def annotations(self, request: ExtendedRequest, pk: int):
-        self._object = self.get_object() # force call of check_object_permissions()
-        if request.method == 'GET':
+        self._object = self.get_object()  # force call of check_object_permissions()
+        if request.method == "GET":
             if not self._object.data:
-                return HttpResponseBadRequest("Exporting annotations from a task without data is not allowed")
+                return HttpResponseBadRequest(
+                    "Exporting annotations from a task without data is not allowed"
+                )
 
-            if (
-                {"format", "filename", "action", "location", "cloud_storage_id"}
-                & request.query_params.keys()
-            ):
-                return get_410_response_for_export_api("/api/tasks/id/dataset/export?save_images=False")
+            if {
+                "format",
+                "filename",
+                "action",
+                "location",
+                "cloud_storage_id",
+            } & request.query_params.keys():
+                return get_410_response_for_export_api(
+                    "/api/tasks/id/dataset/export?save_images=False"
+                )
 
             data = dm.task.get_task_data(self._object.pk)
             return Response(data)
 
-        elif request.method == 'POST' or request.method == 'OPTIONS':
+        elif request.method == "POST" or request.method == "OPTIONS":
             return self.upload_data(request, append_url_name="append-annotations-chunk")
 
-        elif request.method == 'PUT':
+        elif request.method == "PUT":
             if {"format", "rq_id"} & set(request.query_params.keys()):
                 return get_410_response_when_checking_process_status("import")
 
@@ -1367,14 +1610,15 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 data = dm.task.put_task_data(pk, serializer.validated_data)
                 return Response(data)
 
-        elif request.method == 'DELETE':
+        elif request.method == "DELETE":
             dm.task.delete_task_data(pk)
             return Response(status=status.HTTP_204_NO_CONTENT)
-        elif request.method == 'PATCH':
+        elif request.method == "PATCH":
             action = self.request.query_params.get("action", None)
             if action not in dm.task.PatchAction.values():
                 raise serializers.ValidationError(
-                    "Please specify a correct 'action' for the request")
+                    "Please specify a correct 'action' for the request"
+                )
             serializer = LabeledDataSerializer(
                 data=request.data, context={"annotation_action": action}
             )
@@ -1392,30 +1636,28 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
 
     ### --- DEPRECATED METHOD --- ###
     @extend_schema(
-        summary='Get the creation status of a task',
+        summary="Get the creation status of a task",
         responses={
-            '200': RqStatusSerializer,
+            "200": RqStatusSerializer,
         },
         deprecated=True,
         description="This method is deprecated and will be removed in one of the next releases. "
-                    "To check status of task creation, use new common API "
-                    "for managing background operations: GET /api/requests/?action=create&task_id=<task_id>",
+        "To check status of task creation, use new common API "
+        "for managing background operations: GET /api/requests/?action=create&task_id=<task_id>",
     )
-    @action(detail=True, methods=['GET'], serializer_class=RqStatusSerializer)
+    @action(detail=True, methods=["GET"], serializer_class=RqStatusSerializer)
     def status(self, request, pk):
-        task = self.get_object() # force call of check_object_permissions()
+        task = self.get_object()  # force call of check_object_permissions()
         response = self._get_rq_response(
             queue=settings.CVAT_QUEUES.IMPORT_DATA.value,
             job_id=ImportRequestId(
-                action=RequestAction.CREATE,
-                target=RequestTarget.TASK,
-                target_id=task.id
-            ).render()
+                action=RequestAction.CREATE, target=RequestTarget.TASK, target_id=task.id
+            ).render(),
         )
         serializer = RqStatusSerializer(data=response)
 
         serializer.is_valid(raise_exception=True)
-        return Response(serializer.data,  headers={'Deprecation': 'true'})
+        return Response(serializer.data, headers={"Deprecation": "true"})
 
     ### --- DEPRECATED METHOD--- ###
     @staticmethod
@@ -1424,37 +1666,50 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         job = queue.fetch_job(job_id)
         response = {}
         if job is None or job.is_finished:
-            response = { "state": "Finished" }
+            response = {"state": "Finished"}
         elif job.is_queued or job.is_deferred:
-            response = { "state": "Queued" }
+            response = {"state": "Queued"}
         elif job.is_failed:
             # FIXME: It seems that in some cases exc_info can be None.
             # It's not really clear how it is possible, but it can
             # lead to an error in serializing the response
             # https://github.com/cvat-ai/cvat/issues/5215
-            response = { "state": "Failed", "message": parse_exception_message(job.exc_info or "Unknown error") }
+            response = {
+                "state": "Failed",
+                "message": parse_exception_message(job.exc_info or "Unknown error"),
+            }
         else:
             rq_job_meta = ImportRQMeta.for_job(job)
-            response = { "state": "Started" }
+            response = {"state": "Started"}
             if rq_job_meta.status:
-                response['message'] = rq_job_meta.status
-            response['progress'] = rq_job_meta.progress or 0.
+                response["message"] = rq_job_meta.status
+            response["progress"] = rq_job_meta.progress or 0.0
 
         return response
 
-    @extend_schema(methods=['GET'], summary='Get metainformation for media files in a task',
+    @extend_schema(
+        methods=["GET"],
+        summary="Get metainformation for media files in a task",
         responses={
-            '200': DataMetaReadSerializer,
-        })
-    @extend_schema(methods=['PATCH'], summary='Update metainformation for media files in a task',
+            "200": DataMetaReadSerializer,
+        },
+    )
+    @extend_schema(
+        methods=["PATCH"],
+        summary="Update metainformation for media files in a task",
         request=DataMetaWriteSerializer,
         responses={
-            '200': DataMetaReadSerializer,
-        })
-    @action(detail=True, methods=['GET', 'PATCH'], serializer_class=DataMetaReadSerializer,
-        url_path='data/meta')
+            "200": DataMetaReadSerializer,
+        },
+    )
+    @action(
+        detail=True,
+        methods=["GET", "PATCH"],
+        serializer_class=DataMetaReadSerializer,
+        url_path="data/meta",
+    )
     def metadata(self, request: ExtendedRequest, pk: int):
-        db_task = self.get_object() #force to call check_object_permissions
+        db_task = self.get_object()  # force to call check_object_permissions
 
         def prefetch():
             data_queryset = models.Data.objects.select_related("validation_layout")
@@ -1474,12 +1729,12 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                     extra_prefetches += [
                         Prefetch(
                             "data__images",
-                            queryset=models.Image.objects.order_by('frame'),
+                            queryset=models.Image.objects.order_by("frame"),
                         ),
-                        "data__images__related_files"
+                        "data__images__related_files",
                     ]
                 case ("", ""):
-                    pass # noop, nothing to load
+                    pass  # noop, nothing to load
                 case (media_type, mode):
                     assert False, f"Unknown media type '{media_type}' with mode '{mode}'"
 
@@ -1492,7 +1747,7 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
 
         prefetch()
 
-        if request.method == 'PATCH':
+        if request.method == "PATCH":
             if db_task.media_type == models.MediaType.AUDIO:
                 # TODO: introduce support for frame deletion when there's more information
                 # on use cases. Should probably work with ranges.
@@ -1515,6 +1770,7 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
 
             def serialize_media_item(item: models.Audio) -> dict[str, Any]:
                 return {}
+
         elif db_task.media_type in (models.MediaType.IMAGE, models.MediaType.POINT_CLOUD):
             if db_task.mode == models.TaskMode.INTERPOLATION:
                 media = [db_data.video]
@@ -1527,17 +1783,18 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
 
             def serialize_media_item(item: models.Video | models.Image) -> dict[str, Any]:
                 return {
-                    'width': item.width,
-                    'height': item.height,
+                    "width": item.width,
+                    "height": item.height,
                 }
+
         elif db_task.media_type:
             assert False, f"Unknown media type '{db_task.media_type}'"
 
         frame_meta = [
             {
-                'name': item.path,
-                'related_files': (
-                    item.related_files.count() if hasattr(item, 'related_files') else 0
+                "name": item.path,
+                "related_files": (
+                    item.related_files.count() if hasattr(item, "related_files") else 0
                 ),
                 **serialize_media_item(item),
             }
@@ -1552,26 +1809,28 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         return Response(serializer.data)
 
     @extend_schema(exclude=True)
-    @action(detail=True, methods=['GET'], serializer_class=None, url_path='dataset')
+    @action(detail=True, methods=["GET"], serializer_class=None, url_path="dataset")
     def dataset_export(self, request: ExtendedRequest, pk: int):
         return get_410_response_for_export_api("/api/tasks/id/dataset/export?save_images=True")
 
-    @extend_schema(summary='Get a preview image for a task',
+    @extend_schema(
+        summary="Get a preview image for a task",
         responses={
-            '200': OpenApiResponse(description='Task image preview'),
-            '404': OpenApiResponse(description='Task image preview not found'),
-        })
-    @action(detail=True, methods=['GET'], url_path='preview')
+            "200": OpenApiResponse(description="Task image preview"),
+            "404": OpenApiResponse(description="Task image preview not found"),
+        },
+    )
+    @action(detail=True, methods=["GET"], url_path="preview")
     def preview(self, request: ExtendedRequest, pk: int):
-        self._object = self.get_object() # call check_object_permissions as well
+        self._object = self.get_object()  # call check_object_permissions as well
 
         if not self._object.data:
-            return HttpResponseNotFound('Task image preview not found')
+            return HttpResponseNotFound("Task image preview not found")
 
         data_getter = _TaskDataGetter(
             db_task=self._object,
-            data_type='preview',
-            data_quality='compressed',
+            data_type="preview",
+            data_quality="compressed",
         )
         return data_getter()
 
@@ -1579,8 +1838,9 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         methods=["GET"],
         summary="Allows getting current validation configuration",
         responses={
-            '200': OpenApiResponse(TaskValidationLayoutReadSerializer),
-        })
+            "200": OpenApiResponse(TaskValidationLayoutReadSerializer),
+        },
+    )
     @extend_schema(
         methods=["PATCH"],
         summary="Allows updating current validation configuration",
@@ -1591,29 +1851,30 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         """),
         request=TaskValidationLayoutWriteSerializer,
         responses={
-            '200': OpenApiResponse(TaskValidationLayoutReadSerializer),
+            "200": OpenApiResponse(TaskValidationLayoutReadSerializer),
         },
         examples=[
-            OpenApiExample("set honeypots to random validation frames", {
-                "frame_selection_method": models.JobFrameSelectionMethod.RANDOM_UNIFORM
-            }),
-            OpenApiExample("set honeypots manually", {
-                "frame_selection_method": models.JobFrameSelectionMethod.MANUAL,
-                "honeypot_real_frames": [10, 20, 22]
-            }),
-            OpenApiExample("disable validation frames", {
-                "disabled_frames": [4, 5, 8]
-            }),
-            OpenApiExample("restore all validation frames", {
-                "disabled_frames": []
-            }),
-        ])
-    @action(detail=True, methods=["GET", "PATCH"], url_path='validation_layout')
+            OpenApiExample(
+                "set honeypots to random validation frames",
+                {"frame_selection_method": models.JobFrameSelectionMethod.RANDOM_UNIFORM},
+            ),
+            OpenApiExample(
+                "set honeypots manually",
+                {
+                    "frame_selection_method": models.JobFrameSelectionMethod.MANUAL,
+                    "honeypot_real_frames": [10, 20, 22],
+                },
+            ),
+            OpenApiExample("disable validation frames", {"disabled_frames": [4, 5, 8]}),
+            OpenApiExample("restore all validation frames", {"disabled_frames": []}),
+        ],
+    )
+    @action(detail=True, methods=["GET", "PATCH"], url_path="validation_layout")
     @transaction.atomic
     def validation_layout(self, request: ExtendedRequest, pk: int):
-        db_task = cast(models.Task, self.get_object()) # call check_object_permissions as well
+        db_task = cast(models.Task, self.get_object())  # call check_object_permissions as well
 
-        validation_layout = getattr(db_task.data, 'validation_layout', None)
+        validation_layout = getattr(db_task.data, "validation_layout", None)
 
         if request.method == "PATCH":
             if not validation_layout:
@@ -1634,68 +1895,87 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         return Response(response_serializer.data, status=status.HTTP_200_OK)
 
 
-@extend_schema(tags=['jobs'])
+@extend_schema(tags=["jobs"])
 @extend_schema_view(
     create=extend_schema(
-        summary='Create a job',
+        summary="Create a job",
         request=JobWriteSerializer,
         responses={
-            '201': JobReadSerializer, # check JobWriteSerializer.to_representation
+            "201": JobReadSerializer,  # check JobWriteSerializer.to_representation
         },
         examples=[
-            OpenApiExample("create gt job with random 10 frames", {
-                "type": models.JobType.GROUND_TRUTH,
-                "task_id": 42,
-                "frame_selection_method": models.JobFrameSelectionMethod.RANDOM_UNIFORM,
-                "frame_count": 10,
-                "random_seed": 1,
-            }),
-            OpenApiExample("create gt job with random 15% frames", {
-                "type": models.JobType.GROUND_TRUTH,
-                "task_id": 42,
-                "frame_selection_method": models.JobFrameSelectionMethod.RANDOM_UNIFORM,
-                "frame_share": 0.15,
-                "random_seed": 1,
-            }),
-            OpenApiExample("create gt job with 3 random frames in each job", {
-                "type": models.JobType.GROUND_TRUTH,
-                "task_id": 42,
-                "frame_selection_method": models.JobFrameSelectionMethod.RANDOM_PER_JOB,
-                "frames_per_job_count": 3,
-                "random_seed": 1,
-            }),
-            OpenApiExample("create gt job with 20% random frames in each job", {
-                "type": models.JobType.GROUND_TRUTH,
-                "task_id": 42,
-                "frame_selection_method": models.JobFrameSelectionMethod.RANDOM_PER_JOB,
-                "frames_per_job_share": 0.2,
-                "random_seed": 1,
-            }),
-            OpenApiExample("create gt job with manual frame selection", {
-                "type": models.JobType.GROUND_TRUTH,
-                "task_id": 42,
-                "frame_selection_method": models.JobFrameSelectionMethod.MANUAL,
-                "frames": [1, 5, 10, 18],
-            }),
-        ]),
+            OpenApiExample(
+                "create gt job with random 10 frames",
+                {
+                    "type": models.JobType.GROUND_TRUTH,
+                    "task_id": 42,
+                    "frame_selection_method": models.JobFrameSelectionMethod.RANDOM_UNIFORM,
+                    "frame_count": 10,
+                    "random_seed": 1,
+                },
+            ),
+            OpenApiExample(
+                "create gt job with random 15% frames",
+                {
+                    "type": models.JobType.GROUND_TRUTH,
+                    "task_id": 42,
+                    "frame_selection_method": models.JobFrameSelectionMethod.RANDOM_UNIFORM,
+                    "frame_share": 0.15,
+                    "random_seed": 1,
+                },
+            ),
+            OpenApiExample(
+                "create gt job with 3 random frames in each job",
+                {
+                    "type": models.JobType.GROUND_TRUTH,
+                    "task_id": 42,
+                    "frame_selection_method": models.JobFrameSelectionMethod.RANDOM_PER_JOB,
+                    "frames_per_job_count": 3,
+                    "random_seed": 1,
+                },
+            ),
+            OpenApiExample(
+                "create gt job with 20% random frames in each job",
+                {
+                    "type": models.JobType.GROUND_TRUTH,
+                    "task_id": 42,
+                    "frame_selection_method": models.JobFrameSelectionMethod.RANDOM_PER_JOB,
+                    "frames_per_job_share": 0.2,
+                    "random_seed": 1,
+                },
+            ),
+            OpenApiExample(
+                "create gt job with manual frame selection",
+                {
+                    "type": models.JobType.GROUND_TRUTH,
+                    "task_id": 42,
+                    "frame_selection_method": models.JobFrameSelectionMethod.MANUAL,
+                    "frames": [1, 5, 10, 18],
+                },
+            ),
+        ],
+    ),
     retrieve=extend_schema(
-        summary='Get job details',
+        summary="Get job details",
         responses={
-            '200': JobReadSerializer,
-        }),
+            "200": JobReadSerializer,
+        },
+    ),
     list=extend_schema(
-        summary='List jobs',
+        summary="List jobs",
         responses={
-            '200': JobReadSerializer(many=True),
-        }),
+            "200": JobReadSerializer(many=True),
+        },
+    ),
     partial_update=extend_schema(
-        summary='Update a job',
+        summary="Update a job",
         request=JobWriteSerializer(partial=True),
         responses={
-            '200': JobReadSerializer, # check JobWriteSerializer.to_representation
-        }),
+            "200": JobReadSerializer,  # check JobWriteSerializer.to_representation
+        },
+    ),
     destroy=extend_schema(
-        summary='Delete a job',
+        summary="Delete a job",
         description=textwrap.dedent("""\
             Related annotations will be deleted as well.
 
@@ -1703,57 +1983,71 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             it is only available for Ground Truth jobs.
             """),
         responses={
-            '204': OpenApiResponse(description='The job has been deleted'),
-        }),
+            "204": OpenApiResponse(description="The job has been deleted"),
+        },
+    ),
 )
-class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin, PartialUpdateModelMixin, mixins.DestroyModelMixin,
-    UploadMixin, DatasetMixin
+class JobViewSet(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    PartialUpdateModelMixin,
+    mixins.DestroyModelMixin,
+    UploadMixin,
+    DatasetMixin,
 ):
     queryset = Job.objects.select_related(
         # prefetch data for permission checks
-        'segment__task',
-        'segment__task__project',
+        "segment__task",
+        "segment__task__project",
     )
 
     iam_supports_organization_params = True
     iam_permission_class = JobPermission
-    search_fields = ('task_name', 'project_name', 'assignee')
+    search_fields = ("task_name", "project_name", "assignee")
     simple_filters = (
         *search_fields,
-        'task_id', 'project_id', 'type', 'parent_job_id',
-        'dimension', 'media_type', "mode", 'state', 'stage',
+        "task_id",
+        "project_id",
+        "type",
+        "parent_job_id",
+        "dimension",
+        "media_type",
+        "mode",
+        "state",
+        "stage",
     )
-    filter_fields = (*simple_filters, 'id', 'updated_date')
+    filter_fields = (*simple_filters, "id", "updated_date")
     ordering_fields = list(filter_fields)
     ordering = "-id"
     lookup_fields = {
-        'dimension': 'segment__task__dimension',
-        'media_type': 'segment__task__media_type',
-        'mode': 'segment__task__mode',
-        'task_id': 'segment__task_id',
-        'project_id': 'segment__task__project_id',
-        'task_name': 'segment__task__name',
-        'project_name': 'segment__task__project__name',
-        'assignee': 'assignee__username'
+        "dimension": "segment__task__dimension",
+        "media_type": "segment__task__media_type",
+        "mode": "segment__task__mode",
+        "task_id": "segment__task_id",
+        "project_id": "segment__task__project_id",
+        "task_name": "segment__task__name",
+        "project_name": "segment__task__project__name",
+        "assignee": "assignee__username",
     }
 
     def get_queryset(self):
         queryset = super().get_queryset()
 
-        if self.action == 'list':
+        if self.action == "list":
             perm = JobPermission.create_scope_list(self.request)
             queryset = perm.filter(queryset)
-            queryset = queryset.select_related('assignee')
+            queryset = queryset.select_related("assignee")
             # with_* optimized in JobReadListSerializer
-        elif self.action not in ('annotations', 'metadata'):
-            queryset = queryset.select_related('segment__task__data')
+        elif self.action not in ("annotations", "metadata"):
+            queryset = queryset.select_related("segment__task__data")
 
-            if self.action in ('create', 'retrieve', 'update', 'partial_update', 'destroy'):
+            if self.action in ("create", "retrieve", "update", "partial_update", "destroy"):
                 queryset = queryset.select_related(
-                    'assignee',
-                    'segment__task__annotation_guide',
-                    'segment__task__project__annotation_guide',
+                    "assignee",
+                    "segment__task__annotation_guide",
+                    "segment__task__project__annotation_guide",
                 )
                 queryset = queryset.with_issue_counts().with_child_jobs_counts()
 
@@ -1778,9 +2072,9 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
             raise ValidationError("Only ground truth jobs can be removed")
 
         validation_layout: models.ValidationLayout | None = getattr(
-            instance.segment.task.data, 'validation_layout', None
+            instance.segment.task.data, "validation_layout", None
         )
-        if (validation_layout and validation_layout.mode == models.ValidationMode.GT_POOL):
+        if validation_layout and validation_layout.mode == models.ValidationMode.GT_POOL:
             raise ValidationError(
                 'GT jobs cannot be removed when task validation mode is "{}"'.format(
                     models.ValidationMode.GT_POOL
@@ -1798,14 +2092,14 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
 
     # UploadMixin method
     def upload_finished(self, request: ExtendedRequest):
-        if self.action == 'annotations':
+        if self.action == "annotations":
             importer = DatasetImporter(request=request, db_instance=self._object)
             return importer.enqueue_job()
 
-        return Response(data='Unknown upload was finished',
-                        status=status.HTTP_400_BAD_REQUEST)
+        return Response(data="Unknown upload was finished", status=status.HTTP_400_BAD_REQUEST)
 
-    @extend_schema(methods=['GET'],
+    @extend_schema(
+        methods=["GET"],
         summary="Get job annotations",
         description=textwrap.dedent("""\
             Deprecation warning:
@@ -1821,104 +2115,180 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
                 where `result_url` can be found in the response on checking status request
         """),
         parameters=[
-            OpenApiParameter('format', location=OpenApiParameter.QUERY,
-                description='This parameter is no longer supported',
-                type=OpenApiTypes.STR, required=False,
+            OpenApiParameter(
+                "format",
+                location=OpenApiParameter.QUERY,
+                description="This parameter is no longer supported",
+                type=OpenApiTypes.STR,
+                required=False,
                 deprecated=True,
             ),
-            OpenApiParameter('filename', description='This parameter is no longer supported',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False,
+            OpenApiParameter(
+                "filename",
+                description="This parameter is no longer supported",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
                 deprecated=True,
             ),
-            OpenApiParameter('action', location=OpenApiParameter.QUERY,
-                description='This parameter is no longer supported',
-                type=OpenApiTypes.STR, required=False,
+            OpenApiParameter(
+                "action",
+                location=OpenApiParameter.QUERY,
+                description="This parameter is no longer supported",
+                type=OpenApiTypes.STR,
+                required=False,
                 deprecated=True,
             ),
-            OpenApiParameter('location', description='This parameter is no longer supported',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False,
+            OpenApiParameter(
+                "location",
+                description="This parameter is no longer supported",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
                 enum=Location.list(),
                 deprecated=True,
             ),
-            OpenApiParameter('cloud_storage_id', description='This parameter is no longer supported',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.INT, required=False,
+            OpenApiParameter(
+                "cloud_storage_id",
+                description="This parameter is no longer supported",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.INT,
+                required=False,
                 deprecated=True,
             ),
         ],
         responses={
-            '200': OpenApiResponse(LabeledDataSerializer),
-            '410': OpenApiResponse(description="API endpoint no longer handles dataset exporting process"),
-        })
-    @extend_schema(methods=['POST'],
-        summary='Import annotations into a job',
+            "200": OpenApiResponse(LabeledDataSerializer),
+            "410": OpenApiResponse(
+                description="API endpoint no longer handles dataset exporting process"
+            ),
+        },
+    )
+    @extend_schema(
+        methods=["POST"],
+        summary="Import annotations into a job",
         description=textwrap.dedent("""
             The request POST /api/jobs/id/annotations initiates a background process to import annotations into a job.
             Please, use the GET /api/requests/<rq_id> endpoint for checking status of the process.
             The `rq_id` parameter can be found in the response on initiating request.
         """),
         parameters=[
-            OpenApiParameter('format', location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False,
-                description='Input format name\nYou can get the list of supported formats at:\n/server/annotation/formats'),
-            OpenApiParameter('location', description='where to import the annotation from',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False,
-                enum=Location.list()),
-            OpenApiParameter('cloud_storage_id', description='Storage id',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.INT, required=False),
-            OpenApiParameter('use_default_location', description='Use the location that was configured in the task to import annotation',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.BOOL, required=False,
-                default=True, deprecated=True),
-            OpenApiParameter('filename', description='Annotation file name',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False),
-            OpenApiParameter('import_mode', description='How to import annotations',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR, required=False,
+            OpenApiParameter(
+                "format",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+                description="Input format name\nYou can get the list of supported formats at:\n/server/annotation/formats",
+            ),
+            OpenApiParameter(
+                "location",
+                description="where to import the annotation from",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+                enum=Location.list(),
+            ),
+            OpenApiParameter(
+                "cloud_storage_id",
+                description="Storage id",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.INT,
+                required=False,
+            ),
+            OpenApiParameter(
+                "use_default_location",
+                description="Use the location that was configured in the task to import annotation",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.BOOL,
+                required=False,
+                default=True,
+                deprecated=True,
+            ),
+            OpenApiParameter(
+                "filename",
+                description="Annotation file name",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
+            ),
+            OpenApiParameter(
+                "import_mode",
+                description="How to import annotations",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=False,
                 enum=dm.task.AnnotationImportMode.values(),
-                default=dm.task.AnnotationImportMode.REPLACE),
+                default=dm.task.AnnotationImportMode.REPLACE,
+            ),
         ],
         request=AnnotationFileSerializer(required=False),
         responses={
-            '201': OpenApiResponse(description='Uploading has finished'),
-            '202': OpenApiResponse(RqIdSerializer, description='Uploading has been started'),
-            '405': OpenApiResponse(description='Format is not available'),
-        })
+            "201": OpenApiResponse(description="Uploading has finished"),
+            "202": OpenApiResponse(RqIdSerializer, description="Uploading has been started"),
+            "405": OpenApiResponse(description="Format is not available"),
+        },
+    )
     @extend_schema(
-        methods=['PUT'],
-        summary='Replace job annotations',
+        methods=["PUT"],
+        summary="Replace job annotations",
         request=LabeledDataSerializer,
         responses={
-            '200': OpenApiResponse(description='Annotations have been replaced'),
-        })
-    @extend_schema(methods=['PATCH'], summary='Update job annotations',
+            "200": OpenApiResponse(description="Annotations have been replaced"),
+        },
+    )
+    @extend_schema(
+        methods=["PATCH"],
+        summary="Update job annotations",
         parameters=[
-            OpenApiParameter('action', location=OpenApiParameter.QUERY, type=OpenApiTypes.STR,
-                required=True, enum=['create', 'update', 'delete'])
+            OpenApiParameter(
+                "action",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                required=True,
+                enum=["create", "update", "delete"],
+            )
         ],
         request=LabeledDataSerializer,
         responses={
-            '200': OpenApiResponse(description='Annotations successfully uploaded'),
-        })
-    @extend_schema(methods=['DELETE'], summary='Delete job annotations',
+            "200": OpenApiResponse(description="Annotations successfully uploaded"),
+        },
+    )
+    @extend_schema(
+        methods=["DELETE"],
+        summary="Delete job annotations",
         responses={
-            '204': OpenApiResponse(description='The annotation has been deleted'),
-        })
-    @action(detail=True, methods=['GET', 'DELETE', 'PUT', 'PATCH', 'POST', 'OPTIONS'], url_path=r'annotations/?$',
-        serializer_class=LabeledDataSerializer, parser_classes=_UPLOAD_PARSER_CLASSES)
+            "204": OpenApiResponse(description="The annotation has been deleted"),
+        },
+    )
+    @action(
+        detail=True,
+        methods=["GET", "DELETE", "PUT", "PATCH", "POST", "OPTIONS"],
+        url_path=r"annotations/?$",
+        serializer_class=LabeledDataSerializer,
+        parser_classes=_UPLOAD_PARSER_CLASSES,
+    )
     def annotations(self, request: ExtendedRequest, pk: int):
-        self._object: models.Job = self.get_object() # force call of check_object_permissions()
-        if request.method == 'GET':
+        self._object: models.Job = self.get_object()  # force call of check_object_permissions()
+        if request.method == "GET":
 
-            if (
-                {"format", "filename", "location", "action", "cloud_storage_id"}
-                & request.query_params.keys()
-            ):
-                return get_410_response_for_export_api("/api/jobs/id/dataset/export?save_images=False")
+            if {
+                "format",
+                "filename",
+                "location",
+                "action",
+                "cloud_storage_id",
+            } & request.query_params.keys():
+                return get_410_response_for_export_api(
+                    "/api/jobs/id/dataset/export?save_images=False"
+                )
 
             annotations = dm.task.get_job_data(self._object.pk)
             return Response(annotations)
 
-        elif request.method == 'POST' or request.method == 'OPTIONS':
+        elif request.method == "POST" or request.method == "OPTIONS":
             return self.upload_data(request, append_url_name="append-annotations-chunk")
 
-        elif request.method == 'PUT':
+        elif request.method == "PUT":
             if {"format", "rq_id"} & set(request.query_params.keys()):
                 return get_410_response_when_checking_process_status("import")
 
@@ -1931,14 +2301,15 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
                 except (AttributeError, IntegrityError) as e:
                     return Response(data=str(e), status=status.HTTP_400_BAD_REQUEST)
                 return Response(data)
-        elif request.method == 'DELETE':
+        elif request.method == "DELETE":
             dm.task.delete_job_data(pk)
             return Response(status=status.HTTP_204_NO_CONTENT)
-        elif request.method == 'PATCH':
+        elif request.method == "PATCH":
             action = self.request.query_params.get("action", None)
             if action not in dm.task.PatchAction.values():
                 raise serializers.ValidationError(
-                    "Please specify a correct 'action' for the request")
+                    "Please specify a correct 'action' for the request"
+                )
             serializer = LabeledDataSerializer(
                 data=request.data, context={"annotation_action": action}
             )
@@ -1949,68 +2320,101 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
                     return Response(data=str(e), status=status.HTTP_400_BAD_REQUEST)
                 return Response(data)
 
-
     @tus_chunk_action(detail=True, suffix_base="annotations")
     def append_annotations_chunk(self, request: ExtendedRequest, pk: int, file_id: str):
         self._object = self.get_object()
         return self.append_tus_chunk(request, file_id)
 
     @extend_schema(exclude=True)
-    @action(detail=True, methods=['GET'], serializer_class=None, url_path='dataset')
+    @action(detail=True, methods=["GET"], serializer_class=None, url_path="dataset")
     def dataset_export(self, request: ExtendedRequest, pk: int):
         return get_410_response_for_export_api("/api/jobs/id/dataset/export?save_images=True")
 
-    @extend_schema(summary='Get data of a job',
+    @extend_schema(
+        summary="Get data of a job",
         parameters=[
-            OpenApiParameter('type', description='Specifies the type of the requested data',
-                location=OpenApiParameter.QUERY, required=True, type=OpenApiTypes.STR,
-                enum=['chunk', 'frame', 'context_image']),
-            OpenApiParameter('quality', location=OpenApiParameter.QUERY, required=False,
-                type=OpenApiTypes.STR, enum=['compressed', 'original'],
-                description="Specifies the quality level of the requested data"),
-            OpenApiParameter('number',
-                location=OpenApiParameter.QUERY, required=False, type=OpenApiTypes.INT,
+            OpenApiParameter(
+                "type",
+                description="Specifies the type of the requested data",
+                location=OpenApiParameter.QUERY,
+                required=True,
+                type=OpenApiTypes.STR,
+                enum=["chunk", "frame", "context_image"],
+            ),
+            OpenApiParameter(
+                "quality",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=OpenApiTypes.STR,
+                enum=["compressed", "original"],
+                description="Specifies the quality level of the requested data",
+            ),
+            OpenApiParameter(
+                "number",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=OpenApiTypes.INT,
                 description="A unique number value identifying chunk or frame. "
-                    "The numbers are the same as for the task. "
-                    "Deprecated for chunks in favor of 'index'"),
-            OpenApiParameter('index',
-                location=OpenApiParameter.QUERY, required=False, type=OpenApiTypes.INT,
-                description="A unique number value identifying chunk, starts from 0 for each job"),
-            ],
+                "The numbers are the same as for the task. "
+                "Deprecated for chunks in favor of 'index'",
+            ),
+            OpenApiParameter(
+                "index",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=OpenApiTypes.INT,
+                description="A unique number value identifying chunk, starts from 0 for each job",
+            ),
+        ],
         responses={
-            '200': OpenApiResponse(OpenApiTypes.BINARY, description='Data of a specific type'),
-        })
-    @action(detail=True, methods=['GET'],
-        simple_filters=[] # type query parameter conflicts with the filter
+            "200": OpenApiResponse(OpenApiTypes.BINARY, description="Data of a specific type"),
+        },
+    )
+    @action(
+        detail=True,
+        methods=["GET"],
+        simple_filters=[],  # type query parameter conflicts with the filter
     )
     def data(self, request: ExtendedRequest, pk: int):
-        db_job = self.get_object() # call check_object_permissions as well
-        data_type = request.query_params.get('type', None)
-        data_num = request.query_params.get('number', None)
-        data_index = request.query_params.get('index', None)
-        data_quality = request.query_params.get('quality', 'compressed')
+        db_job = self.get_object()  # call check_object_permissions as well
+        data_type = request.query_params.get("type", None)
+        data_num = request.query_params.get("number", None)
+        data_index = request.query_params.get("index", None)
+        data_quality = request.query_params.get("quality", "compressed")
 
         data_getter = _JobDataGetter(
             db_job,
-            data_type=data_type, data_quality=data_quality,
-            data_index=data_index, data_num=data_num
+            data_type=data_type,
+            data_quality=data_quality,
+            data_index=data_index,
+            data_num=data_num,
         )
         return data_getter()
 
-
-    @extend_schema(methods=['GET'], summary='Get metainformation for media files in a job',
+    @extend_schema(
+        methods=["GET"],
+        summary="Get metainformation for media files in a job",
         responses={
-            '200': DataMetaReadSerializer,
-        })
-    @extend_schema(methods=['PATCH'], summary='Update metainformation for media files in a job',
+            "200": DataMetaReadSerializer,
+        },
+    )
+    @extend_schema(
+        methods=["PATCH"],
+        summary="Update metainformation for media files in a job",
         request=JobDataMetaWriteSerializer,
         responses={
-            '200': DataMetaReadSerializer,
-        }, versions=['2.0'])
-    @action(detail=True, methods=['GET', 'PATCH'], serializer_class=DataMetaReadSerializer,
-        url_path='data/meta')
+            "200": DataMetaReadSerializer,
+        },
+        versions=["2.0"],
+    )
+    @action(
+        detail=True,
+        methods=["GET", "PATCH"],
+        serializer_class=DataMetaReadSerializer,
+        url_path="data/meta",
+    )
     def metadata(self, request: ExtendedRequest, pk: int):
-        db_job = self.get_object() # force call of check_object_permissions()
+        db_job = self.get_object()  # force call of check_object_permissions()
 
         def prefetch():
             db_task = db_job.segment.task
@@ -2032,12 +2436,12 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
                     extra_prefetches += [
                         Prefetch(
                             "segment__task__data__images",
-                            queryset=models.Image.objects.order_by('frame'),
+                            queryset=models.Image.objects.order_by("frame"),
                         ),
-                        "segment__task__data__images__related_files"
+                        "segment__task__data__images__related_files",
                     ]
                 case ("", ""):
-                    pass # noop, nothing to load
+                    pass  # noop, nothing to load
                 case (media_type, mode):
                     assert False, f"Unknown media type '{media_type}' with mode '{mode}'"
 
@@ -2049,7 +2453,7 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
 
         prefetch()
 
-        if request.method == 'PATCH':
+        if request.method == "PATCH":
             if db_job.segment.task.media_type == models.MediaType.AUDIO:
                 # TODO: introduce support for frame deletion when there's more information
                 # on use cases. Should probably work with ranges.
@@ -2098,20 +2502,22 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
 
             def serialize_media_item(item: models.Audio) -> dict[str, Any]:
                 return {}
+
         elif db_task.media_type in (models.MediaType.IMAGE, models.MediaType.POINT_CLOUD):
             if db_task.mode == models.TaskMode.INTERPOLATION:
                 media = [db_data.video]
                 chapters = get_video_chapters(
-                    db_task.data.get_manifest_path(),
-                    segment=(data_start_frame, data_stop_frame)
+                    db_task.data.get_manifest_path(), segment=(data_start_frame, data_stop_frame)
                 )
             elif db_task.mode == models.TaskMode.ANNOTATION:
                 media = [
                     # Insert placeholders if frames are skipped
                     # TODO: remove placeholders, UI supports chunks without placeholders already
                     # after https://github.com/cvat-ai/cvat/pull/8272
-                    f if f.frame in segment_frame_set else SimpleNamespace(
-                        path='placeholder.jpg', width=f.width, height=f.height
+                    (
+                        f
+                        if f.frame in segment_frame_set
+                        else SimpleNamespace(path="placeholder.jpg", width=f.width, height=f.height)
                     )
                     for f in db_data.images.all()
                     if f.frame in range(data_start_frame, data_stop_frame + frame_step, frame_step)
@@ -2122,17 +2528,18 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
 
             def serialize_media_item(item: models.Video | models.Image) -> dict[str, Any]:
                 return {
-                    'width': item.width,
-                    'height': item.height,
+                    "width": item.width,
+                    "height": item.height,
                 }
+
         elif db_task.media_type:
             assert False, f"Unknown media type '{db_task.media_type}'"
 
         frame_meta = [
             {
-                'name': item.path,
-                'related_files': (
-                    item.related_files.count() if hasattr(item, 'related_files') else 0
+                "name": item.path,
+                "related_files": (
+                    item.related_files.count() if hasattr(item, "related_files") else 0
                 ),
                 **serialize_media_item(item),
             }
@@ -2145,18 +2552,20 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
         serializer = DataMetaReadSerializer(db_data, context={"task": db_task})
         return Response(serializer.data)
 
-    @extend_schema(summary='Get a preview image for a job',
+    @extend_schema(
+        summary="Get a preview image for a job",
         responses={
-            '200': OpenApiResponse(description='Job image preview'),
-        })
-    @action(detail=True, methods=['GET'], url_path='preview')
+            "200": OpenApiResponse(description="Job image preview"),
+        },
+    )
+    @action(detail=True, methods=["GET"], url_path="preview")
     def preview(self, request: ExtendedRequest, pk: int):
-        self._object = self.get_object() # call check_object_permissions as well
+        self._object = self.get_object()  # call check_object_permissions as well
 
         data_getter = _JobDataGetter(
             db_job=self._object,
-            data_type='preview',
-            data_quality='compressed',
+            data_type="preview",
+            data_quality="compressed",
         )
         return data_getter()
 
@@ -2164,8 +2573,9 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
         methods=["GET"],
         summary="Allows getting current validation configuration",
         responses={
-            '200': OpenApiResponse(JobValidationLayoutReadSerializer),
-        })
+            "200": OpenApiResponse(JobValidationLayoutReadSerializer),
+        },
+    )
     @extend_schema(
         methods=["PATCH"],
         summary="Allows updating current validation configuration",
@@ -2176,34 +2586,40 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
         """),
         request=JobValidationLayoutWriteSerializer,
         responses={
-            '200': OpenApiResponse(JobValidationLayoutReadSerializer),
+            "200": OpenApiResponse(JobValidationLayoutReadSerializer),
         },
         examples=[
-            OpenApiExample("set honeypots to random validation frames", {
-                "frame_selection_method": models.JobFrameSelectionMethod.RANDOM_UNIFORM
-            }),
-            OpenApiExample("set honeypots manually", {
-                "frame_selection_method": models.JobFrameSelectionMethod.MANUAL,
-                "honeypot_real_frames": [10, 20, 22]
-            }),
-        ])
-    @action(detail=True, methods=["GET", "PATCH"], url_path='validation_layout')
+            OpenApiExample(
+                "set honeypots to random validation frames",
+                {"frame_selection_method": models.JobFrameSelectionMethod.RANDOM_UNIFORM},
+            ),
+            OpenApiExample(
+                "set honeypots manually",
+                {
+                    "frame_selection_method": models.JobFrameSelectionMethod.MANUAL,
+                    "honeypot_real_frames": [10, 20, 22],
+                },
+            ),
+        ],
+    )
+    @action(detail=True, methods=["GET", "PATCH"], url_path="validation_layout")
     @transaction.atomic
     def validation_layout(self, request: ExtendedRequest, pk: int):
-        self.get_object() # call check_object_permissions as well
+        self.get_object()  # call check_object_permissions as well
 
         db_job = models.Job.objects.prefetch_related(
-            'segment',
-            'segment__task',
-            Prefetch('segment__task__data',
+            "segment",
+            "segment__task",
+            Prefetch(
+                "segment__task__data",
                 queryset=(
-                    models.Data.objects
-                    .select_related('video', 'validation_layout')
-                    .prefetch_related(
-                        Prefetch('images', queryset=models.Image.objects.order_by('frame'))
+                    models.Data.objects.select_related(
+                        "video", "validation_layout"
+                    ).prefetch_related(
+                        Prefetch("images", queryset=models.Image.objects.order_by("frame"))
                     )
-                )
-            )
+                ),
+            ),
         ).get(pk=pk)
 
         if request.method == "PATCH":
@@ -2214,64 +2630,74 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.CreateMo
         response_serializer = JobValidationLayoutReadSerializer(db_job)
         return Response(response_serializer.data, status=status.HTTP_200_OK)
 
-@extend_schema(tags=['issues'])
+
+@extend_schema(tags=["issues"])
 @extend_schema_view(
     retrieve=extend_schema(
-        summary='Get issue details',
+        summary="Get issue details",
         responses={
-            '200': IssueReadSerializer,
-        }),
+            "200": IssueReadSerializer,
+        },
+    ),
     list=extend_schema(
-        summary='List issues',
+        summary="List issues",
         responses={
-            '200': IssueReadSerializer(many=True),
-        }),
+            "200": IssueReadSerializer(many=True),
+        },
+    ),
     partial_update=extend_schema(
-        summary='Update an issue',
+        summary="Update an issue",
         request=IssueWriteSerializer(partial=True),
         responses={
-            '200': IssueReadSerializer, # check IssueWriteSerializer.to_representation
-        }),
+            "200": IssueReadSerializer,  # check IssueWriteSerializer.to_representation
+        },
+    ),
     create=extend_schema(
-        summary='Create an issue',
+        summary="Create an issue",
         request=IssueWriteSerializer,
         parameters=ORGANIZATION_OPEN_API_PARAMETERS,
         responses={
-            '201': IssueReadSerializer, # check IssueWriteSerializer.to_representation
-        }),
+            "201": IssueReadSerializer,  # check IssueWriteSerializer.to_representation
+        },
+    ),
     destroy=extend_schema(
-        summary='Delete an issue',
+        summary="Delete an issue",
         responses={
-            '204': OpenApiResponse(description='The issue has been deleted'),
-        })
+            "204": OpenApiResponse(description="The issue has been deleted"),
+        },
+    ),
 )
-class IssueViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
-    mixins.RetrieveModelMixin, mixins.CreateModelMixin, mixins.DestroyModelMixin,
-    PartialUpdateModelMixin
+class IssueViewSet(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    PartialUpdateModelMixin,
 ):
     queryset = Issue.objects.prefetch_related(
-        'job__segment__task', 'owner', 'assignee', 'job'
+        "job__segment__task", "owner", "assignee", "job"
     ).all()
 
     iam_supports_organization_params = True
     iam_permission_class = IssuePermission
-    search_fields = ('owner', 'assignee')
-    simple_filters = (*search_fields, 'job_id', 'task_id', 'resolved', 'frame_id')
-    filter_fields = (*simple_filters, 'id')
+    search_fields = ("owner", "assignee")
+    simple_filters = (*search_fields, "job_id", "task_id", "resolved", "frame_id")
+    filter_fields = (*simple_filters, "id")
     ordering_fields = list(filter_fields)
     lookup_fields = {
-        'owner': 'owner__username',
-        'assignee': 'assignee__username',
-        'job_id': 'job',
-        'task_id': 'job__segment__task__id',
-        'frame_id': 'frame',
+        "owner": "owner__username",
+        "assignee": "assignee__username",
+        "job_id": "job",
+        "task_id": "job__segment__task__id",
+        "frame_id": "frame",
     }
-    ordering = '-id'
+    ordering = "-id"
 
     def get_queryset(self):
         queryset = super().get_queryset()
 
-        if self.action == 'list':
+        if self.action == "list":
             perm = IssuePermission.create_scope_list(self.request)
             queryset = perm.filter(queryset)
 
@@ -2286,63 +2712,71 @@ class IssueViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
     def perform_create(self, serializer, **kwargs):
         serializer.save(owner=self.request.user)
 
-@extend_schema(tags=['comments'])
+
+@extend_schema(tags=["comments"])
 @extend_schema_view(
     retrieve=extend_schema(
-        summary='Get comment details',
+        summary="Get comment details",
         responses={
-            '200': CommentReadSerializer,
-        }),
+            "200": CommentReadSerializer,
+        },
+    ),
     list=extend_schema(
-        summary='List comments',
+        summary="List comments",
         responses={
-            '200': CommentReadSerializer(many=True),
-        }),
+            "200": CommentReadSerializer(many=True),
+        },
+    ),
     partial_update=extend_schema(
-        summary='Update a comment',
+        summary="Update a comment",
         request=CommentWriteSerializer(partial=True),
         responses={
-            '200': CommentReadSerializer, # check CommentWriteSerializer.to_representation
-        }),
+            "200": CommentReadSerializer,  # check CommentWriteSerializer.to_representation
+        },
+    ),
     create=extend_schema(
-        summary='Create a comment',
+        summary="Create a comment",
         request=CommentWriteSerializer,
         parameters=ORGANIZATION_OPEN_API_PARAMETERS,
         responses={
-            '201': CommentReadSerializer, # check CommentWriteSerializer.to_representation
-        }),
+            "201": CommentReadSerializer,  # check CommentWriteSerializer.to_representation
+        },
+    ),
     destroy=extend_schema(
-        summary='Delete a comment',
+        summary="Delete a comment",
         responses={
-            '204': OpenApiResponse(description='The comment has been deleted'),
-        })
+            "204": OpenApiResponse(description="The comment has been deleted"),
+        },
+    ),
 )
-class CommentViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
-    mixins.RetrieveModelMixin, mixins.CreateModelMixin, mixins.DestroyModelMixin,
-    PartialUpdateModelMixin
+class CommentViewSet(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    PartialUpdateModelMixin,
 ):
-    queryset = Comment.objects.prefetch_related(
-        'issue', 'issue__job', 'owner'
-    ).all()
+    queryset = Comment.objects.prefetch_related("issue", "issue__job", "owner").all()
 
     iam_supports_organization_params = True
     iam_permission_class = CommentPermission
-    search_fields = ('owner',)
-    simple_filters = (*search_fields, 'issue_id', 'frame_id', 'job_id')
-    filter_fields = (*simple_filters, 'id')
+    search_fields = ("owner",)
+    simple_filters = (*search_fields, "issue_id", "frame_id", "job_id")
+    filter_fields = (*simple_filters, "id")
     ordering_fields = list(filter_fields)
-    ordering = '-id'
+    ordering = "-id"
     lookup_fields = {
-        'owner': 'owner__username',
-        'issue_id': 'issue__id',
-        'job_id': 'issue__job__id',
-        'frame_id': 'issue__frame',
+        "owner": "owner__username",
+        "issue_id": "issue__id",
+        "job_id": "issue__job__id",
+        "frame_id": "issue__frame",
     }
 
     def get_queryset(self):
         queryset = super().get_queryset()
 
-        if self.action == 'list':
+        if self.action == "list":
             perm = CommentPermission.create_scope_list(self.request)
             queryset = perm.filter(queryset)
 
@@ -2358,99 +2792,120 @@ class CommentViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         serializer.save(owner=self.request.user)
 
 
-@extend_schema(tags=['labels'])
+@extend_schema(tags=["labels"])
 @extend_schema_view(
     retrieve=extend_schema(
-        summary='Get label details',
+        summary="Get label details",
         responses={
-            '200': LabelSerializer,
-        }),
+            "200": LabelSerializer,
+        },
+    ),
     list=extend_schema(
-        summary='List labels',
+        summary="List labels",
         parameters=[
             # These filters are implemented differently from others
-            OpenApiParameter('job_id', type=OpenApiTypes.INT,
-                description='A simple equality filter for job id'),
-            OpenApiParameter('task_id', type=OpenApiTypes.INT,
-                description='A simple equality filter for task id'),
-            OpenApiParameter('project_id', type=OpenApiTypes.INT,
-                description='A simple equality filter for project id'),
-            *ORGANIZATION_OPEN_API_PARAMETERS
+            OpenApiParameter(
+                "job_id", type=OpenApiTypes.INT, description="A simple equality filter for job id"
+            ),
+            OpenApiParameter(
+                "task_id", type=OpenApiTypes.INT, description="A simple equality filter for task id"
+            ),
+            OpenApiParameter(
+                "project_id",
+                type=OpenApiTypes.INT,
+                description="A simple equality filter for project id",
+            ),
+            *ORGANIZATION_OPEN_API_PARAMETERS,
         ],
         responses={
-            '200': LabelSerializer(many=True),
-        }),
+            "200": LabelSerializer(many=True),
+        },
+    ),
     partial_update=extend_schema(
-        summary='Update a label',
-        description='To modify a sublabel, please use the PATCH method of the parent label.',
+        summary="Update a label",
+        description="To modify a sublabel, please use the PATCH method of the parent label.",
         request=LabelSerializer(partial=True),
         responses={
-            '200': LabelSerializer,
-        }),
+            "200": LabelSerializer,
+        },
+    ),
     destroy=extend_schema(
-        summary='Delete a label',
-        description='To delete a sublabel, please use the PATCH method of the parent label.',
+        summary="Delete a label",
+        description="To delete a sublabel, please use the PATCH method of the parent label.",
         responses={
-            '204': OpenApiResponse(description='The label has been deleted'),
-        })
+            "204": OpenApiResponse(description="The label has been deleted"),
+        },
+    ),
 )
-class LabelViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
-    mixins.RetrieveModelMixin, mixins.DestroyModelMixin, PartialUpdateModelMixin
+class LabelViewSet(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.DestroyModelMixin,
+    PartialUpdateModelMixin,
 ):
     queryset = Label.objects.prefetch_related(
-        'attributespec_set',
-        'sublabels__attributespec_set',
-        'task',
-        'task__owner',
-        'task__assignee',
-        'task__organization',
-        'project',
-        'project__owner',
-        'project__assignee',
-        'project__organization'
+        "attributespec_set",
+        "sublabels__attributespec_set",
+        "task",
+        "task__owner",
+        "task__assignee",
+        "task__organization",
+        "project",
+        "project__owner",
+        "project__assignee",
+        "project__organization",
     ).all()
 
     iam_supports_organization_params = True
     iam_permission_class = LabelPermission
 
-    search_fields = ('name', 'parent')
-    simple_filters = (*search_fields, 'type', 'color', 'parent_id')
-    filter_fields = (*simple_filters, 'id')
+    search_fields = ("name", "parent")
+    simple_filters = (*search_fields, "type", "color", "parent_id")
+    filter_fields = (*simple_filters, "id")
     ordering_fields = list(filter_fields)
     lookup_fields = {
-        'parent': 'parent__name',
+        "parent": "parent__name",
     }
-    ordering = 'id'
+    ordering = "id"
     serializer_class = LabelSerializer
 
     def get_queryset(self):
-        if self.action == 'list':
-            job_id = self.request.GET.get('job_id', None)
-            task_id = self.request.GET.get('task_id', None)
-            project_id = self.request.GET.get('project_id', None)
+        if self.action == "list":
+            job_id = self.request.GET.get("job_id", None)
+            task_id = self.request.GET.get("task_id", None)
+            project_id = self.request.GET.get("project_id", None)
             if sum(v is not None for v in [job_id, task_id, project_id]) > 1:
                 raise ValidationError(
                     "job_id, task_id and project_id parameters cannot be used together",
-                    code=status.HTTP_400_BAD_REQUEST
+                    code=status.HTTP_400_BAD_REQUEST,
                 )
 
             if job_id or task_id or project_id:
                 if job_id:
                     instance = Job.objects.select_related(
-                        'assignee', 'segment__task__organization',
-                        'segment__task__owner', 'segment__task__assignee',
-                        'segment__task__project__organization',
-                        'segment__task__project__owner',
-                        'segment__task__project__assignee',
+                        "assignee",
+                        "segment__task__organization",
+                        "segment__task__owner",
+                        "segment__task__assignee",
+                        "segment__task__project__organization",
+                        "segment__task__project__owner",
+                        "segment__task__project__assignee",
                     ).get(id=job_id)
                 elif task_id:
                     instance = Task.objects.select_related(
-                        'owner', 'assignee', 'organization',
-                        'project__owner', 'project__assignee', 'project__organization',
+                        "owner",
+                        "assignee",
+                        "organization",
+                        "project__owner",
+                        "project__assignee",
+                        "project__organization",
                     ).get(id=task_id)
                 elif project_id:
                     instance = Project.objects.select_related(
-                        'owner', 'assignee', 'organization',
+                        "owner",
+                        "assignee",
+                        "organization",
                     ).get(id=project_id)
 
                 # NOTE: This filter is too complex to be implemented by other means
@@ -2477,7 +2932,7 @@ class LabelViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         return queryset
 
     def get_serializer(self, *args, **kwargs):
-        kwargs['local'] = True
+        kwargs["local"] = True
         return super().get_serializer(*args, **kwargs)
 
     def perform_update(self, serializer):
@@ -2486,7 +2941,8 @@ class LabelViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             raise ValidationError(
                 "Sublabels cannot be modified this way. "
                 "Please send a PATCH request with updated parent label data instead.",
-                code=status.HTTP_400_BAD_REQUEST)
+                code=status.HTTP_400_BAD_REQUEST,
+            )
 
         return super().perform_update(serializer)
 
@@ -2496,7 +2952,8 @@ class LabelViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             raise ValidationError(
                 "Sublabels cannot be deleted this way. "
                 "Please send a PATCH request with updated parent label data instead.",
-                code=status.HTTP_400_BAD_REQUEST)
+                code=status.HTTP_400_BAD_REQUEST,
+            )
 
         if project := instance.project:
             project.touch()
@@ -2508,67 +2965,76 @@ class LabelViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
         return super().perform_destroy(instance)
 
 
-@extend_schema(tags=['users'])
+@extend_schema(tags=["users"])
 @extend_schema_view(
     list=extend_schema(
-        summary='List users',
+        summary="List users",
         responses={
-            '200': PolymorphicProxySerializer(
-                component_name='MetaUser',
+            "200": PolymorphicProxySerializer(
+                component_name="MetaUser",
                 serializers=[
                     UserSerializer,
                     BasicUserSerializer,
                 ],
                 resource_type_field_name=None,
-                many=True, # https://github.com/tfranzel/drf-spectacular/issues/910
+                many=True,  # https://github.com/tfranzel/drf-spectacular/issues/910
             ),
-        }),
+        },
+    ),
     retrieve=extend_schema(
-        summary='Get user details',
+        summary="Get user details",
         responses={
-            '200': PolymorphicProxySerializer(
-                component_name='MetaUser',
+            "200": PolymorphicProxySerializer(
+                component_name="MetaUser",
                 serializers=[
                     UserSerializer,
                     BasicUserSerializer,
                 ],
                 resource_type_field_name=None,
             ),
-        }),
+        },
+    ),
     partial_update=extend_schema(
-        summary='Update a user',
+        summary="Update a user",
         responses={
-            '200': PolymorphicProxySerializer(
-                component_name='MetaUser',
+            "200": PolymorphicProxySerializer(
+                component_name="MetaUser",
                 serializers=[
                     UserSerializer(partial=True),
                     BasicUserSerializer(partial=True),
                 ],
                 resource_type_field_name=None,
             ),
-        }),
+        },
+    ),
     destroy=extend_schema(
-        summary='Delete a user',
+        summary="Delete a user",
         responses={
-            '204': OpenApiResponse(description='The user has been deleted'),
-        })
+            "204": OpenApiResponse(description="The user has been deleted"),
+        },
+    ),
 )
-class UserViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
-    mixins.RetrieveModelMixin, PartialUpdateModelMixin, mixins.DestroyModelMixin):
-    queryset = User.objects.prefetch_related('groups').all()
+class UserViewSet(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    PartialUpdateModelMixin,
+    mixins.DestroyModelMixin,
+):
+    queryset = User.objects.prefetch_related("groups").all()
     iam_supports_organization_params = True
     iam_permission_class = UserPermission
 
-    search_fields = ('username', 'first_name', 'last_name')
-    simple_filters = (*search_fields, 'is_active')
-    filter_fields = (*simple_filters, 'id')
+    search_fields = ("username", "first_name", "last_name")
+    simple_filters = (*search_fields, "is_active")
+    filter_fields = (*simple_filters, "id")
     ordering_fields = list(filter_fields)
     ordering = "-id"
 
     def get_queryset(self):
         queryset = super().get_queryset()
 
-        if self.action == 'list':
+        if self.action == "list":
             perm = UserPermission.create_scope_list(self.request)
             queryset = perm.filter(queryset)
 
@@ -2576,77 +3042,92 @@ class UserViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
 
     def get_serializer_class(self):
         # Early exit for drf-spectacular compatibility
-        if getattr(self, 'swagger_fake_view', False):
+        if getattr(self, "swagger_fake_view", False):
             return UserSerializer
 
         user = self.request.user
-        is_self = int(self.kwargs.get("pk", 0)) == user.id or \
-            self.action == "self"
+        is_self = int(self.kwargs.get("pk", 0)) == user.id or self.action == "self"
 
         if is_self or user.is_superuser:
             return UserSerializer
         else:
             return BasicUserSerializer
 
-    @extend_schema(summary='Get details of the current user',
+    @extend_schema(
+        summary="Get details of the current user",
         responses={
-            '200': PolymorphicProxySerializer(component_name='MetaUser',
+            "200": PolymorphicProxySerializer(
+                component_name="MetaUser",
                 serializers=[
-                    UserSerializer, BasicUserSerializer,
-                ], resource_type_field_name=None),
-        })
-    @action(detail=False, methods=['GET'])
+                    UserSerializer,
+                    BasicUserSerializer,
+                ],
+                resource_type_field_name=None,
+            ),
+        },
+    )
+    @action(detail=False, methods=["GET"])
     def self(self, request: ExtendedRequest):
         """
         Method returns an instance of a user who is currently authenticated
         """
         serializer_class = self.get_serializer_class()
-        serializer = serializer_class(request.user, context={ "request": request })
+        serializer = serializer_class(request.user, context={"request": request})
         return Response(serializer.data)
 
-@extend_schema(tags=['cloudstorages'])
+
+@extend_schema(tags=["cloudstorages"])
 @extend_schema_view(
     retrieve=extend_schema(
-        summary='Get cloud storage details',
+        summary="Get cloud storage details",
         responses={
-            '200': CloudStorageReadSerializer,
-        }),
+            "200": CloudStorageReadSerializer,
+        },
+    ),
     list=extend_schema(
-        summary='List cloud storages',
+        summary="List cloud storages",
         responses={
-            '200': CloudStorageReadSerializer(many=True),
-        }),
+            "200": CloudStorageReadSerializer(many=True),
+        },
+    ),
     destroy=extend_schema(
-        summary='Delete a cloud storage',
+        summary="Delete a cloud storage",
         responses={
-            '204': OpenApiResponse(description='The cloud storage has been removed'),
-        }),
+            "204": OpenApiResponse(description="The cloud storage has been removed"),
+        },
+    ),
     partial_update=extend_schema(
-        summary='Update a cloud storage',
+        summary="Update a cloud storage",
         request=CloudStorageWriteSerializer(partial=True),
         responses={
-            '200': CloudStorageReadSerializer, # check CloudStorageWriteSerializer.to_representation
-        }),
+            "200": CloudStorageReadSerializer,  # check CloudStorageWriteSerializer.to_representation
+        },
+    ),
     create=extend_schema(
-        summary='Create a cloud storage',
+        summary="Create a cloud storage",
         request=CloudStorageWriteSerializer,
         parameters=ORGANIZATION_OPEN_API_PARAMETERS,
         responses={
-            '201': CloudStorageReadSerializer, # check CloudStorageWriteSerializer.to_representation
-        })
+            "201": CloudStorageReadSerializer,  # check CloudStorageWriteSerializer.to_representation
+        },
+    ),
 )
-class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
-    mixins.RetrieveModelMixin, mixins.CreateModelMixin, mixins.DestroyModelMixin,
-    PartialUpdateModelMixin
+class CloudStorageViewSet(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    PartialUpdateModelMixin,
 ):
     queryset = CloudStorage.objects.all()
 
-    search_fields = ('name', 'resource', 'owner', 'description')
-    simple_filters = ('name', 'resource', 'owner', 'provider_type', 'credentials_type')
-    filter_fields = (*simple_filters, 'id', 'description')
+    search_fields = ("name", "resource", "owner", "description")
+    simple_filters = ("name", "resource", "owner", "provider_type", "credentials_type")
+    filter_fields = (*simple_filters, "id", "description")
     ordering_fields = list(filter_fields)
     ordering = "-id"
-    lookup_fields = {'owner': 'owner__username', 'name': 'display_name'}
+    lookup_fields = {"owner": "owner__username", "name": "display_name"}
     iam_supports_organization_params = True
     iam_permission_class = CloudStoragePermission
 
@@ -2655,7 +3136,7 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
     parser_classes = _UPLOAD_PARSER_CLASSES
 
     def get_serializer_class(self):
-        if self.request.method in ('POST', 'PATCH'):
+        if self.request.method in ("POST", "PATCH"):
             return CloudStorageWriteSerializer
         else:
             return CloudStorageReadSerializer
@@ -2663,22 +3144,22 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
     def get_queryset(self):
         queryset = super().get_queryset()
 
-        if self.action == 'list':
+        if self.action == "list":
             perm = CloudStoragePermission.create_scope_list(self.request)
             queryset = perm.filter(queryset)
-            queryset = queryset.prefetch_related('owner', 'manifests')
+            queryset = queryset.prefetch_related("owner", "manifests")
 
-        provider_type = self.request.query_params.get('provider_type', None)
+        provider_type = self.request.query_params.get("provider_type", None)
         if provider_type:
             if provider_type in CloudProviderChoice.values:
                 return queryset.filter(provider_type=provider_type)
-            raise ValidationError('Unsupported type of cloud provider')
+            raise ValidationError("Unsupported type of cloud provider")
         return queryset
 
     def perform_create(self, serializer):
         serializer.save(
-            owner=self.request.user,
-            organization=self.request.iam_context['organization'])
+            owner=self.request.user, organization=self.request.iam_context["organization"]
+        )
 
     def create(self, request: ExtendedRequest, *args, **kwargs):
         try:
@@ -2687,8 +3168,10 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             msg_body = ""
             for ex in exceptions.args:
                 for field, ex_msg in ex.items():
-                    msg_body += ': '.join([field, ex_msg if isinstance(ex_msg, str) else str(ex_msg[0])])
-                    msg_body += '\n'
+                    msg_body += ": ".join(
+                        [field, ex_msg if isinstance(ex_msg, str) else str(ex_msg[0])]
+                    )
+                    msg_body += "\n"
             return HttpResponseBadRequest(msg_body)
         except APIException as ex:
             return Response(data=ex.get_full_details(), status=ex.status_code)
@@ -2696,62 +3179,92 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             response = HttpResponseBadRequest(str(ex))
         return response
 
-    @extend_schema(summary='Get cloud storage content',
+    @extend_schema(
+        summary="Get cloud storage content",
         parameters=[
-            OpenApiParameter('manifest_path', description='Path to the manifest file in a cloud storage',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR),
-            OpenApiParameter('prefix', description='Prefix to filter data',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR),
-            OpenApiParameter('next_token', description='Used to continue listing files in the bucket',
-                location=OpenApiParameter.QUERY, type=OpenApiTypes.STR),
-            OpenApiParameter('page_size', location=OpenApiParameter.QUERY, type=OpenApiTypes.INT),
+            OpenApiParameter(
+                "manifest_path",
+                description="Path to the manifest file in a cloud storage",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+            ),
+            OpenApiParameter(
+                "prefix",
+                description="Prefix to filter data",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+            ),
+            OpenApiParameter(
+                "next_token",
+                description="Used to continue listing files in the bucket",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+            ),
+            OpenApiParameter("page_size", location=OpenApiParameter.QUERY, type=OpenApiTypes.INT),
         ],
         responses={
-            '200': OpenApiResponse(response=CloudStorageContentSerializer, description='A manifest content'),
+            "200": OpenApiResponse(
+                response=CloudStorageContentSerializer, description="A manifest content"
+            ),
         },
     )
-    @action(detail=True, methods=['GET'], url_path='content-v2')
+    @action(detail=True, methods=["GET"], url_path="content-v2")
     def content_v2(self, request: ExtendedRequest, pk: int):
         storage = None
         try:
             db_storage = self.get_object()
             storage = db_storage_to_storage_instance(db_storage)
-            prefix = request.query_params.get('prefix', "")
-            page_size = request.query_params.get('page_size', str(settings.BUCKET_CONTENT_MAX_PAGE_SIZE))
+            prefix = request.query_params.get("prefix", "")
+            page_size = request.query_params.get(
+                "page_size", str(settings.BUCKET_CONTENT_MAX_PAGE_SIZE)
+            )
             if not page_size.isnumeric():
-                return HttpResponseBadRequest('Wrong value for page_size was found')
+                return HttpResponseBadRequest("Wrong value for page_size was found")
             page_size = min(int(page_size), settings.BUCKET_CONTENT_MAX_PAGE_SIZE)
 
             # make api identical to share api
-            if prefix and prefix.startswith('/'):
+            if prefix and prefix.startswith("/"):
                 prefix = prefix[1:]
 
+            next_token = request.query_params.get("next_token")
 
-            next_token = request.query_params.get('next_token')
-
-            if (manifest_path := request.query_params.get('manifest_path')):
+            if manifest_path := request.query_params.get("manifest_path"):
                 manifest_prefix = os.path.dirname(manifest_path)
 
                 full_manifest_path = db_storage.get_storage_dirname() / manifest_path
-                if not full_manifest_path.exists() or \
-                        datetime.fromtimestamp(full_manifest_path.stat().st_mtime, tz=timezone.utc) < storage.get_file_last_modified(manifest_path):
+                if not full_manifest_path.exists() or datetime.fromtimestamp(
+                    full_manifest_path.stat().st_mtime, tz=timezone.utc
+                ) < storage.get_file_last_modified(manifest_path):
                     storage.download_file(manifest_path, full_manifest_path)
-                manifest = ImageManifestManager(full_manifest_path, db_storage.get_storage_dirname())
+                manifest = ImageManifestManager(
+                    full_manifest_path, db_storage.get_storage_dirname()
+                )
                 # need to update index
                 manifest.set_index()
                 try:
-                    start_index = int(next_token or '0')
+                    start_index = int(next_token or "0")
                 except ValueError:
-                    return HttpResponseBadRequest('Wrong value for the next_token parameter was found.')
+                    return HttpResponseBadRequest(
+                        "Wrong value for the next_token parameter was found."
+                    )
                 content = manifest.emulate_hierarchical_structure(
-                    page_size, manifest_prefix=manifest_prefix, prefix=prefix, default_prefix=storage.prefix, start_index=start_index)
+                    page_size,
+                    manifest_prefix=manifest_prefix,
+                    prefix=prefix,
+                    default_prefix=storage.prefix,
+                    start_index=start_index,
+                )
             else:
-                content = storage.list_files_on_one_page(prefix, next_token=next_token, page_size=page_size, _use_sort=True)
-            for i in content['content']:
-                mime_type = get_mime(i['name']) if i['type'] != 'DIR' else 'DIR' # identical to share point
-                if mime_type == 'zip':
-                    mime_type = 'archive'
-                i['mime_type'] = mime_type
+                content = storage.list_files_on_one_page(
+                    prefix, next_token=next_token, page_size=page_size, _use_sort=True
+                )
+            for i in content["content"]:
+                mime_type = (
+                    get_mime(i["name"]) if i["type"] != "DIR" else "DIR"
+                )  # identical to share point
+                if mime_type == "zip":
+                    mime_type = "archive"
+                i["mime_type"] = mime_type
             serializer = CloudStorageContentSerializer(data=content)
             serializer.is_valid(raise_exception=True)
             content = serializer.data
@@ -2762,22 +3275,28 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             slogger.glob.error(message)
             return HttpResponseNotFound(message)
         except (ValidationError, PermissionDenied, NotFound) as ex:
-            msg = str(ex) if not isinstance(ex, ValidationError) else \
-                '\n'.join([str(d) for d in ex.detail])
+            msg = (
+                str(ex)
+                if not isinstance(ex, ValidationError)
+                else "\n".join([str(d) for d in ex.detail])
+            )
             slogger.cloud_storage[pk].info(msg)
             return Response(data=msg, status=ex.status_code)
         except Exception as ex:
             slogger.glob.error(str(ex))
-            return Response("An internal error has occurred",
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                "An internal error has occurred", status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @extend_schema(summary='Get a preview image for a cloud storage',
+    @extend_schema(
+        summary="Get a preview image for a cloud storage",
         responses={
-            '200': OpenApiResponse(description='Cloud Storage preview'),
-            '400': OpenApiResponse(description='Failed to get cloud storage preview'),
-            '404': OpenApiResponse(description='Cloud Storage preview not found'),
-        })
-    @action(detail=True, methods=['GET'], url_path='preview')
+            "200": OpenApiResponse(description="Cloud Storage preview"),
+            "400": OpenApiResponse(description="Failed to get cloud storage preview"),
+            "404": OpenApiResponse(description="Cloud Storage preview not found"),
+        },
+    )
+    @action(detail=True, methods=["GET"], url_path="preview")
     def preview(self, request: ExtendedRequest, pk: int):
         try:
             db_storage = self.get_object()
@@ -2788,7 +3307,7 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             if not db_storage.has_at_least_one_manifest:
                 result = cache.get_cloud_preview(db_storage)
                 if not result:
-                    return HttpResponseNotFound('Cloud storage preview not found')
+                    return HttpResponseNotFound("Cloud storage preview not found")
                 return HttpResponse(result[0].getvalue(), result[1])
 
             preview, mime = cache.get_or_set_cloud_preview(db_storage)
@@ -2798,31 +3317,37 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             slogger.glob.error(message)
             return HttpResponseNotFound(message)
         except (ValidationError, PermissionDenied, NotFound) as ex:
-            msg = str(ex) if not isinstance(ex, ValidationError) else \
-                '\n'.join([str(d) for d in ex.detail])
+            msg = (
+                str(ex)
+                if not isinstance(ex, ValidationError)
+                else "\n".join([str(d) for d in ex.detail])
+            )
             slogger.cloud_storage[pk].info(msg)
             return Response(data=msg, status=ex.status_code)
         except (TimeoutError, CvatChunkTimestampMismatchError, LockError):
             return Response(
                 status=status.HTTP_429_TOO_MANY_REQUESTS,
-                headers={'Retry-After': _RETRY_AFTER_TIMEOUT},
+                headers={"Retry-After": _RETRY_AFTER_TIMEOUT},
             )
         except Exception as ex:
             slogger.glob.error(str(ex))
-            return Response("An internal error has occurred",
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                "An internal error has occurred", status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @extend_schema(summary='Get the status of a cloud storage',
+    @extend_schema(
+        summary="Get the status of a cloud storage",
         responses={
-            '200': OpenApiResponse(
+            "200": OpenApiResponse(
                 response={
-                    'type': 'string',
-                    'enum': CloudStorageStatus.values(),
+                    "type": "string",
+                    "enum": CloudStorageStatus.values(),
                 },
-                description='Cloud Storage Status'
+                description="Cloud Storage Status",
             ),
-        })
-    @action(detail=True, methods=['GET'], url_path='status')
+        },
+    )
+    @action(detail=True, methods=["GET"], url_path="status")
     def status(self, request: ExtendedRequest, pk: int):
         try:
             db_storage = self.get_object()
@@ -2834,15 +3359,19 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             slogger.glob.error(message)
             return HttpResponseNotFound(message)
 
-    @extend_schema(summary='Get allowed actions for a cloud storage',
+    @extend_schema(
+        summary="Get allowed actions for a cloud storage",
         responses={
-            '200': OpenApiResponse(response=OpenApiTypes.STR, description='Cloud Storage actions (GET | PUT | DELETE)'),
-        })
-    @action(detail=True, methods=['GET'], url_path='actions')
+            "200": OpenApiResponse(
+                response=OpenApiTypes.STR, description="Cloud Storage actions (GET | PUT | DELETE)"
+            ),
+        },
+    )
+    @action(detail=True, methods=["GET"], url_path="actions")
     def actions(self, request: ExtendedRequest, pk: int):
-        '''
+        """
         Method return allowed actions for cloud storage. It's required for reading/writing
-        '''
+        """
         try:
             db_storage = self.get_object()
             storage = db_storage_to_storage_instance(db_storage)
@@ -2856,31 +3385,39 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             msg = str(ex)
             return HttpResponseBadRequest(msg)
 
-@extend_schema(tags=['assets'])
+
+@extend_schema(tags=["assets"])
 @extend_schema_view(
     create=extend_schema(
-        summary='Create an asset',
+        summary="Create an asset",
         request=AssetWriteSerializer,
         responses={
-            '201': AssetReadSerializer,
-        }),
+            "201": AssetReadSerializer,
+        },
+    ),
     retrieve=extend_schema(
-        summary='Get an asset',
-        responses={
-            '200': OpenApiResponse(description='Asset file')
-        }),
+        summary="Get an asset", responses={"200": OpenApiResponse(description="Asset file")}
+    ),
     destroy=extend_schema(
-        summary='Delete an asset',
+        summary="Delete an asset",
         responses={
-            '204': OpenApiResponse(description='The asset has been deleted'),
-        }),
+            "204": OpenApiResponse(description="The asset has been deleted"),
+        },
+    ),
 )
 class AssetsViewSet(
-    viewsets.GenericViewSet, mixins.RetrieveModelMixin,
-    mixins.CreateModelMixin, mixins.DestroyModelMixin
+    viewsets.GenericViewSet,
+    mixins.RetrieveModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
 ):
     queryset = Asset.objects.select_related(
-        'owner', 'guide', 'guide__project', 'guide__task', 'guide__project__organization', 'guide__task__organization',
+        "owner",
+        "guide",
+        "guide__project",
+        "guide__task",
+        "guide__project__organization",
+        "guide__task__organization",
     ).all()
     parser_classes = [MultiPartParser]
     search_fields = ()
@@ -2894,7 +3431,7 @@ class AssetsViewSet(
     def get_permissions(self):
         permissions = super().get_permissions()
 
-        if self.action == 'retrieve':
+        if self.action == "retrieve":
             permissions = [IsAuthenticatedOrReadPublicResource()] + [
                 p for p in permissions if not isinstance(p, IsAuthenticated)
             ]
@@ -2911,22 +3448,25 @@ class AssetsViewSet(
         serializer = AssetWriteSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        db_guide = AnnotationGuide.objects.prefetch_related("assets").get(pk=serializer.validated_data['guide_id'])
+        db_guide = AnnotationGuide.objects.prefetch_related("assets").get(
+            pk=serializer.validated_data["guide_id"]
+        )
         if db_guide.assets.count() >= settings.ASSET_MAX_COUNT_PER_GUIDE:
             raise ValidationError(f"Maximum number of assets per guide reached")
 
         serializer.save(owner=self.request.user)
         return Response(
             AssetReadSerializer(
-                instance=serializer.instance,
-                context={ "request": self.request }
+                instance=serializer.instance, context={"request": self.request}
             ).data,
             status=status.HTTP_201_CREATED,
         )
 
     def retrieve(self, request: ExtendedRequest, *args, **kwargs):
         instance = self.get_object()
-        return sendfile(request, os.path.join(settings.ASSETS_ROOT, str(instance.uuid), instance.filename))
+        return sendfile(
+            request, os.path.join(settings.ASSETS_ROOT, str(instance.uuid), instance.filename)
+        )
 
     def perform_destroy(self, instance):
         full_path = os.path.join(instance.get_asset_dir(), instance.filename)
@@ -2935,40 +3475,57 @@ class AssetsViewSet(
         instance.delete()
 
 
-@extend_schema(tags=['guides'])
+@extend_schema(tags=["guides"])
 @extend_schema_view(
     create=extend_schema(
-        summary='Create an annotation guide',
-        description='The new guide will be bound either to a project or a task, depending on parameters.',
+        summary="Create an annotation guide",
+        description="The new guide will be bound either to a project or a task, depending on parameters.",
         request=AnnotationGuideWriteSerializer,
         responses={
-            '201': AnnotationGuideReadSerializer,
-        }),
+            "201": AnnotationGuideReadSerializer,
+        },
+    ),
     retrieve=extend_schema(
-        summary='Get annotation guide details',
+        summary="Get annotation guide details",
         responses={
-            '200': AnnotationGuideReadSerializer,
-        }),
+            "200": AnnotationGuideReadSerializer,
+        },
+    ),
     destroy=extend_schema(
-        summary='Delete an annotation guide',
-        description='This also deletes all assets attached to the guide.',
+        summary="Delete an annotation guide",
+        description="This also deletes all assets attached to the guide.",
         responses={
-            '204': OpenApiResponse(description='The annotation guide has been deleted'),
-        }),
+            "204": OpenApiResponse(description="The annotation guide has been deleted"),
+        },
+    ),
     partial_update=extend_schema(
-        summary='Update an annotation guide',
+        summary="Update an annotation guide",
         request=AnnotationGuideWriteSerializer(partial=True),
         responses={
-            '200': AnnotationGuideReadSerializer, # check TaskWriteSerializer.to_representation
-        })
+            "200": AnnotationGuideReadSerializer,  # check TaskWriteSerializer.to_representation
+        },
+    ),
 )
 class AnnotationGuidesViewSet(
-    viewsets.GenericViewSet, mixins.RetrieveModelMixin,
-    mixins.CreateModelMixin, mixins.DestroyModelMixin, PartialUpdateModelMixin
+    viewsets.GenericViewSet,
+    mixins.RetrieveModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    PartialUpdateModelMixin,
 ):
-    queryset = AnnotationGuide.objects.order_by('-id').select_related(
-        'project', 'project__owner', 'project__organization', 'task', 'task__owner', 'task__organization'
-    ).prefetch_related('assets').all()
+    queryset = (
+        AnnotationGuide.objects.order_by("-id")
+        .select_related(
+            "project",
+            "project__owner",
+            "project__organization",
+            "task",
+            "task__owner",
+            "task__organization",
+        )
+        .prefetch_related("assets")
+        .all()
+    )
     search_fields = ()
     ordering = "-id"
     iam_supports_organization_params = False
@@ -2983,14 +3540,14 @@ class AnnotationGuidesViewSet(
         # first check if we need to copy some assets and if user has permissions to access them
         for asset_id in asset_ids:
             with suppress(models.Asset.DoesNotExist):
-                db_asset = models.Asset.objects.select_related('guide').get(pk=asset_id)
+                db_asset = models.Asset.objects.select_related("guide").get(pk=asset_id)
                 if db_asset.guide.id != guide.id:
                     perm = AnnotationGuidePermission.create_base_perm(
                         request,
                         self,
                         AnnotationGuidePermission.Scopes.VIEW,
                         get_iam_context(request, db_asset.guide),
-                        db_asset.guide
+                        db_asset.guide,
                     )
 
                     if perm.check_access().allow:
@@ -3025,8 +3582,8 @@ class AnnotationGuidesViewSet(
                     )
 
                     guide.markdown = guide.markdown.replace(
-                        f'(/api/assets/{asset_id})',
-                        f'(/api/assets/{assets_mapping[asset_id].uuid})',
+                        f"(/api/assets/{asset_id})",
+                        f"(/api/assets/{assets_mapping[asset_id].uuid})",
                     )
 
                     new_assets.append(copied_asset)
@@ -3062,10 +3619,10 @@ class AnnotationGuidesViewSet(
         super().perform_destroy(instance)
         target.touch()
 
+
 def rq_exception_handler(rq_job: RQJob, exc_type: type[Exception], exc_value: Exception, tb):
     rq_job_meta = RQMetaWithFailureInfo.for_job(rq_job)
-    rq_job_meta.formatted_exception = "".join(
-        traceback.format_exception_only(exc_type, exc_value))
+    rq_job_meta.formatted_exception = "".join(traceback.format_exception_only(exc_type, exc_value))
     if rq_job.origin == settings.CVAT_QUEUES.CHUNKS.value:
         rq_job_meta.exc_type = exc_type
         rq_job_meta.exc_args = exc_value.args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,5 @@ extend-exclude = """
 ^/cvat/apps/engine/(
     models.py
     |serializers.py
-    |views.py
 )
 """


### PR DESCRIPTION
### Motivation and context

Continuing to remove black exceptions from `pyproject.toml`.

Removes `cvat/apps/engine/views.py` from the `[tool.black]` `extend-exclude` and applies `black` to it.

### How has this been tested?

Ran `black cvat/apps/engine/views.py`.

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have updated the documentation accordingly (n/a)
- [x] I have added tests to cover my changes (n/a — formatting only)

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.

> [!IMPORTANT]
> Make sure to merge without squashing.
