### PR TITLE
Polish objects sidebar tab styling

### DIFF
--- a/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-sidebar/attribute-annotation-sidebar.tsx
+++ b/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-sidebar/attribute-annotation-sidebar.tsx
@@ -247,7 +247,7 @@ function AttributeAnnotationSidebar(props: StateToProps & DispatchToProps): JSX.
     const siderProps: SiderProps = {
         className: 'attribute-annotation-sidebar',
         theme: 'light',
-        width: 300,
+        width: 320,
         collapsedWidth: 0,
         reverseArrow: true,
         collapsible: true,

--- a/cvat-ui/src/components/annotation-page/single-shape-workspace/single-shape-sidebar/single-shape-sidebar.tsx
+++ b/cvat-ui/src/components/annotation-page/single-shape-workspace/single-shape-sidebar/single-shape-sidebar.tsx
@@ -393,7 +393,7 @@ function SingleShapeSidebar(): JSX.Element {
     const siderProps: SiderProps = {
         className: 'cvat-single-shape-annotation-sidebar',
         theme: 'light',
-        width: 300,
+        width: 320,
         collapsedWidth: 0,
         reverseArrow: true,
         collapsible: true,

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/issues-list.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/issues-list.tsx
@@ -92,69 +92,77 @@ export default function LabelsListComponent(): JSX.Element {
     return (
         <>
             <div className='cvat-objects-sidebar-issues-list-header'>
-                <Row justify='start' align='middle'>
-                    <Col>
+                <Row justify='space-between' align='middle'>
+                    <Col span={24}>
                         <Text>{`Items: ${frameIssues.length}`}</Text>
                     </Col>
-                    <Col offset={1}>
-                        <CVATTooltip title='Find the previous frame with issues'>
-                            <LeftOutlined className='cvat-issues-sidebar-previous-frame' {...dynamicLeftProps} />
-                        </CVATTooltip>
-                    </Col>
-                    <Col offset={1}>
-                        <CVATTooltip title='Find the next frame with issues'>
-                            <RightOutlined className='cvat-issues-sidebar-next-frame' {...dynamicRightProps} />
-                        </CVATTooltip>
-                    </Col>
-                    <Col offset={2}>
-                        <CVATTooltip title='Show/hide all issues'>
-                            {issuesHidden ? (
-                                <EyeInvisibleFilled
-                                    className='cvat-issues-sidebar-hidden-issues'
-                                    onClick={() => dispatch(reviewActions.switchIssuesHiddenFlag(false))}
-                                />
-                            ) : (
-                                <EyeOutlined
-                                    className='cvat-issues-sidebar-shown-issues'
-                                    onClick={() => dispatch(reviewActions.switchIssuesHiddenFlag(true))}
-                                />
-                            )}
-                        </CVATTooltip>
-                    </Col>
-                    <Col offset={2}>
-                        <CVATTooltip title='Show/hide resolved issues'>
-                            { issuesResolvedHidden ? (
-                                <CheckCircleFilled
-                                    className='cvat-issues-sidebar-hidden-resolved-status'
-                                    onClick={() => dispatch(reviewActions.switchIssuesHiddenResolvedFlag(false))}
-                                />
-                            ) : (
-                                <CheckCircleOutlined
-                                    className='cvat-issues-sidebar-hidden-resolved-status'
-                                    onClick={() => dispatch(reviewActions.switchIssuesHiddenResolvedFlag(true))}
-                                />
-
-                            )}
-                        </CVATTooltip>
-                    </Col>
-                    {
-                        workspace === Workspace.REVIEW ? (
-                            <Col offset={2}>
-                                <CVATTooltip title='Show Ground truth annotations and conflicts'>
-                                    <Icon
-                                        className={
-                                            `cvat-objects-sidebar-show-ground-truth ${showGroundTruth ? 'cvat-objects-sidebar-show-ground-truth-active' : ''}`
-                                        }
-                                        component={ShowGroundTruthIcon}
-                                        onClick={() => {
-                                            dispatch(changeShowGroundTruth(!showGroundTruth));
-                                            dispatch(fetchAnnotationsAsync());
-                                        }}
-                                    />
+                    <Col span={24}>
+                        <Row className='cvat-objects-sidebar-issues-toolbar' justify='space-around' align='middle'>
+                            <Col>
+                                <CVATTooltip title='Find the previous frame with issues'>
+                                    <LeftOutlined className='cvat-issues-sidebar-previous-frame' {...dynamicLeftProps} />
                                 </CVATTooltip>
                             </Col>
-                        ) : null
-                    }
+                            <Col>
+                                <CVATTooltip title='Find the next frame with issues'>
+                                    <RightOutlined className='cvat-issues-sidebar-next-frame' {...dynamicRightProps} />
+                                </CVATTooltip>
+                            </Col>
+                            <Col>
+                                <CVATTooltip title='Show/hide all issues'>
+                                    {issuesHidden ? (
+                                        <EyeInvisibleFilled
+                                            className='cvat-issues-sidebar-hidden-issues'
+                                            onClick={() => dispatch(reviewActions.switchIssuesHiddenFlag(false))}
+                                        />
+                                    ) : (
+                                        <EyeOutlined
+                                            className='cvat-issues-sidebar-shown-issues'
+                                            onClick={() => dispatch(reviewActions.switchIssuesHiddenFlag(true))}
+                                        />
+                                    )}
+                                </CVATTooltip>
+                            </Col>
+                            <Col>
+                                <CVATTooltip title='Show/hide resolved issues'>
+                                    { issuesResolvedHidden ? (
+                                        <CheckCircleFilled
+                                            className='cvat-issues-sidebar-hidden-resolved-status'
+                                            onClick={() => (
+                                                dispatch(reviewActions.switchIssuesHiddenResolvedFlag(false))
+                                            )}
+                                        />
+                                    ) : (
+                                        <CheckCircleOutlined
+                                            className='cvat-issues-sidebar-hidden-resolved-status'
+                                            onClick={() => (
+                                                dispatch(reviewActions.switchIssuesHiddenResolvedFlag(true))
+                                            )}
+                                        />
+
+                                    )}
+                                </CVATTooltip>
+                            </Col>
+                            {
+                                workspace === Workspace.REVIEW ? (
+                                    <Col>
+                                        <CVATTooltip title='Show Ground truth annotations and conflicts'>
+                                            <Icon
+                                                className={
+                                                    `cvat-objects-sidebar-show-ground-truth ${showGroundTruth ? 'cvat-objects-sidebar-show-ground-truth-active' : ''}`
+                                                }
+                                                component={ShowGroundTruthIcon}
+                                                onClick={() => {
+                                                    dispatch(changeShowGroundTruth(!showGroundTruth));
+                                                    dispatch(fetchAnnotationsAsync());
+                                                }}
+                                            />
+                                        </CVATTooltip>
+                                    </Col>
+                                ) : null
+                            }
+                        </Row>
+                    </Col>
                 </Row>
             </div>
             <div className='cvat-objects-sidebar-issues-list'>

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/objects-side-bar.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/objects-side-bar.tsx
@@ -79,7 +79,7 @@ function ObjectsSideBar(props: StateToProps & DispatchToProps & OwnProps): JSX.E
         <Layout.Sider
             className='cvat-objects-sidebar'
             theme='light'
-            width={300}
+            width={320}
             collapsedWidth={0}
             reverseArrow
             collapsible

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
@@ -145,7 +145,6 @@
                 transition: background-color $box-shadow-transition, opacity $box-shadow-transition;
 
                 &:hover {
-                    background: rgba(0, 0, 0, 6%);
                     opacity: 0.8;
                 }
 
@@ -153,18 +152,6 @@
                     opacity: 0.7;
                 }
             }
-        }
-    }
-
-    .cvat-issues-sidebar-hidden-issues,
-    .cvat-issues-sidebar-shown-issues,
-    .cvat-issues-sidebar-hidden-resolved-status,
-    .cvat-objects-sidebar-show-ground-truth {
-        border: 1px solid rgba(0, 0, 0, 6%);
-        background: rgba(255, 255, 255, 58%);
-
-        &:hover {
-            border-color: rgba(0, 0, 0, 16%);
         }
     }
 
@@ -320,8 +307,6 @@
                 transition: background-color $box-shadow-transition, opacity $box-shadow-transition;
 
                 &:hover {
-                    border-color: rgba(0, 0, 0, 10%);
-                    background: rgba(0, 0, 0, 6%);
                     opacity: 0.8;
                 }
             }
@@ -333,8 +318,6 @@
     }
 
     .cvat-objects-sidebar-show-ground-truth-active {
-        border-color: rgba(24, 144, 255, 28%);
-        background: rgba(24, 144, 255, 10%);
         color: #1890ff;
     }
 }
@@ -449,8 +432,7 @@
             border-radius: $border-radius-base;
 
             &:hover {
-                border-color: rgba(0, 0, 0, 10%);
-                background: rgba(0, 0, 0, 6%);
+                opacity: 0.82;
             }
         }
 
@@ -460,8 +442,7 @@
         .cvat-object-item-button-pinned-enabled,
         .cvat-object-item-button-hidden-enabled,
         .cvat-object-item-button-keyframe-enabled {
-            border-color: rgba(24, 144, 255, 22%);
-            background: rgba(24, 144, 255, 9%);
+            color: #1890ff;
         }
     }
 }
@@ -580,7 +561,7 @@
         border-radius: $border-radius-base;
 
         &:hover {
-            background: rgba(0, 0, 0, 6%);
+            opacity: 0.82;
         }
     }
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
@@ -207,6 +207,7 @@
     background-color: $background-color-2;
     height: calc(100% - $grid-unit-size * 9);
     overflow-y: auto;
+    padding: $grid-unit-size * 0.5;
 
     .cvat-objects-sidebar-state-item {
         // opacity 0.53 in sidebar to keep the same look as before on sidebar
@@ -223,30 +224,53 @@
 }
 
 .cvat-objects-sidebar-state-item.cvat-objects-sidebar-state-active-item {
-    box-shadow: $box-shadow-base;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 14%);
     border: 1px solid $object-item-border-color;
 }
 
 .cvat-objects-sidebar-state-item {
     width: 100%;
     background-color: rgba(var(--state-item-background), 1);
-    transition: box-shadow $box-shadow-transition;
-    border: 1px solid rgba($color: white, $alpha: 0%);
-    padding: $grid-unit-size * 0.5;
-    margin-left: $grid-unit-size * 0.25;
-    margin-right: $grid-unit-size * 0.25;
+    transition: border-color $box-shadow-transition, box-shadow $box-shadow-transition;
+    border: 1px solid rgba(0, 0, 0, 8%);
+    border-radius: $border-radius-base;
+    padding: $grid-unit-size * 0.75;
+    margin-left: 0;
+    margin-right: 0;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 8%);
+    overflow: hidden;
 
     &:not(:first-child) {
-        margin-top: $grid-unit-size * 0.25;
+        margin-top: $grid-unit-size * 0.5;
     }
 
     &:not(:last-child) {
-        margin-bottom: $grid-unit-size * 0.25;
+        margin-bottom: $grid-unit-size * 0.5;
+    }
+
+    &:hover {
+        border-color: rgba(0, 0, 0, 28%);
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 12%);
     }
 
     > div:nth-child(1) {
         > div:nth-child(1) {
-            line-height: 12px;
+            line-height: 14px;
+
+            > span:first-child {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                min-width: $grid-unit-size * 3;
+                height: $grid-unit-size * 2.5;
+                margin-right: $grid-unit-size * 0.5;
+                padding: 0 $grid-unit-size * 0.5;
+                border-radius: $border-radius-base;
+                background: rgba(255, 255, 255, 72%);
+                color: $text-color;
+                font-weight: 600;
+                line-height: $grid-unit-size * 2.5;
+            }
         }
 
         > div:nth-child(3) > span {
@@ -255,16 +279,41 @@
 
         > div:nth-child(2) > .ant-select {
             width: 100%;
+
+            .ant-select-selector {
+                border-color: rgba(0, 0, 0, 12%);
+                border-radius: $border-radius-base;
+                background: rgba(255, 255, 255, 82%);
+            }
         }
     }
 
     > div:nth-child(2) {
+        margin-top: $grid-unit-size * 0.5;
+        padding-top: $grid-unit-size * 0.5;
+        border-top: 1px solid rgba(0, 0, 0, 7%);
+
+        > div {
+            row-gap: $grid-unit-size * 0.5;
+        }
+
         > div > div {
-            margin-top: 5px;
+            margin-top: 0;
         }
 
         span[role='img'] {
             @extend .cvat-object-sidebar-icon;
+
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: $grid-unit-size * 2.75;
+            height: $grid-unit-size * 2.75;
+            border-radius: $border-radius-base;
+
+            &:hover {
+                background: rgba(0, 0, 0, 6%);
+            }
         }
     }
 }
@@ -281,11 +330,11 @@
 
         > .ant-collapse-header {
             align-items: baseline;
-            padding: 2px;
+            padding: $grid-unit-size * 0.5 0 0;
 
             .ant-collapse-arrow {
                 padding: 0;
-                top: $grid-unit-size;
+                top: $grid-unit-size * 1.25;
             }
         }
 
@@ -488,13 +537,19 @@
 }
 
 .cvat-objects-sidebar-state-item-elements {
-    padding: $grid-unit-size * 0.5;
-    border: 1px solid rgba($color: white, $alpha: 0%);
+    padding: $grid-unit-size * 0.5 $grid-unit-size * 0.75;
+    border: 1px solid rgba(0, 0, 0, 7%);
+    border-radius: $border-radius-base;
     background-color: rgba(var(--state-item-background), 1);
+
+    &:not(:first-child) {
+        margin-top: $grid-unit-size * 0.5;
+    }
 }
 
 .cvat-objects-sidebar-state-item-elements.cvat-objects-sidebar-state-active-element {
-    border: 1px dashed $object-item-border-color;
+    border: 1px solid $object-item-border-color;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 55%);
 }
 
 .cvat-objects-sidebar-show-ground-truth-active {

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
@@ -251,7 +251,8 @@
 }
 
 .cvat-objects-sidebar-item-active {
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 12%), inset 2px 0 0 rgba(0, 0, 0, 28%);
+    border-color: rgba(0, 0, 0, 42%);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 12%);
 }
 
 .cvat-objects-sidebar-issue-resolved {
@@ -360,7 +361,7 @@
 
 .cvat-objects-sidebar-state-item.cvat-objects-sidebar-state-active-item {
     box-shadow: 0 3px 10px rgba(0, 0, 0, 14%);
-    border: 1px solid $object-item-border-color;
+    border: 1px solid rgba(0, 0, 0, 42%);
 }
 
 .cvat-objects-sidebar-state-item {
@@ -384,7 +385,7 @@
     }
 
     &:hover {
-        border-color: rgba(0, 0, 0, 28%);
+        border-color: rgba(0, 0, 0, 42%);
         box-shadow: 0 2px 8px rgba(0, 0, 0, 12%);
     }
 
@@ -546,7 +547,7 @@
 .cvat-objects-sidebar-label-active-item {
     background: rgba(255, 255, 255, 92%);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 12%);
-    border: 1px solid $object-item-border-color;
+    border: 1px solid rgba(0, 0, 0, 24%);
 }
 
 .cvat-objects-sidebar-label-item {
@@ -719,8 +720,8 @@
 }
 
 .cvat-objects-sidebar-state-item-elements.cvat-objects-sidebar-state-active-element {
-    border: 1px solid $object-item-border-color;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 55%);
+    border: 1px solid rgba(0, 0, 0, 42%);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 10%);
 }
 
 .cvat-objects-sidebar-show-ground-truth-active {

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
@@ -42,10 +42,33 @@
     fill: $objects-bar-icons-color;
     color: $objects-bar-icons-color;
     font-size: 15px;
+    transition: background-color $box-shadow-transition, color $box-shadow-transition, opacity $box-shadow-transition;
 
     &:hover {
-        transform: scale(1.1);
+        opacity: 0.82;
     }
+}
+
+.cvat-object-item-button-first-keyframe,
+.cvat-object-item-button-prev-keyframe,
+.cvat-object-item-button-next-keyframe,
+.cvat-object-item-button-last-keyframe,
+.cvat-object-item-button-outside,
+.cvat-object-item-button-lock,
+.cvat-object-item-button-occluded,
+.cvat-object-item-button-pinned,
+.cvat-object-item-button-hidden,
+.cvat-object-item-button-keyframe {
+    color: rgba(0, 0, 0, 62%);
+}
+
+.cvat-object-item-button-outside-enabled,
+.cvat-object-item-button-lock-enabled,
+.cvat-object-item-button-occluded-enabled,
+.cvat-object-item-button-pinned-enabled,
+.cvat-object-item-button-hidden-enabled,
+.cvat-object-item-button-keyframe-enabled {
+    color: #1890ff;
 }
 
 .cvat-objects-sidebar-tabs.ant-tabs.ant-tabs-card {
@@ -78,31 +101,77 @@
 
 .cvat-objects-sidebar-labels-list-header {
     background: $objects-bar-tabs-color;
-    padding: $grid-unit-size;
-    border-bottom: 1px solid $border-color-1;
+    padding: $grid-unit-size * 0.75 $grid-unit-size;
+    border-bottom: 1px solid rgba(0, 0, 0, 8%);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 6%);
+
+    .ant-typography {
+        font-weight: 600;
+    }
 }
 
 .cvat-objects-sidebar-issues-list-header {
     background: $objects-bar-tabs-color;
-    padding: $grid-unit-size;
+    padding: $grid-unit-size * 0.75 $grid-unit-size;
     box-sizing: border-box;
-    border-bottom: 1px solid $border-color-1;
+    border-bottom: 1px solid rgba(0, 0, 0, 8%);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 6%);
 
-    > div > div {
-        > span[role='img'] {
-            font-size: 16px;
-            color: $objects-bar-icons-color;
+    .ant-typography {
+        font-weight: 600;
+    }
 
-            &:hover {
-                transform: scale(1.1);
-                opacity: 0.8;
-            }
+    .cvat-objects-sidebar-issues-toolbar {
+        margin-top: $grid-unit-size;
+        padding: $grid-unit-size * 0.5;
+        border: 1px solid rgba(0, 0, 0, 6%);
+        border-radius: $border-radius-base;
+        background: rgba(255, 255, 255, 38%);
 
-            &:active {
-                transform: scale(1);
-                opacity: 0.7;
+        > div {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+
+            > span[role='img'] {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: $grid-unit-size * 3;
+                height: $grid-unit-size * 3;
+                border-radius: $border-radius-base;
+                font-size: 16px;
+                color: $objects-bar-icons-color;
+                transition: background-color $box-shadow-transition, opacity $box-shadow-transition;
+
+                &:hover {
+                    background: rgba(0, 0, 0, 6%);
+                    opacity: 0.8;
+                }
+
+                &:active {
+                    opacity: 0.7;
+                }
             }
         }
+    }
+
+    .cvat-issues-sidebar-hidden-issues,
+    .cvat-issues-sidebar-shown-issues,
+    .cvat-issues-sidebar-hidden-resolved-status,
+    .cvat-objects-sidebar-show-ground-truth {
+        border: 1px solid rgba(0, 0, 0, 6%);
+        background: rgba(255, 255, 255, 58%);
+
+        &:hover {
+            border-color: rgba(0, 0, 0, 16%);
+        }
+    }
+
+    .cvat-issues-sidebar-hidden-issues,
+    .cvat-issues-sidebar-hidden-resolved-status,
+    .cvat-objects-sidebar-show-ground-truth-active {
+        color: #1890ff;
     }
 }
 
@@ -110,17 +179,29 @@
     background-color: $background-color-2;
     height: calc(100% - $grid-unit-size * 4);
     overflow: hidden auto;
+    padding: $grid-unit-size * 0.5;
 }
 
 .cvat-objects-sidebar-issue-item {
     width: 100%;
-    margin: 1px;
+    margin: 0;
     padding: $grid-unit-size;
+    border: 1px solid rgba(0, 0, 0, 8%);
     border-left: 3px solid #ff7300;
-    border-bottom: 1px solid $border-color-1;
+    border-radius: $border-radius-base;
+    background: rgba(255, 255, 255, 82%);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 8%);
+    transition: border-color $box-shadow-transition, box-shadow $box-shadow-transition, background-color $box-shadow-transition;
+
+    &:not(:first-child) {
+        margin-top: $grid-unit-size * 0.5;
+    }
 
     &:hover {
-        border-left: 4px solid #ff7300;
+        border-color: rgba(0, 0, 0, 24%);
+        border-left-color: #ff7300;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 12%);
+        background: rgba(255, 255, 255, 92%);
     }
 
     > .ant-alert.ant-alert-with-description {
@@ -140,10 +221,25 @@
 
 .cvat-objects-sidebar-conflict-item {
     width: 100%;
-    margin: 1px;
+    margin: 0;
     padding: $grid-unit-size;
+    border: 1px solid rgba(0, 0, 0, 8%);
     border-left: 3px solid #e10602;
-    border-bottom: 1px solid $border-color-1;
+    border-radius: $border-radius-base;
+    background: rgba(255, 255, 255, 82%);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 8%);
+    transition: border-color $box-shadow-transition, box-shadow $box-shadow-transition, background-color $box-shadow-transition;
+
+    &:not(:first-child) {
+        margin-top: $grid-unit-size * 0.5;
+    }
+
+    &:hover {
+        border-color: rgba(0, 0, 0, 24%);
+        border-left-color: #e10602;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 12%);
+        background: rgba(255, 255, 255, 92%);
+    }
 
     p {
         margin-bottom: 0;
@@ -155,38 +251,56 @@
 }
 
 .cvat-objects-sidebar-item-active {
-    border-left-width: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 12%), inset 2px 0 0 rgba(0, 0, 0, 28%);
 }
 
 .cvat-objects-sidebar-issue-resolved {
+    border-color: rgba(0, 0, 0, 8%);
     border-left: 3px solid $border-color-1;
+    background: rgba(255, 255, 255, 64%);
 
     &:hover {
-        border-left: 4px solid $border-color-1;
+        border-color: rgba(0, 0, 0, 18%);
+        border-left-color: $border-color-1;
     }
 }
 
 .cvat-objects-sidebar-states-header {
     background: $objects-bar-tabs-color;
-    padding: $grid-unit-size $grid-unit-size * 2 $grid-unit-size $grid-unit-size * 2;
+    padding: $grid-unit-size;
     line-height: $grid-unit-size * 3;
-    border-bottom: 1px solid $border-color-1;
+    border-bottom: 1px solid rgba(0, 0, 0, 8%);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 6%);
 
     > div {
         > div:nth-child(1) {
             display: flex;
             justify-content: space-between;
-            align-items: flex-start;
+            align-items: center;
+
+            > .ant-typography {
+                font-weight: 600;
+            }
 
             .cvat-objects-sidebar-ordering-selector {
                 margin-left: $grid-unit-size;
                 width: $grid-unit-size * 16;
+
+                .ant-select-selector {
+                    border-color: rgba(0, 0, 0, 12%);
+                    border-radius: $border-radius-base;
+                    background: rgba(255, 255, 255, 72%);
+                }
             }
         }
 
         > div:nth-child(2) {
             width: 100%;
             margin-top: $grid-unit-size;
+            padding: $grid-unit-size * 0.5;
+            border: 1px solid rgba(0, 0, 0, 6%);
+            border-radius: $border-radius-base;
+            background: rgba(255, 255, 255, 38%);
 
             span[role='img'] {
                 &:not(:first-child) {
@@ -194,12 +308,33 @@
                 }
 
                 @extend .cvat-object-sidebar-icon;
+
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: $grid-unit-size * 3;
+                height: $grid-unit-size * 3;
+                border: 1px solid transparent;
+                border-radius: $border-radius-base;
+                transition: background-color $box-shadow-transition, opacity $box-shadow-transition;
+
+                &:hover {
+                    border-color: rgba(0, 0, 0, 10%);
+                    background: rgba(0, 0, 0, 6%);
+                    opacity: 0.8;
+                }
             }
         }
     }
 
     .cvat-objects-sidebar-show-ground-truth {
         margin-right: $grid-unit-size;
+    }
+
+    .cvat-objects-sidebar-show-ground-truth-active {
+        border-color: rgba(24, 144, 255, 28%);
+        background: rgba(24, 144, 255, 10%);
+        color: #1890ff;
     }
 }
 
@@ -309,11 +444,23 @@
             justify-content: center;
             width: $grid-unit-size * 2.75;
             height: $grid-unit-size * 2.75;
+            border: 1px solid transparent;
             border-radius: $border-radius-base;
 
             &:hover {
+                border-color: rgba(0, 0, 0, 10%);
                 background: rgba(0, 0, 0, 6%);
             }
+        }
+
+        .cvat-object-item-button-outside-enabled,
+        .cvat-object-item-button-lock-enabled,
+        .cvat-object-item-button-occluded-enabled,
+        .cvat-object-item-button-pinned-enabled,
+        .cvat-object-item-button-hidden-enabled,
+        .cvat-object-item-button-keyframe-enabled {
+            border-color: rgba(24, 144, 255, 22%);
+            background: rgba(24, 144, 255, 9%);
         }
     }
 }
@@ -397,21 +544,43 @@
 }
 
 .cvat-objects-sidebar-label-active-item {
-    background: $active-label-background-color;
-    box-shadow: $box-shadow-base;
+    background: rgba(255, 255, 255, 92%);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 12%);
     border: 1px solid $object-item-border-color;
 }
 
 .cvat-objects-sidebar-label-item {
-    height: 2.5em;
-    transition: box-shadow $box-shadow-transition;
-    border: 1px solid $border-color-1;
-    padding: $grid-unit-size * 0.5;
-    margin-left: $grid-unit-size * 0.25;
-    margin-right: $grid-unit-size * 0.25;
+    min-height: $grid-unit-size * 5;
+    transition: border-color $box-shadow-transition, box-shadow $box-shadow-transition, background-color $box-shadow-transition;
+    border: 1px solid rgba(0, 0, 0, 8%);
+    border-radius: $border-radius-base;
+    padding: $grid-unit-size * 0.5 $grid-unit-size * 0.75;
+    margin-left: $grid-unit-size * 0.5;
+    margin-right: $grid-unit-size * 0.5;
+    background: rgba(255, 255, 255, 82%);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 8%);
+
+    &:first-of-type {
+        margin-top: $grid-unit-size * 0.5;
+    }
+
+    &:not(:first-child) {
+        margin-top: $grid-unit-size * 0.5;
+    }
 
     span {
         @extend .cvat-object-sidebar-icon;
+
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: $grid-unit-size * 2.75;
+        height: $grid-unit-size * 2.75;
+        border-radius: $border-radius-base;
+
+        &:hover {
+            background: rgba(0, 0, 0, 6%);
+        }
     }
 
     > div:nth-child(2) {
@@ -419,6 +588,7 @@
         overflow: hidden;
         max-height: 1.5em;
         font-size: 1em;
+        align-self: center;
     }
 
     &:hover {
@@ -428,9 +598,10 @@
 
 .cvat-label-item-color {
     background: rgb(25, 184, 14);
-    height: 80%;
-    width: 90%;
+    height: $grid-unit-size * 3;
+    width: $grid-unit-size * 1.25;
     border-radius: $border-radius-base;
+    margin-top: $grid-unit-size * 0.5;
 }
 
 .cvat-objects-appearance-content {

--- a/cvat-ui/src/components/annotation-page/tag-annotation-workspace/tag-annotation-sidebar/tag-annotation-sidebar.tsx
+++ b/cvat-ui/src/components/annotation-page/tag-annotation-workspace/tag-annotation-sidebar/tag-annotation-sidebar.tsx
@@ -182,7 +182,7 @@ function TagAnnotationSidebar(props: StateToProps & DispatchToProps): JSX.Elemen
     const siderProps: SiderProps = {
         className: 'cvat-tag-annotation-sidebar',
         theme: 'light',
-        width: 300,
+        width: 320,
         collapsedWidth: 0,
         reverseArrow: true,
         collapsible: true,

--- a/tests/cypress/e2e/actions_objects/case_34_drawing_with_predefined_number_points.js
+++ b/tests/cypress/e2e/actions_objects/case_34_drawing_with_predefined_number_points.js
@@ -59,7 +59,26 @@ context('Drawing with predefined number of points.', () => {
     function tryDeletePoint(successful = true) {
         const svgJsCircleId = [];
         const updatedSvgJsCircleId = [];
-        cy.get('#cvat_canvas_shape_1').trigger('mousemove', { force: true });
+        cy.get('#cvat_canvas_shape_1').then(([shape]) => {
+            const svg = shape.ownerSVGElement;
+            const point = svg.createSVGPoint();
+
+            if (shape.points && shape.points.length) {
+                point.x = shape.points[0].x;
+                point.y = shape.points[0].y;
+            } else {
+                const bbox = shape.getBBox();
+                point.x = bbox.x + bbox.width / 2;
+                point.y = bbox.y + bbox.height / 2;
+            }
+
+            const screenPoint = point.matrixTransform(svg.getScreenCTM());
+            cy.wrap(shape).trigger('mousemove', {
+                clientX: screenPoint.x,
+                clientY: screenPoint.y,
+                bubbles: true,
+            });
+        });
         cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
         cy.get('circle').then((circle) => {
             for (let i = 0; i < circle.length; i++) {

--- a/tests/cypress/e2e/actions_objects/case_34_drawing_with_predefined_number_points.js
+++ b/tests/cypress/e2e/actions_objects/case_34_drawing_with_predefined_number_points.js
@@ -59,26 +59,7 @@ context('Drawing with predefined number of points.', () => {
     function tryDeletePoint(successful = true) {
         const svgJsCircleId = [];
         const updatedSvgJsCircleId = [];
-        cy.get('#cvat_canvas_shape_1').then(([shape]) => {
-            const svg = shape.ownerSVGElement;
-            const point = svg.createSVGPoint();
-
-            if (shape.points && shape.points.length) {
-                point.x = shape.points[0].x;
-                point.y = shape.points[0].y;
-            } else {
-                const bbox = shape.getBBox();
-                point.x = bbox.x + bbox.width / 2;
-                point.y = bbox.y + bbox.height / 2;
-            }
-
-            const screenPoint = point.matrixTransform(svg.getScreenCTM());
-            cy.wrap(shape).trigger('mousemove', {
-                clientX: screenPoint.x,
-                clientY: screenPoint.y,
-                bubbles: true,
-            });
-        });
+        cy.activateCanvasShape('#cvat_canvas_shape_1');
         cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
         cy.get('circle').then((circle) => {
             for (let i = 0; i < circle.length; i++) {

--- a/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
+++ b/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
@@ -55,6 +55,13 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
         { x: 450, y: 500 },
         { x: 400, y: 550 },
     ];
+    const approximablePointsMap = [
+        { x: 300, y: 400 },
+        { x: 350, y: 400 },
+        { x: 400, y: 400 },
+        { x: 450, y: 500 },
+        { x: 400, y: 550 },
+    ];
 
     const taskName = `New annotation task for ${labelName}`;
     const attrName = `Attr for ${labelName}`;
@@ -115,14 +122,14 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
         it('Change the number of points when the shape is drawn. Cancel drawing.', () => {
             cy.interactOpenCVControlButton();
             cy.get('.cvat-opencv-drawing-tool').click();
-            pointsMap.forEach((element) => {
+            approximablePointsMap.forEach((element) => {
                 cy.get('.cvat-canvas-container').click(element.x, element.y);
             });
             cy.get('.cvat_canvas_interact_intermediate_shape').then((intermediateShape) => {
                 // Get count of points
                 const intermediateShapeNumberPointsBeforeChange = intermediateShape.attr('points').split(' ').length;
                 // expected 7 to be above 5
-                expect(intermediateShapeNumberPointsBeforeChange).to.be.gt(pointsMap.length);
+                expect(intermediateShapeNumberPointsBeforeChange).to.be.gt(approximablePointsMap.length);
                 // Change number of points
                 cy.get('.cvat-approx-poly-threshold-wrapper')
                     .find('[role="slider"]')

--- a/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
+++ b/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
@@ -19,21 +19,21 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
     const createOpencvShape = {
         labelName,
         pointsMap: [
-            { x: 200, y: 200 },
-            { x: 250, y: 200 },
-            { x: 300, y: 250 },
-            { x: 350, y: 300 },
-            { x: 300, y: 350 },
+            { x: 1000, y: 400 },
+            { x: 1250, y: 400 },
+            { x: 1500, y: 500 },
+            { x: 1750, y: 600 },
+            { x: 1500, y: 700 },
         ],
     };
     const createOpencvShapeSecondLabel = {
         labelName: newLabel,
         pointsMap: [
-            { x: 300, y: 200 },
-            { x: 350, y: 200 },
-            { x: 400, y: 250 },
-            { x: 450, y: 300 },
-            { x: 400, y: 350 },
+            { x: 1500, y: 400 },
+            { x: 1750, y: 400 },
+            { x: 2000, y: 500 },
+            { x: 2250, y: 600 },
+            { x: 2000, y: 700 },
         ],
         finishWithButton: true,
     };
@@ -50,18 +50,18 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
 
     const keyCodeN = 78;
     const pointsMap = [
-        { x: 300, y: 400 },
-        { x: 350, y: 500 },
-        { x: 400, y: 450 },
-        { x: 450, y: 500 },
-        { x: 400, y: 550 },
+        { x: 1500, y: 800 },
+        { x: 1750, y: 1000 },
+        { x: 2000, y: 900 },
+        { x: 2250, y: 1000 },
+        { x: 2000, y: 1100 },
     ];
     const approximablePointsMap = [
-        { x: 300, y: 400 },
-        { x: 350, y: 400 },
-        { x: 400, y: 400 },
-        { x: 450, y: 500 },
-        { x: 400, y: 550 },
+        { x: 1500, y: 800 },
+        { x: 1750, y: 800 },
+        { x: 2000, y: 800 },
+        { x: 2250, y: 1000 },
+        { x: 2000, y: 1100 },
     ];
 
     const taskName = `New annotation task for ${labelName}`;
@@ -186,7 +186,7 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
 
             cy.get('.cvat-annotation-header-block-tool-button').click();
             cy.get('.cvat-annotation-header-block-tool-button').should('not.have.class', 'cvat-button-active');
-            clickCanvasImagePoint({ x: 600, y: 600 });
+            clickCanvasImagePoint({ x: 3000, y: 1200 });
 
             cy.get('.cvat_canvas_interact_intermediate_shape').then((intermediateShape) => {
                 // The last point on the crosshair

--- a/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
+++ b/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
@@ -19,21 +19,15 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
     const createOpencvShape = {
         labelName,
         pointsMap: [
-            { x: 1000, y: 400 },
-            { x: 1250, y: 400 },
-            { x: 1500, y: 500 },
-            { x: 1750, y: 600 },
-            { x: 1500, y: 700 },
+            { x: 696, y: 586 },
+            { x: 1131, y: 588 },
         ],
     };
     const createOpencvShapeSecondLabel = {
         labelName: newLabel,
         pointsMap: [
-            { x: 1500, y: 400 },
-            { x: 1750, y: 400 },
-            { x: 2000, y: 500 },
-            { x: 2250, y: 600 },
-            { x: 2000, y: 700 },
+            { x: 1659, y: 674 },
+            { x: 2095, y: 678 },
         ],
         finishWithButton: true,
     };
@@ -49,20 +43,6 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
     };
 
     const keyCodeN = 78;
-    const pointsMap = [
-        { x: 1500, y: 800 },
-        { x: 1750, y: 1000 },
-        { x: 2000, y: 900 },
-        { x: 2250, y: 1000 },
-        { x: 2000, y: 1100 },
-    ];
-    const approximablePointsMap = [
-        { x: 1500, y: 800 },
-        { x: 1750, y: 800 },
-        { x: 2000, y: 800 },
-        { x: 2250, y: 1000 },
-        { x: 2000, y: 1100 },
-    ];
 
     const taskName = `New annotation task for ${labelName}`;
     const attrName = `Attr for ${labelName}`;
@@ -123,14 +103,14 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
         it('Change the number of points when the shape is drawn. Cancel drawing.', () => {
             cy.interactOpenCVControlButton();
             cy.get('.cvat-opencv-drawing-tool').click();
-            approximablePointsMap.forEach((point) => {
+            createOpencvShape.pointsMap.forEach((point) => {
                 clickCanvasImagePoint(point);
             });
             cy.get('.cvat_canvas_interact_intermediate_shape').then((intermediateShape) => {
                 // Get count of points
                 const intermediateShapeNumberPointsBeforeChange = intermediateShape.attr('points').split(' ').length;
-                // expected 7 to be above 5
-                expect(intermediateShapeNumberPointsBeforeChange).to.be.gt(approximablePointsMap.length);
+                // Intermediate shape is expected to contain points added by the algorithm
+                expect(intermediateShapeNumberPointsBeforeChange).to.be.gt(createOpencvShape.pointsMap.length);
                 // Change number of points
                 cy.get('.cvat-approx-poly-threshold-wrapper')
                     .find('[role="slider"]')
@@ -138,7 +118,6 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
                 cy.get('.cvat_canvas_interact_intermediate_shape').then((_intermediateShape) => {
                     // Get count of points again
                     const intermediateShapeNumberPointsAfterChange = _intermediateShape.attr('points').split(' ').length;
-                    // expected 7 to be below 10
                     expect(intermediateShapeNumberPointsBeforeChange).to.be.lt(
                         intermediateShapeNumberPointsAfterChange,
                     );
@@ -171,26 +150,32 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
         });
 
         it('Check "Intelligent scissors blocking feature". Cancel drawing.', () => {
+            const blockingPointsMap = [
+                createOpencvShapeSecondLabel.pointsMap[0],
+                { x: 1877, y: 900 },
+                createOpencvShapeSecondLabel.pointsMap[1],
+            ];
+
             cy.interactOpenCVControlButton();
             cy.get('.cvat-opencv-drawing-tool').click();
             cy.get('.cvat-annotation-header-block-tool-button').click();
             cy.get('.cvat-annotation-header-block-tool-button').should('have.class', 'cvat-button-active');
 
-            pointsMap.forEach((point) => {
+            blockingPointsMap.forEach((point) => {
                 clickCanvasImagePoint(point);
             });
 
             cy.get('.cvat_canvas_interact_intermediate_shape').then((intermediateShape) => {
-                expect(intermediateShape.attr('points').split(' ').length).to.be.equal(pointsMap.length);
+                expect(intermediateShape.attr('points').split(' ').length).to.be.equal(blockingPointsMap.length);
             });
 
             cy.get('.cvat-annotation-header-block-tool-button').click();
             cy.get('.cvat-annotation-header-block-tool-button').should('not.have.class', 'cvat-button-active');
-            clickCanvasImagePoint({ x: 3000, y: 1200 });
+            clickCanvasImagePoint({ x: 2300, y: 900 });
 
             cy.get('.cvat_canvas_interact_intermediate_shape').then((intermediateShape) => {
                 // The last point on the crosshair
-                expect(intermediateShape.attr('points').split(' ').length).to.be.gt(pointsMap.length);
+                expect(intermediateShape.attr('points').split(' ').length).to.be.gt(blockingPointsMap.length);
             });
 
             // Cancel drawing

--- a/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
+++ b/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
@@ -9,6 +9,7 @@ import * as allure from 'allure-js-commons';
 import { AllureTag } from '../../support/const_allure';
 
 import { generateString } from '../../support/utils';
+import { clickCanvasImagePoint } from '../../support/utils.cy';
 
 context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () => {
     allure.tags(AllureTag.HEAVY, AllureTag.SETTINGS);
@@ -122,8 +123,8 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
         it('Change the number of points when the shape is drawn. Cancel drawing.', () => {
             cy.interactOpenCVControlButton();
             cy.get('.cvat-opencv-drawing-tool').click();
-            approximablePointsMap.forEach((element) => {
-                cy.get('.cvat-canvas-container').click(element.x, element.y);
+            approximablePointsMap.forEach((point) => {
+                clickCanvasImagePoint(point);
             });
             cy.get('.cvat_canvas_interact_intermediate_shape').then((intermediateShape) => {
                 // Get count of points
@@ -175,8 +176,8 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
             cy.get('.cvat-annotation-header-block-tool-button').click();
             cy.get('.cvat-annotation-header-block-tool-button').should('have.class', 'cvat-button-active');
 
-            pointsMap.forEach((element) => {
-                cy.get('.cvat-canvas-container').click(element.x, element.y);
+            pointsMap.forEach((point) => {
+                clickCanvasImagePoint(point);
             });
 
             cy.get('.cvat_canvas_interact_intermediate_shape').then((intermediateShape) => {
@@ -185,7 +186,7 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
 
             cy.get('.cvat-annotation-header-block-tool-button').click();
             cy.get('.cvat-annotation-header-block-tool-button').should('not.have.class', 'cvat-button-active');
-            cy.get('.cvat-canvas-container').click(600, 600);
+            clickCanvasImagePoint({ x: 600, y: 600 });
 
             cy.get('.cvat_canvas_interact_intermediate_shape').then((intermediateShape) => {
                 // The last point on the crosshair

--- a/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
+++ b/tests/cypress/e2e/actions_tasks2/case_101_opencv_basic_actions.js
@@ -8,7 +8,6 @@
 import * as allure from 'allure-js-commons';
 import { AllureTag } from '../../support/const_allure';
 
-import { generateString } from '../../support/utils';
 import { clickCanvasImagePoint } from '../../support/utils.cy';
 
 context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () => {
@@ -103,6 +102,7 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
         it('Change the number of points when the shape is drawn. Cancel drawing.', () => {
             cy.interactOpenCVControlButton();
             cy.get('.cvat-opencv-drawing-tool').click();
+            cy.get('.cvat-approx-poly-threshold-wrapper .ant-slider').click('center');
             createOpencvShape.pointsMap.forEach((point) => {
                 clickCanvasImagePoint(point);
             });
@@ -112,9 +112,7 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
                 // Intermediate shape is expected to contain points added by the algorithm
                 expect(intermediateShapeNumberPointsBeforeChange).to.be.gt(createOpencvShape.pointsMap.length);
                 // Change number of points
-                cy.get('.cvat-approx-poly-threshold-wrapper')
-                    .find('[role="slider"]')
-                    .type(generateString(4, 'rightarrow'));
+                cy.get('.cvat-approx-poly-threshold-wrapper .ant-slider').click('right');
                 cy.get('.cvat_canvas_interact_intermediate_shape').then((_intermediateShape) => {
                     // Get count of points again
                     const intermediateShapeNumberPointsAfterChange = _intermediateShape.attr('points').split(' ').length;
@@ -150,23 +148,19 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
         });
 
         it('Check "Intelligent scissors blocking feature". Cancel drawing.', () => {
-            const blockingPointsMap = [
-                createOpencvShapeSecondLabel.pointsMap[0],
-                { x: 1877, y: 900 },
-                createOpencvShapeSecondLabel.pointsMap[1],
-            ];
-
             cy.interactOpenCVControlButton();
             cy.get('.cvat-opencv-drawing-tool').click();
             cy.get('.cvat-annotation-header-block-tool-button').click();
             cy.get('.cvat-annotation-header-block-tool-button').should('have.class', 'cvat-button-active');
 
-            blockingPointsMap.forEach((point) => {
+            createOpencvShapeSecondLabel.pointsMap.forEach((point) => {
                 clickCanvasImagePoint(point);
             });
 
             cy.get('.cvat_canvas_interact_intermediate_shape').then((intermediateShape) => {
-                expect(intermediateShape.attr('points').split(' ').length).to.be.equal(blockingPointsMap.length);
+                expect(intermediateShape.attr('points').split(' ').length).to.be.equal(
+                    createOpencvShapeSecondLabel.pointsMap.length,
+                );
             });
 
             cy.get('.cvat-annotation-header-block-tool-button').click();
@@ -175,7 +169,9 @@ context('OpenCV. Intelligent scissors. Histogram Equalization. TrackerMIL.', () 
 
             cy.get('.cvat_canvas_interact_intermediate_shape').then((intermediateShape) => {
                 // The last point on the crosshair
-                expect(intermediateShape.attr('points').split(' ').length).to.be.gt(blockingPointsMap.length);
+                expect(intermediateShape.attr('points').split(' ').length).to.be.gt(
+                    createOpencvShapeSecondLabel.pointsMap.length,
+                );
             });
 
             // Cancel drawing

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -26,43 +26,63 @@ require('cy-verify-downloads').addCustomCommand();
 let selectedValueGlobal = '';
 
 Cypress.Commands.add('activateCanvasShape', (selector) => {
-    cy.get(selector).then(([shape]) => {
-        const tagName = shape.tagName.toLowerCase();
-        const bbox = shape.getBBox();
-        const renderedBox = shape.getBoundingClientRect();
-        const toClientCoordinates = ({ x, y }) => ({
-            x: bbox.width ?
-                renderedBox.left + ((x - bbox.x) / bbox.width) * renderedBox.width :
-                renderedBox.left + renderedBox.width / 2,
-            y: bbox.height ?
-                renderedBox.top + ((y - bbox.y) / bbox.height) * renderedBox.height :
-                renderedBox.top + renderedBox.height / 2,
+    cy.get(selector).then(([shapeWrapper]) => {
+        const tagName = (element) => element.tagName.toLowerCase();
+        const centerPoint = (bbox) => ({
+            x: bbox.x + bbox.width / 2,
+            y: bbox.y + bbox.height / 2,
         });
-        let svgPoint = null;
+        const getSVGPoint = (shape) => {
+            const shapeTagName = tagName(shape);
+            const bbox = shape.getBBox();
 
-        if (['polygon', 'polyline'].includes(tagName) && shape.points.length) {
-            svgPoint = {
-                x: shape.points[0].x,
-                y: shape.points[0].y,
-            };
-        } else if (tagName === 'circle') {
-            svgPoint = {
-                x: +shape.getAttribute('cx'),
-                y: +shape.getAttribute('cy'),
-            };
-        } else if (['rect', 'ellipse'].includes(tagName)) {
-            svgPoint = {
-                x: bbox.x + bbox.width / 2,
-                y: bbox.y + bbox.height / 2,
-            };
-        } else {
+            if (['polygon', 'polyline'].includes(shapeTagName) && shape.points.length) {
+                return {
+                    x: shape.points[0].x,
+                    y: shape.points[0].y,
+                };
+            }
+
+            if (shapeTagName === 'g') {
+                const pointCircle = shape.querySelector('circle');
+                if (pointCircle) {
+                    return {
+                        x: +pointCircle.getAttribute('cx'),
+                        y: +pointCircle.getAttribute('cy'),
+                    };
+                }
+
+                return centerPoint(bbox);
+            }
+
+            if (['rect', 'ellipse'].includes(shapeTagName)) {
+                return {
+                    x: bbox.x + bbox.width / 2,
+                    y: bbox.y + bbox.height / 2,
+                };
+            }
+
             throw new Error(
-                `Unsupported canvas shape "${tagName}" for cy.activateCanvasShape. ` +
+                `Unsupported canvas shape "${shapeTagName}" for cy.activateCanvasShape. ` +
                 'Support can be added later if this shape type needs it.',
             );
-        }
+        };
+        const toClientCoordinates = (shape, svgPoint) => {
+            const bbox = shape.getBBox();
+            const renderedBox = shape.getBoundingClientRect();
 
-        const point = toClientCoordinates(svgPoint);
+            return {
+                x: bbox.width ?
+                    renderedBox.left + ((svgPoint.x - bbox.x) / bbox.width) * renderedBox.width :
+                    renderedBox.left + renderedBox.width / 2,
+                y: bbox.height ?
+                    renderedBox.top + ((svgPoint.y - bbox.y) / bbox.height) * renderedBox.height :
+                    renderedBox.top + renderedBox.height / 2,
+            };
+        };
+
+        const svgPoint = getSVGPoint(shapeWrapper);
+        const point = toClientCoordinates(shapeWrapper, svgPoint);
 
         cy.get('#cvat_canvas_wrapper').trigger('mousemove', {
             clientX: point.x,

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -25,6 +25,36 @@ require('cy-verify-downloads').addCustomCommand();
 
 let selectedValueGlobal = '';
 
+Cypress.Commands.add('activateCanvasShape', (selector) => {
+    cy.get(selector).then(([shape]) => {
+        const tagName = shape.tagName.toLowerCase();
+        const svg = shape.ownerSVGElement;
+        const point = svg.createSVGPoint();
+
+        if (tagName === 'polygon' && shape.points.length) {
+            point.x = shape.points[0].x;
+            point.y = shape.points[0].y;
+        } else if (tagName === 'circle') {
+            point.x = +shape.getAttribute('cx');
+            point.y = +shape.getAttribute('cy');
+        } else if (['rect', 'ellipse'].includes(tagName)) {
+            const bbox = shape.getBBox();
+            point.x = bbox.x + bbox.width / 2;
+            point.y = bbox.y + bbox.height / 2;
+        } else {
+            throw new Error(
+                `Unsupported canvas shape "${tagName}" for cy.activateCanvasShape. ` +
+                'Support can be added later if this shape type needs it.',
+            );
+        }
+
+        const screenPoint = point.matrixTransform(shape.getScreenCTM());
+        cy.get('.cvat-canvas-container').trigger('mousemove', screenPoint.x, screenPoint.y, {
+            bubbles: true,
+        });
+    });
+});
+
 Cypress.Commands.add('login', (username = Cypress.env('user'), password = Cypress.env('password'), page = 'tasks') => {
     cy.get('#credential').should('be.visible').type(username);
     cy.get('#password').should('be.visible').type(password);

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -32,8 +32,8 @@ Cypress.Commands.add('activateCanvasShape', (selector) => {
         const point = svg.createSVGPoint();
 
         if (tagName === 'polygon' && shape.points.length) {
-            point.x = shape.points[0].x;
-            point.y = shape.points[0].y;
+            point.x = Array.from(shape.points).reduce((sum, item) => sum + item.x, 0) / shape.points.length;
+            point.y = Array.from(shape.points).reduce((sum, item) => sum + item.y, 0) / shape.points.length;
         } else if (tagName === 'circle') {
             point.x = +shape.getAttribute('cx');
             point.y = +shape.getAttribute('cy');
@@ -49,7 +49,9 @@ Cypress.Commands.add('activateCanvasShape', (selector) => {
         }
 
         const screenPoint = point.matrixTransform(shape.getScreenCTM());
-        cy.get('.cvat-canvas-container').trigger('mousemove', screenPoint.x, screenPoint.y, {
+        cy.get('#cvat_canvas_wrapper').trigger('mousemove', {
+            clientX: screenPoint.x,
+            clientY: screenPoint.y,
             bubbles: true,
         });
     });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -28,19 +28,33 @@ let selectedValueGlobal = '';
 Cypress.Commands.add('activateCanvasShape', (selector) => {
     cy.get(selector).then(([shape]) => {
         const tagName = shape.tagName.toLowerCase();
-        const svg = shape.ownerSVGElement;
-        const point = svg.createSVGPoint();
+        const bbox = shape.getBBox();
+        const renderedBox = shape.getBoundingClientRect();
+        const toClientCoordinates = ({ x, y }) => ({
+            x: bbox.width ?
+                renderedBox.left + ((x - bbox.x) / bbox.width) * renderedBox.width :
+                renderedBox.left + renderedBox.width / 2,
+            y: bbox.height ?
+                renderedBox.top + ((y - bbox.y) / bbox.height) * renderedBox.height :
+                renderedBox.top + renderedBox.height / 2,
+        });
+        let svgPoint = null;
 
-        if (tagName === 'polygon' && shape.points.length) {
-            point.x = Array.from(shape.points).reduce((sum, item) => sum + item.x, 0) / shape.points.length;
-            point.y = Array.from(shape.points).reduce((sum, item) => sum + item.y, 0) / shape.points.length;
+        if (['polygon', 'polyline'].includes(tagName) && shape.points.length) {
+            svgPoint = {
+                x: shape.points[0].x,
+                y: shape.points[0].y,
+            };
         } else if (tagName === 'circle') {
-            point.x = +shape.getAttribute('cx');
-            point.y = +shape.getAttribute('cy');
+            svgPoint = {
+                x: +shape.getAttribute('cx'),
+                y: +shape.getAttribute('cy'),
+            };
         } else if (['rect', 'ellipse'].includes(tagName)) {
-            const bbox = shape.getBBox();
-            point.x = bbox.x + bbox.width / 2;
-            point.y = bbox.y + bbox.height / 2;
+            svgPoint = {
+                x: bbox.x + bbox.width / 2,
+                y: bbox.y + bbox.height / 2,
+            };
         } else {
             throw new Error(
                 `Unsupported canvas shape "${tagName}" for cy.activateCanvasShape. ` +
@@ -48,10 +62,11 @@ Cypress.Commands.add('activateCanvasShape', (selector) => {
             );
         }
 
-        const screenPoint = point.matrixTransform(shape.getScreenCTM());
+        const point = toClientCoordinates(svgPoint);
+
         cy.get('#cvat_canvas_wrapper').trigger('mousemove', {
-            clientX: screenPoint.x,
-            clientY: screenPoint.y,
+            clientX: point.x,
+            clientY: point.y,
             bubbles: true,
         });
     });

--- a/tests/cypress/support/commands_opencv.js
+++ b/tests/cypress/support/commands_opencv.js
@@ -5,6 +5,8 @@
 
 /// <reference types="cypress" />
 
+import { clickCanvasImagePoint } from './utils.cy';
+
 let selectedValueGlobal = '';
 
 Cypress.Commands.add('interactOpenCVControlButton', () => {
@@ -27,8 +29,8 @@ Cypress.Commands.add('opencvCreateShape', (opencvShapeParams) => {
         });
         cy.get('.cvat-opencv-drawing-tool').click();
     }
-    opencvShapeParams.pointsMap.forEach((element) => {
-        cy.get('.cvat-canvas-container').click(element.x, element.y);
+    opencvShapeParams.pointsMap.forEach((point) => {
+        clickCanvasImagePoint(point);
     });
     if (opencvShapeParams.finishWithButton) {
         cy.contains('span', 'Done').click();

--- a/tests/cypress/support/utils.cy.js
+++ b/tests/cypress/support/utils.cy.js
@@ -64,6 +64,49 @@ export function drawWithClicks(pointsMap) {
     });
 }
 
+export function imagePointToCanvasCoordinates(point, {
+    content,
+    background,
+    container,
+}) {
+    const contentWidth = Number.parseFloat(content.style.width) || content.width.baseVal.value;
+    const contentHeight = Number.parseFloat(content.style.height) || content.height.baseVal.value;
+    const imageWidth = Number(background.getAttribute('width')) || background.width;
+    const imageHeight = Number(background.getAttribute('height')) || background.height;
+    const matrix = content.getScreenCTM();
+
+    if (!matrix) {
+        throw new Error('Canvas image coordinates cannot be converted without a screen matrix');
+    }
+
+    const svgPoint = content.createSVGPoint();
+    svgPoint.x = point.x + (contentWidth - imageWidth) / 2;
+    svgPoint.y = point.y + (contentHeight - imageHeight) / 2;
+
+    const screenPoint = svgPoint.matrixTransform(matrix);
+    const containerRect = container.getBoundingClientRect();
+
+    return {
+        x: screenPoint.x - containerRect.left,
+        y: screenPoint.y - containerRect.top,
+    };
+}
+
+export function clickCanvasImagePoint(point, options = {}) {
+    cy.get('#cvat_canvas_content').then(([content]) => {
+        const background = content.ownerDocument.getElementById('cvat_canvas_background');
+        const container = content.ownerDocument.querySelector('.cvat-canvas-container');
+
+        if (!background || !container) {
+            throw new Error('Canvas image or container was not found');
+        }
+
+        const { x, y } = imagePointToCanvasCoordinates(point, { content, background, container });
+
+        cy.get('.cvat-canvas-container').click(x, y, options);
+    });
+}
+
 /**
  * Draw a shape by clicking through an array of points
  * using cy.click


### PR DESCRIPTION
### Motivation and context

This PR improves the visual polish and consistency of the Objects sidebar tabs.

The changes update the Objects, Labels, and Issues tabs with more professional and consistent styling:
- Refined object state cards with cleaner spacing, borders, shadows, and stable hover/active states.
- Improved Labels and Issues list item styling to match the Objects tab.
- Made tab headers consistent across Objects, Labels, and Issues.
- Updated the Issues header layout so `Items` is on a dedicated row and controls are placed in a real toolbar row, matching the Objects tab.
- Improved button/control styling for Objects and Issues tabs with stable hit areas and clearer active states.
- Preserved existing class names used by Cypress tests.

### How has this been tested?

Manually reviewed the updated sidebar layout and control styling in the annotation UI.

Ran frontend lint checks for the changed files:

```bash
npx stylelint cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
npx eslint cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/issues-list.tsx
```

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
