### PR TITLE
fix: handle degenerate bboxes in QC skeleton/keypoint matching

### DIFF
--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -1081,10 +1081,25 @@ class KeypointsMatcher(datumaro.components.annotations.matcher.PointsMatcher):
     def distance(self, a: dm.Points, b: dm.Points) -> float:
         a_bbox = self.instance_map[id(a)][1]
         b_bbox = self.instance_map[id(b)][1]
-        if datumaro.util.annotation_util.bbox_iou(a_bbox, b_bbox) <= 0:
-            return 0
+
+        a_area = a_bbox[2] * a_bbox[3]
+        b_area = b_bbox[2] * b_bbox[3]
+
+        # The bbox IoU check is an optimization that skips OKS for clearly
+        # non-overlapping annotations. Skip it for degenerate (zero-area) bboxes —
+        # single-point or collinear skeletons always produce IoU=0 even when
+        # the annotations are identical, causing false negatives.
+        if a_area > 0 and b_area > 0:
+            if datumaro.util.annotation_util.bbox_iou(a_bbox, b_bbox) <= 0:
+                return 0
 
         bbox = datumaro.util.annotation_util.mean_bbox([a_bbox, b_bbox])
+
+        # OKS normalizes distances by bbox area (scale = w * h). Expand
+        # degenerate bboxes to avoid division by zero in the exponent.
+        if bbox[2] * bbox[3] <= 0:
+            bbox = (bbox[0], bbox[1], max(bbox[2], 1), max(bbox[3], 1))
+
         return oks(
             a,
             b,

--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -1078,6 +1078,8 @@ def oks(a, b, sigma=0.1, bbox=None, scale=None, visibility_a=None, visibility_b=
 
 @define(kw_only=True)
 class KeypointsMatcher(datumaro.components.annotations.matcher.PointsMatcher):
+    img_size: tuple[int, int] | None = None  # (height, width) for image-space OKS scaling
+
     def distance(self, a: dm.Points, b: dm.Points) -> float:
         a_bbox = self.instance_map[id(a)][1]
         b_bbox = self.instance_map[id(b)][1]
@@ -1085,29 +1087,27 @@ class KeypointsMatcher(datumaro.components.annotations.matcher.PointsMatcher):
         a_area = a_bbox[2] * a_bbox[3]
         b_area = b_bbox[2] * b_bbox[3]
 
-        # The bbox IoU check is an optimization that skips OKS for clearly
-        # non-overlapping annotations. Skip it for degenerate (zero-area) bboxes —
-        # single-point or collinear skeletons always produce IoU=0 even when
-        # the annotations are identical, causing false negatives.
-        if a_area > 0 and b_area > 0:
-            if datumaro.util.annotation_util.bbox_iou(a_bbox, b_bbox) <= 0:
+        visibility_a = [v == dm.Points.Visibility.visible for v in a.visibility]
+        visibility_b = [v == dm.Points.Visibility.visible for v in b.visibility]
+
+        if a_area == 0 and b_area == 0:
+            # Degenerate case: single-point or collinear skeletons produce
+            # zero-area bboxes. bbox_iou() always returns 0 for these, so the
+            # normal IoU guard would block even identical annotations. Instead,
+            # scale OKS by the image area — the same approach used for point
+            # annotations (see match_points._distance, else-branch).
+            if self.img_size is None:
                 return 0
+            img_h, img_w = self.img_size
+            return oks(a, b, sigma=self.sigma, scale=img_h * img_w,
+                       visibility_a=visibility_a, visibility_b=visibility_b)
+
+        if datumaro.util.annotation_util.bbox_iou(a_bbox, b_bbox) <= 0:
+            return 0
 
         bbox = datumaro.util.annotation_util.mean_bbox([a_bbox, b_bbox])
-
-        # OKS normalizes distances by bbox area (scale = w * h). Expand
-        # degenerate bboxes to avoid division by zero in the exponent.
-        if bbox[2] * bbox[3] <= 0:
-            bbox = (bbox[0], bbox[1], max(bbox[2], 1), max(bbox[3], 1))
-
-        return oks(
-            a,
-            b,
-            sigma=self.sigma,
-            bbox=bbox,
-            visibility_a=[v == dm.Points.Visibility.visible for v in a.visibility],
-            visibility_b=[v == dm.Points.Visibility.visible for v in b.visibility],
-        )
+        return oks(a, b, sigma=self.sigma, bbox=bbox,
+                   visibility_a=visibility_a, visibility_b=visibility_b)
 
 
 def _arr_div(a_arr: np.ndarray, b_arr: np.ndarray) -> np.ndarray:
@@ -1835,7 +1835,9 @@ class DistanceComparator(datumaro.components.comparator.DistanceComparator):
                 for ann in instance_group:
                     instance_map[id(ann)] = [instance_group, instance_bbox]
 
-        matcher = KeypointsMatcher(instance_map=instance_map, sigma=self.oks_sigma)
+        img_h, img_w = item_a.media_as(dm.Image).size
+        matcher = KeypointsMatcher(instance_map=instance_map, sigma=self.oks_sigma,
+                                   img_size=(img_h, img_w))
 
         results = self.match_segments(
             dm.AnnotationType.points,

--- a/cvat/apps/quality_control/tests/test_keypoints_matcher.py
+++ b/cvat/apps/quality_control/tests/test_keypoints_matcher.py
@@ -1,0 +1,58 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import unittest
+
+import datumaro as dm
+
+from cvat.apps.quality_control.quality_reports import KeypointsMatcher
+
+
+class TestKeypointsMatcher(unittest.TestCase):
+    """Regression tests for issue #9957.
+
+    Single-point and collinear skeletons produce zero-area bboxes.
+    bbox_iou() returns 0 for zero-area boxes, which previously caused
+    the early-exit guard to block even identical annotations from matching.
+    """
+
+    def _matcher(self, pt_a, bbox_a, pt_b, bbox_b):
+        return KeypointsMatcher(
+            sigma=0.1,
+            instance_map={id(pt_a): [None, bbox_a], id(pt_b): [None, bbox_b]},
+        )
+
+    def test_single_point_identical_returns_one(self):
+        """Identical single-point skeletons must match with OKS=1.0."""
+        pt_a = dm.Points([10, 20], visibility=[dm.Points.Visibility.visible])
+        pt_b = dm.Points([10, 20], visibility=[dm.Points.Visibility.visible])
+        matcher = self._matcher(pt_a, (10, 20, 0, 0), pt_b, (10, 20, 0, 0))
+        self.assertAlmostEqual(matcher.distance(pt_a, pt_b), 1.0)
+
+    def test_collinear_two_point_skeleton_identical_returns_one(self):
+        """Identical horizontal-line skeletons (zero-height bbox) must match."""
+        pt_a = dm.Points([0, 0, 100, 0], visibility=[dm.Points.Visibility.visible] * 2)
+        pt_b = dm.Points([0, 0, 100, 0], visibility=[dm.Points.Visibility.visible] * 2)
+        matcher = self._matcher(pt_a, (0, 0, 100, 0), pt_b, (0, 0, 100, 0))
+        self.assertAlmostEqual(matcher.distance(pt_a, pt_b), 1.0)
+
+    def test_normal_non_overlapping_skeletons_return_zero(self):
+        """Non-overlapping normal (non-degenerate) skeletons must not match."""
+        pt_a = dm.Points([10, 10, 50, 50], visibility=[dm.Points.Visibility.visible] * 2)
+        pt_b = dm.Points([200, 200, 250, 250], visibility=[dm.Points.Visibility.visible] * 2)
+        matcher = self._matcher(pt_a, (10, 10, 40, 40), pt_b, (200, 200, 50, 50))
+        self.assertEqual(matcher.distance(pt_a, pt_b), 0.0)
+
+    def test_normal_overlapping_skeletons_return_nonzero(self):
+        """Overlapping normal skeletons must still compute OKS correctly."""
+        pt_a = dm.Points([10, 10, 50, 50], visibility=[dm.Points.Visibility.visible] * 2)
+        pt_b = dm.Points([12, 12, 52, 52], visibility=[dm.Points.Visibility.visible] * 2)
+        matcher = self._matcher(pt_a, (10, 10, 40, 40), pt_b, (12, 12, 40, 40))
+        result = matcher.distance(pt_a, pt_b)
+        self.assertGreater(result, 0.0)
+        self.assertLessEqual(result, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvat/apps/quality_control/tests/test_keypoints_matcher.py
+++ b/cvat/apps/quality_control/tests/test_keypoints_matcher.py
@@ -5,51 +5,93 @@
 import unittest
 
 import datumaro as dm
+import numpy as np
 
 from cvat.apps.quality_control.quality_reports import KeypointsMatcher
+
+
+# Image size used across all image-space tests: 640x480
+IMG_H, IMG_W = 480, 640
+IMG_SIZE = (IMG_H, IMG_W)
+
+
+def _matcher(pt_a, bbox_a, pt_b, bbox_b, img_size=IMG_SIZE):
+    return KeypointsMatcher(
+        sigma=0.1,
+        instance_map={id(pt_a): [None, bbox_a], id(pt_b): [None, bbox_b]},
+        img_size=img_size,
+    )
 
 
 class TestKeypointsMatcher(unittest.TestCase):
     """Regression tests for issue #9957.
 
     Single-point and collinear skeletons produce zero-area bboxes.
-    bbox_iou() returns 0 for zero-area boxes, which previously caused
-    the early-exit guard to block even identical annotations from matching.
+    bbox_iou() always returns 0 for zero-area boxes, so the old code's
+    early-exit guard blocked even identical annotations from matching.
+
+    Fix: when both bboxes are degenerate (area == 0), skip the IoU guard
+    and use image-area as the OKS scale — the same approach used by
+    match_points._distance for point annotations.
     """
 
-    def _matcher(self, pt_a, bbox_a, pt_b, bbox_b):
-        return KeypointsMatcher(
-            sigma=0.1,
-            instance_map={id(pt_a): [None, bbox_a], id(pt_b): [None, bbox_b]},
-        )
+    # ── Degenerate bbox cases (the bug) ─────────────────────────────────────
 
     def test_single_point_identical_returns_one(self):
-        """Identical single-point skeletons must match with OKS=1.0."""
-        pt_a = dm.Points([10, 20], visibility=[dm.Points.Visibility.visible])
-        pt_b = dm.Points([10, 20], visibility=[dm.Points.Visibility.visible])
-        matcher = self._matcher(pt_a, (10, 20, 0, 0), pt_b, (10, 20, 0, 0))
-        self.assertAlmostEqual(matcher.distance(pt_a, pt_b), 1.0)
+        """Identical single-point skeletons must match (OKS = 1.0)."""
+        pt_a = dm.Points([100, 100], visibility=[dm.Points.Visibility.visible])
+        pt_b = dm.Points([100, 100], visibility=[dm.Points.Visibility.visible])
+        result = _matcher(pt_a, (100, 100, 0, 0), pt_b, (100, 100, 0, 0)).distance(pt_a, pt_b)
+        self.assertAlmostEqual(result, 1.0)
+
+    def test_single_point_slightly_off_returns_high_oks(self):
+        """Slightly-offset single-point skeletons should still score high OKS."""
+        # 5 px apart on a 640x480 image; scale = 307200
+        # OKS = exp(-25 / (2 * 307200 * 0.04)) ≈ exp(-0.001) ≈ 0.999
+        pt_a = dm.Points([100, 100], visibility=[dm.Points.Visibility.visible])
+        pt_b = dm.Points([105, 100], visibility=[dm.Points.Visibility.visible])
+        result = _matcher(pt_a, (100, 100, 0, 0), pt_b, (105, 100, 0, 0)).distance(pt_a, pt_b)
+        self.assertGreater(result, 0.9)
+
+    def test_single_point_far_apart_returns_low_oks(self):
+        """Single-point skeletons far apart should not match."""
+        pt_a = dm.Points([10, 10], visibility=[dm.Points.Visibility.visible])
+        pt_b = dm.Points([500, 400], visibility=[dm.Points.Visibility.visible])
+        result = _matcher(pt_a, (10, 10, 0, 0), pt_b, (500, 400, 0, 0)).distance(pt_a, pt_b)
+        self.assertLess(result, 0.5)
 
     def test_collinear_two_point_skeleton_identical_returns_one(self):
         """Identical horizontal-line skeletons (zero-height bbox) must match."""
-        pt_a = dm.Points([0, 0, 100, 0], visibility=[dm.Points.Visibility.visible] * 2)
-        pt_b = dm.Points([0, 0, 100, 0], visibility=[dm.Points.Visibility.visible] * 2)
-        matcher = self._matcher(pt_a, (0, 0, 100, 0), pt_b, (0, 0, 100, 0))
-        self.assertAlmostEqual(matcher.distance(pt_a, pt_b), 1.0)
+        vis = [dm.Points.Visibility.visible, dm.Points.Visibility.visible]
+        pt_a = dm.Points([0, 0, 100, 0], visibility=vis)
+        pt_b = dm.Points([0, 0, 100, 0], visibility=vis)
+        result = _matcher(pt_a, (0, 0, 100, 0), pt_b, (0, 0, 100, 0)).distance(pt_a, pt_b)
+        self.assertAlmostEqual(result, 1.0)
+
+    def test_degenerate_without_image_size_returns_zero(self):
+        """Without img_size we cannot scale OKS — must return 0 rather than NaN."""
+        pt_a = dm.Points([10, 20], visibility=[dm.Points.Visibility.visible])
+        pt_b = dm.Points([10, 20], visibility=[dm.Points.Visibility.visible])
+        result = _matcher(pt_a, (10, 20, 0, 0), pt_b, (10, 20, 0, 0),
+                          img_size=None).distance(pt_a, pt_b)
+        self.assertEqual(result, 0.0)
+
+    # ── Normal (non-degenerate) bbox cases — regression guard ────────────────
 
     def test_normal_non_overlapping_skeletons_return_zero(self):
-        """Non-overlapping normal (non-degenerate) skeletons must not match."""
-        pt_a = dm.Points([10, 10, 50, 50], visibility=[dm.Points.Visibility.visible] * 2)
-        pt_b = dm.Points([200, 200, 250, 250], visibility=[dm.Points.Visibility.visible] * 2)
-        matcher = self._matcher(pt_a, (10, 10, 40, 40), pt_b, (200, 200, 50, 50))
-        self.assertEqual(matcher.distance(pt_a, pt_b), 0.0)
+        """Non-overlapping skeletons with valid bboxes must still return 0."""
+        vis = [dm.Points.Visibility.visible] * 2
+        pt_a = dm.Points([10, 10, 50, 50], visibility=vis)
+        pt_b = dm.Points([200, 200, 250, 250], visibility=vis)
+        result = _matcher(pt_a, (10, 10, 40, 40), pt_b, (200, 200, 50, 50)).distance(pt_a, pt_b)
+        self.assertEqual(result, 0.0)
 
     def test_normal_overlapping_skeletons_return_nonzero(self):
-        """Overlapping normal skeletons must still compute OKS correctly."""
-        pt_a = dm.Points([10, 10, 50, 50], visibility=[dm.Points.Visibility.visible] * 2)
-        pt_b = dm.Points([12, 12, 52, 52], visibility=[dm.Points.Visibility.visible] * 2)
-        matcher = self._matcher(pt_a, (10, 10, 40, 40), pt_b, (12, 12, 40, 40))
-        result = matcher.distance(pt_a, pt_b)
+        """Overlapping skeletons with valid bboxes must compute OKS > 0."""
+        vis = [dm.Points.Visibility.visible] * 2
+        pt_a = dm.Points([10, 10, 50, 50], visibility=vis)
+        pt_b = dm.Points([12, 12, 52, 52], visibility=vis)
+        result = _matcher(pt_a, (10, 10, 40, 40), pt_b, (12, 12, 40, 40)).distance(pt_a, pt_b)
         self.assertGreater(result, 0.0)
         self.assertLessEqual(result, 1.0)
 


### PR DESCRIPTION
## Summary

Closes #9957 — Quality control cannot match skeletons with degenerate bounding boxes (single-point or collinear skeletons).

### Root cause

Single-point skeletons produce a bbox of `(x, y, 0, 0)`. `bbox_iou()` returns 0 for any zero-area box (0÷0), so the early-exit guard blocks even *identical* annotations from matching.

### Fix (per maintainer suggestion — option 2)

When **both** bboxes have zero area, skip the IoU guard and scale OKS by the **image area** (`scale = img_h × img_w`) instead of the bbox area. This is the same approach already used for point annotations in `match_points._distance`.

Why image size works:
- Provides a meaningful reference scale regardless of object size
- Correctly handles slightly-offset points (not just exact matches)
- Mirrors existing, battle-tested logic in the codebase

Why the initial 1×1 minimum-bbox approach was wrong:
- Only worked for d=0 (exact matches); any slight offset → OKS ≈ 0 due to tiny scale

**Changes:**
- `KeypointsMatcher`: add `img_size: tuple[int, int] | None` field; when both bbox areas are 0 use `scale = img_h * img_w`
- `match_skeletons`: read image size from `item_a` and pass it to `KeypointsMatcher`, mirroring `match_points._distance`

**What did not change:** Normal skeletons with non-overlapping, non-degenerate bboxes are still rejected by the existing IoU guard — no performance regression for the common case.

## Test plan

New tests in `cvat/apps/quality_control/tests/test_keypoints_matcher.py`:

- [ ] `test_single_point_identical_returns_one` — OKS = 1.0 for identical single-point skeletons
- [ ] `test_single_point_slightly_off_returns_high_oks` — OKS > 0.9 for points 5 px apart on 640×480
- [ ] `test_single_point_far_apart_returns_low_oks` — OKS < 0.5 for points far apart
- [ ] `test_collinear_two_point_skeleton_identical_returns_one` — zero-height bbox skeletons match
- [ ] `test_degenerate_without_image_size_returns_zero` — safe fallback when img_size is None
- [ ] `test_normal_non_overlapping_skeletons_return_zero` — regression: non-overlapping normal skeletons still blocked
- [ ] `test_normal_overlapping_skeletons_return_nonzero` — regression: overlapping normal skeletons still compute OKS
