### PR TITLE
Type CVAT UI plugin components by extension point

### DIFF
--- a/cvat-ui/src/actions/plugins-actions.ts
+++ b/cvat-ui/src/actions/plugins-actions.ts
@@ -4,9 +4,8 @@
 // SPDX-License-Identifier: MIT
 
 import { ActionUnion, createAction, ThunkAction } from 'utils/redux';
-import { PluginsList, SupportedPlugins } from 'reducers';
+import { PluginComponentType, PluginsList, SupportedPlugins } from 'reducers';
 import { getCore } from 'cvat-core-wrapper';
-import React from 'react';
 
 const core = getCore();
 
@@ -34,13 +33,13 @@ export const pluginActions = {
     ),
     addUIComponent: (
         path: string,
-        component: React.Component,
+        component: PluginComponentType,
         data: {
             weight?: number;
             shouldBeRendered?: (props?: object, state?: object) => boolean;
         } = {},
     ) => createAction(PluginsActionTypes.ADD_UI_COMPONENT, { path, component, data }),
-    removeUIComponent: (path: string, component: React.Component) => createAction(
+    removeUIComponent: (path: string, component: PluginComponentType) => createAction(
         PluginsActionTypes.REMOVE_UI_COMPONENT, { path, component },
     ),
     addUICallback: (

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
@@ -32,7 +32,7 @@ import {
 } from 'cvat-core-wrapper';
 import openCVWrapper from 'utils/opencv-wrapper/opencv-wrapper';
 import {
-    CombinedState, ActiveControl, ToolsBlockerState, PluginComponent,
+    CombinedState, ActiveControl, ToolsBlockerState, PluginComponent, PluginReactComponent,
 } from 'reducers';
 import {
     interactWithCanvas,
@@ -67,7 +67,7 @@ interface StateToProps {
     defaultApproxPolyAccuracy: number;
     toolsBlockerState: ToolsBlockerState;
     frameIsDeleted: boolean;
-    interactorExtras: PluginComponent[];
+    interactorExtras: PluginComponent<PluginReactComponent>[];
 }
 
 interface DispatchToProps {

--- a/cvat-ui/src/components/annotation-page/top-bar/annotation-menu.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/annotation-menu.tsx
@@ -23,7 +23,7 @@ import { usePlugins } from 'utils/hooks';
 
 import CVATTooltip from 'components/common/cvat-tooltip';
 import { openAnnotationsActionModal } from 'components/annotation-page/annotations-actions/annotations-actions-modal';
-import { CombinedState } from 'reducers';
+import { CombinedState, PluginMenuItemConstructor } from 'reducers';
 import {
     finishCurrentJobAsync,
     removeAnnotationsAsync as removeAnnotationsAsyncAction,
@@ -46,7 +46,7 @@ function AnnotationMenuComponent(): JSX.Element {
     const history = useHistory();
     const jobInstance = useSelector((state: CombinedState) => state.annotation.job.instance as Job);
     const [jobState, setJobState] = useState(jobInstance.state);
-    const pluginActions = usePlugins(
+    const pluginActions = usePlugins<PluginMenuItemConstructor<{ jobInstance: Job }>>(
         (state: CombinedState) => state.plugins.components.annotationPage.menuActions.items,
         { jobInstance },
     );
@@ -243,7 +243,10 @@ function AnnotationMenuComponent(): JSX.Element {
 
     menuItems.push(
         ...pluginActions.map(({ component: Component, weight }, index) => {
-            const menuItem = Component({ key: index, targetProps: { jobInstance } });
+            const menuItem = Component({
+                key: index,
+                targetProps: { jobInstance },
+            });
             return [menuItem, weight] as [NonNullable<MenuProps['items']>[0], number];
         }),
     );

--- a/cvat-ui/src/components/cvat-app.tsx
+++ b/cvat-ui/src/components/cvat-app.tsx
@@ -502,7 +502,7 @@ class CVATApplication extends React.PureComponent<CVATAppProps & RouteComponentP
 
         const routesToRender = pluginComponents.router
             .filter(({ data: { shouldBeRendered } }) => shouldBeRendered(this.props, this.state))
-            .map(({ component: Component }) => Component());
+            .map(({ component: Component }, index) => <Component key={index} />);
 
         const queryParams = new URLSearchParams(location.search);
         const authParams = authQuery(queryParams);

--- a/cvat-ui/src/components/header/header.tsx
+++ b/cvat-ui/src/components/header/header.tsx
@@ -38,7 +38,9 @@ import { switchSettingsModalVisible as switchSettingsModalVisibleAction } from '
 import { logoutAsync } from 'actions/auth-actions';
 import { shortcutsActions, registerComponentShortcuts } from 'actions/shortcuts-actions';
 import { getOrganizationsAsync, organizationActions } from 'actions/organization-actions';
-import { AboutState, CombinedState } from 'reducers';
+import {
+    AboutState, CombinedState, PluginMenuItemConstructor,
+} from 'reducers';
 import { useIsMounted, usePlugins } from 'utils/hooks';
 import GlobalHotKeys, { KeyMap } from 'utils/mousetrap-react';
 import { ShortcutScope } from 'utils/enums';
@@ -288,7 +290,10 @@ function HeaderComponent(props: Props): JSX.Element {
         }
     };
 
-    const plugins = usePlugins((state: CombinedState) => state.plugins.components.header.userMenu.items, props);
+    const plugins = usePlugins<PluginMenuItemConstructor<Props>>(
+        (state: CombinedState) => state.plugins.components.header.userMenu.items,
+        props,
+    );
 
     const menuItems: [NonNullable<MenuProps['items']>[0], number][] = [];
     if (user.isStaff) {
@@ -386,7 +391,7 @@ function HeaderComponent(props: Props): JSX.Element {
 
     menuItems.push(...plugins
         .map(({ component, weight }): typeof menuItems[0] => [
-            (component as (pluginProps?: any) => NonNullable<MenuProps['items']>[0])({ targetProps: props }),
+            component({ targetProps: props }),
             weight,
         ]),
     );

--- a/cvat-ui/src/components/jobs-page/actions-menu-items.tsx
+++ b/cvat-ui/src/components/jobs-page/actions-menu-items.tsx
@@ -5,16 +5,17 @@
 import React from 'react';
 import { MenuProps } from 'antd/lib/menu';
 import { LoadingOutlined } from '@ant-design/icons';
-import { usePlugins } from 'utils/hooks';
+import { Plugin } from 'utils/hooks';
 import { CVATMenuEditLabel } from 'components/common/cvat-menu-edit-label';
 import { LabelWithCountHOF } from 'components/common/label-with-count';
 import { Job, JobType } from 'cvat-core-wrapper';
+import { PluginMenuItemConstructor } from 'reducers';
 
-interface MenuItemsData {
+interface MenuItemsData<TTargetProps> {
     jobId: number;
     taskId: number;
     projectId: number | null;
-    pluginActions: ReturnType<typeof usePlugins>;
+    pluginActions: Plugin<PluginMenuItemConstructor<TTargetProps>>[];
     isMergingConsensusEnabled: boolean;
     onOpenBugTracker: (() => void) | null;
     onImportAnnotations: () => void;
@@ -43,9 +44,9 @@ enum MenuKeys {
     TASK = 'task',
 }
 
-export default function JobActionsItems(
-    menuItemsData: MenuItemsData,
-    jobMenuProps: unknown,
+export default function JobActionsItems<TTargetProps>(
+    menuItemsData: MenuItemsData<TTargetProps>,
+    jobMenuProps: TTargetProps,
 ): MenuProps['items'] {
     const {
         startEditField,
@@ -192,7 +193,10 @@ export default function JobActionsItems(
 
     menuItems.push(
         ...pluginActions.map(({ component: Component, weight }, index) => {
-            const menuItem = Component({ key: index, targetProps: jobMenuProps });
+            const menuItem = Component({
+                key: index,
+                targetProps: jobMenuProps,
+            });
             return [menuItem, weight] as [NonNullable<MenuProps['items']>[0], number];
         }),
     );

--- a/cvat-ui/src/components/jobs-page/actions-menu.tsx
+++ b/cvat-ui/src/components/jobs-page/actions-menu.tsx
@@ -12,7 +12,7 @@ import {
     Job, JobStage, JobState, JobType, User,
 } from 'cvat-core-wrapper';
 import { useDropdownEditField, usePlugins } from 'utils/hooks';
-import { CombinedState } from 'reducers';
+import { CombinedState, PluginMenuItemConstructor } from 'reducers';
 import { exportActions } from 'actions/export-actions';
 import { importActions } from 'actions/import-actions';
 import { mergeConsensusJobsAsync } from 'actions/consensus-actions';
@@ -43,7 +43,10 @@ function JobActionsComponent(
     } = props;
     const dispatch = useDispatch();
 
-    const pluginActions = usePlugins((state: CombinedState) => state.plugins.components.jobActions.items, props);
+    const pluginActions = usePlugins<PluginMenuItemConstructor<Readonly<Props>>>(
+        (state: CombinedState) => state.plugins.components.jobActions.items,
+        props,
+    );
     const {
         mergingConsensus,
         selectedIds,

--- a/cvat-ui/src/components/models-page/actions-menu.tsx
+++ b/cvat-ui/src/components/models-page/actions-menu.tsx
@@ -5,10 +5,12 @@
 
 import React from 'react';
 import Dropdown from 'antd/lib/dropdown';
+import { MenuProps } from 'antd/lib/menu';
 import { MLModel } from 'cvat-core-wrapper';
 import { usePlugins } from 'utils/hooks';
-import { CombinedState } from 'reducers';
-import { MenuProps } from 'antd/lib/menu';
+import {
+    CombinedState, PluginMenuItemConstructor,
+} from 'reducers';
 import { useSelector } from 'react-redux';
 import { shallowEqual } from 'utils/redux';
 
@@ -16,6 +18,11 @@ interface ModelActionsProps {
     model: MLModel;
     triggerElement: (menuItems: NonNullable<MenuProps['items']>) => JSX.Element | null;
     dropdownTrigger?: ('click' | 'hover' | 'contextMenu')[];
+}
+
+interface ModelActionsTargetState {
+    allModels: MLModel[];
+    selectedIds: (number | string)[];
 }
 
 function ModelActionsComponent(props: Readonly<ModelActionsProps>): JSX.Element | null {
@@ -45,18 +52,19 @@ function ModelActionsComponent(props: Readonly<ModelActionsProps>): JSX.Element 
         ...reid,
     ];
 
-    const menuPlugins = usePlugins(
+    const menuPlugins = usePlugins<PluginMenuItemConstructor<Readonly<ModelActionsProps>, ModelActionsTargetState>>(
         (state: CombinedState) => state.plugins.components.modelsPage.modelItem.menu.items,
         { model },
         { allModels, selectedIds },
     );
     const menuItems: [NonNullable<MenuProps['items']>[0], number][] = [];
     menuItems.push(...menuPlugins
-        .map(({ component, weight }): typeof menuItems[0] => [(
-            component as (pluginProps?: any) => NonNullable<MenuProps['items']>[0]
-        )({
-            targetProps: props, targetState: { allModels, selectedIds },
-        }), weight]),
+        .map(({ component, weight }): typeof menuItems[0] => [
+            component({
+                targetProps: props, targetState: { allModels, selectedIds },
+            }),
+            weight,
+        ]),
     );
 
     // Sort menu items by weight before passing to Dropdown

--- a/cvat-ui/src/components/projects-page/actions-menu-items.tsx
+++ b/cvat-ui/src/components/projects-page/actions-menu-items.tsx
@@ -5,14 +5,15 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { MenuProps } from 'antd/lib/menu';
-import { usePlugins } from 'utils/hooks';
+import { Plugin } from 'utils/hooks';
 import { CVATMenuEditLabel } from 'components/common/cvat-menu-edit-label';
 import { LabelWithCountHOF } from 'components/common/label-with-count';
+import { PluginMenuItemConstructor } from 'reducers';
 
-interface MenuItemsData {
+interface MenuItemsData<TTargetProps> {
     projectId: number;
     startEditField: (key: string) => void;
-    pluginActions: ReturnType<typeof usePlugins>;
+    pluginActions: Plugin<PluginMenuItemConstructor<TTargetProps>>[];
     onExportDataset: () => void;
     onImportDataset: () => void;
     onBackupProject: () => void;
@@ -20,9 +21,9 @@ interface MenuItemsData {
     selectedIds: number[];
 }
 
-export default function ProjectActionsItems(
-    menuItemsData: MenuItemsData,
-    projectMenuProps: unknown,
+export default function ProjectActionsItems<TTargetProps>(
+    menuItemsData: MenuItemsData<TTargetProps>,
+    projectMenuProps: TTargetProps,
 ): MenuProps['items'] {
     const {
         projectId,
@@ -107,7 +108,10 @@ export default function ProjectActionsItems(
 
     menuItems.push(
         ...pluginActions.map(({ component: Component, weight }, index) => {
-            const menuItem = Component({ key: index, targetProps: projectMenuProps });
+            const menuItem = Component({
+                key: index,
+                targetProps: projectMenuProps,
+            });
             return [menuItem, weight] as [NonNullable<MenuProps['items']>[0], number];
         }),
     );

--- a/cvat-ui/src/components/projects-page/actions-menu.tsx
+++ b/cvat-ui/src/components/projects-page/actions-menu.tsx
@@ -11,7 +11,7 @@ import Modal from 'antd/lib/modal';
 
 import { Organization, Project, User } from 'cvat-core-wrapper';
 import { useDropdownEditField, usePlugins } from 'utils/hooks';
-import { CombinedState } from 'reducers';
+import { CombinedState, PluginMenuItemConstructor } from 'reducers';
 import { deleteProjectAsync, getProjectsAsync, updateProjectAsync } from 'actions/projects-actions';
 import { cloudStoragesActions } from 'actions/cloud-storage-actions';
 import { exportActions } from 'actions/export-actions';
@@ -38,7 +38,10 @@ function ProjectActionsComponent(props: Readonly<Props>): JSX.Element {
 
     const history = useHistory();
     const dispatch = useDispatch();
-    const pluginActions = usePlugins((state: CombinedState) => state.plugins.components.projectActions.items, props);
+    const pluginActions = usePlugins<PluginMenuItemConstructor<Readonly<Props>>>(
+        (state: CombinedState) => state.plugins.components.projectActions.items,
+        props,
+    );
 
     const {
         selectedIds,

--- a/cvat-ui/src/components/tasks-page/actions-menu-items.tsx
+++ b/cvat-ui/src/components/tasks-page/actions-menu-items.tsx
@@ -5,17 +5,18 @@
 import React from 'react';
 import { LoadingOutlined } from '@ant-design/icons';
 import { MenuProps } from 'antd/lib/menu';
-import { usePlugins } from 'utils/hooks';
+import { Plugin } from 'utils/hooks';
 import { LabelWithCountHOF } from 'components/common/label-with-count';
+import { PluginMenuItemConstructor } from 'reducers';
 import { CVATMenuEditLabel } from '../common/cvat-menu-edit-label';
 
-interface MenuItemsData {
+interface MenuItemsData<TTargetProps> {
     taskId: number;
     projectId: number | null;
     isAutomaticAnnotationEnabled: boolean;
     isConsensusEnabled: boolean;
     isMergingConsensusEnabled: boolean;
-    pluginActions: ReturnType<typeof usePlugins>;
+    pluginActions: Plugin<PluginMenuItemConstructor<TTargetProps>>[];
     onMergeConsensusJobs: (() => void) | null;
     onOpenBugTracker: (() => void) | null;
     onUploadAnnotations: () => void;
@@ -30,7 +31,10 @@ interface MenuItemsData {
 
 const bulkAllowedKeys = ['edit_assignee', 'backup_task', 'export_task_dataset', 'delete_task', 'edit_organization'];
 
-export default function TaskActionsItems(menuItemsData: MenuItemsData, taskMenuProps: unknown): MenuProps['items'] {
+export default function TaskActionsItems<TTargetProps>(
+    menuItemsData: MenuItemsData<TTargetProps>,
+    taskMenuProps: TTargetProps,
+): MenuProps['items'] {
     const {
         startEditField,
         taskId,
@@ -159,7 +163,10 @@ export default function TaskActionsItems(menuItemsData: MenuItemsData, taskMenuP
 
     menuItems.push(
         ...pluginActions.map(({ component: Component, weight }, index) => {
-            const menuItem = Component({ key: index, targetProps: taskMenuProps });
+            const menuItem = Component({
+                key: index,
+                targetProps: taskMenuProps,
+            });
             return [menuItem, weight] as [NonNullable<MenuProps['items']>[0], number];
         }),
     );

--- a/cvat-ui/src/components/tasks-page/actions-menu.tsx
+++ b/cvat-ui/src/components/tasks-page/actions-menu.tsx
@@ -14,7 +14,7 @@ import {
 } from 'cvat-core-wrapper';
 import { useDropdownEditField, usePlugins } from 'utils/hooks';
 
-import { CombinedState } from 'reducers';
+import { CombinedState, PluginMenuItemConstructor } from 'reducers';
 import { exportActions } from 'actions/export-actions';
 import { importActions } from 'actions/import-actions';
 import { modelsActions } from 'actions/models-actions';
@@ -45,7 +45,10 @@ function TaskActionsComponent(props: Readonly<Props>): JSX.Element {
     } = props;
     const history = useHistory();
     const dispatch = useDispatch();
-    const pluginActions = usePlugins((state: CombinedState) => state.plugins.components.taskActions.items, props);
+    const pluginActions = usePlugins<PluginMenuItemConstructor<Readonly<Props>>>(
+        (state: CombinedState) => state.plugins.components.taskActions.items,
+        props,
+    );
     const {
         activeInference,
         mergingConsensus,

--- a/cvat-ui/src/components/tasks-page/task-item.tsx
+++ b/cvat-ui/src/components/tasks-page/task-item.tsx
@@ -14,7 +14,7 @@ import Progress from 'antd/lib/progress';
 import Badge from 'antd/lib/badge';
 import { Task, RQStatus, Request } from 'cvat-core-wrapper';
 import Preview from 'components/common/preview';
-import { ActiveInference, PluginComponent } from 'reducers';
+import { ActiveInference, PluginComponent, PluginReactComponent } from 'reducers';
 import StatusMessage from 'components/requests-page/request-status';
 import { useContextMenuClick, useIsMounted } from 'utils/hooks';
 import AutomaticAnnotationProgress from './automatic-annotation-progress';
@@ -25,7 +25,7 @@ export interface TaskItemProps {
     deleted: boolean;
     activeInference: ActiveInference | null;
     activeRequest: Request | null;
-    ribbonPlugins: PluginComponent[];
+    ribbonPlugins: PluginComponent<PluginReactComponent>[];
     cancelAutoAnnotation(): void;
     updateTaskInState(task: Task): void;
     selected: boolean;

--- a/cvat-ui/src/containers/tasks-page/task-item.tsx
+++ b/cvat-ui/src/containers/tasks-page/task-item.tsx
@@ -6,7 +6,9 @@
 import { connect } from 'react-redux';
 
 import { Task, Request } from 'cvat-core-wrapper';
-import { CombinedState, ActiveInference, PluginComponent } from 'reducers';
+import {
+    CombinedState, ActiveInference, PluginComponent, PluginReactComponent,
+} from 'reducers';
 import TaskItemComponent from 'components/tasks-page/task-item';
 import { updateTaskInState as updateTaskInStateAction, getTaskPreviewAsync } from 'actions/tasks-actions';
 import { cancelInferenceAsync } from 'actions/models-actions';
@@ -16,7 +18,7 @@ interface StateToProps {
     taskInstance: any;
     activeInference: ActiveInference | null;
     activeRequest: Request | null;
-    ribbonPlugins: PluginComponent[];
+    ribbonPlugins: PluginComponent<PluginReactComponent>[];
 }
 
 interface DispatchToProps {

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -13,6 +13,8 @@ import {
     ConsensusSettings, AboutData, ShapeType, ObjectType, ApiToken,
     Membership, AnnotationFormats, CloudStorage,
 } from 'cvat-core-wrapper';
+import type { MenuProps } from 'antd/lib/menu';
+import type React from 'react';
 
 import type { IntelligentScissors, OpenCVTracker } from 'utils/opencv-wrapper/opencv-wrapper';
 import { KeyMap, KeyMapItem } from 'utils/mousetrap-react';
@@ -307,8 +309,24 @@ export type PluginsList = {
 
 export type CallbackReturnType = Promise<undefined | { preventJobStatusChange: boolean }>;
 
-export interface PluginComponent {
-    component: any; // TODO: research correct plugin component type
+export interface PluginContext<TTargetProps = unknown, TTargetState = unknown> {
+    key?: React.Key;
+    targetProps?: TTargetProps;
+    targetState?: TTargetState;
+}
+
+export type PluginReactComponent<TTargetProps = unknown, TTargetState = unknown> = (
+    React.ComponentType<PluginContext<TTargetProps, TTargetState>>
+);
+
+export type PluginMenuItemConstructor<TTargetProps = unknown, TTargetState = unknown> = (
+    props: PluginContext<TTargetProps, TTargetState>
+) => NonNullable<MenuProps['items']>[0];
+
+export type PluginComponentType = PluginReactComponent<any, any> | PluginMenuItemConstructor<any, any>;
+
+export interface PluginComponent<T extends PluginComponentType = PluginComponentType> {
+    component: T;
     data: {
         weight: number;
         shouldBeRendered: (props?: object, state?: object) => boolean;
@@ -388,64 +406,64 @@ export interface PluginsState {
     components: {
         header: {
             userMenu: {
-                items: PluginComponent[];
+                items: PluginComponent<PluginMenuItemConstructor>[];
             };
         };
         loginPage: {
-            loginForm: PluginComponent[];
+            loginForm: PluginComponent<PluginReactComponent>[];
         };
         annotationPage: {
             player: {
-                slider: PluginComponent[];
+                slider: PluginComponent<PluginReactComponent>[];
             };
             menuActions: {
-                items: PluginComponent[];
+                items: PluginComponent<PluginMenuItemConstructor>[];
             };
         }
         modelsPage: {
             topBar: {
-                items: PluginComponent[];
+                items: PluginComponent<PluginReactComponent>[];
             };
             modelItem: {
                 menu: {
-                    items: PluginComponent[];
+                    items: PluginComponent<PluginMenuItemConstructor>[];
                 };
                 topBar:{
                     menu: {
-                        items: PluginComponent[];
+                        items: PluginComponent<PluginReactComponent>[];
                     };
                 };
             };
         };
         projectActions: {
-            items: PluginComponent[];
+            items: PluginComponent<PluginMenuItemConstructor>[];
         };
         taskActions: {
-            items: PluginComponent[];
+            items: PluginComponent<PluginMenuItemConstructor>[];
         };
         jobActions: {
-            items: PluginComponent[];
+            items: PluginComponent<PluginMenuItemConstructor>[];
         };
         taskItem: {
-            ribbon: PluginComponent[];
+            ribbon: PluginComponent<PluginReactComponent>[];
         };
         projectItem: {
-            ribbon: PluginComponent[];
+            ribbon: PluginComponent<PluginReactComponent>[];
         };
         settings: {
-            player: PluginComponent[];
+            player: PluginComponent<PluginReactComponent>[];
         };
         about: {
             links: {
-                items: PluginComponent[];
+                items: PluginComponent<PluginReactComponent>[];
             };
         };
         aiTools: {
             interactors: {
-                extras: PluginComponent[];
+                extras: PluginComponent<PluginReactComponent>[];
             };
         };
-        router: PluginComponent[];
+        router: PluginComponent<PluginReactComponent>[];
     }
 }
 

--- a/cvat-ui/src/utils/hooks.ts
+++ b/cvat-ui/src/utils/hooks.ts
@@ -10,7 +10,9 @@ import {
 } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory, useLocation, useParams } from 'react-router';
-import { CombinedState, PluginComponent, InstanceType } from 'reducers';
+import {
+    CombinedState, PluginComponent, InstanceType, PluginComponentType, PluginReactComponent,
+} from 'reducers';
 import { registerComponentShortcuts } from 'actions/shortcuts-actions';
 import { authQuery } from './auth-query';
 import { KeyMap, KeyMapItem } from './mousetrap-react';
@@ -37,26 +39,26 @@ export function useIsMounted(): () => boolean {
     return useCallback(() => ref.current, []);
 }
 
-export type Plugin = {
-    component: any; // TODO: research which type should be here
+export type Plugin<T extends PluginComponentType = PluginReactComponent<any, any>> = {
+    component: T;
     weight: number;
 };
 
-export function usePlugins(
+export function usePlugins<T extends PluginComponentType = PluginReactComponent<any, any>>(
     getState: (state: CombinedState) => PluginComponent[],
     props: object = {}, state: object = {},
-): Plugin[] {
+): Plugin<T>[] {
     const components = useSelector(getState);
     const filteredComponents = components.filter((component) => component.data.shouldBeRendered(props, state));
     const mappedComponents = filteredComponents
         .map(({ component, data }): {
-            component: any; // TODO: research which type should be here
+            component: T;
             weight: number;
         } => ({
-            component,
+            component: component as T,
             weight: data.weight,
         }));
-    const ref = useRef<Plugin[]>(mappedComponents);
+    const ref = useRef<Plugin<T>[]>(mappedComponents);
 
     if (!_.isEqual(ref.current, mappedComponents)) {
         ref.current = mappedComponents;


### PR DESCRIPTION
Title: Type CVAT UI plugin components by extension point

### Motivation and context

This PR improves CVAT UI plugin typing by replacing broad `any` / `React.Component` usage with explicit plugin component types.

The plugin system supports two different UI registration styles:

- renderable React plugin components
- menu item constructor plugins

It also passes optional host context to plugins through `targetProps` and `targetState`. This PR models that with shared generic types:

- `PluginContext<TTargetProps, TTargetState>`
- `PluginReactComponent<TTargetProps, TTargetState>`
- `PluginMenuItemConstructor<TTargetProps, TTargetState>`
- generic `PluginComponent<T>`

`PluginsState.components` now types each extension point according to how the core app renders or invokes it. This removes unsafe render-site casts like `component as PluginReactComponent` and keeps menu constructor typing limited to plugin boundaries.

### How has this been tested?

Ran focused TypeScript validation:

```bash
../node_modules/.bin/tsc --noEmit -p tsconfig.json 2>&1 | rg "^src/"
```

No host `src/` errors were reported.

Ran ESLint on touched files. It passed with existing warnings only.

### Checklist

- [x] I submit my changes into the `develop` branch
- [ ] ~~I have created a changelog fragment~~
- [ ] ~~I have updated the documentation accordingly~~
- [ ] ~~I have added tests to cover my changes~~
- [ ] ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.