### PR TITLE
Validate label attribute name conflicts before updating

### DIFF
--- a/changelog.d/20260519_103538_sekachev.bs.md
+++ b/changelog.d/20260519_103538_sekachev.bs.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Return a validation error when swapping label attribute names instead of failing with an integrity error
+  (<https://github.com/cvat-ai/cvat/pull/10625>)

--- a/changelog.d/20260519_103538_sekachev.bs.md
+++ b/changelog.d/20260519_103538_sekachev.bs.md
@@ -2,3 +2,7 @@
 
 - Return a validation error when swapping label attribute names instead of failing with an integrity error
   (<https://github.com/cvat-ai/cvat/pull/10625>)
+
+- Return a validation error when renaming a label attribute to an existing attribute name
+  instead of failing with an integrity error
+  (<https://github.com/cvat-ai/cvat/pull/10625>)

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -542,9 +542,7 @@ class LabelSerializer(SublabelSerializer):
             return
 
         current_names_by_id = dict(
-            db_label.attributespec_set.filter(id__in=request_names_by_id).values_list(
-                "id", "name"
-            )
+            db_label.attributespec_set.filter(id__in=request_names_by_id).values_list("id", "name")
         )
 
         # A normal rename to a new name is allowed. The unsafe case is swapping

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -529,39 +529,43 @@ class LabelSerializer(SublabelSerializer):
                 encountered_names.add(attr_name)
 
     @staticmethod
-    def check_no_attr_names_swap(db_label: models.Label, attrs: list[dict[str, Any]]) -> None:
-        request_names_by_id = {
+    def check_attribute_names_available(
+        db_attributes: dict[int, str], attrs: list[dict[str, Any]]
+    ) -> None:
+        requested_attribute_names = {
             attr["id"]: attr["name"]
             for attr in attrs
-            if not attr.get("deleted")
-            and attr.get("id") is not None
-            and attr.get("name") is not None
+            if attr.get("id") is not None and attr.get("name") is not None
         }
 
-        if len(request_names_by_id) < 2:
+        if not requested_attribute_names:
             return
 
-        current_names_by_id = dict(
-            db_label.attributespec_set.filter(id__in=request_names_by_id).values_list("id", "name")
-        )
-
-        # A normal rename to a new name is allowed. The unsafe case is swapping
-        # current names between existing attributes, because the first save
-        # would temporarily violate the unique (label, name) constraint.
-        current_name_ids = {name: attr_id for attr_id, name in current_names_by_id.items()}
+        current_attribute_ids = {name: attr_id for attr_id, name in db_attributes.items()}
         swapped_attr_names = set()
+        busy_attr_names = set()
 
-        for attr_id, attr_name in request_names_by_id.items():
-            current_attr_id = current_name_ids.get(attr_name)
-            if current_attr_id is not None and current_attr_id != attr_id:
+        for attr_id, attr_name in requested_attribute_names.items():
+            current_attr_id = current_attribute_ids.get(attr_name)
+            if current_attr_id is None or current_attr_id == attr_id:
+                continue
+
+            if current_attr_id in requested_attribute_names:
                 swapped_attr_names.add(attr_name)
-                current_name = current_names_by_id.get(attr_id)
-                if current_name is not None:
+                if current_name := db_attributes.get(attr_id):
                     swapped_attr_names.add(current_name)
+            else:
+                busy_attr_names.add(attr_name)
 
         if swapped_attr_names:
-            attr_names = ", ".join(f'"{name}"' for name in sorted(swapped_attr_names))
+            attr_names = ", ".join(f'"{name}"' for name in swapped_attr_names)
             raise serializers.ValidationError(f"Cannot swap attribute names {attr_names}")
+
+        if busy_attr_names:
+            attr_names = ", ".join(f'"{name}"' for name in busy_attr_names)
+            raise serializers.ValidationError(
+                f"Attribute names are already used by this label: {attr_names}"
+            )
 
     @staticmethod
     def _split_attribute_values(values: str) -> list[str]:
@@ -699,9 +703,6 @@ class LabelSerializer(SublabelSerializer):
             db_label.delete()
             return None
 
-        if label_exists:
-            cls.check_no_attr_names_swap(db_label, attributes)
-
         if not validated_data.get("color", None):
             other_label_colors = [
                 label.color
@@ -738,6 +739,10 @@ class LabelSerializer(SublabelSerializer):
             db_attr = get_db_attr(attr_id)
             logger.info("{} attribute for {} label was deleted".format(db_attr.name, db_label.name))
             db_attr.delete()
+
+        if label_exists:
+            db_attributes = dict(db_label.attributespec_set.values_list("id", "name"))
+            cls.check_attribute_names_available(db_attributes, upserted_attributes)
 
         for attr in upserted_attributes:
             attr_id = attr.get("id", None)

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -543,7 +543,7 @@ class LabelSerializer(SublabelSerializer):
 
         current_attribute_ids = {name: attr_id for attr_id, name in db_attributes.items()}
         swapped_attr_names = set()
-        busy_attr_names = set()
+        occupied_attr_names = set()
 
         for attr_id, attr_name in requested_attribute_names.items():
             current_attr_id = current_attribute_ids.get(attr_name)
@@ -555,14 +555,14 @@ class LabelSerializer(SublabelSerializer):
                 if current_name := db_attributes.get(attr_id):
                     swapped_attr_names.add(current_name)
             else:
-                busy_attr_names.add(attr_name)
+                occupied_attr_names.add(attr_name)
 
         if swapped_attr_names:
             attr_names = ", ".join(f'"{name}"' for name in swapped_attr_names)
             raise serializers.ValidationError(f"Cannot swap attribute names {attr_names}")
 
-        if busy_attr_names:
-            attr_names = ", ".join(f'"{name}"' for name in busy_attr_names)
+        if occupied_attr_names:
+            attr_names = ", ".join(f'"{name}"' for name in occupied_attr_names)
             raise serializers.ValidationError(
                 f"Attribute names are already used by this label: {attr_names}"
             )

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -529,6 +529,43 @@ class LabelSerializer(SublabelSerializer):
                 encountered_names.add(attr_name)
 
     @staticmethod
+    def check_no_attr_names_swap(db_label: models.Label, attrs: list[dict[str, Any]]) -> None:
+        request_names_by_id = {
+            attr["id"]: attr["name"]
+            for attr in attrs
+            if not attr.get("deleted")
+            and attr.get("id") is not None
+            and attr.get("name") is not None
+        }
+
+        if len(request_names_by_id) < 2:
+            return
+
+        current_names_by_id = dict(
+            db_label.attributespec_set.filter(id__in=request_names_by_id).values_list(
+                "id", "name"
+            )
+        )
+
+        # A normal rename to a new name is allowed. The unsafe case is swapping
+        # current names between existing attributes, because the first save
+        # would temporarily violate the unique (label, name) constraint.
+        current_name_ids = {name: attr_id for attr_id, name in current_names_by_id.items()}
+        swapped_attr_names = set()
+
+        for attr_id, attr_name in request_names_by_id.items():
+            current_attr_id = current_name_ids.get(attr_name)
+            if current_attr_id is not None and current_attr_id != attr_id:
+                swapped_attr_names.add(attr_name)
+                current_name = current_names_by_id.get(attr_id)
+                if current_name is not None:
+                    swapped_attr_names.add(current_name)
+
+        if swapped_attr_names:
+            attr_names = ", ".join(f'"{name}"' for name in sorted(swapped_attr_names))
+            raise serializers.ValidationError(f"Cannot swap attribute names {attr_names}")
+
+    @staticmethod
     def _split_attribute_values(values: str) -> list[str]:
         return values.split("\n") if values else []
 
@@ -663,6 +700,9 @@ class LabelSerializer(SublabelSerializer):
             assert validated_data["id"]  # must be checked in the validate()
             db_label.delete()
             return None
+
+        if label_exists:
+            cls.check_no_attr_names_swap(db_label, attributes)
 
         if not validated_data.get("color", None):
             other_label_colors = [

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -2695,6 +2695,17 @@ class TaskUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
         response = self._run_api_v2_task_id(self.task.id, self.admin, data)
         self._check_response(response, self.task, data)
 
+    @staticmethod
+    def _attribute_data(attribute, *, name):
+        return {
+            "id": attribute.id,
+            "name": name,
+            "mutable": attribute.mutable,
+            "input_type": attribute.input_type,
+            "default_value": attribute.default_value,
+            "values": [],
+        }
+
     def _run_api_v2_task_id(self, tid, user, data):
         with ForceLogin(user, self.client):
             response = self.client.patch("/api/tasks/{}".format(tid), data=data, format="json")
@@ -2743,16 +2754,6 @@ class TaskUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
         first_attribute = label.attributespec_set.get(name="bool_attribute")
         second_attribute = label.attributespec_set.get(name="second_bool_attribute")
 
-        def attribute_data(attribute, *, name):
-            return {
-                "id": attribute.id,
-                "name": name,
-                "mutable": attribute.mutable,
-                "input_type": attribute.input_type,
-                "default_value": attribute.default_value,
-                "values": [],
-            }
-
         data = {
             "labels": [
                 {
@@ -2763,8 +2764,8 @@ class TaskUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
                     "id": label.id,
                     "name": label.name,
                     "attributes": [
-                        attribute_data(first_attribute, name=second_attribute.name),
-                        attribute_data(second_attribute, name=first_attribute.name),
+                        self._attribute_data(first_attribute, name=second_attribute.name),
+                        self._attribute_data(second_attribute, name=first_attribute.name),
                     ],
                 },
             ],
@@ -2773,10 +2774,9 @@ class TaskUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
         response = self._run_api_v2_task_id(self.task.id, self.admin, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn(
-            'Cannot swap attribute names "bool_attribute", "second_bool_attribute"',
-            str(response.data),
-        )
+        self.assertIn("Cannot swap attribute names", str(response.data))
+        self.assertIn("bool_attribute", str(response.data))
+        self.assertIn("second_bool_attribute", str(response.data))
         self.assertEqual(self.task.label_set.get(id=other_label.id).name, "person")
         self.assertEqual(
             label.attributespec_set.get(id=first_attribute.id).name,
@@ -2786,6 +2786,64 @@ class TaskUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
             label.attributespec_set.get(id=second_attribute.id).name,
             "second_bool_attribute",
         )
+
+    def test_api_v2_tasks_reject_attribute_name_conflict_with_database(self):
+        label = self.task.label_set.get(name="car")
+        first_attribute = label.attributespec_set.get(name="bool_attribute")
+        second_attribute = label.attributespec_set.get(name="second_bool_attribute")
+
+        data = {
+            "labels": [
+                {
+                    "id": label.id,
+                    "name": label.name,
+                    "attributes": [
+                        self._attribute_data(first_attribute, name=second_attribute.name),
+                    ],
+                }
+            ],
+        }
+
+        response = self._run_api_v2_task_id(self.task.id, self.admin, data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Attribute names are already used by this label", str(response.data))
+        self.assertIn("second_bool_attribute", str(response.data))
+        self.assertEqual(
+            label.attributespec_set.get(id=first_attribute.id).name,
+            "bool_attribute",
+        )
+        self.assertEqual(
+            label.attributespec_set.get(id=second_attribute.id).name,
+            "second_bool_attribute",
+        )
+
+    def test_api_v2_tasks_allow_attribute_rename_to_deleted_attribute_name(self):
+        label = self.task.label_set.get(name="car")
+        first_attribute = label.attributespec_set.get(name="bool_attribute")
+        second_attribute = label.attributespec_set.get(name="second_bool_attribute")
+
+        data = {
+            "labels": [
+                {
+                    "id": label.id,
+                    "name": label.name,
+                    "attributes": [
+                        {"id": second_attribute.id, "deleted": True},
+                        self._attribute_data(first_attribute, name=second_attribute.name),
+                    ],
+                }
+            ],
+        }
+
+        response = self._run_api_v2_task_id(self.task.id, self.admin, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            label.attributespec_set.get(id=first_attribute.id).name,
+            "second_bool_attribute",
+        )
+        self.assertFalse(label.attributespec_set.filter(id=second_attribute.id).exists())
 
 
 class TaskMoveAPITestCase(ApiTestBase):

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -2672,6 +2672,12 @@ class TaskUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
                             "mutable": True,
                             "input_type": AttributeType.CHECKBOX,
                             "default_value": "true",
+                        },
+                        {
+                            "name": "second_bool_attribute",
+                            "mutable": True,
+                            "input_type": AttributeType.CHECKBOX,
+                            "default_value": "false",
                         }
                     ],
                 },
@@ -2730,6 +2736,56 @@ class TaskUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
     def test_api_v2_tasks_delete_label(self):
         data = {"labels": [{"id": 2, "name": "Label for deletion", "deleted": True}]}
         self._check_api_v2_task(data)
+
+    def test_api_v2_tasks_reject_attribute_name_swap(self):
+        label = self.task.label_set.get(name="car")
+        other_label = self.task.label_set.get(name="person")
+        first_attribute = label.attributespec_set.get(name="bool_attribute")
+        second_attribute = label.attributespec_set.get(name="second_bool_attribute")
+
+        def attribute_data(attribute, *, name):
+            return {
+                "id": attribute.id,
+                "name": name,
+                "mutable": attribute.mutable,
+                "input_type": attribute.input_type,
+                "default_value": attribute.default_value,
+                "values": [],
+            }
+
+        data = {
+            "labels": [
+                {
+                    "id": other_label.id,
+                    "name": "updated person",
+                },
+                {
+                    "id": label.id,
+                    "name": label.name,
+                    "attributes": [
+                        attribute_data(first_attribute, name=second_attribute.name),
+                        attribute_data(second_attribute, name=first_attribute.name),
+                    ],
+                }
+            ],
+        }
+
+        response = self._run_api_v2_task_id(self.task.id, self.admin, data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            'Cannot swap attribute names "bool_attribute", "second_bool_attribute"',
+            str(response.data),
+        )
+        self.assertEqual(self.task.label_set.get(id=other_label.id).name, "person")
+        self.assertEqual(
+            label.attributespec_set.get(id=first_attribute.id).name,
+            "bool_attribute",
+        )
+        self.assertEqual(
+            label.attributespec_set.get(id=second_attribute.id).name,
+            "second_bool_attribute",
+        )
 
 
 class TaskMoveAPITestCase(ApiTestBase):

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -2678,7 +2678,7 @@ class TaskUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
                             "mutable": True,
                             "input_type": AttributeType.CHECKBOX,
                             "default_value": "false",
-                        }
+                        },
                     ],
                 },
                 {
@@ -2766,7 +2766,7 @@ class TaskUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
                         attribute_data(first_attribute, name=second_attribute.name),
                         attribute_data(second_attribute, name=first_attribute.name),
                     ],
-                }
+                },
             ],
         }
 


### PR DESCRIPTION
### Motivation and context

When updating label attributes, renaming attributes to names already used by the same label can hit the database unique constraint on `(label, name)`. This includes swapping names between attributes and renaming one attribute to another existing attribute name.

This PR moves that failure to serializer-level validation and returns a normal validation error before attribute updates are applied. It also preserves the valid case where an attribute is deleted and another attribute is renamed to the deleted attribute’s name in the same request.

### How has this been tested?

- Added REST API coverage for attribute name swaps.
- Added REST API coverage for renaming to an existing attribute name.
- Added REST API coverage for renaming to a deleted attribute name in the same request.
- Ran:
  - `python -m py_compile cvat/apps/engine/serializers.py cvat/apps/engine/tests/test_rest_api.py`
  - `git diff --check -- cvat/apps/engine/serializers.py cvat/apps/engine/tests/test_rest_api.py changelog.d/20260519_103538_sekachev.bs.md`

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- [ ] ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [ ] ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same MIT License that covers the project.