### PR TITLE
silence frequent warnings in eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -290,6 +290,7 @@ export default [
             ...securityPlugin.configs['recommended-legacy'].rules,
             ...noUnsanitizedPlugin.configs['recommended-legacy'].rules,
             'no-constant-condition': ['error', { checkLoops: 'allExceptWhileTrue' }],
+            'security/detect-object-injection': 'off'
         },
     },
     // Legacy package configs are still the source of truth; FlatCompat scopes
@@ -377,9 +378,9 @@ export default [
             'no-prototype-builtins': 'off',
             'no-underscore-dangle': 'off',
             'cypress/no-unnecessary-waiting': 'off',
-            'security/detect-object-injection': 'off',
             'no-unused-expressions': 0,
             'chai-friendly/no-unused-expressions': 'error',
+            'security/detect-object-injection': 'off',
         },
     },
     {


### PR DESCRIPTION
https://github.com/cvat-ai/cvat/actions/runs/26081944977/job/76685580310 has a lot of security warnings. Basically, this bans modification of objects by dynamic keys. Which is not desired

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
