### PR TITLE
Track navigator.onLine when network error with code 0 happens

### DIFF
--- a/cvat-ui/src/cvat-logger.ts
+++ b/cvat-ui/src/cvat-logger.ts
@@ -42,9 +42,10 @@ export function logError(
             stack: error.stack,
             ...extras,
         };
+
         if ('code' in error && typeof error.code === 'number') {
             payload.code = error.code;
-            if (error.code === 0) {
+            if (error.code === 0 && 'onLine' in navigator) {
                 payload.is_online = navigator.onLine;
             }
         }

--- a/cvat-ui/src/cvat-logger.ts
+++ b/cvat-ui/src/cvat-logger.ts
@@ -34,7 +34,7 @@ export function logError(
         }
 
         const filename = stackFrames[0].fileName;
-        const payload = {
+        const payload: Record<string, unknown> = {
             filename,
             line: stackFrames[0].lineNumber,
             message: error.message,
@@ -42,6 +42,12 @@ export function logError(
             stack: error.stack,
             ...extras,
         };
+        if ('code' in error && typeof error.code === 'number') {
+            payload.code = error.code;
+            if (error.code === 0) {
+                payload.is_online = navigator.onLine;
+            }
+        }
 
         if (!filename || ignoredSources.some((source) => filename.startsWith(source))) {
             // filename is missing or the error comes from external script (extension, console, snippets, etc)


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
To investigate reasons and improve UX in further

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
