### PR TITLE
Use None instead of the none_type alias in generated SDK type annotations

### DIFF
--- a/changelog.d/20260520_120000_asishkumar_sdk_none_type_annotations.md
+++ b/changelog.d/20260520_120000_asishkumar_sdk_none_type_annotations.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- \[SDK\] Generated type annotations for optional fields and return values no
+  longer use the `none_type` alias, which prevented static type checkers
+  (Pyright/Pylance) from resolving the annotated types
+  (<https://github.com/cvat-ai/cvat/pull/10638>)

--- a/cvat-sdk/gen/postprocess.py
+++ b/cvat-sdk/gen/postprocess.py
@@ -67,6 +67,14 @@ class Replacer:
         # single optional arg pattern
         type_repr = re.sub(r"^(.+, none_type)$", r"typing.Union[\1]", type_repr)
 
+        # Emit the None singleton instead of the none_type alias (none_type = type(None)).
+        # The indirection is valid at runtime, but static type checkers (Pyright/Pylance,
+        # mypy) can't resolve it to None, so every nullable field degrades to Unknown/Any
+        # in the public type annotations. None resolves correctly and is equivalent here.
+        # The none_type alias is still used by the runtime type metadata (openapi_types,
+        # etc.), so its import remains required. See cvat-ai/cvat#10531.
+        type_repr = re.sub(r"\bnone_type\b", "None", type_repr)
+
         return type_repr
 
     allowed_actions = {


### PR DESCRIPTION
### Motivation and context

<!-- Why is this change required? What problem does it solve? -->

Fixes #10531.

The Python SDK is generated with openapi-generator. For nullable fields and
return values, the templates emit type annotations that reference the
`none_type` alias, e.g. in `cvat_sdk/api_client/model/data_meta_read.py`:

```python
frames: typing.Union[list[FrameMeta], none_type]
```

`none_type` is a module-level alias defined as `none_type = type(None)` and
imported from `cvat_sdk.api_client.model_utils`. The indirection is valid at
runtime, but static type checkers cannot resolve a plain module-level variable
used in a type position. Pyright/Pylance report `Variable not allowed in type
expression (reportInvalidTypeForm)` and degrade every nullable field to
`Unknown` (e.g. `list[FrameMeta] | Unknown`), and that `Unknown` then
propagates through any code that consumes the SDK. This was deliberately left
untouched when the hand-written SDK code was modernized in #10064 ("kept the
old syntax in generator templates"); this PR addresses the remaining generated
annotations.

This PR changes the generator post-processing step (`make_type_annotation`) to
emit the `None` singleton instead of the `none_type` alias, so the generated
annotations become:

```python
frames: typing.Union[list[FrameMeta], None]
```

`None` is special-cased by the typing system and resolves correctly in all type
checkers, while remaining equivalent to the previous annotation. The change is
intentionally limited to the public type annotations: the `none_type` alias is
still used by the runtime type metadata (`openapi_types`, the `ApiClient`
parameter tables, etc.), so its import remains required and unchanged.

### How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Regenerated the SDK with the updated post-processing
  (`./cvat-sdk/gen/generate.sh`) and confirmed:
  - no `none_type` remains in any type-annotation position (only in runtime
    type metadata and docstrings, as before);
  - all generated modules byte-compile and import successfully.
- Reproduced the original problem and verified the fix with Pyright on a
  faithful minimal example (alias imported from another module, mirroring the
  generated layout):
  - **before** — `error: Variable not allowed in type expression`; the field
    resolves to `list[int] | Unknown`;
  - **after** — no error; the field resolves to `list[int]`.
- Ran Pyright over the whole regenerated `cvat_sdk/api_client/model/` tree:
  no `none_type`-related diagnostics remain.

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~ <!-- the generated code is not committed and there is no test harness for the generator; verified by regeneration + Pyright, as in #10064 -->
- [x] I have linked related issues (see [GitHub docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
