### PR TITLE
Fix label name truncation in annotation sidebar

### DIFF
--- a/changelog.d/20260520_125238_sekachev.bs_updated_styles.md
+++ b/changelog.d/20260520_125238_sekachev.bs_updated_styles.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed severe truncation of label names in the annotation page Labels sidebar
+  (<https://github.com/cvat-ai/cvat/pull/10641>)

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
@@ -550,7 +550,7 @@
         margin-top: $grid-unit-size * 0.5;
     }
 
-    span {
+    span[role='img'] {
         @extend .cvat-object-sidebar-icon;
 
         display: inline-flex;
@@ -566,6 +566,7 @@
     }
 
     > div:nth-child(2) {
+        white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
         max-height: 1.5em;


### PR DESCRIPTION
### Motivation and context
Fixes #10640.

In the annotation page Labels sidebar, label names were severely truncated because the label card styled every descendant `span` as an icon-sized element. Since Ant Design `Typography.Text` renders as a `span`, the label text inherited the fixed icon width and only the first couple of characters were visible.

This change scopes the fixed-size styling to icon spans and keeps overflowing label names on one line so the existing overflow handling can show an ellipsis instead of clipping labels to two characters.

### How has this been tested?
Not run. The change is limited to SCSS selector/layout rules.

### Checklist
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.