### PR TITLE
Add a thread-pool RQ worker for I/O-bound queues

### DIFF
--- a/changelog.d/20260521_122228_alekseyysosov_add_threadpool_rq_worker.md
+++ b/changelog.d/20260521_122228_alekseyysosov_add_threadpool_rq_worker.md
@@ -1,0 +1,11 @@
+### Added
+
+- A new thread-pool background worker that lets a single worker process handle
+  many jobs at once. For queues whose jobs mostly wait on network I/O (such as
+  outgoing webhooks), one such worker can now do the work that previously needed
+  several separate worker processes, lowering the memory footprint of a CVAT
+  deployment. It is off by default; administrators can enable it for a specific
+  queue by starting that worker with `--worker-class
+  cvat.apps.redis_handler.worker.ThreadPoolWorker` and setting the number
+  of concurrent jobs through the `CVAT_RQ_THREAD_POOL_SIZE` environment variable
+  (<https://github.com/cvat-ai/cvat/pull/10650>)

--- a/cvat/apps/redis_handler/apps.py
+++ b/cvat/apps/redis_handler/apps.py
@@ -72,6 +72,12 @@ class RedisHandlerConfig(AppConfig):
     name = "cvat.apps.redis_handler"
 
     def ready(self) -> None:
+        from . import default_settings
+
+        for key in dir(default_settings):
+            if key.isupper() and not hasattr(settings, key):
+                setattr(settings, key, getattr(default_settings, key))
+
         from cvat.apps.iam.permissions import load_app_iam_rules
 
         load_app_iam_rules(self)

--- a/cvat/apps/redis_handler/default_settings.py
+++ b/cvat/apps/redis_handler/default_settings.py
@@ -1,0 +1,20 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import os
+
+RQ_THREAD_POOL_SIZE = int(os.getenv("CVAT_RQ_THREAD_POOL_SIZE", 1))
+"""
+Number of concurrent job slots for ThreadPoolWorker (the +1 heartbeat
+slot is added internally). Only meaningful when a queue's worker is launched
+with --worker-class cvat.apps.redis_handler.worker.ThreadPoolWorker.
+"""
+
+RQ_THREAD_POOL_JOB_EXECUTION_TIME_THRESHOLD = int(
+    os.getenv("CVAT_RQ_THREAD_POOL_JOB_EXECUTION_TIME_THRESHOLD", 60)
+)
+"""
+ThreadPoolWorker soft per-job SLO in seconds; also reused as the drain
+timeout on shutdown. Not a kill timeout — threads cannot be killed mid-job.
+"""

--- a/cvat/apps/redis_handler/mixins.py
+++ b/cvat/apps/redis_handler/mixins.py
@@ -1,0 +1,186 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import traceback
+from datetime import timedelta
+from random import shuffle
+from typing import TYPE_CHECKING, Optional
+
+from rq import worker_registration
+from rq.exceptions import DeserializationError
+from rq.utils import utcformat, utcnow
+from rq.worker import DequeueStrategy
+
+if TYPE_CHECKING:
+    from redis.client import Pipeline
+
+try:
+    from setproctitle import setproctitle as setprocname
+except ImportError:
+
+    def setprocname(*args, **kwargs):  # noqa
+        pass
+
+
+class RqWorkerPortMixin:
+    """Methods copy-pasted verbatim from `rq.worker.Worker` @ 1.16.0.
+
+    Each method below is referenced by `BaseWorker` (or by us through the BaseWorker
+    contract) but lives only on `Worker`. Nothing in this mixin diverges from
+    upstream — modifications, if any, belong in the subclass that uses the mixin.
+
+    rq-version re-sync checklist (run on every rq bump; `test_rq_version_pin`
+    pins the version and points here):
+      1. Diff each method below against the new upstream `rq.worker.Worker` and
+         re-apply any changes verbatim.
+      2. Re-validate the upstream-adapted methods in `worker.py`
+         (`handle_job_failure`, `get_heartbeat_ttl`, `prepare_job_execution`,
+         `_perform_job`, `handle_job_success`) against upstream and re-apply
+         documented divergences.
+    """
+
+    @property
+    def connection_timeout(self) -> int:
+        return self.dequeue_timeout + 10
+
+    def set_state(self, state: str, pipeline=None) -> None:
+        self._state = state
+        connection = pipeline if pipeline is not None else self.connection
+        connection.hset(self.key, "state", state)
+
+    def get_state(self) -> str:
+        return self._state
+
+    def push_exc_handler(self, handler_func) -> None:
+        self._exc_handlers.append(handler_func)
+
+    def pop_exc_handler(self):
+        return self._exc_handlers.pop()
+
+    def procline(self, message: str) -> None:
+        setprocname(f"rq:worker:{self.name}: {message}")
+
+    def reorder_queues(self, reference_queue) -> None:
+        if self._dequeue_strategy is None:
+            self._dequeue_strategy = DequeueStrategy.DEFAULT
+
+        if self._dequeue_strategy not in ("default", "random", "round_robin"):
+            raise ValueError(
+                f"Dequeue strategy {self._dequeue_strategy} is not allowed. "
+                "Use `default`, `random` or `round_robin`."
+            )
+        if self._dequeue_strategy == DequeueStrategy.DEFAULT:
+            return
+        if self._dequeue_strategy == DequeueStrategy.ROUND_ROBIN:
+            pos = self._ordered_queues.index(reference_queue)
+            self._ordered_queues = self._ordered_queues[pos + 1 :] + self._ordered_queues[: pos + 1]
+            return
+        if self._dequeue_strategy == DequeueStrategy.RANDOM:
+            shuffle(self._ordered_queues)
+            return
+
+    def register_birth(self) -> None:
+        self.log.debug("Registering birth of worker %s", self.name)
+        if self.connection.exists(self.key) and not self.connection.hexists(self.key, "death"):
+            raise ValueError(f"There exists an active worker named {self.name!r} already")
+        with self.connection.pipeline() as p:
+            p.delete(self.key)
+            now = utcnow()
+            now_in_string = utcformat(now)
+            self.birth_date = now
+            mapping = {
+                "birth": now_in_string,
+                "last_heartbeat": now_in_string,
+                "queues": ",".join(self.queue_names()),
+                "pid": self.pid,
+                "hostname": self.hostname,
+                "ip_address": self.ip_address,
+                "version": self.version,
+                "python_version": self.python_version,
+            }
+            if self.get_redis_server_version() >= (4, 0, 0):
+                p.hset(self.key, mapping=mapping)
+            else:
+                p.hmset(self.key, mapping)
+            worker_registration.register(self, p)
+            p.expire(self.key, self.worker_ttl + 60)
+            p.execute()
+
+    def register_death(self) -> None:
+        self.log.debug("Registering death")
+        with self.connection.pipeline() as p:
+            worker_registration.unregister(self, p)
+            p.hset(self.key, "death", utcformat(utcnow()))
+            p.expire(self.key, 60)
+            p.execute()
+
+    def set_shutdown_requested_date(self) -> None:
+        self.connection.hset(
+            self.key,
+            "shutdown_requested_date",
+            utcformat(self._shutdown_requested_date),
+        )
+
+    def increment_failed_job_count(self, pipeline: Optional["Pipeline"] = None) -> None:
+        connection = pipeline if pipeline is not None else self.connection
+        connection.hincrby(self.key, "failed_job_count", 1)
+
+    def increment_successful_job_count(self, pipeline: Optional["Pipeline"] = None) -> None:
+        connection = pipeline if pipeline is not None else self.connection
+        connection.hincrby(self.key, "successful_job_count", 1)
+
+    def increment_total_working_time(
+        self, job_execution_time: timedelta, pipeline: "Pipeline"
+    ) -> None:
+        pipeline.hincrbyfloat(self.key, "total_working_time", job_execution_time.total_seconds())
+
+    def handle_exception(self, job, *exc_info) -> None:
+        """Walks the exception handler stack to delegate exception handling.
+        If the job cannot be deserialized, it will raise when func_name or
+        the other properties are accessed, which will stop exceptions from
+        being properly logged, so we guard against it here.
+        """
+        self.log.debug("Handling exception for %s.", job.id)
+        exc_string = "".join(traceback.format_exception(*exc_info))
+        try:
+            extra = {
+                "func": job.func_name,
+                "arguments": job.args,
+                "kwargs": job.kwargs,
+            }
+            func_name = job.func_name
+        except DeserializationError:
+            extra = {}
+            func_name = "<DeserializationError>"
+
+        extra.update({"queue": job.origin, "job_id": job.id})
+
+        self.log.error(
+            "[Job %s]: exception raised while executing (%s)\n%s",
+            job.id,
+            func_name,
+            exc_string,
+            extra=extra,
+        )
+
+        for handler in self._exc_handlers:
+            self.log.debug("Invoking exception handler %s", handler)
+            fallthrough = handler(job, *exc_info)
+
+            if fallthrough is None:
+                fallthrough = True
+
+            if not fallthrough:
+                break
+
+    def stop_scheduler(self) -> None:
+        import os
+        import signal
+
+        if self.scheduler._process and self.scheduler._process.pid:
+            try:
+                os.kill(self.scheduler._process.pid, signal.SIGTERM)
+            except OSError:
+                pass
+            self.scheduler._process.join()

--- a/cvat/apps/redis_handler/tests/test_worker.py
+++ b/cvat/apps/redis_handler/tests/test_worker.py
@@ -1,0 +1,614 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import logging
+import signal
+import threading
+import time
+import uuid
+from concurrent.futures import Future
+from typing import Any
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import fakeredis
+import rq
+from rq import Queue, Retry
+from rq.job import Job, JobStatus
+from rq.registry import FailedJobRegistry, FinishedJobRegistry, StartedJobRegistry
+from rq.worker import StopRequested, WorkerStatus
+
+from cvat.apps.redis_handler import worker as worker_module
+from cvat.apps.redis_handler.worker import RqThreadPoolWorker, ThreadPoolWorker
+
+
+def _say_hello(name: str = "World") -> str:
+    return f"Hi there, {name}!"
+
+
+def _div_by_zero(x: int) -> int:
+    return x // 0
+
+
+def _sleep_for(seconds: float) -> None:
+    time.sleep(seconds)
+
+
+def _ambient_connection() -> "fakeredis.FakeRedis":
+    # NOTE @sosov: inside a job thread the worker pushes self.connection onto
+    # rq._connection_stack, so rq.Queue() with no explicit connection= resolves
+    # to it. Under fakeredis that is the same client bound to the shared
+    # FakeServer the test holds — no host/port round-trip needed.
+    return rq.Queue().connection
+
+
+def _record_thread_ident_and_wait_for_peers(barrier_key: str, expected: int) -> int:
+    conn = _ambient_connection()
+    ident = threading.get_ident()
+    conn.lpush(barrier_key, str(ident))
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if conn.llen(barrier_key) >= expected:
+            return ident
+        time.sleep(0.01)
+    raise TimeoutError(f"timed out waiting for {expected} peers at {barrier_key}")
+
+
+def _block_on_redis_key(release_key: str) -> str:
+    conn = _ambient_connection()
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if conn.exists(release_key):
+            return "released"
+        time.sleep(0.05)
+    raise TimeoutError(f"timed out waiting for release key {release_key}")
+
+
+def _implicit_rq_connection_resolves() -> bool:
+    # rq.Queue() with no connection= relies on rq._connection_stack (a
+    # threading.get_ident-keyed LocalStack). Returning ping() proves the
+    # implicit connection both exists in this thread and is a working Redis.
+    return bool(rq.Queue().connection.ping())
+
+
+class _WorkerTestBase(TestCase):
+    def setUp(self) -> None:
+        _server = fakeredis.FakeServer()
+        self.conn = fakeredis.FakeRedis(server=_server)
+        self.queue = Queue(f"test_threadpool_{uuid.uuid4().hex[:8]}", connection=self.conn)
+        self._created_workers: list[RqThreadPoolWorker] = []
+
+    def tearDown(self) -> None:
+        for worker in self._created_workers:
+            worker._heartbeat_stop_event.set()
+            worker._executor.shutdown(wait=False)
+
+    def _make_worker(self, **overrides: Any) -> RqThreadPoolWorker:
+        kwargs: dict[str, Any] = {
+            "queues": [self.queue],
+            "connection": self.conn,
+            "jobs_pool_size": 3,
+            "job_execution_time_threshold": 5,
+        }
+        kwargs.update(overrides)
+        worker = RqThreadPoolWorker(**kwargs)
+        self._created_workers.append(worker)
+        return worker
+
+
+class TestRqVersionPin(TestCase):
+    def test_rq_version_pin(self) -> None:
+        expected = "1.16.0"
+        if rq.VERSION != expected:
+            self.fail(
+                f"rq is pinned at {expected} (via django-rq in cvat/requirements) but the "
+                f"installed version is {rq.VERSION}.\n"
+                "\n"
+                "RqThreadPoolWorker depends on rq internals in two places that MUST "
+                "be re-validated on every rq bump:\n"
+                "\n"
+                "  1. cvat/apps/redis_handler/mixins.py — every method is\n"
+                "     verbatim-pasted from rq.worker.Worker. Diff each method\n"
+                "     against the new upstream Worker and re-apply any changes.\n"
+                "\n"
+                "  2. cvat/apps/redis_handler/worker.py —\n"
+                "     handle_job_failure, get_heartbeat_ttl,\n"
+                "     prepare_job_execution, _perform_job, and handle_job_success\n"
+                "     are adapted from upstream Worker.perform_job / related\n"
+                "     helpers. Diff each against upstream and re-apply documented\n"
+                "     divergences.\n"
+                "\n"
+                "After verifying both, update the expected version in this test."
+            )
+
+
+class TestMultithreadingWorker(_WorkerTestBase):
+    def test_get_heartbeat_ttl_uses_monitoring_interval_plus_buffer(self) -> None:
+        # NOTE @sosov: threshold deliberately chosen to differ from
+        # job_monitoring_interval so the negative assertion below catches a
+        # regression to the old `threshold + slack` formula.
+        worker = self._make_worker(job_execution_time_threshold=999, job_monitoring_interval=10)
+
+        ttl = worker.get_heartbeat_ttl(MagicMock(spec=Job))
+
+        self.assertEqual(
+            ttl, worker.job_monitoring_interval + worker_module._JOB_HEARTBEAT_REFRESH_BUFFER_SEC
+        )
+        self.assertNotEqual(ttl, 999 + worker_module._JOB_HEARTBEAT_REFRESH_BUFFER_SEC)
+
+    def test_is_threadpool_full_saturates_at_jobs_pool_size_plus_one(self) -> None:
+        # jobs_pool_size=3 → executor of 4 (3 jobs + 1 heartbeat slot).
+        worker = self._make_worker(jobs_pool_size=3)
+
+        self.assertIs(worker._is_threadpool_full, False)
+
+        worker._active_futures.extend([Future(), Future(), Future()])
+        self.assertIs(worker._is_threadpool_full, False)
+
+        worker._active_futures.append(Future())
+        self.assertIs(worker._is_threadpool_full, True)
+
+    def test_on_future_performed_sets_idle_when_only_heartbeat_remains(self) -> None:
+        worker = self._make_worker(jobs_pool_size=3)
+        state_calls: list[str] = []
+        worker.set_state = state_calls.append
+
+        heartbeat_future = Future()
+        job_future = Future()
+        worker._heartbeat_future = heartbeat_future
+        worker._active_futures = [heartbeat_future, job_future]
+
+        worker._on_future_performed(job_future)
+
+        self.assertEqual(state_calls, [WorkerStatus.IDLE])
+        self.assertEqual(worker._active_futures, [heartbeat_future])
+
+    def test_on_future_performed_does_not_idle_when_other_jobs_running(self) -> None:
+        worker = self._make_worker(jobs_pool_size=3)
+        state_calls: list[str] = []
+        worker.set_state = state_calls.append
+
+        heartbeat_future = Future()
+        job_future_a = Future()
+        job_future_b = Future()
+        worker._heartbeat_future = heartbeat_future
+        worker._active_futures = [heartbeat_future, job_future_a, job_future_b]
+
+        worker._on_future_performed(job_future_a)
+
+        self.assertEqual(state_calls, [])
+        self.assertEqual(worker._active_futures, [heartbeat_future, job_future_b])
+
+    def test_on_future_performed_handles_missing_future(self) -> None:
+        worker = self._make_worker(jobs_pool_size=3)
+        worker.set_state = lambda _state: None
+        worker._heartbeat_future = Future()
+        worker._active_futures = [worker._heartbeat_future]
+
+        # Removing a future that was never tracked must be swallowed and must
+        # not corrupt the active-futures list.
+        worker._on_future_performed(Future())
+
+        self.assertEqual(worker._active_futures, [worker._heartbeat_future])
+
+    def test_on_future_performed_pops_from_active_jobs(self) -> None:
+        worker = self._make_worker(jobs_pool_size=3)
+        worker.set_state = lambda _state: None
+
+        heartbeat_future = Future()
+        job_future = Future()
+        job = MagicMock(spec=Job)
+        worker._heartbeat_future = heartbeat_future
+        worker._active_futures = [heartbeat_future, job_future]
+        worker._active_jobs = {job_future: job}
+
+        worker._on_future_performed(job_future)
+
+        self.assertEqual(worker._active_futures, [heartbeat_future])
+        self.assertEqual(worker._active_jobs, {})
+
+    def test_maintain_active_job_heartbeats_is_noop_when_empty(self) -> None:
+        worker = self._make_worker()
+        # _active_jobs is empty on a fresh worker; the helper must short-circuit
+        # at `if not jobs: return` before opening a Redis pipeline.
+        with patch.object(
+            worker.connection, "pipeline", wraps=worker.connection.pipeline
+        ) as pipeline_spy:
+            worker._maintain_active_job_heartbeats()
+
+        pipeline_spy.assert_not_called()
+
+    def test_maintain_active_job_heartbeats_extends_registry_ttl(self) -> None:
+        worker = self._make_worker(jobs_pool_size=1)
+        job = self.queue.enqueue(_say_hello)
+        started_registry = StartedJobRegistry(queue=self.queue)
+        started_registry.add(job, ttl=worker.get_heartbeat_ttl(job))
+        initial_score = self.queue.connection.zscore(started_registry.key, job.id)
+        self.assertIsNotNone(initial_score)
+
+        with worker._lock:
+            worker._active_jobs[Future()] = job
+
+        # NOTE @sosov: sleep just enough that the new heartbeat timestamp is
+        # measurably later than the initial one.
+        time.sleep(1.1)
+
+        worker._maintain_active_job_heartbeats()
+
+        new_score = self.queue.connection.zscore(started_registry.key, job.id)
+        self.assertIsNotNone(new_score)
+        self.assertGreater(
+            new_score,
+            initial_score,
+            f"registry TTL should be extended; was {initial_score}, is {new_score}",
+        )
+
+    def test_maintain_active_job_heartbeats_does_not_reanimate_removed_entry(self) -> None:
+        # NOTE @sosov: xx=True must prevent recreating a registry entry that
+        # _handle_success / _handle_failure already removed in a race.
+        worker = self._make_worker(jobs_pool_size=1)
+        job = self.queue.enqueue(_say_hello)
+        started_registry = StartedJobRegistry(queue=self.queue)
+        self.assertIsNone(self.queue.connection.zscore(started_registry.key, job.id))
+
+        with worker._lock:
+            worker._active_jobs[Future()] = job
+
+        worker._maintain_active_job_heartbeats()
+
+        self.assertIsNone(self.queue.connection.zscore(started_registry.key, job.id))
+
+    def test_subscribe_is_noop(self) -> None:
+        worker = self._make_worker()
+
+        worker.subscribe()
+
+        self.assertIsNone(worker.pubsub_thread)
+        worker.unsubscribe()
+
+    def test_request_force_stop_raises_system_exit(self) -> None:
+        worker = self._make_worker()
+
+        with self.assertRaises(SystemExit):
+            worker.request_force_stop(signal.SIGINT, None)
+
+    def test_request_stop_sets_flag_and_raises_stoprequested(self) -> None:
+        worker = self._make_worker()
+        worker.set_shutdown_requested_date = lambda: None
+
+        with patch.object(signal, "signal", lambda *_args, **_kwargs: None):
+            with self.assertRaises(StopRequested):
+                worker.request_stop(signal.SIGTERM, None)
+
+        self.assertIs(worker._stop_requested, True)
+
+    def test_start_heartbeat_adds_one_active_future(self) -> None:
+        worker = self._make_worker(jobs_pool_size=1, job_execution_time_threshold=1)
+
+        self.assertEqual(worker._active_futures, [])
+
+        worker._start_heartbeat()
+        try:
+            self.assertEqual(len(worker._active_futures), 1)
+            self.assertIs(worker._active_futures[0], worker._heartbeat_future)
+            self.assertIs(worker._heartbeat_future.done(), False)
+        finally:
+            worker._stop_heartbeat()
+
+    def test_stop_heartbeat_completes_the_heartbeat_future(self) -> None:
+        worker = self._make_worker(jobs_pool_size=1, job_execution_time_threshold=1)
+        worker._start_heartbeat()
+
+        worker._stop_heartbeat()
+        worker._heartbeat_future.result(timeout=5)
+
+        self.assertIs(worker._heartbeat_future.done(), True)
+
+    def test_pool_full_when_jobs_pool_size_plus_one_futures_in_flight(self) -> None:
+        worker = self._make_worker(jobs_pool_size=3)
+        release = threading.Event()
+        # Executor has jobs_pool_size + 1 = 4 slots; saturate all 4.
+        futures = [worker._executor.submit(release.wait) for _ in range(4)]
+
+        with worker._lock:
+            worker._active_futures.extend(futures)
+
+        try:
+            self.assertIs(worker._is_threadpool_full, True)
+        finally:
+            release.set()
+            for future in futures:
+                future.result(timeout=5)
+
+    def test_jobs_pool_size_one_runs_one_job_with_heartbeat(self) -> None:
+        # NOTE @sosov: jobs_pool_size=1 is the minimum allowed and must work
+        # without deadlocking against the heartbeat slot.
+        self.queue.enqueue(_say_hello, name="Frank")
+        worker = self._make_worker(jobs_pool_size=1)
+
+        worker.work(burst=True)
+
+        self.assertEqual(len(FinishedJobRegistry(queue=self.queue).get_job_ids()), 1)
+
+    def test_concurrent_jobs_run_on_distinct_threads(self) -> None:
+        # Enqueue 3 jobs that synchronize on a Redis-backed barrier so all three
+        # are guaranteed to be in flight simultaneously; otherwise a fast worker
+        # could process them sequentially on the same thread.
+        barrier_key = f"test_threadpool_barrier_{uuid.uuid4().hex[:8]}"
+        expected = 3
+
+        jobs = [
+            self.queue.enqueue(_record_thread_ident_and_wait_for_peers, barrier_key, expected)
+            for _ in range(expected)
+        ]
+
+        # jobs_pool_size = expected; the heartbeat slot is added internally.
+        worker = self._make_worker(jobs_pool_size=expected)
+        worker.work(burst=True)
+
+        idents = []
+        for job in jobs:
+            job.refresh()
+            idents.append(job.return_value())
+
+        self.assertEqual(len(set(idents)), expected, f"jobs reused threads: {idents}")
+
+    def test_implicit_rq_connection_is_available_inside_job_thread(self) -> None:
+        # NOTE @sosov: rq stores the current Redis connection in
+        # rq._connection_stack — a LocalStack keyed by threading.get_ident().
+        # Upstream Worker.perform_job pushes self.connection in the forked
+        # child; RqThreadPoolWorker must push it in the executor thread so user
+        # code calling rq.Queue() without an explicit connection= can resolve.
+        job = self.queue.enqueue(_implicit_rq_connection_resolves)
+        worker = self._make_worker(jobs_pool_size=1)
+
+        worker.work(burst=True)
+
+        job.refresh()
+        self.assertEqual(
+            job.get_status(), JobStatus.FINISHED, f"job failed; exc_info=\n{job.exc_info}"
+        )
+        self.assertIs(job.return_value(), True)
+
+    def test_long_running_job_survives_past_initial_heartbeat_ttl(self) -> None:
+        # NOTE @sosov: regression guard for the abandonment race. We shrink the
+        # TTL buffer to 1s and set job_monitoring_interval=1 so the initial
+        # registry TTL is ~2s; the job is held longer than that via a Redis
+        # release key. If the background loop fails to refresh the heartbeat,
+        # StartedJobRegistry.cleanup() called after the original TTL would
+        # treat the job as abandoned.
+        #
+        # We drive the worker manually (`_start_heartbeat` + `execute_job`)
+        # rather than via `worker.work()` because `work()` installs signal
+        # handlers and only runs on the main thread.
+        release_key = f"test_threadpool_release_{uuid.uuid4().hex[:8]}"
+        job = self.queue.enqueue(_block_on_redis_key, release_key)
+
+        worker = self._make_worker(jobs_pool_size=1, job_monitoring_interval=1)
+        started_registry = StartedJobRegistry(queue=self.queue)
+
+        with patch.object(worker_module, "_JOB_HEARTBEAT_REFRESH_BUFFER_SEC", 1):
+            worker._start_heartbeat()
+            try:
+                worker.execute_job(job=job, queue=self.queue)
+
+                deadline = time.monotonic() + 5
+                while time.monotonic() < deadline:
+                    if self.queue.connection.zscore(started_registry.key, job.id) is not None:
+                        break
+                    time.sleep(0.05)
+                else:
+                    self.fail("worker never wrote initial job heartbeat")
+
+                # Sleep past the *initial* TTL so any non-refreshing implementation
+                # would have a stale registry score.
+                time.sleep(3)
+
+                # Cleanup with a current timestamp must NOT consider the job
+                # abandoned because the background loop has been refreshing it.
+                started_registry.cleanup(timestamp=time.time())
+                self.assertIn(
+                    job.id,
+                    started_registry.get_job_ids(),
+                    "job was treated as abandoned despite its future being active",
+                )
+            finally:
+                self.queue.connection.set(release_key, "1")
+                deadline = time.monotonic() + 10
+                while time.monotonic() < deadline:
+                    with worker._lock:
+                        if not worker._active_jobs:
+                            break
+                    time.sleep(0.05)
+                worker._stop_heartbeat()
+                self.queue.connection.delete(release_key)
+
+        job.refresh()
+        self.assertEqual(job.get_status(), JobStatus.FINISHED)
+        self.assertNotIn(job.id, started_registry.get_job_ids())
+        self.assertIn(job.id, FinishedJobRegistry(queue=self.queue).get_job_ids())
+
+    def test_teardown_drains_in_flight_within_threshold(self) -> None:
+        worker = self._make_worker(jobs_pool_size=1, job_execution_time_threshold=5)
+        worker.register_death = lambda: None
+
+        future = worker._executor.submit(time.sleep, 0.3)
+        with worker._lock:
+            worker._active_futures.append(future)
+        future.add_done_callback(worker._on_future_performed)
+
+        start = time.monotonic()
+        worker.teardown()
+        elapsed = time.monotonic() - start
+
+        self.assertIs(future.done(), True)
+        self.assertIsNone(future.exception())
+        self.assertLess(elapsed, 3.0)
+
+    def test_teardown_warns_and_returns_when_drain_exceeds_threshold(self) -> None:
+        worker = self._make_worker(jobs_pool_size=1, job_execution_time_threshold=1)
+        worker.register_death = lambda: None
+        release = threading.Event()
+
+        future = worker._executor.submit(release.wait)
+        with worker._lock:
+            worker._active_futures.append(future)
+        future.add_done_callback(worker._on_future_performed)
+
+        try:
+            start = time.monotonic()
+            with self.assertLogs(level=logging.WARNING) as captured:
+                worker.teardown()
+            elapsed = time.monotonic() - start
+
+            self.assertLess(elapsed, 3.0)
+            self.assertTrue(any("Drain timed out" in line for line in captured.output))
+            self.assertIs(future.done(), False)
+        finally:
+            release.set()
+            future.result(timeout=5)
+
+
+class TestPortedFromRq(_WorkerTestBase):
+    def test_create_worker(self) -> None:
+        connection = self.conn
+
+        single_str = RqThreadPoolWorker(queues="foo", connection=connection, jobs_pool_size=2)
+        self.assertEqual(single_str.queues[0].name, "foo")
+
+        list_of_str = RqThreadPoolWorker(
+            queues=["foo", "bar"], connection=connection, jobs_pool_size=2
+        )
+        self.assertEqual([q.name for q in list_of_str.queues], ["foo", "bar"])
+        self.assertEqual(
+            list_of_str.queue_keys(), [list_of_str.queues[0].key, list_of_str.queues[1].key]
+        )
+        self.assertEqual(list_of_str.queue_names(), ["foo", "bar"])
+
+        single_queue = RqThreadPoolWorker(
+            queues=Queue("foo", connection=connection), connection=connection, jobs_pool_size=2
+        )
+        self.assertEqual(single_queue.queues[0].name, "foo")
+
+        list_of_queues = RqThreadPoolWorker(
+            queues=[Queue("foo", connection=connection), Queue("bar", connection=connection)],
+            connection=connection,
+            jobs_pool_size=2,
+        )
+        self.assertEqual([q.name for q in list_of_queues.queues], ["foo", "bar"])
+
+        for worker in (single_str, list_of_str, single_queue, list_of_queues):
+            worker._heartbeat_stop_event.set()
+            worker._executor.shutdown(wait=False)
+
+    def test_work_and_quit(self) -> None:
+        # NOTE @sosov: upstream calls work(burst=True) twice on the same
+        # instance — we can't, ThreadPoolExecutor.shutdown() in teardown() is
+        # irreversible.
+        self.queue.enqueue(_say_hello, name="Frank")
+        worker = self._make_worker()
+
+        worker.work(burst=True)
+
+        self.assertEqual(len(FinishedJobRegistry(queue=self.queue).get_job_ids()), 1)
+
+    def test_work_via_string_argument(self) -> None:
+        # NOTE @sosov: upstream asserts `job.worker_name is None` after work —
+        # that only holds when the worker forks (the in-test job object never
+        # sees the forked process's mutations). In threads the same Python
+        # object IS mutated, so worker_name stays set.
+        job = self.queue.enqueue(
+            "cvat.apps.redis_handler.tests.test_worker._say_hello",
+            name="Frank",
+        )
+        worker = self._make_worker()
+
+        worker.work(burst=True)
+
+        job.refresh()
+        self.assertEqual(job.return_value(), "Hi there, Frank!")
+        self.assertEqual(job.get_status(), JobStatus.FINISHED)
+
+    def test_work_fails_moves_job_to_failed_registry(self) -> None:
+        job = self.queue.enqueue(_div_by_zero, 1)
+        enqueued_at = str(job.enqueued_at)
+        worker = self._make_worker()
+
+        worker.work(burst=True)
+
+        self.assertEqual(self.queue.count, 0)
+        self.assertIn(job, FailedJobRegistry(queue=self.queue))
+        job.refresh()
+        self.assertEqual(job.origin, self.queue.name)
+        self.assertEqual(str(job.enqueued_at), enqueued_at)
+        self.assertTrue(job.exc_info)
+        self.assertIn("ZeroDivisionError", job.exc_info)
+
+    def test_job_times_are_recorded(self) -> None:
+        job = self.queue.enqueue(_say_hello)
+        worker = self._make_worker()
+
+        worker.work(burst=True)
+
+        job.refresh()
+        self.assertIsNotNone(job.enqueued_at)
+        self.assertIsNotNone(job.started_at)
+        self.assertIsNotNone(job.ended_at)
+        self.assertLessEqual(job.enqueued_at, job.started_at)
+        self.assertLessEqual(job.started_at, job.ended_at)
+
+    def test_handle_retry_re_enqueues_until_exhausted(self) -> None:
+        job = self.queue.enqueue(_div_by_zero, 1, retry=Retry(max=2))
+        registry = FailedJobRegistry(queue=self.queue)
+        worker = self._make_worker()
+
+        self.queue.empty()
+        worker.handle_job_failure(job, self.queue)
+        job.refresh()
+        self.assertEqual(job.retries_left, 1)
+        self.assertEqual(self.queue.job_ids, [job.id])
+        self.assertNotIn(job, registry)
+
+        self.queue.empty()
+        worker.handle_job_failure(job, self.queue)
+        job.refresh()
+        self.assertEqual(job.retries_left, 0)
+        self.assertEqual(self.queue.job_ids, [job.id])
+
+        self.queue.empty()
+        worker.handle_job_failure(job, self.queue)
+        job.refresh()
+        self.assertEqual(job.retries_left, 0)
+        self.assertEqual(self.queue.job_ids, [])
+        self.assertIn(job, registry)
+
+    def test_job_timeout_is_silently_ignored(self) -> None:
+        job = self.queue.enqueue(_sleep_for, 0.2, job_timeout=1)
+        worker = self._make_worker()
+
+        worker.work(burst=True)
+
+        job.refresh()
+        self.assertEqual(job.get_status(), JobStatus.FINISHED)
+        self.assertNotIn(job, FailedJobRegistry(queue=self.queue))
+        self.assertIn(job, FinishedJobRegistry(queue=self.queue))
+
+
+class TestThreadPoolWorkerCancellation(_WorkerTestBase):
+    def test_register_birth_marks_worker_non_cancellable(self) -> None:
+        # The worker can't interrupt a running thread, so it writes the
+        # cvat_can_stop_started_jobs="0" marker that RequestViewSet reads to
+        # reject started-job cancellation (otherwise cancel returns 200 while
+        # the job keeps running).
+        worker = ThreadPoolWorker(
+            queues=[self.queue],
+            connection=self.conn,
+            jobs_pool_size=1,
+            job_execution_time_threshold=5,
+        )
+        self._created_workers.append(worker)
+
+        worker.register_birth()
+
+        self.assertEqual(self.conn.hget(worker.key, "cvat_can_stop_started_jobs"), b"0")

--- a/cvat/apps/redis_handler/utils.py
+++ b/cvat/apps/redis_handler/utils.py
@@ -10,3 +10,17 @@ def get_class_from_module(module_path: str | Path, class_name: str) -> type | No
     module = importlib.import_module(module_path)
     klass = getattr(module, class_name, None)
     return klass
+
+
+class NoOpDeathPenalty:
+    """Death-penalty stand-in for the thread-pool worker — threads cannot be
+    interrupted mid-blocking-IO, so job/callback timeouts are no-ops."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def __enter__(self) -> "NoOpDeathPenalty":
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        return False

--- a/cvat/apps/redis_handler/views.py
+++ b/cvat/apps/redis_handler/views.py
@@ -208,8 +208,9 @@ class RequestViewSet(viewsets.GenericViewSet):
 
         worker_key = f"{RQWorker.redis_worker_namespace_prefix}{rq_job.worker_name}"
         # The marker is CVAT-specific and can be absent on already running or older production
-        # workers. Only SimpleWorker writes "0", so default to "can stop" for backward
-        # compatibility.
+        # workers. Workers that cannot stop a started job write "0" (SimpleWorker, which runs
+        # in-process, and ThreadPoolWorker, which can't interrupt a running thread); everything
+        # else defaults to "can stop" for backward compatibility.
         can_stop_started_jobs = (
             rq_job.connection.hget(worker_key, CVAT_CAN_STOP_STARTED_JOBS_KEY) or "1"
         )

--- a/cvat/apps/redis_handler/worker.py
+++ b/cvat/apps/redis_handler/worker.py
@@ -1,0 +1,481 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import signal
+import sys
+import threading
+import time
+import traceback
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+from contextlib import suppress
+from types import FrameType
+from typing import Optional
+
+import redis.exceptions
+from django.db import close_old_connections
+from rq.connections import pop_connection, push_connection
+from rq.defaults import DEFAULT_LOGGING_DATE_FORMAT, DEFAULT_LOGGING_FORMAT
+from rq.job import Job, JobStatus
+from rq.queue import Queue
+from rq.registry import StartedJobRegistry
+from rq.utils import utcnow
+from rq.worker import BaseWorker, DequeueStrategy, StopRequested, WorkerStatus
+
+from cvat.apps.redis_handler.mixins import RqWorkerPortMixin
+from cvat.apps.redis_handler.utils import NoOpDeathPenalty
+
+_POOL_FULL_POLL_INTERVAL: float = 0.1
+
+_JOB_HEARTBEAT_REFRESH_BUFFER_SEC: int = 15
+
+
+class RqThreadPoolWorker(RqWorkerPortMixin, BaseWorker):
+    def __init__(
+        self,
+        *args,
+        jobs_pool_size: int,
+        job_execution_time_threshold: int = 60,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        # NOTE @sosov: +1 reserves the heartbeat slot; jobs_pool_size is the
+        # user-facing job-slot count.
+        self.threadpool_size = jobs_pool_size + 1
+
+        self._job_execution_time_threshold_sec = job_execution_time_threshold
+
+        self._executor = ThreadPoolExecutor(
+            max_workers=self.threadpool_size,
+            thread_name_prefix="rq_threadpool_",
+        )
+        self._active_futures: list[Future] = []
+        self._active_jobs: dict[Future, Job] = {}
+        self._lock = threading.Lock()
+
+        self._heartbeat_future: Optional[Future] = None
+        self._heartbeat_stop_event = threading.Event()
+
+    def subscribe(self) -> None:
+        # NOTE @sosov: BaseWorker.subscribe opens a pubsub channel for
+        # stop-job / kill-horse / shutdown commands — all horse-bound and
+        # inapplicable to threads. No-op; unsubscribe() is then also a no-op
+        # because self.pubsub_thread stays None.
+        pass
+
+    @property
+    def _is_threadpool_full(self) -> bool:
+        with self._lock:
+            return len(self._active_futures) >= self.threadpool_size
+
+    def _on_future_performed(self, future: Future) -> None:
+        with self._lock:
+            try:
+                self._active_futures.remove(future)
+            except ValueError:
+                pass
+
+            self._active_jobs.pop(future, None)
+
+            if future is self._heartbeat_future:
+                return
+
+            if all(f is self._heartbeat_future for f in self._active_futures):
+                self.set_state(WorkerStatus.IDLE)
+
+    def _maintain_active_job_heartbeats(self) -> None:
+        with self._lock:
+            jobs = list(self._active_jobs.values())
+
+        if not jobs:
+            return
+
+        try:
+            with self.connection.pipeline() as pipeline:
+                now = utcnow()
+                for job in jobs:
+                    job.heartbeat(
+                        timestamp=now,
+                        ttl=self.get_heartbeat_ttl(job),
+                        pipeline=pipeline,
+                        xx=True,
+                    )
+                pipeline.execute()
+        except Exception:  # pylint: disable=broad-except
+            self.log.warning("Active-job heartbeat refresh failed", exc_info=True)
+
+    def _heartbeat_loop(self) -> None:
+        while not self._heartbeat_stop_event.is_set():
+            try:
+                self.heartbeat()
+            except Exception:  # pylint: disable=broad-except
+                self.log.warning("Background heartbeat failed", exc_info=True)
+
+            self._maintain_active_job_heartbeats()
+
+            self._heartbeat_stop_event.wait(timeout=self.job_monitoring_interval)
+
+    def _start_heartbeat(self) -> None:
+        self._heartbeat_stop_event.clear()
+
+        self._heartbeat_future = self._executor.submit(self._heartbeat_loop)
+
+        with self._lock:
+            self._active_futures.append(self._heartbeat_future)
+
+        self._heartbeat_future.add_done_callback(self._on_future_performed)
+
+    def get_heartbeat_ttl(self, job: Job) -> int:
+        return self.job_monitoring_interval + _JOB_HEARTBEAT_REFRESH_BUFFER_SEC
+
+    def prepare_job_execution(
+        self,
+        job: Job,
+        remove_from_intermediate_queue: bool = False,
+    ) -> None:
+        with self.connection.pipeline() as pipeline:
+            job.prepare_for_execution(worker_name=self.name, pipeline=pipeline)
+            job.heartbeat(
+                timestamp=utcnow(),
+                ttl=self.get_heartbeat_ttl(job),
+                pipeline=pipeline,
+            )
+
+            if remove_from_intermediate_queue:
+                intermediate_queue = Queue(name=job.origin, connection=self.connection)
+                pipeline.lrem(intermediate_queue.intermediate_queue_key, 1, job.id)
+
+            pipeline.execute()
+
+    def handle_job_success(
+        self,
+        job: Job,
+        queue: Queue,
+        started_job_registry: StartedJobRegistry,
+    ) -> None:
+        with self.connection.pipeline() as pipeline:
+            while True:
+                try:
+                    pipeline.watch(job.dependents_key)
+                    queue.enqueue_dependents(job=job, pipeline=pipeline)
+
+                    if not pipeline.explicit_transaction:
+                        pipeline.multi()
+
+                    self.increment_successful_job_count(pipeline=pipeline)
+                    self.increment_total_working_time(
+                        job_execution_time=job.ended_at - job.started_at,
+                        pipeline=pipeline,
+                    )
+
+                    result_ttl = job.get_result_ttl(self.default_result_ttl)
+                    if result_ttl != 0:
+                        job._handle_success(result_ttl=result_ttl, pipeline=pipeline)
+
+                    job.cleanup(ttl=result_ttl, pipeline=pipeline, remove_from_queue=False)
+                    started_job_registry.remove(job, pipeline=pipeline)
+
+                    pipeline.execute()
+                    break
+                except redis.exceptions.WatchError:
+                    continue
+
+        self.log.info("Job %s succeeded", job.id)
+
+    def handle_job_failure(
+        self,
+        job: Job,
+        queue: Queue,
+        started_job_registry: Optional[StartedJobRegistry] = None,
+        exc_string: str = "",
+    ) -> None:
+        self.log.debug("Handling failed execution of job %s", job.id)
+        with self.connection.pipeline() as pipeline:
+            if started_job_registry is None:
+                started_job_registry = StartedJobRegistry(
+                    name=job.origin,
+                    connection=self.connection,
+                    job_class=self.job_class,
+                    serializer=self.serializer,
+                )
+
+            retry = job.retries_left and job.retries_left > 0
+            if not retry:
+                job.set_status(JobStatus.FAILED, pipeline=pipeline)
+
+            started_job_registry.remove(job, pipeline=pipeline)
+
+            if not self.disable_default_exception_handler and not retry:
+                job._handle_failure(exc_string=exc_string, pipeline=pipeline)
+                with suppress(redis.exceptions.ConnectionError):
+                    pipeline.execute()
+
+            self.increment_failed_job_count(pipeline=pipeline)
+
+            if job.started_at and job.ended_at:
+                self.increment_total_working_time(
+                    job_execution_time=job.ended_at - job.started_at,
+                    pipeline=pipeline,
+                )
+
+            if retry:
+                job.retry(queue=queue, pipeline=pipeline)
+                enqueue_dependents = False
+            else:
+                enqueue_dependents = True
+
+            try:
+                pipeline.execute()
+                if enqueue_dependents:
+                    queue.enqueue_dependents(job=job)
+            except Exception:  # nosec B110  pylint: disable=broad-except
+                # Ensure that custom exception handlers are called even if Redis is down.
+                pass
+
+    def _perform_job(self, job: Job, queue: Queue) -> None:
+        push_connection(self.connection)
+        try:
+            started_registry = queue.started_job_registry
+
+            try:
+                remove_from_intermediate_queue = len(self.queues) == 1
+                self.prepare_job_execution(
+                    job=job,
+                    remove_from_intermediate_queue=remove_from_intermediate_queue,
+                )
+
+                rv = job.perform()
+
+                job.ended_at = utcnow()
+                job._result = rv
+
+                job.heartbeat(timestamp=utcnow(), ttl=job.success_callback_timeout)
+                job.execute_success_callback(
+                    death_penalty_class=NoOpDeathPenalty,
+                    result=rv,
+                )
+
+                self.handle_job_success(
+                    job=job,
+                    queue=queue,
+                    started_job_registry=started_registry,
+                )
+
+            except Exception:  # pylint: disable=broad-except
+                exc_info = sys.exc_info()
+                exc_string = "".join(traceback.format_exception(*exc_info))
+                self.log.warning("Job %s raised an exception", job.id)
+                job.ended_at = utcnow()
+
+                try:
+                    job.heartbeat(timestamp=utcnow(), ttl=job.failure_callback_timeout)
+                    job.execute_failure_callback(NoOpDeathPenalty, *exc_info)
+                except Exception:  # pylint: disable=broad-except
+                    exc_info = sys.exc_info()
+                    exc_string = "".join(traceback.format_exception(*exc_info))
+
+                self.handle_job_failure(
+                    job=job,
+                    queue=queue,
+                    started_job_registry=started_registry,
+                    exc_string=exc_string,
+                )
+                self.handle_exception(job, *exc_info)
+
+            if job.started_at and job.ended_at:
+                elapsed_sec = (job.ended_at - job.started_at).total_seconds()
+                if elapsed_sec > self._job_execution_time_threshold_sec:
+                    self.log.warning(
+                        "Job %s exceeded execution threshold: %.1fs > %ds",
+                        job.id,
+                        elapsed_sec,
+                        self._job_execution_time_threshold_sec,
+                    )
+        finally:
+            pop_connection()
+
+    def execute_job(self, job: Job, queue: Queue) -> None:
+        future = self._executor.submit(self._perform_job, job=job, queue=queue)
+
+        with self._lock:
+            self._active_futures.append(future)
+            self._active_jobs[future] = job
+            self.set_state(WorkerStatus.BUSY)
+
+        future.add_done_callback(self._on_future_performed)
+
+    def work(
+        self,
+        burst: bool = False,
+        logging_level: str = "INFO",
+        date_format: str = DEFAULT_LOGGING_DATE_FORMAT,
+        log_format: str = DEFAULT_LOGGING_FORMAT,
+        max_idle_time: Optional[int] = None,
+        with_scheduler: bool = False,
+        dequeue_strategy: DequeueStrategy = DequeueStrategy.DEFAULT,
+        # NOTE @sosov: accepted-and-ignored
+        # reason: adds complexity to implementation, while we will never use such functionality
+        max_jobs: Optional[int] = None,
+    ) -> None:
+        self.bootstrap(
+            logging_level=logging_level,
+            date_format=date_format,
+            log_format=log_format,
+        )
+        self._dequeue_strategy = dequeue_strategy
+
+        if with_scheduler:
+            self._start_scheduler(
+                burst=burst,
+                logging_level=logging_level,
+                date_format=date_format,
+                log_format=log_format,
+            )
+
+        self._install_signal_handlers()
+
+        self._start_heartbeat()
+
+        try:
+            while True:
+                try:
+                    if self._stop_requested:
+                        self.log.info("Worker %s: stopping on request", self.key)
+                        break
+
+                    self.check_for_suspension(burst)
+
+                    if self.should_run_maintenance_tasks:
+                        self.run_maintenance_tasks()
+
+                    if self._is_threadpool_full:
+                        time.sleep(_POOL_FULL_POLL_INTERVAL)
+                        continue
+
+                    result = self.dequeue_job_and_maintain_ttl(
+                        timeout=None if burst else self.dequeue_timeout,
+                        max_idle_time=max_idle_time,
+                    )
+                    if result is None:
+                        if burst:
+                            self.log.info("Worker %s: done, quitting", self.key)
+                        elif max_idle_time is not None:
+                            self.log.info(
+                                "Worker %s: idle for %d seconds, quitting",
+                                self.key,
+                                max_idle_time,
+                            )
+                        break
+
+                    job, queue = result
+                    self.execute_job(job=job, queue=queue)
+
+                except redis.exceptions.TimeoutError:
+                    self.log.error("Worker %s: Redis connection timeout, quitting...", self.key)
+                    break
+
+                except StopRequested:
+                    break
+
+                except SystemExit:
+                    raise
+
+                except:  # noqa pylint: disable=bare-except
+                    self.log.error(
+                        "Worker %s: found an unhandled exception, quitting...",
+                        self.key,
+                        exc_info=True,
+                    )
+                    break
+        finally:
+            self.teardown()
+
+    def handle_warm_shutdown_request(self) -> None:
+        self.log.info("Worker %s [PID %d]: warm shut down requested", self.name, self.pid)
+
+    def _shutdown(self) -> None:
+        self._stop_requested = True
+
+        self.set_shutdown_requested_date()
+
+        if self.scheduler:
+            self.stop_scheduler()
+
+        raise StopRequested()
+
+    def request_force_stop(self, signum: int, frame: Optional[FrameType]) -> None:
+        self.log.warning("Cold shut down")
+        raise SystemExit()
+
+    def request_stop(self, signum: int, frame: Optional[FrameType]) -> None:
+        self.log.debug("Got signal %s", signum)
+        self._shutdown_requested_date = utcnow()
+
+        signal.signal(signal.SIGINT, self.request_force_stop)
+        signal.signal(signal.SIGTERM, self.request_force_stop)
+
+        self.handle_warm_shutdown_request()
+        self._shutdown()
+
+    def _stop_heartbeat(self) -> None:
+        self._heartbeat_stop_event.set()
+
+    def teardown(self) -> None:
+        if self.scheduler:
+            self.stop_scheduler()
+
+        with self._lock:
+            job_futures = [f for f in self._active_futures if f is not self._heartbeat_future]
+
+        if job_futures:
+            _, not_done = wait(job_futures, timeout=self._job_execution_time_threshold_sec)
+            if not_done:
+                self.log.warning(
+                    "Drain timed out after %ds, %d job(s) still running; "
+                    "letting K8s SIGKILL them",
+                    self._job_execution_time_threshold_sec,
+                    len(not_done),
+                )
+
+        self._stop_heartbeat()
+
+        self._executor.shutdown(wait=False)
+
+        self.register_death()
+
+
+class ThreadPoolWorker(RqThreadPoolWorker):
+    def __init__(
+        self,
+        *args,
+        jobs_pool_size: Optional[int] = None,
+        job_execution_time_threshold: Optional[int] = None,
+        **kwargs,
+    ) -> None:
+        from django.conf import settings
+
+        super().__init__(
+            *args,
+            jobs_pool_size=(
+                jobs_pool_size if jobs_pool_size is not None else settings.RQ_THREAD_POOL_SIZE
+            ),
+            job_execution_time_threshold=(
+                job_execution_time_threshold
+                if job_execution_time_threshold is not None
+                else settings.RQ_THREAD_POOL_JOB_EXECUTION_TIME_THRESHOLD
+            ),
+            **kwargs,
+        )
+
+    def register_birth(self) -> None:
+        super().register_birth()
+        # NOTE @sosov: a running thread can't be interrupted, so RequestViewSet
+        # must reject started-job cancellation for this worker. Mirrors SimpleWorker.
+        self.connection.hset(self.key, "cvat_can_stop_started_jobs", 0)
+
+    def _perform_job(self, job: Job, queue: Queue) -> None:
+        close_old_connections()
+        try:
+            super()._perform_job(job=job, queue=queue)
+        finally:
+            close_old_connections()

--- a/cvat/apps/redis_handler/worker.py
+++ b/cvat/apps/redis_handler/worker.py
@@ -20,7 +20,8 @@ from rq.job import Job, JobStatus
 from rq.queue import Queue
 from rq.registry import StartedJobRegistry
 from rq.utils import utcnow
-from rq.worker import BaseWorker, DequeueStrategy, StopRequested, WorkerStatus
+from rq.worker import BaseWorker as _RqBaseWorker
+from rq.worker import DequeueStrategy, StopRequested, WorkerStatus
 
 from cvat.apps.redis_handler.mixins import RqWorkerPortMixin
 from cvat.apps.redis_handler.utils import NoOpDeathPenalty
@@ -30,7 +31,11 @@ _POOL_FULL_POLL_INTERVAL: float = 0.1
 _JOB_HEARTBEAT_REFRESH_BUFFER_SEC: int = 15
 
 
-class RqThreadPoolWorker(RqWorkerPortMixin, BaseWorker):
+class BaseWorker(_RqBaseWorker, RqWorkerPortMixin):
+    pass
+
+
+class RqThreadPoolWorker(BaseWorker):
     def __init__(
         self,
         *args,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
CVAT scales RQ throughput by running multiple worker processes per pod. For I/O-bound queues — those whose jobs spend almost all their time blocked on remote HTTP / Redis / Postgres — this is wasteful: every fork carries a full Python interpreter and Django app just to wait on a socket.

This adds a thread-pool worker that runs N jobs concurrently inside one process, opt-in per queue. Administrators enable it by starting a queue's worker with `--worker-class cvat.apps.redis_handler.worker.ThreadPoolWorker` and setting `CVAT_RQ_THREAD_POOL_SIZE`. It refreshes DB connections at each job boundary, since threads (unlike forks) don't get a clean connection per job. Stock `rq.Worker` stays the default — nothing changes unless a queue is explicitly switched, and no queue is migrated in this PR.

Caveats, because a running thread can't be interrupted mid-blocking-I/O:
- `Job.timeout`, callback timeouts, and the pubsub stop-job/kill commands are no-ops on this worker — per-job watchdogs belong inside the job function (e.g. `requests.post(..., timeout=...)`).
- The worker marks itself non-cancellable, so the requests API rejects cancellation of an already-started job on it instead of reporting a success that wouldn't take effect.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
