### PR TITLE
Load the secret key in a way that doesn't involve code execution

### DIFF
--- a/changelog.d/20260526_181006_roman_secret_key_loading.md
+++ b/changelog.d/20260526_181006_roman_secret_key_loading.md
@@ -1,0 +1,5 @@
+### Changed
+
+- CVAT will now refuse to start if `keys/secret_key.py` contains arbitrary
+  code
+  (<https://github.com/cvat-ai/cvat/pull/10670>)

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -15,8 +15,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 
+import ast
 import os
-import sys
 import tempfile
 import urllib
 from datetime import timedelta
@@ -69,14 +69,43 @@ def generate_secret_key():
             pass
 
 
-if not SECRET_KEY:
-    sys.path.append(os.fspath(BASE_DIR))
+def load_secret_key() -> str:
+    """
+    Loads secret_key.py while avoiding code execution.
+    The keys directory has to be writable by the django user, so if the server
+    is tricked by an attacker into overwriting this file, this will at least
+    prevent the attacker from executing arbitrary code.
+    """
 
+    secret_key_path = BASE_DIR / "keys/secret_key.py"
+    module_node = ast.parse(secret_key_path.read_text(), secret_key_path)
+
+    secret_key = None
+
+    for statement_node in module_node.body:
+        error_prefix = f"{secret_key_path}:{statement_node.lineno}: "
+        match statement_node:
+            case ast.Assign(targets=[ast.Name("SECRET_KEY")]):
+                secret_key = ast.literal_eval(statement_node.value)
+                if not isinstance(secret_key, str):
+                    raise ImproperlyConfigured(error_prefix + "SECRET_KEY must be a string")
+            case _:
+                raise ImproperlyConfigured(
+                    error_prefix + "unsupported statement; only SECRET_KEY assignment is allowed"
+                )
+
+    if secret_key is None:
+        raise ImproperlyConfigured(f"{secret_key_path}: no SECRET_KEY assignment found")
+
+    return secret_key
+
+
+if not SECRET_KEY:
     try:
-        from keys.secret_key import SECRET_KEY  # pylint: disable=unused-import
-    except ModuleNotFoundError:
+        SECRET_KEY = load_secret_key()
+    except FileNotFoundError:
         generate_secret_key()
-        from keys.secret_key import SECRET_KEY
+        SECRET_KEY = load_secret_key()
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 INSTALLED_APPS = [


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This is a defense-in-depth measure aimed to reduce the damage in case a vulnerability grants an attacker the ability to overwrite arbitrary files. It prevents the attacker from easily executing arbitrary code by overwriting `secret_key.py`.

In addition, this avoids adding `/home/django` to `sys.path`, which is writable by the `django` user, and thus could potentially also be used for ACE attacks. Note that even with this patch, this directory will still be in `sys.path`, as we currently install the CVAT sources in there directory too. I will try to fix that with a followup patch.

This could break instances where `secret_key.py` was manually modified with custom code; however, such modifications were never supported, and better alternatives exist (`/etc/cvat/init.d`, custom settings files).

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
