### PR TITLE
Native function agents now download and process task image chunks incrementally

### DIFF
--- a/changelog.d/stream-agent-task-chunks.md
+++ b/changelog.d/stream-agent-task-chunks.md
@@ -1,6 +1,6 @@
 ### Changed
 
-- [CLI] Native function agents now download and process task image chunks incrementally
+- \[CLI\] Native function agents now download and process task image chunks incrementally
   for task annotation requests, reducing temporary disk usage and allowing progress
   updates to start sooner.
   (<https://github.com/cvat-ai/cvat/pull/10675>)

--- a/changelog.d/stream-agent-task-chunks.md
+++ b/changelog.d/stream-agent-task-chunks.md
@@ -1,0 +1,6 @@
+### Changed
+
+- [CLI] Native function agents now download and process task image chunks incrementally
+  for task annotation requests, reducing temporary disk usage and allowing progress
+  updates to start sooner.
+  (<https://github.com/cvat-ai/cvat/pull/10675>)

--- a/cvat-cli/src/cvat_cli/_internal/agent.py
+++ b/cvat-cli/src/cvat_cli/_internal/agent.py
@@ -867,7 +867,7 @@ class _Agent:
         sample_index = 0
 
         with ds.iter_samples(delete_finished_chunks=True) as samples:
-            for sample in samples:
+            for sample_index, sample in enumerate(samples):
                 context = self._create_detection_function_context(ar_params, sample.frame_name)
                 annotations = self._executor.result(
                     self._executor.submit(_worker_job_detect, context, sample.media.load_image())

--- a/cvat-cli/src/cvat_cli/_internal/agent.py
+++ b/cvat-cli/src/cvat_cli/_internal/agent.py
@@ -866,7 +866,7 @@ class _Agent:
 
         sample_index = 0
 
-        with ds.iter_samples(delete_finished_chunks=True) as samples:
+        with ds.iter_samples(temporary_chunks=True) as samples:
             for sample_index, sample in enumerate(samples):
                 context = self._create_detection_function_context(ar_params, sample.frame_name)
                 annotations = self._executor.result(

--- a/cvat-cli/src/cvat_cli/_internal/agent.py
+++ b/cvat-cli/src/cvat_cli/_internal/agent.py
@@ -864,8 +864,6 @@ class _Agent:
 
         all_annotations = models.PatchedLabeledDataRequest(tags=[], shapes=[])
 
-        sample_index = 0
-
         with ds.iter_samples(temporary_chunks=True) as samples:
             for sample_index, sample in enumerate(samples):
                 context = self._create_detection_function_context(ar_params, sample.frame_name)
@@ -877,11 +875,10 @@ class _Agent:
                 all_annotations.tags.extend(tags)
                 all_annotations.shapes.extend(shapes)
 
-                sample_index += 1
                 current_timestamp = datetime.now(tz=timezone.utc)
 
                 if current_timestamp >= last_update_timestamp + _UPDATE_INTERVAL:
-                    self._update_ar(ar_id, sample_index / len(ds.samples))
+                    self._update_ar(ar_id, (sample_index + 1) / len(ds.samples))
                     last_update_timestamp = current_timestamp
 
                 # Interactive requests are time sensitive, so if there are any,

--- a/cvat-cli/src/cvat_cli/_internal/agent.py
+++ b/cvat-cli/src/cvat_cli/_internal/agent.py
@@ -866,8 +866,8 @@ class _Agent:
 
         sample_index = 0
 
-        for chunk_samples in ds.iter_sample_chunks(delete_finished_chunks=True):
-            for sample in chunk_samples:
+        with ds.iter_samples(delete_finished_chunks=True) as samples:
+            for sample in samples:
                 context = self._create_detection_function_context(ar_params, sample.frame_name)
                 annotations = self._executor.result(
                     self._executor.submit(_worker_job_detect, context, sample.media.load_image())

--- a/cvat-cli/src/cvat_cli/_internal/agent.py
+++ b/cvat-cli/src/cvat_cli/_internal/agent.py
@@ -157,7 +157,7 @@ class _TrackingStateContainer:
             raise _BadArError(f"Tracking state {state_id!r} is not for task #{task_id}")
 
         if image_dims != ext_state.original_image_dims:
-            raise _BadArError(f"Image sizes of the start frame and the current frame are different")
+            raise _BadArError("Image sizes of the start frame and the current frame are different")
 
         ext_state.last_accessed_at = datetime.now(tz=timezone.utc)
         self._id_to_ext_state.move_to_end(state_id)
@@ -848,7 +848,12 @@ class _Agent:
         )
 
     def _calculate_result_for_annotate_task_ar(self, ar_id: str, ar_params) -> dict[str, Any]:
-        ds = cvatds.TaskDataset(self._client, ar_params["task"], load_annotations=False)
+        ds = cvatds.TaskDataset(
+            self._client,
+            ar_params["task"],
+            load_annotations=False,
+            media_download_policy=cvatds.MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND,
+        )
 
         # Fetching the dataset might take a while, so do a progress update to let the server
         # know we're still alive.
@@ -859,25 +864,29 @@ class _Agent:
 
         all_annotations = models.PatchedLabeledDataRequest(tags=[], shapes=[])
 
-        for sample_index, sample in enumerate(ds.samples):
-            context = self._create_detection_function_context(ar_params, sample.frame_name)
-            annotations = self._executor.result(
-                self._executor.submit(_worker_job_detect, context, sample.media.load_image())
-            )
+        sample_index = 0
 
-            tags, shapes = mapper.validate_and_remap(annotations, sample.frame_index)
-            all_annotations.tags.extend(tags)
-            all_annotations.shapes.extend(shapes)
+        for chunk_samples in ds.iter_sample_chunks(delete_finished_chunks=True):
+            for sample in chunk_samples:
+                context = self._create_detection_function_context(ar_params, sample.frame_name)
+                annotations = self._executor.result(
+                    self._executor.submit(_worker_job_detect, context, sample.media.load_image())
+                )
 
-            current_timestamp = datetime.now(tz=timezone.utc)
+                tags, shapes = mapper.validate_and_remap(annotations, sample.frame_index)
+                all_annotations.tags.extend(tags)
+                all_annotations.shapes.extend(shapes)
 
-            if current_timestamp >= last_update_timestamp + _UPDATE_INTERVAL:
-                self._update_ar(ar_id, (sample_index + 1) / len(ds.samples))
-                last_update_timestamp = current_timestamp
+                sample_index += 1
+                current_timestamp = datetime.now(tz=timezone.utc)
 
-            # Interactive requests are time sensitive, so if there are any,
-            # we have to put the current AR on hold and process them ASAP.
-            self._process_available_ars(REQUEST_CATEGORY_INTERACTIVE)
+                if current_timestamp >= last_update_timestamp + _UPDATE_INTERVAL:
+                    self._update_ar(ar_id, sample_index / len(ds.samples))
+                    last_update_timestamp = current_timestamp
+
+                # Interactive requests are time sensitive, so if there are any,
+                # we have to put the current AR on hold and process them ASAP.
+                self._process_available_ars(REQUEST_CATEGORY_INTERACTIVE)
 
         return {"annotations": all_annotations}
 

--- a/cvat-sdk/cvat_sdk/datasets/common.py
+++ b/cvat-sdk/cvat_sdk/datasets/common.py
@@ -69,5 +69,12 @@ class MediaDownloadPolicy(Enum):
     PRELOAD_ALL = auto()
     """Download and cache all media data when the dataset object is created."""
 
+    FETCH_CHUNKS_ON_DEMAND = auto()
+    """
+    Download image chunks lazily as frames are accessed and cache them locally.
+
+    This policy is only supported for image-set tasks.
+    """
+
     FETCH_FRAMES_ON_DEMAND = auto()
     """Download the media element for each frame whenever MediaElement.load_* is invoked."""

--- a/cvat-sdk/cvat_sdk/datasets/common.py
+++ b/cvat-sdk/cvat_sdk/datasets/common.py
@@ -67,13 +67,19 @@ class MediaDownloadPolicy(Enum):
     """Defines policies controlling when media data is downloaded."""
 
     PRELOAD_ALL = auto()
-    """Download and cache all media data when the dataset object is created."""
+    """
+    Download and cache all media data when the dataset object is created.
+
+    This requires the task's original chunks to be image sets, meaning that each chunk
+    contains individual images. Tasks created from video may still satisfy this requirement.
+    """
 
     FETCH_CHUNKS_ON_DEMAND = auto()
     """
-    Download image chunks lazily as frames are accessed and cache them locally.
+    Download image-set chunks lazily as they are needed and cache them locally.
 
-    This policy is only supported for image-set tasks.
+    This requires the task's original chunks to be image sets, meaning that each chunk
+    contains individual images. Tasks created from video may still satisfy this requirement.
     """
 
     FETCH_FRAMES_ON_DEMAND = auto()

--- a/cvat-sdk/cvat_sdk/datasets/task_dataset.py
+++ b/cvat-sdk/cvat_sdk/datasets/task_dataset.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import contextlib
-import shutil
+import itertools
 import tempfile
 import zipfile
 from collections.abc import Iterable, Sequence
@@ -13,6 +13,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Generator, Iterator
 
+import attrs
 import PIL.Image
 
 import cvat_sdk.core
@@ -120,7 +121,7 @@ class TaskDataset:
             self._load_frame_image = self._load_frame_image_from_cache
         elif media_download_policy == MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND:
             self._init_chunk_dir()
-            self._load_frame_image = self._load_frame_image_from_chunk_cache
+            self._load_frame_image = self._load_frame_image_from_cache
         elif media_download_policy == MediaDownloadPolicy.FETCH_FRAMES_ON_DEMAND:
             assert update_policy != UpdatePolicy.NEVER
             self._load_frame_image = self._load_frame_image_from_server
@@ -160,19 +161,12 @@ class TaskDataset:
         self._chunk_dir.mkdir(exist_ok=True, parents=True)
 
     def _ensure_chunk_in_dir(self, chunk_dir: Path, chunk_index: int) -> None:
-        chunk_path = chunk_dir / f"{chunk_index}.zip"
-        if chunk_path.exists():
-            return
-
-        chunk_dir.mkdir(exist_ok=True, parents=True)
-
         if chunk_dir == self._chunk_dir:
             self._cache_manager.ensure_chunk(self._task, chunk_index)
             return
 
-        cache_chunk_path = self._chunk_dir / f"{chunk_index}.zip"
-        if cache_chunk_path.exists():
-            shutil.copyfile(cache_chunk_path, chunk_path)
+        chunk_path = self._chunk_path(chunk_dir, chunk_index)
+        if chunk_path.exists():
             return
 
         self._logger.info("Downloading chunk #%d...", chunk_index)
@@ -235,7 +229,7 @@ class TaskDataset:
 
     @contextlib.contextmanager
     def iter_samples(
-        self, *, delete_finished_chunks: bool = False
+        self, *, temporary_chunks: bool = False
     ) -> Generator[Iterator[Sample], Any, None]:
         """
         Returns a context manager yielding an iterator over the task samples.
@@ -244,9 +238,9 @@ class TaskDataset:
         chunk, then starts prefetching the next chunk while the caller processes samples
         from the current chunk.
 
-        If `delete_finished_chunks` is true, chunk files are materialized in a temporary directory
-        separate from the shared cache and deleted after the iterator advances past them.
-        This applies only to chunk-based media download policies.
+        If `temporary_chunks` is true and `media_download_policy` is `FETCH_CHUNKS_ON_DEMAND`,
+        chunk files are materialized in a temporary directory separate from the shared cache
+        and deleted after the iterator advances past them.
         """
 
         if self._media_download_policy == MediaDownloadPolicy.FETCH_FRAMES_ON_DEMAND:
@@ -255,7 +249,18 @@ class TaskDataset:
 
         sample_chunks = self._group_samples_by_chunk()
 
-        if delete_finished_chunks:
+        if self._media_download_policy == MediaDownloadPolicy.PRELOAD_ALL:
+            assert not temporary_chunks
+            yield self._iter_samples_from_chunks(
+                sample_chunks,
+                chunk_dir=self._chunk_dir,
+                temporary_chunks=False,
+            )
+            return
+
+        assert self._media_download_policy == MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND
+
+        if temporary_chunks:
             with (
                 tempfile.TemporaryDirectory(
                     prefix=f"cvat-task-{self._task.id}-chunks-"
@@ -265,59 +270,37 @@ class TaskDataset:
                 yield self._iter_samples_from_chunks(
                     sample_chunks,
                     chunk_dir=Path(temp_dir),
-                    delete_finished_chunks=True,
+                    temporary_chunks=True,
                     download_pool=pool,
                 )
             return
-
-        if self._media_download_policy == MediaDownloadPolicy.PRELOAD_ALL:
-            yield self._iter_samples_from_chunks(
-                sample_chunks,
-                chunk_dir=self._chunk_dir,
-                delete_finished_chunks=False,
-            )
-            return
-
-        assert self._media_download_policy == MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND
 
         with ThreadPoolExecutor(max_workers=1) as pool:
             yield self._iter_samples_from_chunks(
                 sample_chunks,
                 chunk_dir=self._chunk_dir,
-                delete_finished_chunks=False,
+                temporary_chunks=False,
                 download_pool=pool,
             )
 
     def _group_samples_by_chunk(self) -> list[tuple[int, list[Sample]]]:
-        sample_chunks: list[tuple[int, list[Sample]]] = []
-        current_chunk_index: int | None = None
-        current_chunk_samples: list[Sample] = []
+        return [
+            (chunk_index, list(chunk_samples))
+            for chunk_index, chunk_samples in itertools.groupby(
+                self._samples,
+                key=lambda sample: sample.frame_index // self._task.data_chunk_size,
+            )
+        ]
 
-        for sample in self._samples:
-            sample_chunk_index = sample.frame_index // self._task.data_chunk_size
-
-            if sample_chunk_index != current_chunk_index:
-                if current_chunk_samples:
-                    assert current_chunk_index is not None
-                    sample_chunks.append((current_chunk_index, current_chunk_samples))
-
-                current_chunk_index = sample_chunk_index
-                current_chunk_samples = [sample]
-            else:
-                current_chunk_samples.append(sample)
-
-        if current_chunk_samples:
-            assert current_chunk_index is not None
-            sample_chunks.append((current_chunk_index, current_chunk_samples))
-
-        return sample_chunks
+    def _chunk_path(self, chunk_dir: Path, chunk_index: int) -> Path:
+        return chunk_dir / f"{chunk_index}.zip"
 
     def _iter_samples_from_chunks(
         self,
         sample_chunks: Sequence[tuple[int, Sequence[Sample]]],
         *,
         chunk_dir: Path,
-        delete_finished_chunks: bool,
+        temporary_chunks: bool,
         download_pool: ThreadPoolExecutor | None = None,
     ) -> Iterator[Sample]:
         next_chunk_future = None
@@ -346,19 +329,19 @@ class TaskDataset:
                 if chunk_dir == self._chunk_dir:
                     yield sample
                 else:
-                    yield Sample(
-                        frame_index=sample.frame_index,
-                        frame_name=sample.frame_name,
-                        annotations=sample.annotations,
+                    yield attrs.evolve(
+                        sample,
                         media=self._TaskChunkDirMediaElement(self, sample.frame_index, chunk_dir),
                     )
 
-            if delete_finished_chunks:
-                (chunk_dir / f"{chunk_index}.zip").unlink(missing_ok=True)
+            if temporary_chunks:
+                self._chunk_path(chunk_dir, chunk_index).unlink(missing_ok=True)
 
     def _load_frame_image_from_cache(self, frame_index: int) -> PIL.Image:
         assert frame_index in self._frame_annotations
 
+        chunk_index = frame_index // self._task.data_chunk_size
+        self._cache_manager.ensure_chunk(self._task, chunk_index)
         return self._load_frame_image_from_chunk_dir(frame_index, self._chunk_dir)
 
     def _load_frame_image_from_chunk_dir(self, frame_index: int, chunk_dir: Path) -> PIL.Image:
@@ -367,19 +350,12 @@ class TaskDataset:
         chunk_index = frame_index // self._task.data_chunk_size
         member_index = frame_index % self._task.data_chunk_size
 
-        with zipfile.ZipFile(chunk_dir / f"{chunk_index}.zip", "r") as chunk_zip:
+        with zipfile.ZipFile(self._chunk_path(chunk_dir, chunk_index), "r") as chunk_zip:
             with chunk_zip.open(chunk_zip.infolist()[member_index]) as chunk_member:
                 image = PIL.Image.open(chunk_member)
                 image.load()
 
         return image
-
-    def _load_frame_image_from_chunk_cache(self, frame_index: int) -> PIL.Image:
-        assert frame_index in self._frame_annotations
-
-        chunk_index = frame_index // self._task.data_chunk_size
-        self._cache_manager.ensure_chunk(self._task, chunk_index)
-        return self._load_frame_image_from_cache(frame_index)
 
     def _load_frame_image_from_server(self, frame_index: int) -> PIL.Image:
         assert frame_index in self._frame_annotations

--- a/cvat-sdk/cvat_sdk/datasets/task_dataset.py
+++ b/cvat-sdk/cvat_sdk/datasets/task_dataset.py
@@ -241,6 +241,9 @@ class TaskDataset:
         If `temporary_chunks` is true and `media_download_policy` is `FETCH_CHUNKS_ON_DEMAND`,
         chunk files are materialized in a temporary directory separate from the shared cache
         and deleted after the iterator advances past them.
+
+        WARNING: Callers should finish using each sample's media data before advancing the iterator.
+        Keeping references to previous samples after requesting the next sample is unsupported.
         """
 
         if self._media_download_policy == MediaDownloadPolicy.FETCH_FRAMES_ON_DEMAND:

--- a/cvat-sdk/cvat_sdk/datasets/task_dataset.py
+++ b/cvat-sdk/cvat_sdk/datasets/task_dataset.py
@@ -11,7 +11,7 @@ import zipfile
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Iterator, Any, Generator
+from typing import Any, Generator, Iterator
 
 import PIL.Image
 
@@ -257,7 +257,9 @@ class TaskDataset:
 
         if delete_finished_chunks:
             with (
-                tempfile.TemporaryDirectory(prefix=f"cvat-task-{self._task.id}-chunks-") as temp_dir,
+                tempfile.TemporaryDirectory(
+                    prefix=f"cvat-task-{self._task.id}-chunks-"
+                ) as temp_dir,
                 ThreadPoolExecutor(max_workers=1) as pool,
             ):
                 yield self._iter_samples_from_chunks(

--- a/cvat-sdk/cvat_sdk/datasets/task_dataset.py
+++ b/cvat-sdk/cvat_sdk/datasets/task_dataset.py
@@ -4,16 +4,21 @@
 
 from __future__ import annotations
 
+import contextlib
+import shutil
+import tempfile
 import zipfile
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from typing import Iterator
+from pathlib import Path
+from typing import Iterator, Any, Generator
 
 import PIL.Image
 
 import cvat_sdk.core
 import cvat_sdk.core.exceptions
 import cvat_sdk.models as models
+from cvat_sdk.core.utils import atomic_writer
 from cvat_sdk.datasets.caching import CacheManager, UpdatePolicy, make_cache_manager
 from cvat_sdk.datasets.common import (
     FrameAnnotations,
@@ -38,7 +43,7 @@ class TaskDataset:
 
     Limitations:
 
-    * Only tasks with image (not video) data are supported at the moment.
+    * Only tasks whose media can be accessed as images are supported at the moment.
     * Track annotations are currently not accessible.
     """
 
@@ -49,6 +54,17 @@ class TaskDataset:
 
         def load_image(self) -> PIL.Image.Image:
             return self._dataset._load_frame_image(self._frame_index)
+
+    class _TaskChunkDirMediaElement(MediaElement):
+        def __init__(self, dataset: TaskDataset, frame_index: int, chunk_dir: Path) -> None:
+            self._dataset = dataset
+            self._frame_index = frame_index
+            self._chunk_dir = chunk_dir
+
+        def load_image(self) -> PIL.Image.Image:
+            return self._dataset._load_frame_image_from_chunk_dir(
+                self._frame_index, self._chunk_dir
+            )
 
     def __init__(
         self,
@@ -135,12 +151,33 @@ class TaskDataset:
     def _init_chunk_dir(self) -> None:
         if self._task.data_original_chunk_type != "imageset":
             raise UnsupportedDatasetError(
-                f"Chunk-based media access is only supported for tasks with image chunks;"
-                f" current chunk type is {self._task.data_original_chunk_type!r}"
+                "Chunk-based media access is only supported for tasks whose original chunks "
+                f"are image sets; current original chunk type is "
+                f"{self._task.data_original_chunk_type!r}"
             )
 
         self._chunk_dir = self._cache_manager.chunk_dir(self._task.id)
         self._chunk_dir.mkdir(exist_ok=True, parents=True)
+
+    def _ensure_chunk_in_dir(self, chunk_dir: Path, chunk_index: int) -> None:
+        chunk_path = chunk_dir / f"{chunk_index}.zip"
+        if chunk_path.exists():
+            return
+
+        chunk_dir.mkdir(exist_ok=True, parents=True)
+
+        if chunk_dir == self._chunk_dir:
+            self._cache_manager.ensure_chunk(self._task, chunk_index)
+            return
+
+        cache_chunk_path = self._chunk_dir / f"{chunk_index}.zip"
+        if cache_chunk_path.exists():
+            shutil.copyfile(cache_chunk_path, chunk_path)
+            return
+
+        self._logger.info("Downloading chunk #%d...", chunk_index)
+        with atomic_writer(chunk_path, "wb") as chunk_file:
+            self._task.download_chunk(chunk_index, chunk_file, quality="original")
 
     def _ensure_chunks(self, chunk_indexes: Iterable[int]) -> None:
         self._logger.info("Downloading chunks...")
@@ -148,7 +185,7 @@ class TaskDataset:
         with ThreadPoolExecutor(_NUM_DOWNLOAD_THREADS) as pool:
 
             def ensure_chunk(chunk_index):
-                self._cache_manager.ensure_chunk(self._task, chunk_index)
+                self._ensure_chunk_in_dir(self._chunk_dir, chunk_index)
 
             for _ in pool.map(ensure_chunk, sorted(chunk_indexes)):
                 # just need to loop through all results so that any exceptions are propagated
@@ -196,31 +233,60 @@ class TaskDataset:
         """
         return self._samples
 
-    def iter_sample_chunks(
+    @contextlib.contextmanager
+    def iter_samples(
         self, *, delete_finished_chunks: bool = False
-    ) -> Iterator[Sequence[Sample]]:
+    ) -> Generator[Iterator[Sample], Any, None]:
         """
-        Iterates over the task samples chunk by chunk.
+        Returns a context manager yielding an iterator over the task samples.
 
-        The current chunk is ensured before it is yielded, and the next chunk is downloaded
-        in the background while the caller processes the current one.
+        When `media_download_policy` is `FETCH_CHUNKS_ON_DEMAND`, the iterator downloads the first
+        image-set chunk, then starts prefetching the next chunk while the caller processes samples
+        from the current chunk.
 
-        If `delete_finished_chunks` is true, each chunk file is deleted after iteration
-        advances past that chunk. Callers should therefore consume the yielded samples
-        sequentially and not keep references for later media access.
+        If `delete_finished_chunks` is true, chunk files are materialized in a temporary directory
+        separate from the shared cache and deleted after the iterator advances past them.
+        This applies only to chunk-based media download policies.
         """
 
         if self._media_download_policy == MediaDownloadPolicy.FETCH_FRAMES_ON_DEMAND:
-            raise UnsupportedDatasetError(
-                "iter_sample_chunks is not supported with FETCH_FRAMES_ON_DEMAND"
+            yield iter(self._samples)
+            return
+
+        sample_chunks = self._group_samples_by_chunk()
+
+        if delete_finished_chunks:
+            with (
+                tempfile.TemporaryDirectory(prefix=f"cvat-task-{self._task.id}-chunks-") as temp_dir,
+                ThreadPoolExecutor(max_workers=1) as pool,
+            ):
+                yield self._iter_samples_from_chunks(
+                    sample_chunks,
+                    chunk_dir=Path(temp_dir),
+                    delete_finished_chunks=True,
+                    download_pool=pool,
+                )
+            return
+
+        if self._media_download_policy == MediaDownloadPolicy.PRELOAD_ALL:
+            yield self._iter_samples_from_chunks(
+                sample_chunks,
+                chunk_dir=self._chunk_dir,
+                delete_finished_chunks=False,
+            )
+            return
+
+        assert self._media_download_policy == MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            yield self._iter_samples_from_chunks(
+                sample_chunks,
+                chunk_dir=self._chunk_dir,
+                delete_finished_chunks=False,
+                download_pool=pool,
             )
 
-        if self._task.data_original_chunk_type != "imageset":
-            raise UnsupportedDatasetError(
-                f"Chunk iteration is only supported for tasks with image chunks;"
-                f" current chunk type is {self._task.data_original_chunk_type!r}"
-            )
-
+    def _group_samples_by_chunk(self) -> list[tuple[int, list[Sample]]]:
         sample_chunks: list[tuple[int, list[Sample]]] = []
         current_chunk_index: int | None = None
         current_chunk_samples: list[Sample] = []
@@ -242,38 +308,64 @@ class TaskDataset:
             assert current_chunk_index is not None
             sample_chunks.append((current_chunk_index, current_chunk_samples))
 
-        if not sample_chunks:
-            return
+        return sample_chunks
 
-        with ThreadPoolExecutor(max_workers=1) as pool:
-            next_chunk_future = pool.submit(
-                self._cache_manager.ensure_chunk,
-                self._task,
+    def _iter_samples_from_chunks(
+        self,
+        sample_chunks: Sequence[tuple[int, Sequence[Sample]]],
+        *,
+        chunk_dir: Path,
+        delete_finished_chunks: bool,
+        download_pool: ThreadPoolExecutor | None = None,
+    ) -> Iterator[Sample]:
+        next_chunk_future = None
+
+        if download_pool and sample_chunks:
+            next_chunk_future = download_pool.submit(
+                self._ensure_chunk_in_dir,
+                chunk_dir,
                 sample_chunks[0][0],
             )
 
-            for chunk_offset, (chunk_index, chunk_samples) in enumerate(sample_chunks):
+        for chunk_offset, (chunk_index, chunk_samples) in enumerate(sample_chunks):
+            if next_chunk_future:
                 next_chunk_future.result()
 
-                if chunk_offset + 1 < len(sample_chunks):
-                    next_chunk_future = pool.submit(
-                        self._cache_manager.ensure_chunk,
-                        self._task,
-                        sample_chunks[chunk_offset + 1][0],
+            if download_pool and chunk_offset + 1 < len(sample_chunks):
+                next_chunk_future = download_pool.submit(
+                    self._ensure_chunk_in_dir,
+                    chunk_dir,
+                    sample_chunks[chunk_offset + 1][0],
+                )
+            else:
+                next_chunk_future = None
+
+            for sample in chunk_samples:
+                if chunk_dir == self._chunk_dir:
+                    yield sample
+                else:
+                    yield Sample(
+                        frame_index=sample.frame_index,
+                        frame_name=sample.frame_name,
+                        annotations=sample.annotations,
+                        media=self._TaskChunkDirMediaElement(self, sample.frame_index, chunk_dir),
                     )
 
-                yield chunk_samples
-
-                if delete_finished_chunks:
-                    (self._chunk_dir / f"{chunk_index}.zip").unlink(missing_ok=True)
+            if delete_finished_chunks:
+                (chunk_dir / f"{chunk_index}.zip").unlink(missing_ok=True)
 
     def _load_frame_image_from_cache(self, frame_index: int) -> PIL.Image:
+        assert frame_index in self._frame_annotations
+
+        return self._load_frame_image_from_chunk_dir(frame_index, self._chunk_dir)
+
+    def _load_frame_image_from_chunk_dir(self, frame_index: int, chunk_dir: Path) -> PIL.Image:
         assert frame_index in self._frame_annotations
 
         chunk_index = frame_index // self._task.data_chunk_size
         member_index = frame_index % self._task.data_chunk_size
 
-        with zipfile.ZipFile(self._chunk_dir / f"{chunk_index}.zip", "r") as chunk_zip:
+        with zipfile.ZipFile(chunk_dir / f"{chunk_index}.zip", "r") as chunk_zip:
             with chunk_zip.open(chunk_zip.infolist()[member_index]) as chunk_member:
                 image = PIL.Image.open(chunk_member)
                 image.load()
@@ -281,6 +373,8 @@ class TaskDataset:
         return image
 
     def _load_frame_image_from_chunk_cache(self, frame_index: int) -> PIL.Image:
+        assert frame_index in self._frame_annotations
+
         chunk_index = frame_index // self._task.data_chunk_size
         self._cache_manager.ensure_chunk(self._task, chunk_index)
         return self._load_frame_image_from_cache(frame_index)

--- a/cvat-sdk/cvat_sdk/datasets/task_dataset.py
+++ b/cvat-sdk/cvat_sdk/datasets/task_dataset.py
@@ -241,7 +241,7 @@ class TaskDataset:
         Returns a context manager yielding an iterator over the task samples.
 
         When `media_download_policy` is `FETCH_CHUNKS_ON_DEMAND`, the iterator downloads the first
-        image-set chunk, then starts prefetching the next chunk while the caller processes samples
+        chunk, then starts prefetching the next chunk while the caller processes samples
         from the current chunk.
 
         If `delete_finished_chunks` is true, chunk files are materialized in a temporary directory

--- a/cvat-sdk/cvat_sdk/datasets/task_dataset.py
+++ b/cvat-sdk/cvat_sdk/datasets/task_dataset.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import zipfile
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from typing import Iterator
 
 import PIL.Image
 
@@ -32,8 +33,8 @@ class TaskDataset:
     Each sample corresponds to one frame in the task, and provides access to
     the corresponding annotations and media data. Deleted frames are omitted.
 
-    This class caches all data and annotations for the task on the local file system
-    during construction.
+    This class caches task metadata for the task on the local file system
+    during construction. Media data caching depends on `media_download_policy`.
 
     Limitations:
 
@@ -70,14 +71,15 @@ class TaskDataset:
 
         `media_download_policy` determines when media data is downloaded.
 
-        `MediaDownloadPolicy.FETCH_FRAMES_ON_DEMAND` may not be used with with `UpdatePolicy.NEVER`,
+        `MediaDownloadPolicy.FETCH_FRAMES_ON_DEMAND` may not be used with `UpdatePolicy.NEVER`,
         as it requires network access.
         """
 
         self._logger = client.logger
+        self._media_download_policy = media_download_policy
 
-        cache_manager = make_cache_manager(client, update_policy)
-        self._task = cache_manager.retrieve_task(task_id)
+        self._cache_manager = make_cache_manager(client, update_policy)
+        self._task = self._cache_manager.retrieve_task(task_id)
 
         if not self._task.size or not self._task.data_chunk_size:
             raise UnsupportedDatasetError("The task has no data")
@@ -85,7 +87,7 @@ class TaskDataset:
         self._logger.info("Fetching labels...")
         self._labels = tuple(self._task.get_labels())
 
-        data_meta = cache_manager.ensure_task_model(
+        data_meta = self._cache_manager.ensure_task_model(
             self._task.id,
             "data_meta.json",
             models.DataMetaRead,
@@ -96,9 +98,13 @@ class TaskDataset:
         active_frame_indexes = set(range(self._task.size)) - set(data_meta.deleted_frames)
 
         if media_download_policy == MediaDownloadPolicy.PRELOAD_ALL:
+            self._init_chunk_dir()
             needed_chunks = {index // self._task.data_chunk_size for index in active_frame_indexes}
-            self._ensure_chunks(task_id, cache_manager, needed_chunks)
+            self._ensure_chunks(needed_chunks)
             self._load_frame_image = self._load_frame_image_from_cache
+        elif media_download_policy == MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND:
+            self._init_chunk_dir()
+            self._load_frame_image = self._load_frame_image_from_chunk_cache
         elif media_download_policy == MediaDownloadPolicy.FETCH_FRAMES_ON_DEMAND:
             assert update_policy != UpdatePolicy.NEVER
             self._load_frame_image = self._load_frame_image_from_server
@@ -106,7 +112,7 @@ class TaskDataset:
             assert False, "Unknown media download policy"
 
         if load_annotations:
-            self._load_annotations(cache_manager, sorted(active_frame_indexes))
+            self._load_annotations(self._cache_manager, sorted(active_frame_indexes))
         else:
             self._frame_annotations = {
                 frame_index: None for frame_index in sorted(active_frame_indexes)
@@ -126,22 +132,23 @@ class TaskDataset:
             for k, v in self._frame_annotations.items()
         ]
 
-    def _ensure_chunks(self, task_id, cache_manager, chunk_indexes):
+    def _init_chunk_dir(self) -> None:
         if self._task.data_original_chunk_type != "imageset":
             raise UnsupportedDatasetError(
-                f"Preloading media data is only supported for tasks with image chunks;"
+                f"Chunk-based media access is only supported for tasks with image chunks;"
                 f" current chunk type is {self._task.data_original_chunk_type!r}"
             )
 
-        self._logger.info("Downloading chunks...")
-
-        self._chunk_dir = cache_manager.chunk_dir(task_id)
+        self._chunk_dir = self._cache_manager.chunk_dir(self._task.id)
         self._chunk_dir.mkdir(exist_ok=True, parents=True)
+
+    def _ensure_chunks(self, chunk_indexes: Iterable[int]) -> None:
+        self._logger.info("Downloading chunks...")
 
         with ThreadPoolExecutor(_NUM_DOWNLOAD_THREADS) as pool:
 
             def ensure_chunk(chunk_index):
-                cache_manager.ensure_chunk(self._task, chunk_index)
+                self._cache_manager.ensure_chunk(self._task, chunk_index)
 
             for _ in pool.map(ensure_chunk, sorted(chunk_indexes)):
                 # just need to loop through all results so that any exceptions are propagated
@@ -189,6 +196,77 @@ class TaskDataset:
         """
         return self._samples
 
+    def iter_sample_chunks(
+        self, *, delete_finished_chunks: bool = False
+    ) -> Iterator[Sequence[Sample]]:
+        """
+        Iterates over the task samples chunk by chunk.
+
+        The current chunk is ensured before it is yielded, and the next chunk is downloaded
+        in the background while the caller processes the current one.
+
+        If `delete_finished_chunks` is true, each chunk file is deleted after iteration
+        advances past that chunk. Callers should therefore consume the yielded samples
+        sequentially and not keep references for later media access.
+        """
+
+        if self._media_download_policy == MediaDownloadPolicy.FETCH_FRAMES_ON_DEMAND:
+            raise UnsupportedDatasetError(
+                "iter_sample_chunks is not supported with FETCH_FRAMES_ON_DEMAND"
+            )
+
+        if self._task.data_original_chunk_type != "imageset":
+            raise UnsupportedDatasetError(
+                f"Chunk iteration is only supported for tasks with image chunks;"
+                f" current chunk type is {self._task.data_original_chunk_type!r}"
+            )
+
+        sample_chunks: list[tuple[int, list[Sample]]] = []
+        current_chunk_index: int | None = None
+        current_chunk_samples: list[Sample] = []
+
+        for sample in self._samples:
+            sample_chunk_index = sample.frame_index // self._task.data_chunk_size
+
+            if sample_chunk_index != current_chunk_index:
+                if current_chunk_samples:
+                    assert current_chunk_index is not None
+                    sample_chunks.append((current_chunk_index, current_chunk_samples))
+
+                current_chunk_index = sample_chunk_index
+                current_chunk_samples = [sample]
+            else:
+                current_chunk_samples.append(sample)
+
+        if current_chunk_samples:
+            assert current_chunk_index is not None
+            sample_chunks.append((current_chunk_index, current_chunk_samples))
+
+        if not sample_chunks:
+            return
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            next_chunk_future = pool.submit(
+                self._cache_manager.ensure_chunk,
+                self._task,
+                sample_chunks[0][0],
+            )
+
+            for chunk_offset, (chunk_index, chunk_samples) in enumerate(sample_chunks):
+                next_chunk_future.result()
+
+                if chunk_offset + 1 < len(sample_chunks):
+                    next_chunk_future = pool.submit(
+                        self._cache_manager.ensure_chunk,
+                        self._task,
+                        sample_chunks[chunk_offset + 1][0],
+                    )
+
+                yield chunk_samples
+
+                if delete_finished_chunks:
+                    (self._chunk_dir / f"{chunk_index}.zip").unlink(missing_ok=True)
+
     def _load_frame_image_from_cache(self, frame_index: int) -> PIL.Image:
         assert frame_index in self._frame_annotations
 
@@ -201,6 +279,11 @@ class TaskDataset:
                 image.load()
 
         return image
+
+    def _load_frame_image_from_chunk_cache(self, frame_index: int) -> PIL.Image:
+        chunk_index = frame_index // self._task.data_chunk_size
+        self._cache_manager.ensure_chunk(self._task, chunk_index)
+        return self._load_frame_image_from_cache(frame_index)
 
     def _load_frame_image_from_server(self, frame_index: int) -> PIL.Image:
         assert frame_index in self._frame_annotations

--- a/tests/python/sdk/test_datasets.py
+++ b/tests/python/sdk/test_datasets.py
@@ -356,4 +356,6 @@ class TestTaskDataset:
         sample_chunks = list(dataset.iter_sample_chunks())
 
         assert len(sample_chunks) == 1
-        assert [sample.frame_index for sample in sample_chunks[0]] == list(range(len(self.image_paths)))
+        assert [sample.frame_index for sample in sample_chunks[0]] == list(
+            range(len(self.image_paths))
+        )

--- a/tests/python/sdk/test_datasets.py
+++ b/tests/python/sdk/test_datasets.py
@@ -153,6 +153,31 @@ class TestTaskDataset:
         assert dataset.samples[5].media.load_image() == PIL.Image.open(self.images[6])
         assert len(dataset.samples[5].annotations.shapes) == 1
 
+    @pytest.mark.parametrize("media_download_policy", cvatds.MediaDownloadPolicy)
+    def test_iter_samples_with_deleted_frames(
+        self, media_download_policy: cvatds.MediaDownloadPolicy
+    ):
+        deleted_frame_indexes = {1, 3, 8}
+        self.task.remove_frames_by_ids(sorted(deleted_frame_indexes))
+
+        dataset = cvatds.TaskDataset(
+            self.client,
+            self.task.id,
+            load_annotations=False,
+            media_download_policy=media_download_policy,
+        )
+
+        with dataset.iter_samples() as samples:
+            actual_samples = list(samples)
+
+        expected_frame_indexes = [
+            index for index in range(len(self.images)) if index not in deleted_frame_indexes
+        ]
+        assert [sample.frame_index for sample in actual_samples] == expected_frame_indexes
+
+        for sample in actual_samples:
+            assert sample.media.load_image() == PIL.Image.open(self.images[sample.frame_index])
+
     def test_offline(self, monkeypatch: pytest.MonkeyPatch):
         dataset = cvatds.TaskDataset(
             self.client,
@@ -236,6 +261,8 @@ class TestTaskDataset:
     def test_iter_samples_prefetches_and_deletes_finished_chunks(
         self, monkeypatch: pytest.MonkeyPatch
     ):
+        # Seed the shared cache first. The iterator below uses a temporary chunk directory,
+        # so these files let the test verify that temporary cleanup does not touch cached chunks.
         cvatds.TaskDataset(
             self.client,
             self.task.id,
@@ -259,9 +286,11 @@ class TestTaskDataset:
             if chunk_dir != dataset._chunk_dir:
                 observed_temp_chunk_dirs.add(chunk_dir)
 
+            # Pause the background prefetch of chunk #1. This keeps chunk #0 readable
+            # while proving that chunk #1 is being fetched before callers request it.
             if chunk_dir != dataset._chunk_dir and chunk_index == 1:
                 second_chunk_download_started.set()
-                assert allow_second_chunk_download.wait(timeout=5)
+                allow_second_chunk_download.wait()
 
             return original_ensure_chunk_in_dir(chunk_dir, chunk_index)
 
@@ -271,11 +300,12 @@ class TestTaskDataset:
         assert (chunk_dir / "0.zip").exists()
         assert (chunk_dir / "1.zip").exists()
 
-        with dataset.iter_samples(delete_finished_chunks=True) as samples:
+        with dataset.iter_samples(temporary_chunks=True) as samples:
+            # Reading the first chunk should start downloading the next chunk in the background.
             first_chunk_samples = [next(samples) for _ in range(3)]
 
             assert [sample.frame_index for sample in first_chunk_samples] == [0, 1, 2]
-            assert second_chunk_download_started.wait(timeout=5)
+            second_chunk_download_started.wait()
             assert len(observed_temp_chunk_dirs) == 1
             temp_chunk_dir = next(iter(observed_temp_chunk_dirs))
             assert temp_chunk_dir != chunk_dir
@@ -287,6 +317,8 @@ class TestTaskDataset:
             for sample in first_chunk_samples:
                 assert sample.media.load_image() == PIL.Image.open(self.images[sample.frame_index])
 
+            # Let the background download finish. Advancing into chunk #1 should then delete
+            # the temporary copy of chunk #0, while leaving the shared cache untouched.
             allow_second_chunk_download.set()
 
             fourth_sample = next(samples)
@@ -309,9 +341,23 @@ class TestTaskDataset:
         )
 
         with dataset.iter_samples() as samples:
-            actual_frame_indexes = [sample.frame_index for sample in samples]
+            actual_samples = list(samples)
 
-        assert actual_frame_indexes == list(range(self.task.size))
+        assert [sample.frame_index for sample in actual_samples] == list(range(self.task.size))
+        for sample in actual_samples:
+            assert sample.media.load_image() == PIL.Image.open(self.images[sample.frame_index])
+
+    def test_iter_samples_rejects_temporary_chunks_with_preload_all(self):
+        dataset = cvatds.TaskDataset(
+            self.client,
+            self.task.id,
+            load_annotations=False,
+            media_download_policy=cvatds.MediaDownloadPolicy.PRELOAD_ALL,
+        )
+
+        with pytest.raises(AssertionError):
+            with dataset.iter_samples(temporary_chunks=True):
+                pass
 
     def test_non_imageset_video_task_is_unsupported_for_chunk_based_media_access(self):
         video_file = generate_video_file(4)
@@ -340,43 +386,30 @@ class TestTaskDataset:
                 media_download_policy=cvatds.MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND,
             )
 
-    def test_iter_samples_keeps_files_when_delete_is_disabled(self):
+    @pytest.mark.parametrize(
+        "media_download_policy",
+        [
+            cvatds.MediaDownloadPolicy.PRELOAD_ALL,
+            cvatds.MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND,
+        ],
+    )
+    def test_iter_samples_keeps_files_when_delete_is_disabled(
+        self, media_download_policy: cvatds.MediaDownloadPolicy
+    ):
         dataset = cvatds.TaskDataset(
             self.client,
             self.task.id,
             load_annotations=False,
-            media_download_policy=cvatds.MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND,
+            media_download_policy=media_download_policy,
         )
 
         chunk_dir = dataset._cache_manager.chunk_dir(self.task.id)
 
-        with dataset.iter_samples(delete_finished_chunks=False) as samples:
-            actual_frame_indexes = [sample.frame_index for sample in samples]
+        with dataset.iter_samples(temporary_chunks=False) as samples:
+            actual_samples = list(samples)
 
-        assert actual_frame_indexes == list(range(self.task.size))
+        assert [sample.frame_index for sample in actual_samples] == list(range(self.task.size))
+        for sample in actual_samples:
+            assert sample.media.load_image() == PIL.Image.open(self.images[sample.frame_index])
+
         assert all((chunk_dir / f"{chunk_index}.zip").exists() for chunk_index in range(4))
-
-    def test_iter_samples_yields_single_chunk(self):
-        single_chunk_task = self.client.tasks.create_from_data(
-            models.TaskWriteRequest(
-                "Dataset layer single chunk task",
-                labels=[
-                    models.PatchedLabelRequest(name="person"),
-                ],
-            ),
-            resource_type=ResourceType.LOCAL,
-            resources=self.image_paths,
-            data_params={"chunk_size": len(self.image_paths)},
-        )
-
-        dataset = cvatds.TaskDataset(
-            self.client,
-            single_chunk_task.id,
-            load_annotations=False,
-            media_download_policy=cvatds.MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND,
-        )
-
-        with dataset.iter_samples() as samples:
-            actual_frame_indexes = [sample.frame_index for sample in samples]
-
-        assert actual_frame_indexes == list(range(len(self.image_paths)))

--- a/tests/python/sdk/test_datasets.py
+++ b/tests/python/sdk/test_datasets.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import io
+import threading
 from logging import Logger
 from pathlib import Path
 
@@ -13,7 +14,7 @@ from cvat_sdk import Client, models
 from cvat_sdk.core.proxies.annotations import AnnotationUpdateAction
 from cvat_sdk.core.proxies.tasks import ResourceType
 
-from shared.utils.helpers import generate_image_files
+from shared.utils.helpers import generate_image_files, generate_video_file
 
 from .util import restrict_api_requests
 
@@ -44,6 +45,7 @@ class TestTaskDataset:
         fxt_login: tuple[Client, str],
     ):
         self.client = fxt_login[0]
+        self.tmp_path = tmp_path
         self.images = generate_image_files(10)
 
         image_dir = tmp_path / "images"
@@ -55,6 +57,7 @@ class TestTaskDataset:
             image_path.write_bytes(image.getbuffer())
             image_paths.append(image_path)
 
+        self.image_paths = image_paths
         self.task = self.client.tasks.create_from_data(
             models.TaskWriteRequest(
                 "Dataset layer test task",
@@ -229,3 +232,128 @@ class TestTaskDataset:
             assert actual_image == expected_image
 
             assert sample.annotations is None
+
+    def test_iter_sample_chunks_prefetches_and_deletes_finished_chunks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        dataset = cvatds.TaskDataset(
+            self.client,
+            self.task.id,
+            load_annotations=False,
+            media_download_policy=cvatds.MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND,
+        )
+
+        second_chunk_download_started = threading.Event()
+        allow_second_chunk_download = threading.Event()
+        original_ensure_chunk = dataset._cache_manager.ensure_chunk
+
+        def wrapped_ensure_chunk(task, chunk_index):
+            if chunk_index == 1:
+                second_chunk_download_started.set()
+                assert allow_second_chunk_download.wait(timeout=5)
+
+            return original_ensure_chunk(task, chunk_index)
+
+        monkeypatch.setattr(dataset._cache_manager, "ensure_chunk", wrapped_ensure_chunk)
+
+        chunk_dir = dataset._cache_manager.chunk_dir(self.task.id)
+        chunk_iterator = iter(dataset.iter_sample_chunks(delete_finished_chunks=True))
+
+        first_chunk_samples = next(chunk_iterator)
+
+        assert [sample.frame_index for sample in first_chunk_samples] == [0, 1, 2]
+        assert second_chunk_download_started.wait(timeout=5)
+        assert (chunk_dir / "0.zip").exists()
+        assert not (chunk_dir / "1.zip").exists()
+
+        for sample in first_chunk_samples:
+            assert sample.media.load_image() == PIL.Image.open(self.images[sample.frame_index])
+
+        allow_second_chunk_download.set()
+
+        second_chunk_samples = next(chunk_iterator)
+
+        assert [sample.frame_index for sample in second_chunk_samples] == [3, 4, 5]
+        assert not (chunk_dir / "0.zip").exists()
+
+        for _ in chunk_iterator:
+            pass
+
+    def test_iter_sample_chunks_rejects_fetch_frames_on_demand(self):
+        dataset = cvatds.TaskDataset(
+            self.client,
+            self.task.id,
+            load_annotations=False,
+            media_download_policy=cvatds.MediaDownloadPolicy.FETCH_FRAMES_ON_DEMAND,
+        )
+
+        with pytest.raises(
+            cvatds.UnsupportedDatasetError,
+            match="iter_sample_chunks is not supported with FETCH_FRAMES_ON_DEMAND",
+        ):
+            list(dataset.iter_sample_chunks())
+
+    def test_video_task_is_unsupported_for_chunked_media_access(self):
+        video_file = generate_video_file(4)
+        video_path = self.tmp_path / video_file.name
+        video_path.write_bytes(video_file.getbuffer())
+
+        video_task = self.client.tasks.create_from_data(
+            models.TaskWriteRequest(
+                "Dataset layer video task",
+                labels=[models.PatchedLabelRequest(name="video-object")],
+            ),
+            resource_type=ResourceType.LOCAL,
+            resources=[video_path],
+        )
+
+        with pytest.raises(
+            cvatds.UnsupportedDatasetError,
+            match="Chunk-based media access is only supported for tasks with image chunks",
+        ):
+            cvatds.TaskDataset(
+                self.client,
+                video_task.id,
+                load_annotations=False,
+                media_download_policy=cvatds.MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND,
+            )
+
+    def test_iter_sample_chunks_keeps_files_when_delete_is_disabled(self):
+        dataset = cvatds.TaskDataset(
+            self.client,
+            self.task.id,
+            load_annotations=False,
+            media_download_policy=cvatds.MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND,
+        )
+
+        chunk_dir = dataset._cache_manager.chunk_dir(self.task.id)
+
+        sample_chunks = list(dataset.iter_sample_chunks(delete_finished_chunks=False))
+
+        assert [len(chunk_samples) for chunk_samples in sample_chunks] == [3, 3, 3, 1]
+        assert all((chunk_dir / f"{chunk_index}.zip").exists() for chunk_index in range(4))
+
+    def test_iter_sample_chunks_yields_single_chunk(self):
+        single_chunk_task = self.client.tasks.create_from_data(
+            models.TaskWriteRequest(
+                "Dataset layer single chunk task",
+                labels=[
+                    models.PatchedLabelRequest(name="person"),
+                ],
+            ),
+            resource_type=ResourceType.LOCAL,
+            resources=self.image_paths,
+            data_params={"chunk_size": len(self.image_paths)},
+        )
+
+        dataset = cvatds.TaskDataset(
+            self.client,
+            single_chunk_task.id,
+            load_annotations=False,
+            media_download_policy=cvatds.MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND,
+        )
+
+        sample_chunks = list(dataset.iter_sample_chunks())
+
+        assert len(sample_chunks) == 1
+        assert [sample.frame_index for sample in sample_chunks[0]] == list(range(len(self.image_paths)))

--- a/tests/python/sdk/test_datasets.py
+++ b/tests/python/sdk/test_datasets.py
@@ -233,9 +233,16 @@ class TestTaskDataset:
 
             assert sample.annotations is None
 
-    def test_iter_sample_chunks_prefetches_and_deletes_finished_chunks(
+    def test_iter_samples_prefetches_and_deletes_finished_chunks(
         self, monkeypatch: pytest.MonkeyPatch
     ):
+        cvatds.TaskDataset(
+            self.client,
+            self.task.id,
+            load_annotations=False,
+            media_download_policy=cvatds.MediaDownloadPolicy.PRELOAD_ALL,
+        )
+
         dataset = cvatds.TaskDataset(
             self.client,
             self.task.id,
@@ -245,41 +252,55 @@ class TestTaskDataset:
 
         second_chunk_download_started = threading.Event()
         allow_second_chunk_download = threading.Event()
-        original_ensure_chunk = dataset._cache_manager.ensure_chunk
+        observed_temp_chunk_dirs = set()
+        original_ensure_chunk_in_dir = dataset._ensure_chunk_in_dir
 
-        def wrapped_ensure_chunk(task, chunk_index):
-            if chunk_index == 1:
+        def wrapped_ensure_chunk_in_dir(chunk_dir, chunk_index):
+            if chunk_dir != dataset._chunk_dir:
+                observed_temp_chunk_dirs.add(chunk_dir)
+
+            if chunk_dir != dataset._chunk_dir and chunk_index == 1:
                 second_chunk_download_started.set()
                 assert allow_second_chunk_download.wait(timeout=5)
 
-            return original_ensure_chunk(task, chunk_index)
+            return original_ensure_chunk_in_dir(chunk_dir, chunk_index)
 
-        monkeypatch.setattr(dataset._cache_manager, "ensure_chunk", wrapped_ensure_chunk)
+        monkeypatch.setattr(dataset, "_ensure_chunk_in_dir", wrapped_ensure_chunk_in_dir)
 
         chunk_dir = dataset._cache_manager.chunk_dir(self.task.id)
-        chunk_iterator = iter(dataset.iter_sample_chunks(delete_finished_chunks=True))
-
-        first_chunk_samples = next(chunk_iterator)
-
-        assert [sample.frame_index for sample in first_chunk_samples] == [0, 1, 2]
-        assert second_chunk_download_started.wait(timeout=5)
         assert (chunk_dir / "0.zip").exists()
-        assert not (chunk_dir / "1.zip").exists()
+        assert (chunk_dir / "1.zip").exists()
 
-        for sample in first_chunk_samples:
-            assert sample.media.load_image() == PIL.Image.open(self.images[sample.frame_index])
+        with dataset.iter_samples(delete_finished_chunks=True) as samples:
+            first_chunk_samples = [next(samples) for _ in range(3)]
 
-        allow_second_chunk_download.set()
+            assert [sample.frame_index for sample in first_chunk_samples] == [0, 1, 2]
+            assert second_chunk_download_started.wait(timeout=5)
+            assert len(observed_temp_chunk_dirs) == 1
+            temp_chunk_dir = next(iter(observed_temp_chunk_dirs))
+            assert temp_chunk_dir != chunk_dir
+            assert (temp_chunk_dir / "0.zip").exists()
+            assert not (temp_chunk_dir / "1.zip").exists()
+            assert (chunk_dir / "0.zip").exists()
+            assert (chunk_dir / "1.zip").exists()
 
-        second_chunk_samples = next(chunk_iterator)
+            for sample in first_chunk_samples:
+                assert sample.media.load_image() == PIL.Image.open(self.images[sample.frame_index])
 
-        assert [sample.frame_index for sample in second_chunk_samples] == [3, 4, 5]
-        assert not (chunk_dir / "0.zip").exists()
+            allow_second_chunk_download.set()
 
-        for _ in chunk_iterator:
-            pass
+            fourth_sample = next(samples)
 
-    def test_iter_sample_chunks_rejects_fetch_frames_on_demand(self):
+            assert fourth_sample.frame_index == 3
+            assert not (temp_chunk_dir / "0.zip").exists()
+            assert (chunk_dir / "0.zip").exists()
+
+            for _ in samples:
+                pass
+
+        assert not temp_chunk_dir.exists()
+
+    def test_iter_samples_works_with_fetch_frames_on_demand(self):
         dataset = cvatds.TaskDataset(
             self.client,
             self.task.id,
@@ -287,13 +308,12 @@ class TestTaskDataset:
             media_download_policy=cvatds.MediaDownloadPolicy.FETCH_FRAMES_ON_DEMAND,
         )
 
-        with pytest.raises(
-            cvatds.UnsupportedDatasetError,
-            match="iter_sample_chunks is not supported with FETCH_FRAMES_ON_DEMAND",
-        ):
-            list(dataset.iter_sample_chunks())
+        with dataset.iter_samples() as samples:
+            actual_frame_indexes = [sample.frame_index for sample in samples]
 
-    def test_video_task_is_unsupported_for_chunked_media_access(self):
+        assert actual_frame_indexes == list(range(self.task.size))
+
+    def test_non_imageset_video_task_is_unsupported_for_chunk_based_media_access(self):
         video_file = generate_video_file(4)
         video_path = self.tmp_path / video_file.name
         video_path.write_bytes(video_file.getbuffer())
@@ -307,9 +327,11 @@ class TestTaskDataset:
             resources=[video_path],
         )
 
+        assert video_task.data_original_chunk_type != "imageset"
+
         with pytest.raises(
             cvatds.UnsupportedDatasetError,
-            match="Chunk-based media access is only supported for tasks with image chunks",
+            match="tasks whose original chunks are image sets",
         ):
             cvatds.TaskDataset(
                 self.client,
@@ -318,7 +340,7 @@ class TestTaskDataset:
                 media_download_policy=cvatds.MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND,
             )
 
-    def test_iter_sample_chunks_keeps_files_when_delete_is_disabled(self):
+    def test_iter_samples_keeps_files_when_delete_is_disabled(self):
         dataset = cvatds.TaskDataset(
             self.client,
             self.task.id,
@@ -328,12 +350,13 @@ class TestTaskDataset:
 
         chunk_dir = dataset._cache_manager.chunk_dir(self.task.id)
 
-        sample_chunks = list(dataset.iter_sample_chunks(delete_finished_chunks=False))
+        with dataset.iter_samples(delete_finished_chunks=False) as samples:
+            actual_frame_indexes = [sample.frame_index for sample in samples]
 
-        assert [len(chunk_samples) for chunk_samples in sample_chunks] == [3, 3, 3, 1]
+        assert actual_frame_indexes == list(range(self.task.size))
         assert all((chunk_dir / f"{chunk_index}.zip").exists() for chunk_index in range(4))
 
-    def test_iter_sample_chunks_yields_single_chunk(self):
+    def test_iter_samples_yields_single_chunk(self):
         single_chunk_task = self.client.tasks.create_from_data(
             models.TaskWriteRequest(
                 "Dataset layer single chunk task",
@@ -353,9 +376,7 @@ class TestTaskDataset:
             media_download_policy=cvatds.MediaDownloadPolicy.FETCH_CHUNKS_ON_DEMAND,
         )
 
-        sample_chunks = list(dataset.iter_sample_chunks())
+        with dataset.iter_samples() as samples:
+            actual_frame_indexes = [sample.frame_index for sample in samples]
 
-        assert len(sample_chunks) == 1
-        assert [sample.frame_index for sample in sample_chunks[0]] == list(
-            range(len(self.image_paths))
-        )
+        assert actual_frame_indexes == list(range(len(self.image_paths)))

--- a/tests/python/sdk/test_datasets.py
+++ b/tests/python/sdk/test_datasets.py
@@ -168,15 +168,17 @@ class TestTaskDataset:
         )
 
         with dataset.iter_samples() as samples:
-            actual_samples = list(samples)
-
-        expected_frame_indexes = [
-            index for index in range(len(self.images)) if index not in deleted_frame_indexes
-        ]
-        assert [sample.frame_index for sample in actual_samples] == expected_frame_indexes
-
-        for sample in actual_samples:
-            assert sample.media.load_image() == PIL.Image.open(self.images[sample.frame_index])
+            for sample, expected_frame_index in zip(
+                samples,
+                (
+                    index
+                    for index in range(len(self.images))
+                    if index not in deleted_frame_indexes
+                ),
+                strict=True,
+            ):
+                assert sample.frame_index == expected_frame_index
+                assert sample.media.load_image() == PIL.Image.open(self.images[expected_frame_index])
 
     def test_offline(self, monkeypatch: pytest.MonkeyPatch):
         dataset = cvatds.TaskDataset(
@@ -302,9 +304,13 @@ class TestTaskDataset:
 
         with dataset.iter_samples(temporary_chunks=True) as samples:
             # Reading the first chunk should start downloading the next chunk in the background.
-            first_chunk_samples = [next(samples) for _ in range(3)]
+            for expected_frame_index in range(3):
+                sample = next(samples)
+                assert sample.frame_index == expected_frame_index
+                assert sample.media.load_image() == PIL.Image.open(
+                    self.images[expected_frame_index]
+                )
 
-            assert [sample.frame_index for sample in first_chunk_samples] == [0, 1, 2]
             second_chunk_download_started.wait()
             assert len(observed_temp_chunk_dirs) == 1
             temp_chunk_dir = next(iter(observed_temp_chunk_dirs))
@@ -313,9 +319,6 @@ class TestTaskDataset:
             assert not (temp_chunk_dir / "1.zip").exists()
             assert (chunk_dir / "0.zip").exists()
             assert (chunk_dir / "1.zip").exists()
-
-            for sample in first_chunk_samples:
-                assert sample.media.load_image() == PIL.Image.open(self.images[sample.frame_index])
 
             # Let the background download finish. Advancing into chunk #1 should then delete
             # the temporary copy of chunk #0, while leaving the shared cache untouched.
@@ -341,11 +344,13 @@ class TestTaskDataset:
         )
 
         with dataset.iter_samples() as samples:
-            actual_samples = list(samples)
-
-        assert [sample.frame_index for sample in actual_samples] == list(range(self.task.size))
-        for sample in actual_samples:
-            assert sample.media.load_image() == PIL.Image.open(self.images[sample.frame_index])
+            for expected_frame_index, sample in zip(
+                range(self.task.size), samples, strict=True
+            ):
+                assert sample.frame_index == expected_frame_index
+                assert sample.media.load_image() == PIL.Image.open(
+                    self.images[expected_frame_index]
+                )
 
     def test_iter_samples_rejects_temporary_chunks_with_preload_all(self):
         dataset = cvatds.TaskDataset(
@@ -406,10 +411,12 @@ class TestTaskDataset:
         chunk_dir = dataset._cache_manager.chunk_dir(self.task.id)
 
         with dataset.iter_samples(temporary_chunks=False) as samples:
-            actual_samples = list(samples)
-
-        assert [sample.frame_index for sample in actual_samples] == list(range(self.task.size))
-        for sample in actual_samples:
-            assert sample.media.load_image() == PIL.Image.open(self.images[sample.frame_index])
+            for expected_frame_index, sample in zip(
+                range(self.task.size), samples, strict=True
+            ):
+                assert sample.frame_index == expected_frame_index
+                assert sample.media.load_image() == PIL.Image.open(
+                    self.images[expected_frame_index]
+                )
 
         assert all((chunk_dir / f"{chunk_index}.zip").exists() for chunk_index in range(4))

--- a/tests/python/sdk/test_datasets.py
+++ b/tests/python/sdk/test_datasets.py
@@ -170,15 +170,13 @@ class TestTaskDataset:
         with dataset.iter_samples() as samples:
             for sample, expected_frame_index in zip(
                 samples,
-                (
-                    index
-                    for index in range(len(self.images))
-                    if index not in deleted_frame_indexes
-                ),
+                (index for index in range(len(self.images)) if index not in deleted_frame_indexes),
                 strict=True,
             ):
                 assert sample.frame_index == expected_frame_index
-                assert sample.media.load_image() == PIL.Image.open(self.images[expected_frame_index])
+                assert sample.media.load_image() == PIL.Image.open(
+                    self.images[expected_frame_index]
+                )
 
     def test_offline(self, monkeypatch: pytest.MonkeyPatch):
         dataset = cvatds.TaskDataset(
@@ -344,9 +342,7 @@ class TestTaskDataset:
         )
 
         with dataset.iter_samples() as samples:
-            for expected_frame_index, sample in zip(
-                range(self.task.size), samples, strict=True
-            ):
+            for expected_frame_index, sample in zip(range(self.task.size), samples, strict=True):
                 assert sample.frame_index == expected_frame_index
                 assert sample.media.load_image() == PIL.Image.open(
                     self.images[expected_frame_index]
@@ -411,9 +407,7 @@ class TestTaskDataset:
         chunk_dir = dataset._cache_manager.chunk_dir(self.task.id)
 
         with dataset.iter_samples(temporary_chunks=False) as samples:
-            for expected_frame_index, sample in zip(
-                range(self.task.size), samples, strict=True
-            ):
+            for expected_frame_index, sample in zip(range(self.task.size), samples, strict=True):
                 assert sample.frame_index == expected_frame_index
                 assert sample.media.load_image() == PIL.Image.open(
                     self.images[expected_frame_index]


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
**Problem Statement:**
Before these changes, when the agent receives a task annotation request, it first downloads all the images (in chunks), then iterates through them and runs the model on each one. But it's not the best behavior for the agent: it means the agent needs enough disk space to store all the images (even though they're not all in use at the same time); moreover, the progress bar in the UI hangs at zero for a long time, which isn't very informative.

Now it works like this: the agent downloads the first chunk, then immediately processes it. While it's processing, the agent downloads the next chunk. After processing, the chunk is deleted.

### How has this been tested?
Manual and automated tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
