### PR TITLE
Lazy-load dataset formats

### DIFF
--- a/cvat/apps/dataset_manager/project.py
+++ b/cvat/apps/dataset_manager/project.py
@@ -25,7 +25,6 @@ from cvat.apps.engine.utils import av_scan_paths, transaction_with_repeatable_re
 
 from .annotation import AnnotationIR
 from .bindings import CvatDatasetNotFoundError, CvatImportError, ProjectData, load_dataset_data
-from .formats.registry import make_exporter, make_importer
 
 dlogger = DatasetLogManager()
 
@@ -40,6 +39,8 @@ def export_project(
     save_images: bool = False,
     temp_dir: str | None = None,
 ):
+    from .formats.registry import make_exporter
+
     project = ProjectAnnotation(project_id)
     project.init_from_db(streaming=True)
 
@@ -213,6 +214,8 @@ class ProjectAnnotation:
 
 @transaction.atomic
 def import_dataset_as_project(src_file, project_id, format_name, conv_mask_to_poly):
+    from .formats.registry import make_importer
+
     rq_job = rq.get_current_job()
     rq_job_meta = ImportRQMeta.for_job(rq_job)
     rq_job_meta.status = "Dataset import has been started..."

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -24,7 +24,6 @@ from cvat.apps.dataset_manager.bindings import (
     JobData,
     TaskData,
 )
-from cvat.apps.dataset_manager.formats.registry import make_exporter, make_importer
 from cvat.apps.dataset_manager.util import TmpDirManager, faster_deepcopy
 from cvat.apps.engine import models, serializers
 from cvat.apps.engine.log import DatasetLogManager
@@ -1314,6 +1313,8 @@ def export_job(
     save_images=False,
     temp_dir: str | None = None,
 ):
+    from cvat.apps.dataset_manager.formats.registry import make_exporter
+
     job = JobAnnotation(job_id, prefetch_images=True)
     job.init_from_db(streaming=True)
 
@@ -1371,6 +1372,8 @@ def export_task(
     save_images: bool = False,
     temp_dir: str | None = None,
 ):
+    from cvat.apps.dataset_manager.formats.registry import make_exporter
+
     task = TaskAnnotation(task_id)
     task.init_from_db(streaming=True)
 
@@ -1388,6 +1391,8 @@ def import_task_annotations(
     *,
     import_mode: AnnotationImportMode = AnnotationImportMode.REPLACE,
 ):
+    from cvat.apps.dataset_manager.formats.registry import make_importer
+
     av_scan_paths(src_file)
     task = TaskAnnotation(task_id, write_only=True)
 
@@ -1413,6 +1418,8 @@ def import_job_annotations(
     *,
     import_mode: AnnotationImportMode = AnnotationImportMode.REPLACE,
 ):
+    from cvat.apps.dataset_manager.formats.registry import make_importer
+
     av_scan_paths(src_file)
     job = JobAnnotation(job_id, prefetch_images=True)
 

--- a/cvat/apps/dataset_manager/views.py
+++ b/cvat/apps/dataset_manager/views.py
@@ -24,7 +24,6 @@ from cvat.apps.engine.models import Job, Project, Task
 from cvat.apps.engine.rq import ExportRQMeta
 from cvat.apps.engine.utils import get_rq_lock_by_user, parse_exception_message
 
-from .formats.registry import EXPORT_FORMATS, IMPORT_FORMATS
 from .signals import ExportStatus, export_finished
 from .util import (
     ExportCacheManager,
@@ -281,10 +280,14 @@ def export_project_annotations(project_id: int, dst_format: str, *, server_url: 
 
 
 def get_export_formats():
+    from .formats.registry import EXPORT_FORMATS
+
     return list(EXPORT_FORMATS.values())
 
 
 def get_import_formats():
+    from .formats.registry import IMPORT_FORMATS
+
     return list(IMPORT_FORMATS.values())
 
 

--- a/cvat/apps/engine/background.py
+++ b/cvat/apps/engine/background.py
@@ -17,7 +17,6 @@ from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.reverse import reverse
 
 import cvat.apps.dataset_manager as dm
-from cvat.apps.dataset_manager.formats.registry import EXPORT_FORMATS
 from cvat.apps.dataset_manager.util import TmpDirManager
 from cvat.apps.dataset_manager.views import get_export_callback
 from cvat.apps.engine.backup import (
@@ -149,6 +148,8 @@ class DatasetExporter(AbstractExporter):
         )
 
     def get_result_filename(self) -> str:
+        from cvat.apps.dataset_manager.formats.registry import EXPORT_FORMATS
+
         filename = self.export_args.filename
 
         if not filename:

--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -37,7 +37,6 @@ from cvat.apps.dataset_manager.bindings import (
     JobData,
     match_dm_item,
 )
-from cvat.apps.dataset_manager.formats.registry import dm_env
 from cvat.apps.dataset_manager.task import JobAnnotation
 from cvat.apps.engine.filters import JsonLogicFilter
 from cvat.apps.engine.media_io.frame_provider import TaskFrameProvider
@@ -892,6 +891,8 @@ class JobDataProvider:
 
     @cached_property
     def dm_dataset(self):
+        from cvat.apps.dataset_manager.formats.registry import dm_env
+
         extractor = GetCVATDataExtractor(self.job_data, convert_annotations=self._annotation_memo)
         return dm.Dataset.from_extractors(extractor, env=dm_env)
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
When `cvat.apps.dataset_manager.registry` is loaded, this causes a Datumaro environment to be created, and all the individual format modules and their dependencies to be loaded too.  This is a pretty large amount of work that isn't always needed; many Django-based processes (e.g. the `migrate` command or some workers) never work with datasets.

Load the registry module on demand instead. I measured the following improvements from this:

* Number of Python modules loaded by `manage.py shell`: 3535 -> 2901.
* Time to run `manage.py help`: 1.250 ms -> 0.970 ms.
* Memory use of `manage.py shell`: 309720 KiB -> 224956 KiB.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
