### PR TITLE
fix: handle COCO JSON with category ID 0 on import

### DIFF
--- a/cvat/apps/dataset_manager/formats/coco.py
+++ b/cvat/apps/dataset_manager/formats/coco.py
@@ -3,9 +3,11 @@
 #
 # SPDX-License-Identifier: MIT
 
+import json
+import shutil
 import zipfile
 from pathlib import Path
-from typing import BinaryIO
+from typing import BinaryIO, Union
 
 from datumaro.components.annotation import AnnotationType
 from datumaro.components.dataset import StreamDataset
@@ -24,6 +26,69 @@ from .registry import dm_env, exporter, importer
 from .transformations import EllipsesToMasks
 
 
+def _fix_zero_category_ids(coco_json_path: Union[str, Path]) -> bool:
+    """Fix COCO JSON files where category IDs start from 0.
+
+    COCO standard conventionally reserves category_id 0 for background/no class,
+    but some tools (like FiftyOne) export datasets with category_id=0 as a valid
+    category. Datumaro's COCO parser treats category_id=0 as 'no label' (int 0 is
+    falsy in Python), which causes import failures in CVAT.
+
+    This function shifts all category IDs by +1 (and updates annotation references)
+    to work around this limitation.
+
+    Returns True if the file was modified, False otherwise.
+    """
+    with open(coco_json_path, "r") as f:
+        data = json.load(f)
+
+    if "categories" not in data:
+        return False
+
+    has_zero_id = any(cat.get("id") == 0 for cat in data["categories"])
+    if not has_zero_id:
+        return False
+
+    # Build mapping: old category id -> new category id (+1 shift)
+    id_map = {}
+    for cat in data["categories"]:
+        old_id = cat["id"]
+        new_id = old_id + 1
+        id_map[old_id] = new_id
+        cat["id"] = new_id
+
+    # Update category_id references in annotations
+    for ann in data.get("annotations", []):
+        old_cat_id = ann.get("category_id")
+        if old_cat_id in id_map:
+            ann["category_id"] = id_map[old_cat_id]
+
+    # Also handle alternate annotation keys (e.g. stuff_annotations)
+    for key in data:
+        if key.endswith("_annotations") and isinstance(data[key], list):
+            for ann in data[key]:
+                old_cat_id = ann.get("category_id")
+                if old_cat_id in id_map:
+                    ann["category_id"] = id_map[old_cat_id]
+
+    with open(coco_json_path, "w") as f:
+        json.dump(data, f)
+
+    return True
+
+
+def _fix_coco_dir_annotations(temp_dir: Path) -> None:
+    """Find and fix zero-based category IDs in all COCO JSON files
+    under the annotations/ directory of an extracted COCO dataset."""
+    annotations_dir = temp_dir / "annotations"
+    if annotations_dir.is_dir():
+        for json_file in sorted(annotations_dir.glob("*.json")):
+            try:
+                _fix_zero_category_ids(json_file)
+            except Exception:
+                pass  # skip malformed files, let datumaro fail with its own error
+
+
 @exporter(name="COCO", ext="ZIP", version="1.0")
 def _export_instances(dst_file, temp_dir, instance_data, save_images=False):
     with GetCVATDataExtractor(instance_data, include_images=save_images) as extractor:
@@ -40,6 +105,7 @@ def _import_instances(
 ):
     if zipfile.is_zipfile(src_file):
         zipfile.ZipFile(src_file).extractall(temp_dir)
+        _fix_coco_dir_annotations(Path(temp_dir))
         # We use coco importer because it gives better error message
         detect_dataset(temp_dir, format_name="coco", importer=CocoImporter)
         dataset = StreamDataset.import_from(temp_dir, "coco_instances", env=dm_env)
@@ -52,7 +118,11 @@ def _import_instances(
 
         tmp_src_file_link = Path(temp_dir) / "annotations" / "default.json"
         tmp_src_file_link.parent.mkdir()
-        tmp_src_file_link.symlink_to(src_file.name)
+
+        # Copy the JSON file (we need to potentially modify it)
+        shutil.copy2(src_file.name, str(tmp_src_file_link))
+        _fix_zero_category_ids(tmp_src_file_link)
+
         dataset = StreamDataset.import_from(
             str(tmp_src_file_link.absolute()), "coco_instances", env=dm_env
         )
@@ -85,6 +155,7 @@ class RemoveBboxAnnotations(ItemTransform):
 def _import_keypoints(src_file, temp_dir, instance_data, load_data_callback=None, **kwargs):
     if zipfile.is_zipfile(src_file):
         zipfile.ZipFile(src_file).extractall(temp_dir)
+        _fix_coco_dir_annotations(Path(temp_dir))
         # We use coco importer because it gives better error message
         detect_dataset(temp_dir, format_name="coco", importer=CocoImporter)
         dataset = StreamDataset.import_from(temp_dir, "coco_person_keypoints", env=dm_env)
@@ -98,7 +169,11 @@ def _import_keypoints(src_file, temp_dir, instance_data, load_data_callback=None
 
         tmp_src_file_link = Path(temp_dir) / "annotations" / "default.json"
         tmp_src_file_link.parent.mkdir()
-        tmp_src_file_link.symlink_to(src_file.name)
+
+        # Copy the JSON file (we need to potentially modify it)
+        shutil.copy2(src_file.name, str(tmp_src_file_link))
+        _fix_zero_category_ids(tmp_src_file_link)
+
         dataset = StreamDataset.import_from(
             str(tmp_src_file_link.absolute()), "coco_person_keypoints", env=dm_env
         )


### PR DESCRIPTION
## Summary

Some tools (e.g. FiftyOne) export COCO JSON annotation files with category IDs starting from **0**. Datumaro's COCO parser treats `category_id=0` as 'no label' because `if not cat_id:` evaluates `0` as falsy in Python, causing CVAT to reject the annotations with:

> `Image X: can't import annotation #Y (bbox): annotation has no label`

## Changes

Adds a preprocessing step in the COCO import pipeline that detects when category IDs start from 0 and shifts them by +1 (along with updating all annotation `category_id` references) before passing the data to datumaro.

- `_fix_zero_category_ids(path)` — fixes a single COCO JSON file in-place
- `_fix_coco_dir_annotations(temp_dir)` — applies the fix to all JSON files under the `annotations/` dir (used for zip imports)
- Both `_import_instances` and `_import_keypoints` call the fix before datumaro processes the data
- Non-zip (single JSON) path changed from `symlink_to` to `copy2` since we need to modify the copy

## Test Plan

- [ ] Manual: Create a minimal COCO JSON with `category_id: 0`, import to CVAT
- [ ] Manual: Import a COCO ZIP with zero-based category IDs (e.g. FiftyOne export)
- [ ] Existing COCO import tests should still pass (no regression — non-zero IDs are a no-op)

Closes #4750