### PR TITLE
fix: Recreate manifest when sorting method differs from lexicographical

### DIFF
--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -1765,6 +1765,21 @@ def create_thread(
         raise ValidationError("It isn't supported to upload manifest file and use random sorting")
 
     if (
+        not is_backup_restore
+        and manifest_file
+        and not is_data_in_cloud
+        and data["sorting_method"]
+        not in {models.SortingMethod.LEXICOGRAPHICAL, models.SortingMethod.RANDOM}
+    ):
+        # The manifest was created with lexicographical order by default,
+        # but the task uses a different sorting method. Delete the existing
+        # manifest so it gets recreated with the correct sorted order later.
+        manifest_full_path = os.path.join(manifest_root, manifest_file)
+        if os.path.exists(manifest_full_path):
+            os.remove(manifest_full_path)
+        manifest_file = None
+
+    if (
         is_backup_restore
         and db_data.storage_method == models.StorageMethodChoice.FILE_SYSTEM
         and data["sorting_method"] in {models.SortingMethod.RANDOM, models.SortingMethod.PREDEFINED}


### PR DESCRIPTION
Fixes #10104

## Description

When creating a task with non-cloud images and a manifest file, if the selected sorting method (e.g. "natural") differs from the lexicographical order used when the manifest was created, the task creation fails with:

```
ValidationError: Incorrect file mapping to manifest content
```

This happens because `_collect_image_dataset_descriptors` checks that `manifest[frame_id]` matches `extractor.get_path(frame_id)`, but the manifest entries are in the original upload order while the extractor sorts the files by the requested method.

## Fix

When a manifest is present and the sorting method is neither `lexicographical` nor `random` (already rejected via earlier validation), the manifest file is removed so that `_collect_image_dataset_descriptors` recreates it using the already-sorted extractor paths.

This mirrors the approach already used for cloud storage tasks, where manifests are recreated from sorted media.

## Changes

- `cvat/apps/engine/task.py`: Add a check in `create_thread` that removes the uploaded manifest file when a non-lexicographical sorting method is used with non-cloud data, allowing the manifest to be regenerated in the correct order.