### PR TITLE
Feat #9578: implement rotation and scaling edit mode for polygons and polylines

### DIFF
--- a/changelog.d/20260525_171326_duarte.cruz_issue9578.md
+++ b/changelog.d/20260525_171326_duarte.cruz_issue9578.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Bounding Box Edit Mode:** Added the ability to scale and rotate Polygons and Polylines using a bounding box (`bboxEditMode`).
+- **Shape Mirroring:** Added the ability to mathematically mirror Polygons and Polylines horizontally and vertically.
+- **UI Controls:** Added a BBox edit mode toggle to the object sidebar and Vertical Mirroring to the object context menu.
+- **Shortcuts:** Added keyboard shortcuts for toggling BBox edit mode (`S`), Horizontal Mirroring (`Shift+H`) and Vertical Mirroring (`Shift+V`).
+- **History Support:** Integrated BBox edit mode and mirroring into the CVAT history engine, fully supporting Undo (`Ctrl+Z`) and Redo (`Ctrl+Shift+Z`).
+
+(<https://github.com/cvat-ai/cvat/issues/9578>)

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -36,6 +36,7 @@ import {
     composeShapeDimensions, getRoundedRotation,
     clamp, validateUnionResult, processPolygonUnionResult,
     applySnapToShapePoint, isPolygonSelfIntersecting,
+    computeWrappingBox,
 } from './shared';
 import {
     CanvasModel, Geometry, UpdateReasons, FrameZoom, ActiveElement,
@@ -89,8 +90,10 @@ export class CanvasViewImpl implements CanvasView, Listener {
     private highlightedElements: HighlightedElements;
     private configuration: Configuration;
     private snapToAngleResize: number;
+    private activeUIBbox: SVG.Rect | null;
     private draggableShape: SVG.Shape | null;
     private resizableShape: SVG.Shape | null;
+    private polygonResizeSnapshot: number[] | null = null;
     private ctrlPressed: boolean;
     private innerObjectsFlags: {
         drawHidden: Record<number, boolean>;
@@ -1177,7 +1180,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
             (shape as any).selectize(value, {
                 deepSelect: true,
                 pointSize: (2 * this.configuration.controlPointsSize) / this.geometry.scale,
-                rotationPoint: shape.type === 'rect' || shape.type === 'ellipse',
+                rotationPoint: shape.type === 'rect' || shape.type === 'ellipse' || shape.hasClass('cvat_canvas_active_bbox'),
                 pointsExclude: shape.type === 'image' ? ['lt', 'rt', 'rb', 'lb', 't', 'r', 'b', 'l'] : [],
                 pointType(cx: number, cy: number): SVG.Circle {
                     const circle: SVG.Circle = this.nested
@@ -1409,6 +1412,8 @@ export class CanvasViewImpl implements CanvasView, Listener {
         let resizableInstance = shape;
         let skeletonSVGTemplate: SVG.G = null;
 
+        const currentDrawnState = state || (this.activeElement.clientID ? this.drawnStates[this.activeElement.clientID] : null);
+
         if (shape.classes().includes('cvat_canvas_shape_skeleton')) {
             // for skeletons we use wrapping rectangle to resize the skeleton itself
             resizableInstance = (shape as any).children().find((child: SVG.Element) => child.type === 'rect');
@@ -1453,6 +1458,14 @@ export class CanvasViewImpl implements CanvasView, Listener {
             });
         }
 
+        if (state?.bboxEditMode
+            && currentDrawnState
+            && (currentDrawnState.shapeType === 'polygon' || currentDrawnState.shapeType === 'polyline')
+            && this.activeUIBbox) {
+
+            resizableInstance = this.activeUIBbox;
+        }
+
         if (state) {
             let resized = false;
             let aborted = false;
@@ -1471,6 +1484,15 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     this.resizableShape = shape;
                     const detail = (e.detail.event.detail as any);
                     draggedPointIndex = detail?.i ?? null;
+
+                    if (state.bboxEditMode && (state.shapeType === 'polygon' || state.shapeType === 'polyline')) {
+                        this.polygonResizeSnapshot = pointsToNumberArray(shape.attr('points'));
+
+                        resizableInstance.attr('data-xtl', resizableInstance.x());
+                        resizableInstance.attr('data-ytl', resizableInstance.y());
+                        resizableInstance.attr('data-xbr', resizableInstance.x() + resizableInstance.width());
+                        resizableInstance.attr('data-ybr', resizableInstance.y() + resizableInstance.height());
+                    }
                 })
                 .on('resizing', (e: CustomEvent): void => {
                     resized = true;
@@ -1530,6 +1552,35 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         skeletonSVGTemplate = skeletonSVGTemplate ?? makeSVGFromTemplate(state.label.structure.svg);
                         setupSkeletonEdges(shape as SVG.G, skeletonSVGTemplate);
                     }
+
+                    if (state.bboxEditMode && (state.shapeType === 'polygon' || state.shapeType === 'polyline') && this.polygonResizeSnapshot) {
+                        const { rotation } = resizableInstance.transform();
+
+                        const [x, y] = [resizableInstance.x(), resizableInstance.y()];
+                        const prevXtl = +resizableInstance.attr('data-xtl');
+                        const prevYtl = +resizableInstance.attr('data-ytl');
+                        const prevXbr = +resizableInstance.attr('data-xbr');
+                        const prevYbr = +resizableInstance.attr('data-ybr');
+
+                        if (prevXbr - prevXtl > 0.1 && prevYbr - prevYtl > 0.1) {
+                            const projectedPoints = [];
+
+                            // Map vertices linearly to the scaling box dimensions
+                            for (let i = 0; i < this.polygonResizeSnapshot.length; i += 2) {
+                                const offsetX = (this.polygonResizeSnapshot[i] - prevXtl) / (prevXbr - prevXtl);
+                                const offsetY = (this.polygonResizeSnapshot[i + 1] - prevYtl) / (prevYbr - prevYtl);
+                                projectedPoints.push(offsetX * resizableInstance.width() + x, offsetY * resizableInstance.height() + y);
+                            }
+
+                            // Update geometry and apply native SVG rotation matching the bounding box
+                            shape.untransform();
+                            (shape as any).plot(stringifyPoints(projectedPoints));
+
+                            if (rotation) {
+                                shape.rotate(rotation, resizableInstance.cx(), resizableInstance.cy());
+                            }
+                        }
+                    }
                 })
                 .on('resizedone', (): void => {
                     if (aborted) {
@@ -1565,6 +1616,17 @@ export class CanvasViewImpl implements CanvasView, Listener {
                                 });
                                 this.onEditDone(state, points, 0);
                             }
+                        } else if (state.bboxEditMode && (state.shapeType === 'polygon' || state.shapeType === 'polyline')) {
+                            let finalPoints = readPointsFromShape(shape);
+
+                            if (rotation && this.activeUIBbox) {
+                                const cx = this.activeUIBbox.cx();
+                                const cy = this.activeUIBbox.cy();
+                                finalPoints = rotate2DPoints(cx, cy, rotation, finalPoints);
+                            }
+                            shape.untransform();
+                            this.polygonResizeSnapshot = null;
+                            this.onEditDone(state, this.translateFromCanvas(finalPoints), 0);
                         } else {
                             // these points does not take into account possible transformations, applied on the element
                             // so, if any (like rotation) we need to map them to canvas coordinate space
@@ -1692,6 +1754,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
             sliceHidden: {},
         };
 
+        this.activeUIBbox = null;
         this.isImageLoading = true;
         this.draggableShape = null;
         this.resizableShape = null;
@@ -2528,6 +2591,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
             descriptions: [...state.descriptions],
             zOrder: state.zOrder,
             pinned: state.pinned,
+            bboxEditMode: state.bboxEditMode,
             updated: state.updated,
             frame: state.frame,
             label: state.label,
@@ -2631,7 +2695,10 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 }
             }
 
-            if (drawnState.pinned !== state.pinned && this.activeElement.clientID !== null) {
+            const toggledPin = drawnState.pinned !== state.pinned;
+            const toggledBboxEdit = drawnState.bboxEditMode !== state.bboxEditMode;
+
+            if ((toggledPin || toggledBboxEdit) && this.activeElement.clientID !== null) {
                 const activeElement = { ...this.activeElement };
                 this.deactivate();
                 this.activate(activeElement);
@@ -2680,6 +2747,17 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     if (state.shapeType === 'points' && !isInvisible) {
                         this.selectize(false, shape);
                         this.setupPoints(shape as SVG.PolyLine, state);
+                    }
+
+                    if (this.activeElement.clientID === clientID && (state.shapeType === 'polygon' || state.shapeType === 'polyline') && this.activeUIBbox) {
+                        this.selectize(false, this.activeUIBbox);
+                        this.activeUIBbox.untransform();
+
+                        const originalPoints = readPointsFromShape(shape);
+                        const bbox = computeWrappingBox(originalPoints);
+
+                        this.activeUIBbox.move(bbox.x, bbox.y).size(bbox.width, bbox.height);
+                        this.selectize(true, this.activeUIBbox);
                     }
                 }
             }
@@ -2881,6 +2959,12 @@ export class CanvasViewImpl implements CanvasView, Listener {
             const drawnState = this.drawnStates[clientID];
             const shape = this.svgShapes[clientID];
 
+            if (this.activeUIBbox) {
+                this.selectize(false, this.activeUIBbox);
+                this.activeUIBbox.remove();
+                this.activeUIBbox = null;
+            }
+
             if (drawnState.shapeType === 'points') {
                 this.svgShapes[clientID]
                     .remember('_selectHandler').nested
@@ -2996,7 +3080,9 @@ export class CanvasViewImpl implements CanvasView, Listener {
             (shape as any).attr('projections', true);
         }
 
-        if (state.shapeType !== 'points') {
+        const isBboxEditMode = state.bboxEditMode && (state.shapeType === 'polygon' || state.shapeType === 'polyline');
+
+        if (state.shapeType !== 'points' && !isBboxEditMode) {
             this.selectize(true, shape);
         }
 
@@ -3031,6 +3117,26 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     this.hideDirection(shape as SVG.Polygon | SVG.PolyLine);
                 }
             };
+
+            if (state.bboxEditMode && (state.shapeType === 'polygon' || state.shapeType === 'polyline')) {
+                const originalPoints = readPointsFromShape(shape);
+                const bbox = computeWrappingBox(originalPoints);
+
+                this.activeUIBbox = this.adoptedContent.rect(bbox.width, bbox.height)
+                    .move(bbox.x, bbox.y)
+                    .attr({
+                        fill: shape.attr('fill'),
+                        'fill-opacity': 0,
+                        'stroke': shape.attr('fill'),
+                        'stroke-width': consts.BASE_STROKE_WIDTH / this.geometry.scale,
+                        'stroke-dasharray': '5,5',
+                        'pointer-events': 'none',
+                    })
+                    .addClass('cvat_canvas_active_bbox');
+
+                this.content.append(this.activeUIBbox.node);
+                this.selectize(true, this.activeUIBbox);
+            }
 
             let shapeSizeElement: ShapeSizeElement | null = null;
             this.resizable(state, shape, () => {

--- a/cvat-canvas/src/typescript/shared.ts
+++ b/cvat-canvas/src/typescript/shared.ts
@@ -52,6 +52,7 @@ export interface DrawnState {
     descriptions: string[];
     zOrder?: number;
     pinned?: boolean;
+    bboxEditMode?: boolean;
     updated: number;
     frame: number;
     label: any;
@@ -796,4 +797,19 @@ export function applySnapToShapePoint(
         pointsArray[pointIndex] = [snapTarget.x, snapTarget.y];
         shape.plot(pointsArray);
     }
+}
+
+export function mirror2DPoints(points: number[], horizontal: boolean, vertical: boolean): number[] {
+    const bbox = computeWrappingBox(points);
+    const cx = bbox.x + bbox.width / 2;
+    const cy = bbox.y + bbox.height / 2;
+
+    return points.map((val, idx) => {
+        if (idx % 2 === 0) {
+            // x coordinate
+            return horizontal ? 2 * cx - val : val;
+        }
+        // y coordinate
+        return vertical ? 2 * cy - val : val;
+    });
 }

--- a/cvat-core/src/annotations-objects.ts
+++ b/cvat-core/src/annotations-objects.ts
@@ -343,6 +343,10 @@ class Annotation {
             checkObjectType('pinned', data.pinned, 'boolean');
         }
 
+        if (updated.bboxEditMode) {
+            checkObjectType('bboxEditMode', data.bboxEditMode, 'boolean');
+        }
+
         if (updated.color) {
             checkObjectType('color', data.color, 'string');
             if (!/^#[0-9A-F]{6}$/i.test(data.color)) {
@@ -433,6 +437,7 @@ class Drawn extends Annotation {
     protected descriptions: string[];
     public hidden: boolean;
     protected pinned: boolean;
+    public bboxEditMode: boolean;
     public shapeType: ShapeType;
 
     constructor(data, clientID: number, color: string, injection: AnnotationInjection) {
@@ -441,6 +446,7 @@ class Drawn extends Annotation {
         this.descriptions = data.descriptions || [];
         this.hidden = false;
         this.pinned = true;
+        this.bboxEditMode = data.bboxEditMode || false;
         this.shapeType = null;
     }
 
@@ -467,6 +473,27 @@ class Drawn extends Annotation {
         );
 
         this.pinned = pinned;
+    }
+
+    protected saveBboxEditMode(bboxEditMode: boolean, frame: number): void {
+        const undoBboxEditMode = this.bboxEditMode;
+        const redoBboxEditMode = bboxEditMode;
+
+        this.history.do(
+            HistoryActions.CHANGED_BBOX_EDIT_MODE,
+            () => {
+                this.bboxEditMode = undoBboxEditMode;
+                this.updated = Date.now();
+            },
+            () => {
+                this.bboxEditMode = redoBboxEditMode;
+                this.updated = Date.now();
+            },
+            [this.clientID],
+            frame,
+        );
+
+        this.bboxEditMode = bboxEditMode;
     }
 
     protected saveHidden(hidden: boolean, frame: number): void {
@@ -626,6 +653,7 @@ export class Shape extends Drawn {
             hidden: this.hidden,
             updated: this.updated,
             pinned: this.pinned,
+            bboxEditMode: this.bboxEditMode,
             frame,
             source: this.source,
             score: this.score,
@@ -771,6 +799,7 @@ export class Shape extends Drawn {
     }
 
     public save(frame: number, data: ObjectState): ObjectState {
+        console.log("2. CVAT Core is saving the object. bboxEditMode flag:", data.updateFlags.bboxEditMode);
         if (frame !== this.frame) {
             throw new ScriptingError('Received frame is not equal to the frame of the shape');
         }
@@ -826,6 +855,10 @@ export class Shape extends Drawn {
 
         if (updated.pinned) {
             this.savePinned(data.pinned, frame);
+        }
+
+        if (updated.bboxEditMode) {
+            this.saveBboxEditMode(data.bboxEditMode, frame);
         }
 
         if (updated.color) {
@@ -972,6 +1005,7 @@ export class Track extends Drawn {
             updated: this.updated,
             label: this.label,
             pinned: this.pinned,
+            bboxEditMode: this.bboxEditMode,
             keyframes: {
                 prev,
                 next,
@@ -1377,6 +1411,10 @@ export class Track extends Drawn {
             this.savePinned(data.pinned, frame);
         }
 
+        if (updated.bboxEditMode) {
+            this.saveBboxEditMode(data.bboxEditMode, frame);
+        }
+
         if (updated.color) {
             this.saveColor(data.color, frame);
         }
@@ -1496,7 +1534,7 @@ export class Tag extends Annotation {
 
     public get(frame: number): Omit<Required<SerializedData>,
     'elements' | 'occluded' | 'outside' | 'rotation' | 'zOrder' |
-    'points' | 'hidden' | 'pinned' | 'keyframe' | 'shapeType' |
+    'points' | 'hidden' | 'pinned' | 'bboxEditMode' | 'keyframe' | 'shapeType' |
     'parentID' | 'descriptions' | 'keyframes'
     > {
         if (frame !== this.frame) {
@@ -2084,6 +2122,7 @@ export class SkeletonShape extends Shape {
             color: this.color,
             updated: Math.max(this.updated, ...this.elements.map((element) => element.updated)),
             pinned: this.pinned,
+            bboxEditMode: this.bboxEditMode,
             outside: elements.every((el) => el.outside),
             occluded: elements.every((el) => el.occluded),
             lock: elements.every((el) => el.lock),

--- a/cvat-core/src/enums.ts
+++ b/cvat-core/src/enums.ts
@@ -139,6 +139,7 @@ export enum HistoryActions {
     CHANGED_KEYFRAME = 'Changed keyframe',
     CHANGED_LOCK = 'Changed lock',
     CHANGED_PINNED = 'Changed pinned',
+    CHANGED_BBOX_EDIT_MODE = 'Changed bbox edit mode',
     CHANGED_COLOR = 'Changed color',
     CHANGED_HIDDEN = 'Changed hidden',
     CHANGED_SOURCE = 'Changed source',

--- a/cvat-core/src/object-state.ts
+++ b/cvat-core/src/object-state.ts
@@ -25,6 +25,7 @@ interface UpdateFlags {
     color: boolean;
     hidden: boolean;
     descriptions: boolean;
+    bboxEditMode: boolean;
     reset: () => void;
 }
 
@@ -40,6 +41,7 @@ export interface SerializedData {
     lock?: boolean;
     hidden?: boolean;
     pinned?: boolean;
+    bboxEditMode?: boolean;
     attributes?: Record<number, string>;
     group?: { color: string; id: number; };
     color?: string;
@@ -68,6 +70,8 @@ export interface SerializedData {
 }
 
 export default class ObjectState {
+
+    private static bboxEditModeMap: Record<number, boolean> = {};
     private readonly __internal: {
         save: (objectState: ObjectState) => ObjectState;
         delete: (frame: number, force: boolean) => boolean;
@@ -96,6 +100,7 @@ export default class ObjectState {
     public color: string;
     public hidden: boolean;
     public pinned: boolean;
+    public bboxEditMode: boolean;
     public points: number[] | null;
     public rotation: number | null;
     public zOrder: number;
@@ -146,6 +151,7 @@ export default class ObjectState {
                 this.color = false;
                 this.hidden = false;
                 this.descriptions = false;
+                this.bboxEditMode = false;
 
                 return reset;
             },
@@ -171,6 +177,7 @@ export default class ObjectState {
             color: '#000000',
             hidden: false,
             pinned: false,
+            bboxEditMode: serialized.bboxEditMode !== undefined ? serialized.bboxEditMode : false,
             source: serialized.source || Source.MANUAL,
             keyframes: serialized.keyframes || null,
             group: serialized.group || null,
@@ -413,6 +420,15 @@ export default class ObjectState {
                         data.pinned = pinned;
                     },
                 },
+                bboxEditMode: {
+                    get: () => {
+                        return ObjectState.bboxEditModeMap[data.clientID] || false;
+                    },
+                    set: (bboxEditMode) => {
+                        data.updateFlags.bboxEditMode = true;
+                        ObjectState.bboxEditModeMap[data.clientID] = bboxEditMode;
+                    },
+                },
                 updated: {
                     get: () => data.updated,
                 },
@@ -483,6 +499,9 @@ export default class ObjectState {
         }
         if (typeof serialized.hidden === 'boolean') {
             data.hidden = serialized.hidden;
+        }
+        if (typeof serialized.bboxEditMode === 'boolean') {
+            ObjectState.bboxEditModeMap[data.clientID] = serialized.bboxEditMode;
         }
         if (typeof serialized.color === 'string') {
             data.color = serialized.color;

--- a/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-sidebar/attribute-annotation-sidebar.tsx
+++ b/cvat-ui/src/components/annotation-page/attribute-annotation-workspace/attribute-annotation-sidebar/attribute-annotation-sidebar.tsx
@@ -10,7 +10,7 @@ import Layout, { SiderProps } from 'antd/lib/layout';
 import Text from 'antd/lib/typography/Text';
 
 import { filterApplicableLabels } from 'utils/filter-applicable-labels';
-import { Label, ObjectType } from 'cvat-core-wrapper';
+import { Label, ObjectType, ShapeType } from 'cvat-core-wrapper';
 import {
     activateObject as activateObjectAction,
     changeFrameAsync,
@@ -29,6 +29,7 @@ import AttributeEditor from './attribute-editor';
 import AttributeSwitcher from './attribute-switcher';
 import ObjectBasicsEditor from './object-basics-editor';
 import ObjectSwitcher from './object-switcher';
+import { mirror2DPoints } from 'cvat-ui/src/utils/math';
 
 interface StateToProps {
     activatedStateID: number | null;
@@ -82,6 +83,12 @@ const componentShortcuts = {
         sequences: ['p'],
         scope: ShortcutScope.OBJECTS_SIDEBAR,
     },
+    SWITCH_BBOX_EDIT_MODE: {
+        name: 'Toggle edit mode',
+        description: 'Change bounding box edit mode for an active object',
+        sequences: ['s'],
+        scope: ShortcutScope.OBJECTS_SIDEBAR,
+    },
     NEXT_KEY_FRAME: {
         name: 'Next keyframe',
         description: 'Go to the next keyframe of an active track',
@@ -93,6 +100,18 @@ const componentShortcuts = {
         description: 'Go to the previous keyframe of an active track',
         sequences: ['e'],
         scope: ShortcutScope.OBJECTS_SIDEBAR,
+    },
+    MIRROR_HORIZONTAL: {
+        name: 'Mirror horizontal',
+        description: 'Mirror the selected polygon or polyline horizontally',
+        sequences: ['shift+h'],
+        scope: ShortcutScope.ATTRIBUTE_ANNOTATION_WORKSPACE,
+    },
+    MIRROR_VERTICAL: {
+        name: 'Mirror vertical',
+        description: 'Mirror the selected polygon or polyline vertically',
+        sequences: ['shift+v'],
+        scope: ShortcutScope.ATTRIBUTE_ANNOTATION_WORKSPACE,
     },
 };
 
@@ -291,6 +310,13 @@ function AttributeAnnotationSidebar(props: StateToProps & DispatchToProps): JSX.
                 updateAnnotations([activeObjectState]);
             }
         },
+        SWITCH_BBOX_EDIT_MODE: (event: KeyboardEvent | undefined) => {
+            preventDefault(event);
+            if (activeObjectState && [ShapeType.POLYGON, ShapeType.POLYLINE].includes(activeObjectState.shapeType)) {
+                activeObjectState.bboxEditMode = !activeObjectState.bboxEditMode;
+                updateAnnotations([activeObjectState]);
+            }
+        },
         NEXT_KEY_FRAME: (event: KeyboardEvent | undefined) => {
             preventDefault(event);
             if (activeObjectState && activeObjectState.objectType === ObjectType.TRACK) {
@@ -309,6 +335,20 @@ function AttributeAnnotationSidebar(props: StateToProps & DispatchToProps): JSX.
                 if (frame !== null && isAbleToChangeFrame(frame)) {
                     changeFrame(frame);
                 }
+            }
+        },
+        MIRROR_HORIZONTAL: (event: KeyboardEvent | undefined) => {
+            preventDefault(event);
+            if (activeObjectState && activeObjectState.points && [ShapeType.POLYGON, ShapeType.POLYLINE].includes(activeObjectState.shapeType)) {
+                activeObjectState.points = mirror2DPoints(activeObjectState.points, true, false);
+                updateAnnotations([activeObjectState]);
+            }
+        },
+        MIRROR_VERTICAL: (event: KeyboardEvent | undefined) => {
+            preventDefault(event);
+            if (activeObjectState && activeObjectState.points && [ShapeType.POLYGON, ShapeType.POLYLINE].includes(activeObjectState.shapeType)) {
+                activeObjectState.points = mirror2DPoints(activeObjectState.points, false, true);
+                updateAnnotations([activeObjectState]);
             }
         },
     };

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-basics.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-basics.tsx
@@ -56,6 +56,8 @@ interface Props {
     edit(): void;
     slice(): void;
     simplify(): void;
+    mirrorHorizontal(): void;
+    mirrorVertical(): void;
 }
 
 function ItemTopComponent(props: Props): JSX.Element {
@@ -99,6 +101,8 @@ function ItemTopComponent(props: Props): JSX.Element {
         slice,
         simplify,
         jobInstance,
+        mirrorHorizontal,
+        mirrorVertical,
     } = props;
 
     const [colorPickerVisible, setColorPickerVisible] = useState(false);
@@ -185,6 +189,8 @@ function ItemTopComponent(props: Props): JSX.Element {
                             slice,
                             simplify,
                             runAnnotationAction,
+                            mirrorHorizontal,
+                            mirrorVertical,
                         })}
                     >
                         <Col span={2}>

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-buttons.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-buttons.tsx
@@ -17,6 +17,8 @@ import Icon, {
     SelectOutlined,
     StarOutlined,
     EyeOutlined,
+    ExpandAltOutlined,
+    NodeIndexOutlined,
 } from '@ant-design/icons';
 
 import CVATTooltip from 'components/common/cvat-tooltip';
@@ -34,6 +36,7 @@ interface Props {
     locked: boolean;
     pinned: boolean;
     hidden: boolean;
+    bboxEditMode: boolean;
     keyframe: boolean | undefined;
     outsideDisabled: boolean;
     hiddenDisabled: boolean;
@@ -46,6 +49,7 @@ interface Props {
     switchKeyFrameShortcut: string;
     nextKeyFrameShortcut: string;
     prevKeyFrameShortcut: string;
+    switchBboxEditModeShortcut: string;
 
     navigateFirstKeyframe: null | (() => void);
     navigatePrevKeyframe: null | (() => void);
@@ -64,6 +68,8 @@ interface Props {
     unpin(): void;
     hide(): void;
     show(): void;
+    setBboxEditMode(): void;
+    unsetBboxEditMode(): void;
 }
 
 const classes = {
@@ -90,6 +96,10 @@ const classes = {
     hidden: {
         enabled: { className: 'cvat-object-item-button-hidden cvat-object-item-button-hidden-enabled' },
         disabled: { className: 'cvat-object-item-button-hidden' },
+    },
+    bboxEditMode: {
+        enabled: { className: 'cvat-object-item-button-bbox-mode cvat-object-item-button-bbox-mode-enabled' },
+        disabled: { className: 'cvat-object-item-button-bbox-mode' },
     },
     keyframe: {
         enabled: { className: 'cvat-object-item-button-keyframe cvat-object-item-button-keyframe-enabled' },
@@ -229,6 +239,31 @@ function SwitchHidden(props: Props): JSX.Element {
     );
 }
 
+function SwitchBboxEditMode(props: Props): JSX.Element {
+    const {
+        locked, bboxEditMode, setBboxEditMode, unsetBboxEditMode, switchBboxEditModeShortcut
+    } = props;
+
+    const style = locked ? disabledStyle : {};
+    return (
+        <CVATTooltip title={`Toggle bounding box edit mode ${switchBboxEditModeShortcut}`}>
+            {bboxEditMode ? (
+                <ExpandAltOutlined
+                    {...classes.bboxEditMode.enabled}
+                    onClick={locked ? undefined : unsetBboxEditMode}
+                    style={style}
+                />
+            ) : (
+                <NodeIndexOutlined
+                    {...classes.bboxEditMode.disabled}
+                    onClick={locked ? undefined : setBboxEditMode}
+                    style={style}
+                />
+            )}
+        </CVATTooltip>
+    );
+}
+
 function SwitchOutside(props: Props): JSX.Element {
     const {
         outside, locked, switchOutsideShortcut, outsideDisabled, unsetOutside, setOutside,
@@ -324,6 +359,11 @@ function ItemButtonsComponent(props: Props): JSX.Element {
                                 <SwitchPinned {...props} />
                             </Col>
                         )}
+                        {[ShapeType.POLYGON, ShapeType.POLYLINE].includes(shapeType) && (
+                            <Col>
+                                <SwitchBboxEditMode {...props} />
+                            </Col>
+                        )}
                     </Row>
                 </Col>
             </Row>
@@ -352,6 +392,11 @@ function ItemButtonsComponent(props: Props): JSX.Element {
                         {shapeType !== ShapeType.POINTS && (
                             <Col>
                                 <SwitchPinned {...props} />
+                            </Col>
+                        )}
+                        {[ShapeType.POLYGON, ShapeType.POLYLINE].includes(shapeType) && (
+                            <Col>
+                                <SwitchBboxEditMode {...props} />
                             </Col>
                         )}
                     </Row>

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-menu.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-menu.tsx
@@ -8,7 +8,7 @@ import Button from 'antd/lib/button';
 import { MenuProps } from 'antd/lib/menu';
 import Icon, {
     LinkOutlined, CopyOutlined, BlockOutlined, RetweetOutlined, DeleteOutlined, EditOutlined,
-    FunctionOutlined,
+    FunctionOutlined, SwapOutlined,
 } from '@ant-design/icons';
 
 import {
@@ -56,6 +56,8 @@ interface Props {
     slice(): void;
     simplify(): void;
     runAnnotationAction(): void;
+    mirrorHorizontal(): void;
+    mirrorVertical(): void;
     jobInstance: Job;
 }
 
@@ -310,6 +312,40 @@ function RunAnnotationActionItem(props: ItemProps): JSX.Element {
     );
 }
 
+function MirrorHorizontalItem(props: ItemProps): JSX.Element {
+    const { toolProps } = props;
+    const { mirrorHorizontal } = toolProps;
+    return (
+        <CVATTooltip title='Mirror horizontally'>
+            <Button
+                type='link'
+                icon={<SwapOutlined />}
+                onClick={mirrorHorizontal}
+                className='cvat-object-item-menu-mirror-horizontal'
+            >
+                Mirror horizontally
+            </Button>
+        </CVATTooltip>
+    );
+}
+
+function MirrorVerticalItem(props: ItemProps): JSX.Element {
+    const { toolProps } = props;
+    const { mirrorVertical } = toolProps;
+    return (
+        <CVATTooltip title='Mirror vertically'>
+            <Button
+                type='link'
+                icon={<SwapOutlined rotate={90} />}
+                onClick={mirrorVertical}
+                className='cvat-object-item-menu-mirror-vertical'
+            >
+                Mirror vertically
+            </Button>
+        </CVATTooltip>
+    );
+}
+
 export default function ItemMenu(props: Props): MenuProps {
     const {
         locked, shapeType, objectType, colorBy, jobInstance,
@@ -330,6 +366,8 @@ export default function ItemMenu(props: Props): MenuProps {
         EDIT_MASK = 'edit_mask',
         SLICE_ITEM = 'slice_item',
         SIMPLIFY_ITEM = 'simplify_item',
+        MIRROR_HORIZONTAL = 'mirror_horizontal',
+        MIRROR_VERTICAL = 'mirror_vertical',
         RUN_ANNOTATION_ACTION = 'run_annotation_action',
     }
 
@@ -419,6 +457,21 @@ export default function ItemMenu(props: Props): MenuProps {
         items.push({
             key: MenuKeys.SWITCH_COLOR,
             label: <SwitchColorItem toolProps={props} />,
+        });
+    }
+
+    if (
+        !locked && objectType === ObjectType.SHAPE &&
+        [ShapeType.POLYGON, ShapeType.POLYLINE].includes(shapeType)
+    ) {
+        items.push({
+            key: MenuKeys.MIRROR_HORIZONTAL,
+            label: <MirrorHorizontalItem key={MenuKeys.MIRROR_HORIZONTAL} toolProps={props} />,
+        });
+
+        items.push({
+            key: MenuKeys.MIRROR_VERTICAL,
+            label: <MirrorVerticalItem key={MenuKeys.MIRROR_VERTICAL} toolProps={props} />,
         });
     }
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
@@ -48,6 +48,8 @@ interface Props {
     edit(): void;
     slice(): void;
     simplify(): void;
+    mirrorHorizontal(): void;
+    mirrorVertical(): void;
 }
 
 function ObjectItemComponent(props: Props): JSX.Element {
@@ -84,6 +86,8 @@ function ObjectItemComponent(props: Props): JSX.Element {
         slice,
         simplify,
         jobInstance,
+        mirrorHorizontal,
+        mirrorVertical,
     } = props;
 
     const type =
@@ -148,6 +152,8 @@ function ObjectItemComponent(props: Props): JSX.Element {
                     slice={slice}
                     simplify={simplify}
                     runAnnotationAction={runAnnotationAction}
+                    mirrorHorizontal={mirrorHorizontal}
+                    mirrorVertical={mirrorVertical}
                 />
                 <ObjectButtonsContainer clientID={clientID} />
                 <ItemDetailsContainer

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-buttons.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-buttons.tsx
@@ -146,6 +146,18 @@ class ItemButtonsWrapper extends React.PureComponent<StateToProps & DispatchToPr
         this.commit();
     };
 
+    private setBboxEditMode = (): void => {
+        const { objectState } = this.props;
+        objectState.bboxEditMode = true;
+        this.commit();
+    };
+
+    private unsetBboxEditMode = (): void => {
+        const { objectState } = this.props;
+        objectState.bboxEditMode = false;
+        this.commit();
+    };
+
     private show = (): void => {
         const { objectState, editedState, changeHideEditedState } = this.props;
         if (objectState.clientID === editedState?.clientID) {
@@ -235,7 +247,7 @@ class ItemButtonsWrapper extends React.PureComponent<StateToProps & DispatchToPr
 
         const {
             parentID, objectType, shapeType,
-            occluded, outside, lock, pinned, hidden, keyframe,
+            occluded, outside, lock, pinned, hidden, keyframe, bboxEditMode,
         } = objectState;
 
         return (
@@ -249,6 +261,7 @@ class ItemButtonsWrapper extends React.PureComponent<StateToProps & DispatchToPr
                 pinned={pinned}
                 hidden={hidden}
                 keyframe={keyframe}
+                bboxEditMode={bboxEditMode}
                 switchOccludedShortcut={normalizedKeyMap.SWITCH_OCCLUDED}
                 switchPinnedShortcut={normalizedKeyMap.SWITCH_PINNED}
                 switchOutsideShortcut={normalizedKeyMap.SWITCH_OUTSIDE}
@@ -257,6 +270,7 @@ class ItemButtonsWrapper extends React.PureComponent<StateToProps & DispatchToPr
                 switchKeyFrameShortcut={normalizedKeyMap.SWITCH_KEYFRAME}
                 nextKeyFrameShortcut={normalizedKeyMap.NEXT_KEY_FRAME}
                 prevKeyFrameShortcut={normalizedKeyMap.PREV_KEY_FRAME}
+                switchBboxEditModeShortcut={normalizedKeyMap.SWITCH_BBOX_EDIT_MODE}
                 outsideDisabled={outsideDisabled}
                 hiddenDisabled={hiddenDisabled}
                 keyframeDisabled={keyframeDisabled || (first === last && keyframe)}
@@ -276,6 +290,8 @@ class ItemButtonsWrapper extends React.PureComponent<StateToProps & DispatchToPr
                 unpin={this.unpin}
                 hide={this.hide}
                 show={this.show}
+                setBboxEditMode={this.setBboxEditMode}
+                unsetBboxEditMode={this.unsetBboxEditMode}
             />
         );
     }

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
@@ -35,6 +35,7 @@ import { Canvas, CanvasMode } from 'cvat-canvas-wrapper';
 import { Canvas3d } from 'cvat-canvas3d-wrapper';
 import { filterApplicableLabels } from 'utils/filter-applicable-labels';
 import { toClipboard } from 'utils/to-clipboard';
+import { mirror2DPoints } from 'cvat-ui/src/utils/math';
 
 interface OwnProps {
     clientID: number;
@@ -424,6 +425,30 @@ class ObjectItemContainer extends React.PureComponent<Props, State> {
         }
     };
 
+    private mirrorHorizontal = (): void => {
+        const { objectState, updateState } = this.props;
+
+        if ([ShapeType.POLYGON, ShapeType.POLYLINE].includes(objectState.shapeType)) {
+            const points = objectState.points as number[];
+            if (points && points.length > 0) {
+                objectState.points = mirror2DPoints(points, true, false);
+                updateState(objectState);
+            }
+        }
+    };
+
+    private mirrorVertical = (): void => {
+        const { objectState, updateState } = this.props;
+
+        if ([ShapeType.POLYGON, ShapeType.POLYLINE].includes(objectState.shapeType)) {
+            const points = objectState.points as number[];
+            if (points && points.length > 0) {
+                objectState.points = mirror2DPoints(points, false, true);
+                updateState(objectState);
+            }
+        }
+    };
+
     private toBackground = (): void => {
         const { objectState, minZLayer } = this.props;
 
@@ -605,6 +630,8 @@ class ObjectItemContainer extends React.PureComponent<Props, State> {
                     edit={this.edit}
                     slice={this.slice}
                     simplify={this.requestSimplification}
+                    mirrorHorizontal={this.mirrorHorizontal}
+                    mirrorVertical={this.mirrorVertical}
                     resetCuboidPerspective={this.resetCuboidPerspective}
                     runAnnotationAction={this.runAnnotationAction}
                 />

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/objects-list.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/objects-list.tsx
@@ -35,6 +35,7 @@ import { registerComponentShortcuts } from 'actions/shortcuts-actions';
 import { ShortcutScope } from 'utils/enums';
 import { subKeyMap } from 'utils/component-subkeymap';
 import { openAnnotationsActionModal } from 'components/annotation-page/annotations-actions/annotations-actions-modal';
+import { mirror2DPoints } from 'cvat-ui/src/utils/math';
 
 interface StateToProps {
     jobInstance: any;
@@ -108,6 +109,12 @@ const componentShortcuts = {
         name: 'Switch pinned property',
         description: 'Change pinned property for an active object',
         sequences: ['p'],
+        scope: ShortcutScope.OBJECTS_SIDEBAR,
+    },
+    SWITCH_BBOX_EDIT_MODE: {
+        name: 'Toggle edit mode',
+        description: 'Change bounding box edit mode for an active object',
+        sequences: ['s'],
         scope: ShortcutScope.OBJECTS_SIDEBAR,
     },
     SWITCH_KEYFRAME: {
@@ -192,6 +199,18 @@ const componentShortcuts = {
         name: 'Simplify polygon',
         description: 'Activate simplification mode for the selected polygon or polyline',
         sequences: [],
+        scope: ShortcutScope.OBJECTS_SIDEBAR,
+    },
+    MIRROR_HORIZONTAL: {
+        name: 'Mirror horizontal',
+        description: 'Mirror the selected polygon or polyline horizontally',
+        sequences: ['shift+h'],
+        scope: ShortcutScope.OBJECTS_SIDEBAR,
+    },
+    MIRROR_VERTICAL: {
+        name: 'Mirror vertical',
+        description: 'Mirror the selected polygon or polyline vertically',
+        sequences: ['shift+v'],
         scope: ShortcutScope.OBJECTS_SIDEBAR,
     },
 };
@@ -552,6 +571,14 @@ class ObjectsListContainer extends React.PureComponent<Props, State> {
                     updateAnnotations([state]);
                 }
             },
+            SWITCH_BBOX_EDIT_MODE: (event?: KeyboardEvent) => {
+                preventDefault(event);
+                const state = activatedState(true);
+                if (state && [ShapeType.POLYGON, ShapeType.POLYLINE].includes(state.shapeType)) {
+                    state.bboxEditMode = !state.bboxEditMode;
+                    updateAnnotations([state]);
+                }
+            },
             SWITCH_KEYFRAME: (event?: KeyboardEvent) => {
                 preventDefault(event);
                 const state = activatedState();
@@ -673,6 +700,22 @@ class ObjectsListContainer extends React.PureComponent<Props, State> {
                 const state = activatedState(true);
                 if (state && [ShapeType.POLYGON, ShapeType.POLYLINE].includes(state.shapeType)) {
                     switchSimplifyVisibility(state.clientID);
+                }
+            },
+            MIRROR_HORIZONTAL: (event?: KeyboardEvent) => {
+                preventDefault(event);
+                const state = activatedState(true);
+                if (state && state.points && [ShapeType.POLYGON, ShapeType.POLYLINE].includes(state.shapeType)) {
+                    state.points = mirror2DPoints(state.points, true, false);
+                    updateAnnotations([state]);
+                }
+            },
+            MIRROR_VERTICAL: (event?: KeyboardEvent) => {
+                preventDefault(event);
+                const state = activatedState(true);
+                if (state && state.points && [ShapeType.POLYGON, ShapeType.POLYLINE].includes(state.shapeType)) {
+                    state.points = mirror2DPoints(state.points, false, true);
+                    updateAnnotations([state]);
                 }
             },
         };

--- a/cvat-ui/src/utils/math.ts
+++ b/cvat-ui/src/utils/math.ts
@@ -20,3 +20,27 @@ export function rotatePoint(x: number, y: number, angle: number, cx = 0, cy = 0)
     const rotY = (y - cy) * cos + (x - cx) * sin + cy;
     return [rotX, rotY];
 }
+
+export function mirror2DPoints(points: number[], horizontal: boolean, vertical: boolean): number[] {
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+
+    for (let i = 0; i < points.length; i += 2) {
+        if (points[i] < minX) minX = points[i];
+        if (points[i] > maxX) maxX = points[i];
+        if (points[i + 1] < minY) minY = points[i + 1];
+        if (points[i + 1] > maxY) maxY = points[i + 1];
+    }
+
+    const cx = (minX + maxX) / 2;
+    const cy = (minY + maxY) / 2;
+
+    return points.map((val, index) => {
+        if (index % 2 === 0) {
+            return horizontal ? 2 * cx - val : val;
+        }
+        return vertical ? 2 * cy - val : val;
+    });
+}

--- a/site/content/en/docs/annotation/annotation-editor/objects-sidebar.md
+++ b/site/content/en/docs/annotation/annotation-editor/objects-sidebar.md
@@ -62,6 +62,8 @@ The action menu contains:
     copy of the object on `N` _subsequent_ frames at the same position.
   - **Propagate backward** (![Back propagate](/images/propagate_back.png)) creates
     a copy of the object on `N` _previous_ frames at the same position.
+- **Mirror horizontal** - mirrors the shape horizontally. Keyboard shortcut **Shift+H**.
+- **Mirror vertical** - mirrors the shape vertically. Keyboard shortcut **Shift+V**.
 
   ![Window with options and parameters for object propagation](/images/image053.jpg)
 
@@ -92,6 +94,8 @@ You can change the way an object is displayed on a frame (show or hide).
 **Switch pinned property** - when enabled, a shape cannot be moved by dragging or dropping.
 
 ![Objects sidebar with highlighted button for pinning object](/images/image052.jpg)
+
+**BBox edit mode** - toggles a bounding box for resizing and rotating complex shapes (like polygons and polylines). Shortcut: **S**.
 
 **Tracker switcher** - enable/disable {{< ilink "/docs/annotation/auto-annotation/ai-tools#trackers" "tracking" >}} for
 the object.

--- a/site/content/en/docs/annotation/manual-annotation/shapes/annotation-with-polygons/edit-polygon.md
+++ b/site/content/en/docs/annotation/manual-annotation/shapes/annotation-with-polygons/edit-polygon.md
@@ -22,6 +22,16 @@ To edit a polygon you have to click on it while holding `Shift`, it will open th
   In this case after closing the polygon, you can select the part of the polygon you want to leave.
 
   ![Setting for Intelligent polygon cropping](/images/image209.jpg)
+- To scale or rotate a shape as a whole, rather than editing individual points, you can either press `S` or
+  click the BBox edit mode button on obeject side bar. After that, a bounding box will appear around the shape,
+  in which you can:
+  - Scale by dragging any of the bouding box corners or edge handles to resize the shape.
+  - Rotate by clicking and draging the rotation handle to rotate the shape around its center.
+- You can mathematically mirror a shape across its center axis:
+  - You can mirror horizontally by pressing `Shift+H` or selecting ****Mirror horizontally** from the object's
+  action menu in the sidebar.
+  - Tou can mirror vertically by pressing `Shift+V` or selecting **Mirror vertically** from the object's action
+  menu in the sidebar.
 
 - You can press `Esc` to cancel editing.
 

--- a/site/content/en/docs/annotation/manual-annotation/shapes/annotation-with-polylines.md
+++ b/site/content/en/docs/annotation/manual-annotation/shapes/annotation-with-polylines.md
@@ -19,6 +19,15 @@ you either create points by clicking or by dragging a mouse on the screen while 
 When `Shift` isn't pressed, you can zoom in/out (when scrolling the mouse wheel)
 and move (when clicking the mouse wheel and moving the mouse), you can delete
 previous points by right-clicking on it.
+Press `S` or click the `BBox edit mode` button on the object sidebar to scale or rotate the shape
+as a whole, rather than editing individual points. To scale, drag any of the bounding box corners
+or edge handles to resize the shape. To rotate click and drag the rotation handle (the point
+extending from the bounding box) to rotate the shape around its center. Press `S` again to exit
+the bounding box edit mode.
+Press `Shift+H` or select **Mirror horizontally** from the object's action menu in the sidebar to
+mathematically mirror a shape across its center axis horizontally. Press `Shift+H` or select
+**Mirror vertically** from the object's action menu in the sidebar to mathematically mirror
+a shape across its center axis vertically.
 Press `N` again or click the `Done` button on the top panel to complete the shape.
 You can delete a point by clicking on it with pressed `Ctrl` or right-clicking on a point
 and selecting `Delete point`. Click with pressed `Shift` will open a polyline editor.

--- a/tests/cypress/e2e/issues_prs2/issue_9578_mirror_and_bbox_edit_mode.js
+++ b/tests/cypress/e2e/issues_prs2/issue_9578_mirror_and_bbox_edit_mode.js
@@ -1,0 +1,212 @@
+// Copyright (C) 2020-2022 Intel Corporation
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName, labelName } from '../../support/const';
+
+context('Feature: Mirroring and BBox Edit Mode', () => {
+    const issueId = '9578';
+
+    const createPolygonPoints = {
+        type: 'Shape',
+        labelName: labelName,
+        pointsMap: [
+            { x: 300, y: 300 },
+            { x: 500, y: 300 },
+            { x: 400, y: 500 },
+        ],
+    };
+
+    const createPolylinePoints = {
+        type: 'Shape',
+        labelName: labelName,
+        pointsMap: [
+            { x: 600, y: 300 },
+            { x: 700, y: 400 },
+            { x: 600, y: 500 },
+        ],
+    };
+
+    before(() => {
+        cy.prepareUserSession();
+        cy.openTaskJob(taskName);
+    });
+
+    describe(`Testing PR "${issueId}": Bounding Box Edit Mode`, () => {
+        it('Create a polygon shape', () => {
+            cy.createPolygon(createPolygonPoints);
+        });
+
+        it('Activate BBox Edit Mode via the sidebar button', () => {
+            cy.get('#cvat-objects-sidebar-state-item-1').trigger('mouseover');
+            cy.get('.cvat-object-item-button-bbox-mode').click();
+            cy.get('.cvat_canvas_active_bbox').should('exist');
+        });
+
+        it('Deactivate BBox Edit Mode via shortcut "s"', () => {
+            cy.get('body').type('s');
+            cy.get('.cvat_canvas_active_bbox').should('not.exist');
+        });
+
+        it('Scale the polygon by dragging the BBox corner', () => {
+            cy.get('#cvat_canvas_shape_1').click();
+            cy.get('body').type('s');
+
+            cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').then((originalPoints) => {
+                cy.get('.svg_select_points_rb').trigger('mousedown', { button: 0 });
+                cy.get('#cvat_canvas_wrapper').trigger('mousemove', { clientX: 600, clientY: 600 });
+                cy.get('#cvat_canvas_wrapper').trigger('mouseup');
+
+                cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').should((scaledPoints) => {
+                    expect(scaledPoints).not.to.equal(originalPoints);
+                });
+            });
+            cy.get('body').type('s');
+        });
+
+        it('Rotate the polygon using the BBox rotation handle', () => {
+            cy.get('#cvat_canvas_shape_1').click();
+            cy.get('body').type('s');
+
+            cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').then((originalPoints) => {
+                cy.get('.svg_select_points_rot').trigger('mousedown', { button: 0 });
+
+                cy.get('#cvat_canvas_wrapper').trigger('mousemove', { clientX: 450, clientY: 200 });
+                cy.get('#cvat_canvas_wrapper').trigger('mouseup');
+
+                cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').should((rotatedPoints) => {
+                    expect(rotatedPoints).not.to.equal(originalPoints);
+                });
+            });
+
+            cy.get('body').type('s');
+        });
+    });
+
+    describe(`Testing PR "${issueId}": Mirroring Math and History`, () => {
+        it('Mirror the polygon horizontally via shortcut "Shift+H"', () => {
+            cy.get('#cvat_canvas_shape_1').click();
+            cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').then((originalPoints) => {
+                cy.get('body').type('{shift}h');
+                cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').should('not.equal', originalPoints);
+            });
+        });
+
+        it('Verify undo history (Ctrl+Z) reverts the mirroring', () => {
+            cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').then((currentPoints) => {
+                cy.get('body').type('{ctrl}z');
+                cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').should('not.equal', currentPoints);
+            });
+        });
+
+        it('Verify redo history (Ctrl+Shift+Z) reapplies the mirroring', () => {
+            cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').then((currentPoints) => {
+                cy.get('body').type('{ctrl}{shift}z');
+                cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').should('not.equal', currentPoints);
+            });
+        });
+
+        it('Mirror the polygon vertically via the Object Item Menu', () => {
+            cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').then((originalPoints) => {
+                cy.get('#cvat-objects-sidebar-state-item-1').find('.ant-dropdown-trigger').click({ force: true });
+                cy.get('.cvat-object-item-menu-mirror-vertical').click();
+
+                cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').should('not.equal', originalPoints);
+            });
+        });
+
+        it('Mirror the polygon horizontally via the Object Item Menu', () => {
+            cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').then((originalPoints) => {
+                cy.get('#cvat-objects-sidebar-state-item-1').find('.ant-dropdown-trigger').click({ force: true });
+
+                cy.get('.cvat-object-item-menu-mirror-horizontal').click();
+
+                cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').should('not.equal', originalPoints);
+            });
+        });
+    });
+
+    describe(`Testing PR "${issueId}": Polyline Support`, () => {
+        it('Create a polyline shape', () => {
+            cy.createPolyline(createPolylinePoints);
+        });
+
+        it('Scale the polyline using BBox edit mode', () => {
+            cy.get('#cvat_canvas_shape_2').click();
+            cy.get('body').type('s');
+
+            cy.get('#cvat_canvas_shape_2').invoke('attr', 'points').then((originalPoints) => {
+                cy.get('.svg_select_points_rb').trigger('mousedown', { button: 0 });
+                cy.get('#cvat_canvas_wrapper').trigger('mousemove', { clientX: 750, clientY: 550 });
+                cy.get('#cvat_canvas_wrapper').trigger('mouseup');
+
+                cy.get('#cvat_canvas_shape_2').invoke('attr', 'points').should((scaledPoints) => {
+                    expect(scaledPoints).not.to.equal(originalPoints);
+                });
+            });
+            cy.get('body').type('s');
+        });
+
+        it('Mirror the polyline vertically', () => {
+            cy.get('#cvat_canvas_shape_2').click({ force: true });
+            cy.get('#cvat_canvas_shape_2').invoke('attr', 'points').then((originalPoints) => {
+                cy.get('body').type('{shift}v');
+                cy.get('#cvat_canvas_shape_2').invoke('attr', 'points').should('not.equal', originalPoints);
+            });
+        });
+
+        it('Scale the polyline using the right-middle BBox handle', () => {
+            cy.get('#cvat_canvas_shape_2').click({ force: true });
+            cy.get('body').type('s');
+
+            cy.get('#cvat_canvas_shape_2').invoke('attr', 'points').then((originalPoints) => {
+                cy.get('.svg_select_points_r').trigger('mousedown', { button: 0 });
+                cy.get('#cvat_canvas_wrapper').trigger('mousemove', { clientX: 850, clientY: 400 });
+                cy.get('#cvat_canvas_wrapper').trigger('mouseup');
+
+                cy.get('#cvat_canvas_shape_2').invoke('attr', 'points').should((scaledPoints) => {
+                    expect(scaledPoints).not.to.equal(originalPoints);
+                });
+            });
+            cy.get('body').type('s');
+        });
+
+        it('Rotate the polyline using the BBox rotation handle', () => {
+            cy.get('#cvat_canvas_shape_2').click({ force: true });
+            cy.get('body').type('s');
+
+            cy.get('#cvat_canvas_shape_2').invoke('attr', 'points').then((originalPoints) => {
+                cy.get('.svg_select_points_rot').trigger('mousedown', { button: 0 });
+                cy.get('#cvat_canvas_wrapper').trigger('mousemove', { clientX: 500, clientY: 150 });
+                cy.get('#cvat_canvas_wrapper').trigger('mouseup');
+
+                cy.get('#cvat_canvas_shape_2').invoke('attr', 'points').should((rotatedPoints) => {
+                    expect(rotatedPoints).not.to.equal(originalPoints);
+                });
+            });
+            cy.get('body').type('s');
+        });
+    });
+
+    describe(`Testing PR "${issueId}": Persistence`, () => {
+        it('Save the job, reload the page, and verify the shapes retain modifications', () => {
+            cy.get('.cvat-canvas-container').click();
+
+            cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').as('pointsBeforeSave');
+
+            cy.saveJob();
+
+            cy.reload();
+            cy.get('.cvat-canvas-container').should('exist');
+
+            cy.get('@pointsBeforeSave').then((pointsBeforeSave) => {
+                cy.get('#cvat_canvas_shape_1').invoke('attr', 'points').should((pointsAfterReload) => {
+                    expect(pointsAfterReload).to.equal(pointsBeforeSave);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Closes #9578

This PR addresses the need to easily adjust manually created polygon tracks to fit shapes in subsequent frames. Previously, quickly changing the angulation and size of polygons and polylines was not supported in the same intuitive way as rectangles.

To solve this, we have added scaling and rotating capabilities for polygons and polylines using a new bounding box (BBox) edit mode. This mode can be toggled through the 'object card' or via the shortcut `s`. The new toggle button is designed to only appear for polygons and polylines to avoid empty UI space on unsupported shape types.

<img width="796" height="460" alt="image" src="https://github.com/user-attachments/assets/bd67a536-b42f-42f3-a8fc-cdec16d36f45" />
<img width="796" height="460" alt="image" src="https://github.com/user-attachments/assets/73710aae-986c-447b-98f8-0554b767bbef" />


Within the new mode, users can rotate the shape through a draggable point at the top of the bounding box.

Scaling can be done diagonally through the draggable corners, or vertically and horizontally through the middle draggable points.

Additionally, we added buttons to mirror these shapes horizontally and vertically in the 'action menu', which can also be triggered through the new shortcuts `Shift+H` and `Shift+V`, respectively.

<img width="798" height="666" alt="image" src="https://github.com/user-attachments/assets/c9bc1aa1-484a-4bdf-bb90-4ed6cc43e784" />


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Cypress e2e tests were added to ensure that these mathematical transformations are applied accurately and that the new UI interactions function as intended. The test suite, located in `tests/cypress/e2e/issues_prs2/issue_9578_mirror_and_bbox_edit_mode.js`, verifies activating and deactivating the BBox Edit Mode via the sidebar button and the s shortcut. It tests scaling using both corner and middle BBox handles, as well as rotation, on both polygons and polylines. The tests validate horizontal and vertical mirroring via shortcuts and the Object Item Menu, ensuring that undo (`Ctrl+Z`) and redo (`Ctrl+Shift+Z`) history correctly reverts and reapplies the mirroring logic. Finally, the suite confirms that structural modifications made to shapes using the BBox edit mode are properly retained after saving the job and reloading the page.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
