### PR TITLE
Fix preview error in tasks in projects with unfinished data processing

### DIFF
--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -867,6 +867,8 @@ class _TaskDataGetter(_DataGetter):
                 return TaskAudioProvider(self._db_task)
             case models.MediaType.IMAGE | models.MediaType.POINT_CLOUD:
                 return TaskFrameProvider(self._db_task)
+            case "":
+                raise NotFound("Task has no media")
             case _ as media_type:
                 assert False, f"Unknown media type {media_type}"
 

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -2772,6 +2772,22 @@ class TestGetTaskPreview:
 
         self._test_assigned_users_cannot_see_task_preview(tasks, users, is_task_staff)
 
+    @pytest.mark.usefixtures("restore_db_per_function")
+    @pytest.mark.usefixtures("restore_redis_inmem_per_function")
+    def test_can_get_readable_error_in_task_without_data(self, admin_user, fxt_test_name):
+        with make_api_client(admin_user) as api_client:
+            task_id = api_client.tasks_api.create(
+                task_write_request=models.TaskWriteRequest(name=fxt_test_name)
+            )[0].id
+
+            api_client.tasks_api.create_data(task_id, upload_start=True)
+
+            preview_response = api_client.tasks_api.retrieve_preview(
+                task_id, _parse_response=False, _check_status=False
+            )[1]
+            assert preview_response.status == HTTPStatus.NOT_FOUND
+            assert preview_response.data == b'"Task has no media"'
+
 
 @pytest.mark.usefixtures("restore_redis_ondisk_per_function")
 @pytest.mark.usefixtures("restore_redis_ondisk_after_class")


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Some tasks can exist without media. There are 2 cases for this: 
- a task was created and no data uploading attempts happened yet (no `Data` model yet, this one was handled)
- a task was created and and there was an unfinished data uploading or data processing has not been finished yet

The second case resulted in empty `task.data.media_type` value, leading to 500 errors on task data access.

- Fixes the 500 error on getting previews in tasks and projects with unfinished uploaded data processing. Such calls to `/api/{projects,tasks}/<id>/{data,preview}` endpoints will now result in a 404 error with an explanatory message instead.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Unit test

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
