### PR TITLE
Fix flaky TestGetAuditEvents test

### DIFF
--- a/tests/python/rest_api/test_analytics.py
+++ b/tests/python/rest_api/test_analytics.py
@@ -117,20 +117,38 @@ class TestGetAuditEvents:
         assert project_request_id is not None
         assert all(t[1] is not None for t in task_ids)
 
+        # Events are pushed to ClickHouse asynchronously,
+        # so we must wait until the expected number of events for every scope is present.
+        # Items: (filters, expected_count)
         event_filters = [
             (
-                (lambda e: json.loads(e["payload"])["request"]["id"], [project_request_id]),
-                ("scope", ["create:project"]),
+                (
+                    (lambda e: json.loads(e["payload"])["request"]["id"], [project_request_id]),
+                    ("scope", ["create:project"]),
+                ),
+                1,
             ),
         ]
-        for task_id in task_ids:
+        for task_id, task_request_id in task_ids:
             event_filters.extend(
                 (
                     (
-                        (lambda e: json.loads(e["payload"])["request"]["id"], [task_id[1]]),
-                        ("scope", ["create:task"]),
+                        (
+                            (
+                                lambda e: json.loads(e["payload"])["request"]["id"],
+                                [task_request_id],
+                            ),
+                            ("scope", ["create:task"]),
+                        ),
+                        1,
                     ),
-                    (("scope", ["create:job"]),),
+                    (
+                        (
+                            ("task_id", [str(task_id)]),
+                            ("scope", ["create:job"]),
+                        ),
+                        2,
+                    ),
                 )
             )
         self._wait_for_request_ids(event_filters)
@@ -141,7 +159,10 @@ class TestGetAuditEvents:
         while MAX_RETRIES > 0:
             data = self._test_get_audit_logs_as_csv()
             events = self._csv_to_dict(data)
-            if all(self._filter_events(events, filter) for filter in event_filters):
+            if all(
+                len(self._filter_events(events, filters)) >= expected_count
+                for filters, expected_count in event_filters
+            ):
                 break
             MAX_RETRIES -= 1
             sleep(SLEEP_INTERVAL)

--- a/tests/python/rest_api/test_analytics.py
+++ b/tests/python/rest_api/test_analytics.py
@@ -293,20 +293,30 @@ class TestGetAuditEvents:
         response = delete_method("admin1", f"projects/{self.project_id}")
         assert response.status_code == HTTPStatus.NO_CONTENT
 
+        request_id = response.headers.get("X-Request-Id")
+        # Items: (filters, expected_count). The cascade delete emits one event per
+        # affected object under the same request id, so wait for all of them.
         event_filters = (
             (
                 (
-                    lambda e: json.loads(e["payload"])["request"]["id"],
-                    [response.headers.get("X-Request-Id")],
+                    (lambda e: json.loads(e["payload"])["request"]["id"], [request_id]),
+                    ("scope", ["delete:project"]),
                 ),
-                ("scope", ["delete:project"]),
+                1,
             ),
             (
                 (
-                    lambda e: json.loads(e["payload"])["request"]["id"],
-                    [response.headers.get("X-Request-Id")],
+                    (lambda e: json.loads(e["payload"])["request"]["id"], [request_id]),
+                    ("scope", ["delete:task"]),
                 ),
-                ("scope", ["delete:task"]),
+                2,
+            ),
+            (
+                (
+                    (lambda e: json.loads(e["payload"])["request"]["id"], [request_id]),
+                    ("scope", ["delete:job"]),
+                ),
+                4,
             ),
         )
 


### PR DESCRIPTION
### Motivation and context

`TestGetAuditEvents::test_filter_by_project` intermittently failed with:

```
assert event_count["create:job"] == 4
E   assert 2 == 4
```

Audit events are pushed to ClickHouse **asynchronously**. The `setup` fixture's wait loop (`_wait_for_request_ids`) only checked that at least one event matched each filter — `_filter_events` returns a list, used as a truthy bool. The `create:job` filter had neither a request-id nor a count, so the loop broke as soon as the **first** of the 4 job events landed, while the rest were still in flight. The subsequent assertions then saw fewer than 4 `create:job` events.

### How has this been tested?

Carry an expected count per filter and wait until each scope has at least that many events present. `create:job` is now scoped per task (`task_id`) with an expected count of 2 each → 4 total enforced before the tests run.

### Checklist

- [x] I have linked related issues (if any)
- [x] I have updated/created tests where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)