### PR TITLE
Add request timeout in SDK client

### DIFF
--- a/changelog.d/20260601_185544_mzhiltsov_sdk_connection_timeout.md
+++ b/changelog.d/20260601_185544_mzhiltsov_sdk_connection_timeout.md
@@ -1,0 +1,14 @@
+### Added
+
+- \[SDK\] A new `Config.request_timeout` option to set a per-request HTTP timeout,
+  and a `timeout` argument for `Client.wait_for_completion()` that bounds how long it
+  polls a background request before raising `TimeoutError`
+  (<https://github.com/cvat-ai/cvat/pull/10701>)
+
+### Fixed
+
+- \[SDK\] A client request could hang indefinitely on a silently-dropped
+  keep-alive connection (e.g. closed by a load balancer or NAT). The client now
+  enables TCP keepalive and applies a finite default request timeout, so such
+  requests fail (and idempotent ones are retried) instead of blocking forever
+  (<https://github.com/cvat-ai/cvat/pull/10701>)

--- a/cvat-sdk/cvat_sdk/core/client.py
+++ b/cvat-sdk/cvat_sdk/core/client.py
@@ -11,7 +11,7 @@ from abc import ABCMeta
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager, suppress
 from pathlib import Path
-from time import sleep
+from time import monotonic, sleep
 from typing import Any, TypeVar
 from urllib.parse import urlsplit
 
@@ -49,6 +49,11 @@ class Config:
 
     status_check_period: float = 5
     """Operation status check period, in seconds"""
+
+    request_timeout: float | tuple[float, float] | None = None
+    """Timeout for individual HTTP requests, in seconds. A single value sets the
+    total timeout; a (connect, read) tuple sets them separately. If None, the
+    default of (60, 120) is used."""
 
     allow_unsupported_server: bool = True
     """Allow to use SDK with an unsupported server version. If disabled, raise an exception"""
@@ -120,9 +125,15 @@ class Client:
         self.api_map = CVAT_API_V2(url)
         """Handles server API URL interaction logic"""
 
-        self.api_client = ApiClient(
-            Configuration(host=self.api_map.host, verify_ssl=self.config.verify_ssl)
-        )
+        configuration = Configuration(host=self.api_map.host, verify_ssl=self.config.verify_ssl)
+        if self.config.request_timeout is not None:
+            if isinstance(self.config.request_timeout, tuple):
+                connect, read = self.config.request_timeout
+                configuration.timeout = urllib3.Timeout(connect=connect, read=read)
+            else:
+                configuration.timeout = urllib3.Timeout(total=self.config.request_timeout)
+
+        self.api_client = ApiClient(configuration)
         """Provides low-level access to the CVAT server"""
 
         if check_server_version:
@@ -277,10 +288,13 @@ class Client:
         rq_id: str,
         *,
         status_check_period: int | None = None,
+        timeout: float | None = None,
         log_prefix: str | None = None,
     ) -> tuple[models.Request, urllib3.HTTPResponse]:
         if status_check_period is None:
             status_check_period = self.config.status_check_period
+
+        deadline = None if timeout is None else monotonic() + timeout
 
         while True:
             request, response = self.api_client.requests_api.retrieve(rq_id)
@@ -297,6 +311,12 @@ class Client:
                 break
             elif status.value == models.RequestStatus.allowed_values[("value",)]["FAILED"]:
                 raise BackgroundRequestException(message)
+
+            if deadline is not None and monotonic() + status_check_period >= deadline:
+                raise TimeoutError(
+                    f"{log_prefix} did not finish within {timeout}s "
+                    f"(last status: {status.value})"
+                )
 
             sleep(status_check_period)
 

--- a/cvat-sdk/gen/templates/openapi-generator/configuration.mustache
+++ b/cvat-sdk/gen/templates/openapi-generator/configuration.mustache
@@ -5,9 +5,11 @@ import logging
 {{^asyncio}}
 import multiprocessing
 {{/asyncio}}
+import socket
 import sys
 import typing
 import urllib3
+import urllib3.connection
 import urllib3.util
 
 from http import client as http_client
@@ -330,11 +332,28 @@ class Configuration:
         )
         """Adding retries to override urllib3 default value 3"""
 
+        self.timeout = urllib3.Timeout(connect=60.0, read=120.0)
+        """Default timeout for HTTP requests. A finite read timeout ensures a
+           request blocked on a silently-dropped (e.g. by a load balancer or
+           NAT) keep-alive connection eventually fails - and is retried for
+           idempotent methods - instead of hanging forever. Can be overridden
+           per request via the `_request_timeout` argument.
+        """
+
         # Enable client side validation
         self.client_side_validation = True
 
-        # Options to pass down to the underlying urllib3 socket
-        self.socket_options = None
+        # Enable TCP keepalive so that connections broken while idle (e.g. closed
+        # by a load balancer or NAT) are eventually detected and evicted from
+        # urllib3's connection pool instead of being reused and blocking on a
+        # dead socket. urllib3 reuses pooled connections but does not enable
+        # keepalive by default. Keepalive timing is left at the OS defaults to
+        # avoid platform-specific tuning (TCP_KEEPIDLE etc.); the request read
+        # timeout above is the primary, portable fast-fail guard.
+        # https://urllib3.readthedocs.io/en/stable/reference/urllib3.connection.html#urllib3.connection.HTTPConnection.default_socket_options
+        self.socket_options = list(
+            urllib3.connection.HTTPConnection.default_socket_options
+        ) + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
 
     def __deepcopy__(self, memo):
         cls = self.__class__

--- a/cvat-sdk/gen/templates/openapi-generator/rest.mustache
+++ b/cvat-sdk/gen/templates/openapi-generator/rest.mustache
@@ -42,6 +42,10 @@ class RESTClientObject(object):
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 
+        # Default timeout applied to every request when the caller does not
+        # pass an explicit `_request_timeout`.
+        self.default_timeout = getattr(configuration, 'timeout', None)
+
         if maxsize is None:
             if configuration.connection_pool_maxsize is not None:
                 maxsize = configuration.connection_pool_maxsize
@@ -119,7 +123,7 @@ class RESTClientObject(object):
         post_params = post_params or {}
         headers = headers or {}
 
-        timeout = None
+        timeout = self.default_timeout
         if _request_timeout:
             if isinstance(_request_timeout, (int, float)):  # noqa: E501,F821
                 timeout = urllib3.Timeout(total=_request_timeout)

--- a/tests/python/cli/util.py
+++ b/tests/python/cli/util.py
@@ -16,8 +16,9 @@ from typing import Any
 import pytest
 import requests
 from cvat_sdk import make_client
+from cvat_sdk.core.client import Config
 
-from shared.utils.config import BASE_URL, USER_PASS
+from shared.utils.config import BASE_URL, DEFAULT_INTERVAL, TEST_REQUEST_TIMEOUT, USER_PASS
 from shared.utils.helpers import generate_image_file
 
 
@@ -103,16 +104,28 @@ class TestCliBase:
         fxt_stdout: io.StringIO,
         tmp_path: Path,
         admin_user: str,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         self.tmp_path = tmp_path
         self.stdout = fxt_stdout
         self.host, self.port = BASE_URL.rsplit(":", maxsplit=1)
         self.user = admin_user
         self.password = USER_PASS
+
+        # The CLI builds its own Client (inside build_client), so inject a short
+        # HTTP request timeout via the Config it constructs. This makes a request
+        # blocked on a dead connection fail fast instead of stalling until the
+        # pytest-timeout fires with an opaque error.
+        def config_with_test_timeout(**kwargs):
+            kwargs.setdefault("request_timeout", TEST_REQUEST_TIMEOUT)
+            return Config(**kwargs)
+
+        monkeypatch.setattr("cvat_cli._internal.common.Config", config_with_test_timeout)
+
         self.client = make_client(
             host=self.host, port=self.port, credentials=(self.user, self.password)
         )
-        self.client.config.status_check_period = 0.01
+        self.client.config.status_check_period = DEFAULT_INTERVAL
 
         yield
 

--- a/tests/python/rest_api/utils.py
+++ b/tests/python/rest_api/utils.py
@@ -22,10 +22,9 @@ from cvat_sdk.core.helpers import get_paginated_collection
 from deepdiff import DeepDiff
 from urllib3 import HTTPResponse
 
-from shared.utils.config import USER_PASS, make_api_client, post_method
+from shared.utils.config import DEFAULT_INTERVAL, USER_PASS, make_api_client, post_method
 
 DEFAULT_RETRIES = 50
-DEFAULT_INTERVAL = 0.1
 
 
 def initialize_export(endpoint: Endpoint, *, expect_forbidden: bool = False, **kwargs) -> str:

--- a/tests/python/sdk/fixtures.py
+++ b/tests/python/sdk/fixtures.py
@@ -10,7 +10,13 @@ from cvat_sdk import Client
 from cvat_sdk.core.proxies.types import Location
 from PIL import Image
 
-from shared.utils.config import BASE_URL, IMPORT_EXPORT_BUCKET_ID, USER_PASS
+from shared.utils.config import (
+    BASE_URL,
+    DEFAULT_INTERVAL,
+    IMPORT_EXPORT_BUCKET_ID,
+    USER_PASS,
+    make_sdk_client_config,
+)
 from shared.utils.helpers import generate_image_file
 
 from .util import generate_coco_json
@@ -20,11 +26,12 @@ from .util import generate_coco_json
 def fxt_client(fxt_logger):
     logger, _ = fxt_logger
 
-    client = Client(BASE_URL, logger=logger)
+    client = Client(
+        BASE_URL, logger=logger, config=make_sdk_client_config(status_check_period=DEFAULT_INTERVAL)
+    )
     api_client = client.api_client
     for k in api_client.configuration.logger:
         api_client.configuration.logger[k] = logger
-    client.config.status_check_period = 0.01
 
     with client:
         yield client
@@ -51,8 +58,7 @@ def fxt_coco_file(tmp_path: Path, fxt_image_file: Path):
 
 @pytest.fixture(scope="class")
 def fxt_login(admin_user: str, restore_db_per_class):
-    client = Client(BASE_URL)
-    client.config.status_check_period = 0.01
+    client = Client(BASE_URL, config=make_sdk_client_config(status_check_period=DEFAULT_INTERVAL))
     user = admin_user
 
     with client:

--- a/tests/python/sdk/test_client.py
+++ b/tests/python/sdk/test_client.py
@@ -3,12 +3,15 @@
 # SPDX-License-Identifier: MIT
 
 import io
+import socket
 from contextlib import ExitStack
 from logging import Logger
+from types import SimpleNamespace
 
 import packaging.version as pv
 import pytest
 from cvat_sdk import Client, models
+from cvat_sdk.api_client import Configuration
 from cvat_sdk.core.client import AccessTokenCredentials, Config, PasswordCredentials, make_client
 from cvat_sdk.core.exceptions import IncompatibleVersionException, InvalidHostException
 from cvat_sdk.exceptions import ApiException
@@ -326,3 +329,70 @@ def test_organization_context_manager():
         assert client.organization_slug == "def"
 
     assert client.organization_slug == "abc"
+
+
+def _fake_request(status_value: int, *, message: str = "", op_type: str = "import"):
+    return SimpleNamespace(
+        status=SimpleNamespace(value=status_value),
+        message=message,
+        operation=SimpleNamespace(type=op_type),
+    )
+
+
+def test_configuration_enables_keepalive_and_default_timeout():
+    config = Configuration(host=BASE_URL)
+
+    # A finite read timeout keeps a request blocked on a dead connection from
+    # hanging forever; TCP keepalive lets the OS eventually evict dead idle
+    # connections from the pool.
+    assert config.timeout.connect_timeout == 60.0
+    assert config.timeout.read_timeout == 120.0
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in config.socket_options
+
+
+@pytest.mark.parametrize(
+    "request_timeout, expected_connect_read",
+    [
+        (None, (60.0, 120.0)),  # falls back to the api_client default
+        ((5.0, 10.0), (5.0, 10.0)),
+    ],
+)
+def test_config_request_timeout_is_applied(request_timeout, expected_connect_read):
+    config = Config(request_timeout=request_timeout)
+    client = Client(BASE_URL, config=config, check_server_version=False)
+
+    timeout = client.api_client.configuration.timeout
+    assert (timeout.connect_timeout, timeout.read_timeout) == expected_connect_read
+
+
+def test_config_request_timeout_accepts_single_value():
+    client = Client(BASE_URL, config=Config(request_timeout=12.0), check_server_version=False)
+
+    assert client.api_client.configuration.timeout.total == 12.0
+
+
+def test_wait_for_completion_times_out(monkeypatch):
+    client = Client(BASE_URL, check_server_version=False)
+    monkeypatch.setattr(
+        client.api_client.requests_api,
+        "retrieve",
+        lambda rq_id: (_fake_request("started"), None),
+    )
+
+    with pytest.raises(TimeoutError):
+        client.wait_for_completion("test", status_check_period=0.01, timeout=0.1)
+
+
+def test_wait_for_completion_returns_when_finished(monkeypatch):
+    finished = models.RequestStatus.allowed_values[("value",)]["FINISHED"]
+    statuses = iter(["started", "started", finished])
+    client = Client(BASE_URL, check_server_version=False)
+    monkeypatch.setattr(
+        client.api_client.requests_api,
+        "retrieve",
+        lambda rq_id: (_fake_request(next(statuses)), "resp"),
+    )
+
+    # No timeout -> unbounded polling preserved; returns the final response.
+    _, response = client.wait_for_completion("test", status_check_period=0.01)
+    assert response == "resp"

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -15,7 +15,7 @@ import pytest
 import requests
 import yaml
 
-from shared.utils.config import ASSETS_DIR, get_server_url
+from shared.utils.config import ASSETS_DIR, TEST_REQUEST_TIMEOUT, get_server_url
 
 logger = logging.getLogger(__name__)
 
@@ -351,7 +351,10 @@ def wait_for_services(num_secs: int = 300) -> None:
         logger.debug(f"waiting for the server to load ... ({i})")
 
         try:
-            response = requests.get(get_server_url("api/server/health/", format="json"))
+            response = requests.get(
+                get_server_url("api/server/health/", format="json"),
+                timeout=TEST_REQUEST_TIMEOUT,
+            )
 
             statuses = response.json()
             logger.debug(f"server status: \n{statuses}")

--- a/tests/python/shared/utils/config.py
+++ b/tests/python/shared/utils/config.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import requests
+import urllib3
 from cvat_sdk.api_client import ApiClient, Configuration
 from cvat_sdk.core.client import Client, Config
 
@@ -17,6 +18,17 @@ SHARE_DIR = (ROOT_DIR.parents[1] / "mounted_file_share").resolve()
 USER_PASS = "!Q@W#E$R"  # nosec
 BASE_URL = "http://localhost:8080"
 API_URL = BASE_URL + "/api/"
+
+# Default interval, in seconds, between polls when waiting for a background
+# request to finish (SDK status checks, REST/CLI poll-waits).
+DEFAULT_INTERVAL = 0.1
+
+# Short HTTP request timeout (connect, read) for SDK/CLI clients in tests. Keeps
+# a request blocked on a dead/stale connection from hanging: it fails fast with
+# a clear error, well before the pytest-timeout kills the test with an opaque
+# "Timeout >Ns". Read timeout stays comfortably above any legitimate single
+# response (test traffic is sub-second) yet below the pytest-timeout.
+TEST_REQUEST_TIMEOUT = (5.0, 10.0)
 
 # MiniIO settings
 MINIO_KEY = "minio_access_key"
@@ -38,37 +50,70 @@ def get_api_url(endpoint, **kwargs):
 
 
 def get_method(username, endpoint, **kwargs):
-    return requests.get(get_api_url(endpoint, **kwargs), auth=(username, USER_PASS))
+    return requests.get(
+        get_api_url(endpoint, **kwargs), auth=(username, USER_PASS), timeout=TEST_REQUEST_TIMEOUT
+    )
 
 
 def options_method(username, endpoint, **kwargs):
-    return requests.options(get_api_url(endpoint, **kwargs), auth=(username, USER_PASS))
+    return requests.options(
+        get_api_url(endpoint, **kwargs), auth=(username, USER_PASS), timeout=TEST_REQUEST_TIMEOUT
+    )
 
 
 def delete_method(username, endpoint, **kwargs):
-    return requests.delete(get_api_url(endpoint, **kwargs), auth=(username, USER_PASS))
+    return requests.delete(
+        get_api_url(endpoint, **kwargs), auth=(username, USER_PASS), timeout=TEST_REQUEST_TIMEOUT
+    )
 
 
 def patch_method(username, endpoint, data, **kwargs):
-    return requests.patch(get_api_url(endpoint, **kwargs), json=data, auth=(username, USER_PASS))
+    return requests.patch(
+        get_api_url(endpoint, **kwargs),
+        json=data,
+        auth=(username, USER_PASS),
+        timeout=TEST_REQUEST_TIMEOUT,
+    )
 
 
 def post_method(username, endpoint, data, **kwargs):
-    return requests.post(get_api_url(endpoint, **kwargs), json=data, auth=(username, USER_PASS))
+    return requests.post(
+        get_api_url(endpoint, **kwargs),
+        json=data,
+        auth=(username, USER_PASS),
+        timeout=TEST_REQUEST_TIMEOUT,
+    )
 
 
 def post_files_method(username, endpoint, data, files, **kwargs):
     return requests.post(
-        get_api_url(endpoint, **kwargs), data=data, files=files, auth=(username, USER_PASS)
+        get_api_url(endpoint, **kwargs),
+        data=data,
+        files=files,
+        auth=(username, USER_PASS),
+        timeout=TEST_REQUEST_TIMEOUT,
     )
 
 
 def put_method(username, endpoint, data, **kwargs):
-    return requests.put(get_api_url(endpoint, **kwargs), json=data, auth=(username, USER_PASS))
+    return requests.put(
+        get_api_url(endpoint, **kwargs),
+        json=data,
+        auth=(username, USER_PASS),
+        timeout=TEST_REQUEST_TIMEOUT,
+    )
 
 
 def server_get(username, endpoint, **kwargs):
-    return requests.get(get_server_url(endpoint, **kwargs), auth=(username, USER_PASS))
+    return requests.get(
+        get_server_url(endpoint, **kwargs), auth=(username, USER_PASS), timeout=TEST_REQUEST_TIMEOUT
+    )
+
+
+def make_sdk_client_config(**kwargs) -> Config:
+    """Build a cvat_sdk Config with test-friendly defaults applied to clients."""
+    kwargs.setdefault("request_timeout", TEST_REQUEST_TIMEOUT)
+    return Config(**kwargs)
 
 
 def make_api_client(
@@ -82,6 +127,9 @@ def make_api_client(
     ), "Expected only one of the 'access_token' and 'user' args"
 
     configuration = Configuration(host=BASE_URL)
+    configuration.timeout = urllib3.Timeout(
+        connect=TEST_REQUEST_TIMEOUT[0], read=TEST_REQUEST_TIMEOUT[1]
+    )
     if access_token:
         configuration.access_token = access_token
     else:
@@ -93,6 +141,8 @@ def make_api_client(
 
 @contextmanager
 def make_sdk_client(user: str, *, password: str = None) -> Generator[Client, None, None]:
-    with Client(BASE_URL, config=Config(status_check_period=0.01)) as client:
+    with Client(
+        BASE_URL, config=make_sdk_client_config(status_check_period=DEFAULT_INTERVAL)
+    ) as client:
         client.login((user, password or USER_PASS))
         yield client

--- a/tests/python/shared/utils/resource_import_export.py
+++ b/tests/python/shared/utils/resource_import_export.py
@@ -10,7 +10,7 @@ import pytest
 
 T = TypeVar("T")
 
-from shared.utils.config import get_method, post_method
+from shared.utils.config import DEFAULT_INTERVAL, get_method, post_method
 
 FILENAME_TEMPLATE = "cvat/{}/{}.zip"
 EXPORT_FORMAT = "CVAT for images 1.1"
@@ -58,7 +58,7 @@ def _wait_request(
     user: str,
     request_id: str,
     *,
-    sleep_interval: float = 0.1,
+    sleep_interval: float = DEFAULT_INTERVAL,
     number_of_checks: int = 100,
 ):
     for _ in range(number_of_checks):


### PR DESCRIPTION
### Motivation

A client request could hang indefinitely when a keep-alive connection was silently dropped (e.g. by a load balancer or NAT): urllib3 reuses pooled connections but sets no read timeout, so the reused socket blocked on `recv()` forever, ending only when an external killer (e.g. `pytest-timeout`) fired. 

### Changes

**SDK**
- The generated `api_client` `Configuration` now enables TCP keepalive (portable `SO_KEEPALIVE`, OS-default timing) and applies a finite default request timeout (`connect=60`, `read=120`). A broken connection is now detected, evicted from the pool, and retried (for idempotent requests) instead of blocking forever.
- New `Config.request_timeout` knob, wired through `Client` to `Configuration.timeout`.
- `Client.wait_for_completion()` gains an optional `timeout` that raises a clear `TimeoutError` instead of polling unbounded. Default `None` preserves existing behaviour.

**Tests**
- Shared `TEST_REQUEST_TIMEOUT` and `DEFAULT_INTERVAL` constants in `shared/utils/config.py`, applied across every test HTTP path: SDK fixtures, the CLI-built client (`build_client`), `make_api_client`, `make_sdk_client`, the raw `requests` helpers, and the startup health poll. A hang now surfaces fast with a clear error, well before the pytest-timeout.
- Added SDK unit tests for the default timeout, `request_timeout`, and the `wait_for_completion` deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)