### PR TITLE
Fix flaky test `TestRequestsListFilters`

### DIFF
--- a/tests/python/rest_api/test_requests.py
+++ b/tests/python/rest_api/test_requests.py
@@ -35,6 +35,7 @@ from .utils import (
 )
 
 
+@pytest.mark.timeout(60)
 @pytest.mark.usefixtures("restore_db_per_class")
 @pytest.mark.usefixtures("restore_redis_inmem_per_class")
 @pytest.mark.usefixtures("restore_redis_ondisk_per_class")
@@ -59,12 +60,12 @@ class TestRequestsListFilters(CollectionSimpleFilterTestBase):
 
     @pytest.fixture(scope="class")
     @classmethod
-    def setup_user(cls, find_users):
+    def setup_user(cls, restore_db_per_class, find_users):
         cls.user = find_users(privilege="user")[0]["username"]
 
     @pytest.fixture(scope="class")
     @classmethod
-    def setup_org_users(cls, find_users, organizations, memberships):
+    def setup_org_users(cls, restore_db_per_class, find_users, organizations, memberships):
         cls.org_slug = next(o["slug"] for o in organizations if o["id"] == cls._ORG_ID)
         # Pick an owner/maintainer so they can create projects/tasks in the org.
         cls.org_user = next(
@@ -77,7 +78,9 @@ class TestRequestsListFilters(CollectionSimpleFilterTestBase):
 
     @pytest.fixture(scope="class")
     @classmethod
-    def fxt_resources_ids(cls, setup_user):
+    def fxt_resources_ids(
+        cls, setup_user, restore_redis_inmem_per_class, restore_redis_ondisk_per_class
+    ):
         with make_api_client(cls.user) as api_client:
             project_ids = [
                 api_client.projects_api.create(

--- a/tests/python/rest_api/utils.py
+++ b/tests/python/rest_api/utils.py
@@ -54,11 +54,13 @@ def wait_background_request(
     for _ in range(max_retries):
         background_request, response = api_client.requests_api.retrieve(rq_id)
         assert response.status == HTTPStatus.OK
-        if (
-            background_request.status.value
-            == models.RequestStatus.allowed_values[("value",)]["FINISHED"]
-        ):
+
+        if background_request.status.value == "finished":
             return background_request, response
+        assert (
+            background_request.status.value != "failed"
+        ), f"Background request failed with message: {background_request.message}"
+
         sleep(interval)
 
     assert False, (


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
There are actually two problems with it:

* The fixtures could execute in the wrong order, because all of the fixtures in this test are class-level, and the order pytest executes these in is indeterminate. So the DB/Redis reset could happen after the creation of test data. Fix it by adding explicit fixture dependencies.

* It takes a while for all the setup to execute, which can time out. Bump the timeout.

In addition, update the `wait_background_request` function to stop waiting if a request fails. This lets the test fail early if something goes wrong, instead of timing out.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
