### PR TITLE
Fix minor style issues in unit tests

### DIFF
--- a/cvat/apps/dataset_manager/tests/test_formats.py
+++ b/cvat/apps/dataset_manager/tests/test_formats.py
@@ -52,13 +52,13 @@ class _DbTestBase(ApiTestBase):
 
     def _put_api_v2_task_id_annotations(self, tid, data):
         with ForceLogin(self.user, self.client):
-            response = self.client.put("/api/tasks/%s/annotations" % tid, data=data, format="json")
+            response = self.client.put(f"/api/tasks/{tid}/annotations", data=data, format="json")
 
         return response
 
     def _put_api_v2_job_id_annotations(self, jid, data):
         with ForceLogin(self.user, self.client):
-            response = self.client.put("/api/jobs/%s/annotations" % jid, data=data, format="json")
+            response = self.client.put(f"/api/jobs/{jid}/annotations", data=data, format="json")
 
         return response
 
@@ -68,7 +68,7 @@ class _DbTestBase(ApiTestBase):
             assert response.status_code == status.HTTP_201_CREATED, response.status_code
             tid = response.data["id"]
 
-            response = self.client.post("/api/tasks/%s/data" % tid, data=image_data)
+            response = self.client.post(f"/api/tasks/{tid}/data", data=image_data)
             assert response.status_code == status.HTTP_202_ACCEPTED, response.status_code
             rq_id = response.json()["rq_id"]
 
@@ -76,7 +76,7 @@ class _DbTestBase(ApiTestBase):
             assert response.status_code == status.HTTP_200_OK, response.status_code
             assert response.json()["status"] == "finished", response.json().get("status")
 
-            response = self.client.get("/api/tasks/%s" % tid)
+            response = self.client.get(f"/api/tasks/{tid}")
 
             if 200 <= response.status_code < 400:
                 labels_response = list(
@@ -214,9 +214,7 @@ class TaskExportTest(_DbTestBase):
         return self._generate_custom_annotations(annotations, task)
 
     def _generate_task_images(self, count):  # pylint: disable=no-self-use
-        images = {
-            "client_files[%d]" % i: generate_image_file("image_%d.jpg" % i) for i in range(count)
-        }
+        images = {f"client_files[{i}]": generate_image_file(f"image_{i}.jpg") for i in range(count)}
         images["image_quality"] = 75
         return images
 
@@ -693,7 +691,7 @@ class TaskAnnotationsImportTest(_DbTestBase):
 
     def _generate_task_images(self, count, name="image", **image_params):
         images = {
-            "client_files[%d]" % i: generate_image_file("%s_%d.jpg" % (name, i), **image_params)
+            f"client_files[{i}]": generate_image_file(f"{name}_{i}.jpg", **image_params)
             for i in range(count)
         }
         images["image_quality"] = 75

--- a/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
+++ b/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
@@ -170,13 +170,13 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
 
     def _put_api_v2_task_id_annotations(self, tid, data):
         with ForceLogin(self.admin, self.client):
-            response = self.client.put("/api/tasks/%s/annotations" % tid, data=data, format="json")
+            response = self.client.put(f"/api/tasks/{tid}/annotations", data=data, format="json")
 
         return response
 
     def _put_api_v2_job_id_annotations(self, jid, data):
         with ForceLogin(self.admin, self.client):
-            response = self.client.put("/api/jobs/%s/annotations" % jid, data=data, format="json")
+            response = self.client.put(f"/api/jobs/{jid}/annotations", data=data, format="json")
 
         return response
 
@@ -194,7 +194,7 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
     @staticmethod
     def _generate_task_images(count, name_offsets=0):  # pylint: disable=no-self-use
         images = {
-            "client_files[%d]" % i: generate_image_file("image_%d.jpg" % (i + name_offsets))
+            f"client_files[{i}]": generate_image_file(f"image_{i + name_offsets}.jpg")
             for i in range(count)
         }
         images["image_quality"] = 75
@@ -202,9 +202,7 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
 
     @staticmethod
     def _generate_task_videos(count):  # pylint: disable=no-self-use
-        videos = {
-            "client_files[%d]" % i: generate_video_file("video_%d.mp4" % i) for i in range(count)
-        }
+        videos = {f"client_files[{i}]": generate_video_file(f"video_{i}.mp4") for i in range(count)}
         videos["image_quality"] = 75
         return videos
 
@@ -214,7 +212,7 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             tid = response.data["id"]
 
-            response = self.client.post("/api/tasks/%s/data" % tid, data=image_data)
+            response = self.client.post(f"/api/tasks/{tid}/data", data=image_data)
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
             rq_id = response.json()["rq_id"]
 
@@ -225,7 +223,7 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
                 response_json["status"], "finished", msg=f"Message: {response_json['message']}"
             )
 
-            response = self.client.get("/api/tasks/%s" % tid)
+            response = self.client.get(f"/api/tasks/{tid}")
 
             if 200 <= response.status_code < 400:
                 labels_response = list(

--- a/cvat/apps/dataset_manager/tests/test_streaming_efficiency.py
+++ b/cvat/apps/dataset_manager/tests/test_streaming_efficiency.py
@@ -372,7 +372,7 @@ class TestImporters(ApiTestBase):
             assert response.status_code == status.HTTP_201_CREATED, response.status_code
             tid = response.data["id"]
 
-            response = self.client.post("/api/tasks/%s/data" % tid, data=image_data)
+            response = self.client.post(f"/api/tasks/{tid}/data", data=image_data)
             assert response.status_code == status.HTTP_202_ACCEPTED, response.status_code
             rq_id = response.json()["rq_id"]
 
@@ -380,7 +380,7 @@ class TestImporters(ApiTestBase):
             assert response.status_code == status.HTTP_200_OK, response.status_code
             assert response.json()["status"] == "finished", response.json().get("status")
 
-            response = self.client.get("/api/tasks/%s" % tid)
+            response = self.client.get(f"/api/tasks/{tid}")
 
             if 200 <= response.status_code < 400:
                 labels_response = list(

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -318,7 +318,7 @@ class JobGetAPITestCase(ApiTestBase):
 
     def _run_api_v2_jobs_id(self, jid, user):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/jobs/{}".format(jid))
+            response = self.client.get(f"/api/jobs/{jid}")
 
         return response
 
@@ -380,7 +380,7 @@ class JobPartialUpdateAPITestCase(ApiTestBase):
 
     def _run_api_v2_jobs_id(self, jid, user, data):
         with ForceLogin(user, self.client):
-            response = self.client.patch("/api/jobs/{}".format(jid), data=data, format="json")
+            response = self.client.patch(f"/api/jobs/{jid}", data=data, format="json")
 
         return response
 
@@ -465,7 +465,7 @@ class JobUpdateAPITestCase(ApiTestBase):
 
     def _run_api_v2_jobs_id(self, jid, user, data):
         with ForceLogin(user, self.client):
-            response = self.client.put("/api/jobs/{}".format(jid), data=data, format="json")
+            response = self.client.put(f"/api/jobs/{jid}", data=data, format="json")
 
         return response
 
@@ -494,9 +494,7 @@ class JobDataMetaPartialUpdateAPITestCase(ApiTestBase):
 
     def _run_api_v1_jobs_data_meta_id(self, jid, user, data):
         with ForceLogin(user, self.client):
-            response = self.client.patch(
-                "/api/jobs/{}/data/meta".format(jid), data=data, format="json"
-            )
+            response = self.client.patch(f"/api/jobs/{jid}/data/meta", data=data, format="json")
 
         return response
 
@@ -579,7 +577,7 @@ class ServerAboutAPITestCase(ApiTestBase):
     def _run_api_server_about(self, user, version):
         with ForceLogin(user, self.client):
             response = self.client.get(
-                "/api/server/about", HTTP_ACCEPT=self.ACCEPT_HEADER_TEMPLATE.format(version)
+                "/api/server/about", headers={"Accept": self.ACCEPT_HEADER_TEMPLATE.format(version)}
             )
         return response
 
@@ -802,7 +800,7 @@ class UserSelfAPITestCase(UserAPITestCase):
 class UserGetAPITestCase(UserAPITestCase):
     def _run_api_v2_users_id(self, user, user_id):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/users/{}".format(user_id))
+            response = self.client.get(f"/api/users/{user_id}")
 
         return response
 
@@ -845,7 +843,7 @@ class UserGetAPITestCase(UserAPITestCase):
 class UserPartialUpdateAPITestCase(UserAPITestCase):
     def _run_api_v2_users_id(self, user, user_id, data):
         with ForceLogin(user, self.client):
-            response = self.client.patch("/api/users/{}".format(user_id), data=data, format="json")
+            response = self.client.patch(f"/api/users/{user_id}", data=data, format="json")
 
         return response
 
@@ -899,7 +897,7 @@ class UserPartialUpdateAPITestCase(UserAPITestCase):
 class UserDeleteAPITestCase(UserAPITestCase):
     def _run_api_v2_users_id(self, user, user_id):
         with ForceLogin(user, self.client):
-            response = self.client.delete("/api/users/{}".format(user_id))
+            response = self.client.delete(f"/api/users/{user_id}")
 
         return response
 
@@ -988,7 +986,7 @@ class ProjectGetAPITestCase(ApiTestBase):
 
     def _run_api_v2_projects_id(self, pid, user):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/projects/{}".format(pid))
+            response = self.client.get(f"/api/projects/{pid}")
 
         return response
 
@@ -1035,7 +1033,7 @@ class ProjectDeleteAPITestCase(ApiTestBase):
 
     def _run_api_v2_projects_id(self, pid, user):
         with ForceLogin(user, self.client):
-            response = self.client.delete("/api/projects/{}".format(pid), format="json")
+            response = self.client.delete(f"/api/projects/{pid}", format="json")
 
         return response
 
@@ -1186,7 +1184,7 @@ class ProjectPartialUpdateAPITestCase(ApiTestBase):
 
     def _run_api_v2_projects_id(self, pid, user, data):
         with ForceLogin(user, self.client):
-            response = self.client.patch("/api/projects/{}".format(pid), data=data, format="json")
+            response = self.client.patch(f"/api/projects/{pid}", data=data, format="json")
 
             if 200 <= response.status_code < 400:
                 labels_response = list(
@@ -1337,7 +1335,7 @@ class ProjectUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
 
     def _run_api_v2_project_id(self, pid, user, data):
         with ForceLogin(user, self.client):
-            response = self.client.patch("/api/projects/{}".format(pid), data=data, format="json")
+            response = self.client.patch(f"/api/projects/{pid}", data=data, format="json")
 
             if 200 <= response.status_code < 400:
                 labels_response = list(
@@ -1462,17 +1460,12 @@ class ProjectBackupAPITestCase(ExportApiTestBase, ImportApiTestBase):
 
         cls.media_data.append(
             {
-                **{
-                    "image_quality": 75,
-                    "copy_data": True,
-                    "start_frame": 2,
-                    "stop_frame": 9,
-                    "frame_filter": "step=2",
-                },
-                **{
-                    "server_files[{}]".format(i): imagename_pattern.format(i)
-                    for i in range(image_count)
-                },
+                "image_quality": 75,
+                "copy_data": True,
+                "start_frame": 2,
+                "stop_frame": 9,
+                "frame_filter": "step=2",
+                **{f"server_files[{i}]": imagename_pattern.format(i) for i in range(image_count)},
             }
         )
 
@@ -1536,19 +1529,12 @@ class ProjectBackupAPITestCase(ExportApiTestBase, ImportApiTestBase):
         cls.media["files"].append(manifest_path)
         cls.media_data.append(
             {
-                **{
-                    "image_quality": 70,
-                    "copy_data": True,
-                    "use_cache": True,
-                    "frame_filter": "step=2",
-                    "server_files[0]": "manifest.jsonl",
-                },
-                **{
-                    **{
-                        "server_files[{}]".format(i): imagename_pattern.format(i)
-                        for i in range(1, 8)
-                    },
-                },
+                "image_quality": 70,
+                "copy_data": True,
+                "use_cache": True,
+                "frame_filter": "step=2",
+                "server_files[0]": "manifest.jsonl",
+                **{f"server_files[{i}]": imagename_pattern.format(i) for i in range(1, 8)},
             }
         )
 
@@ -1589,7 +1575,7 @@ class ProjectBackupAPITestCase(ExportApiTestBase, ImportApiTestBase):
             for media in media_data.values():
                 if isinstance(media, io.BytesIO):
                     media.seek(0)
-            response = cls.client.post("/api/tasks/{}/data".format(tid), data=media_data)
+            response = cls.client.post(f"/api/tasks/{tid}/data", data=media_data)
             assert response.status_code == status.HTTP_202_ACCEPTED, response.status_code
             rq_id = response.json()["rq_id"]
 
@@ -1599,7 +1585,7 @@ class ProjectBackupAPITestCase(ExportApiTestBase, ImportApiTestBase):
             rqjob_status, msg = response_json["status"], response_json["message"]
             assert rqjob_status == "finished", f"{rqjob_status=}\n{msg=}"
 
-            response = cls.client.get("/api/tasks/{}".format(tid))
+            response = cls.client.get(f"/api/tasks/{tid}")
             data_id = response.data["data"]
             cls.tasks.append(
                 {
@@ -1760,7 +1746,7 @@ class ProjectBackupAPITestCase(ExportApiTestBase, ImportApiTestBase):
 
     def _run_api_v2_projects_id(self, pid, user):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/projects/{}".format(pid), format="json")
+            response = self.client.get(f"/api/projects/{pid}", format="json")
 
         return response.data
 
@@ -1990,17 +1976,17 @@ class _CloudStorageTestBase(ApiTestBase):
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             tid = response.data["id"]
 
-            response = self.client.post("/api/tasks/%s/data" % tid, data=image_data)
+            response = self.client.post(f"/api/tasks/{tid}/data", data=image_data)
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
             rq_id = response.data["rq_id"]
 
-            response = self.client.get("/api/requests/%s" % rq_id)
+            response = self.client.get(f"/api/requests/{rq_id}")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(
                 response.data["status"], "finished", "Message: " + response.data["message"]
             )
 
-            response = self.client.get("/api/tasks/%s" % tid)
+            response = self.client.get(f"/api/tasks/{tid}")
             task = response.data
 
         return task
@@ -2219,7 +2205,7 @@ class ProjectExportAPITestCase(ExportApiTestBase):
 
     def _run_api_v2_tasks_id_delete(self, tid, user):
         with ForceLogin(user, self.client):
-            response = self.client.delete("/api/tasks/{}".format(tid), format="json")
+            response = self.client.delete(f"/api/tasks/{tid}", format="json")
         return response
 
     def _check_tasks_count(self, project, expected_result):
@@ -2269,21 +2255,15 @@ class ProjectImportExportAPITestCase(ExportApiTestBase, ImportApiTestBase):
         cls.media_data = [
             {
                 **{
-                    **{
-                        f"client_files[{i}]": generate_random_image_file(f"test_{i}.jpg")[1]
-                        for i in range(10)
-                    },
+                    f"client_files[{i}]": generate_random_image_file(f"test_{i}.jpg")[1]
+                    for i in range(10)
                 },
-                **{
-                    "image_quality": 75,
-                },
+                "image_quality": 75,
             },
             {
                 **{
-                    **{
-                        f"client_files[{i}]": generate_random_image_file(f"test_{i}.jpg")[1]
-                        for i in range(10)
-                    },
+                    f"client_files[{i}]": generate_random_image_file(f"test_{i}.jpg")[1]
+                    for i in range(10)
                 },
                 "image_quality": 75,
             },
@@ -2300,7 +2280,7 @@ class ProjectImportExportAPITestCase(ExportApiTestBase, ImportApiTestBase):
             for media in media_data.values():
                 if isinstance(media, io.BytesIO):
                     media.seek(0)
-            response = self.client.post("/api/tasks/{}/data".format(tid), data=media_data)
+            response = self.client.post(f"/api/tasks/{tid}/data", data=media_data)
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
             rq_id = response.json()["rq_id"]
 
@@ -2310,7 +2290,7 @@ class ProjectImportExportAPITestCase(ExportApiTestBase, ImportApiTestBase):
             rqjob_status, msg = response_json["status"], response_json["message"]
             self.assertEqual(rqjob_status, "finished", f"Message: {msg}")
 
-            response = self.client.get("/api/tasks/{}".format(tid))
+            response = self.client.get(f"/api/tasks/{tid}")
             data_id = response.data["data"]
             self.tasks.append(
                 {
@@ -2454,7 +2434,7 @@ class TaskGetAPITestCase(ApiTestBase):
 
     def _run_api_v2_tasks_id(self, tid, user):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/tasks/{}".format(tid))
+            response = self.client.get(f"/api/tasks/{tid}")
 
             if 200 <= response.status_code < 400:
                 labels_response = list(
@@ -2520,7 +2500,7 @@ class TaskDeleteAPITestCase(ApiTestBase):
 
     def _run_api_v2_tasks_id(self, tid, user):
         with ForceLogin(user, self.client):
-            response = self.client.delete("/api/tasks/{}".format(tid), format="json")
+            response = self.client.delete(f"/api/tasks/{tid}", format="json")
 
         return response
 
@@ -2567,7 +2547,7 @@ class TaskUpdateAPITestCase(ApiTestBase):
 
     def _run_api_v2_tasks_id(self, tid, user, data):
         with ForceLogin(user, self.client):
-            response = self.client.put("/api/tasks/{}".format(tid), data=data, format="json")
+            response = self.client.put(f"/api/tasks/{tid}", data=data, format="json")
 
         return response
 
@@ -2635,7 +2615,7 @@ class TaskPartialUpdateAPITestCase(ApiTestBase):
 
     def _run_api_v2_tasks_id(self, tid, user, data):
         with ForceLogin(user, self.client):
-            response = self.client.patch("/api/tasks/{}".format(tid), data=data, format="json")
+            response = self.client.patch(f"/api/tasks/{tid}", data=data, format="json")
 
             if 200 <= response.status_code < 400:
                 labels_response = list(
@@ -2762,9 +2742,7 @@ class TaskDataMetaPartialUpdateAPITestCase(ApiTestBase):
 
     def _run_api_v1_task_data_meta_id(self, tid, user, data):
         with ForceLogin(user, self.client):
-            response = self.client.patch(
-                "/api/tasks/{}/data/meta".format(tid), data=data, format="json"
-            )
+            response = self.client.patch(f"/api/tasks/{tid}/data/meta", data=data, format="json")
 
         return response
 
@@ -2855,7 +2833,7 @@ class TaskUpdateLabelsAPITestCase(UpdateLabelsAPITestCase):
 
     def _run_api_v2_task_id(self, tid, user, data):
         with ForceLogin(user, self.client):
-            response = self.client.patch("/api/tasks/{}".format(tid), data=data, format="json")
+            response = self.client.patch(f"/api/tasks/{tid}", data=data, format="json")
 
             if 200 <= response.status_code < 400:
                 labels_response = list(
@@ -3149,14 +3127,14 @@ class TaskMoveAPITestCase(ApiTestBase):
 
     def _run_api_v2_tasks_id(self, tid, data):
         with ForceLogin(self.admin, self.client):
-            response = self.client.patch("/api/tasks/{}".format(tid), data=data, format="json")
+            response = self.client.patch(f"/api/tasks/{tid}", data=data, format="json")
 
         return response
 
     def _run_api_v2_job_id_annotation(self, jid, data):
         with ForceLogin(self.admin, self.client):
             response = self.client.patch(
-                "/api/jobs/{}/annotations?action=create".format(jid), data=data, format="json"
+                f"/api/jobs/{jid}/annotations?action=create", data=data, format="json"
             )
 
         return response
@@ -3347,10 +3325,7 @@ class TaskImportExportAPITestCase(ExportApiTestBase, ImportApiTestBase):
             "start_frame": 2,
             "stop_frame": 9,
             "frame_filter": "step=2",
-            **{
-                "server_files[{}]".format(i): imagename_pattern.format(i)
-                for i in range(image_count)
-            },
+            **{f"server_files[{i}]": imagename_pattern.format(i) for i in range(image_count)},
         }
         use_cache_data = {
             **data,
@@ -3475,19 +3450,12 @@ class TaskImportExportAPITestCase(ExportApiTestBase, ImportApiTestBase):
         )
         cls.media_data.append(
             {
-                **{
-                    "image_quality": 70,
-                    "copy_data": True,
-                    "use_cache": True,
-                    "frame_filter": "step=2",
-                    "server_files[0]": "manifest.jsonl",
-                },
-                **{
-                    **{
-                        "server_files[{}]".format(i): imagename_pattern.format(i)
-                        for i in range(1, 8)
-                    },
-                },
+                "image_quality": 70,
+                "copy_data": True,
+                "use_cache": True,
+                "frame_filter": "step=2",
+                "server_files[0]": "manifest.jsonl",
+                **{f"server_files[{i}]": imagename_pattern.format(i) for i in range(1, 8)},
             }
         )
 
@@ -3601,7 +3569,7 @@ class TaskImportExportAPITestCase(ExportApiTestBase, ImportApiTestBase):
             for media in media_data.values():
                 if isinstance(media, io.BytesIO):
                     media.seek(0)
-            response = self.client.post("/api/tasks/{}/data".format(tid), data=media_data)
+            response = self.client.post(f"/api/tasks/{tid}/data", data=media_data)
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
             rq_id = response.json()["rq_id"]
 
@@ -3611,7 +3579,7 @@ class TaskImportExportAPITestCase(ExportApiTestBase, ImportApiTestBase):
             rqjob_status, msg = response_json["status"], response_json["message"]
             self.assertEqual(rqjob_status, "finished", f"Message: {msg}")
 
-            response = self.client.get("/api/tasks/{}".format(tid))
+            response = self.client.get(f"/api/tasks/{tid}")
             data_id = response.data["data"]
             self.tasks.append(
                 {
@@ -3680,7 +3648,7 @@ class TaskImportExportAPITestCase(ExportApiTestBase, ImportApiTestBase):
 
     def _run_api_v2_tasks_id(self, tid, user):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/tasks/{}".format(tid), format="json")
+            response = self.client.get(f"/api/tasks/{tid}", format="json")
 
         return response.data
 
@@ -3836,7 +3804,7 @@ def generate_zip_archive_file(filename, count):
     zip_buf = BytesIO()
     with zipfile.ZipFile(zip_buf, "w") as zip_chunk:
         for idx in range(count):
-            image_name = "image_{:6d}.jpg".format(idx)
+            image_name = f"image_{idx:6d}.jpg"
             size, image_buf = generate_random_image_file(image_name)
             image_sizes.append(size)
             zip_chunk.writestr(image_name, image_buf.getvalue())
@@ -4107,20 +4075,13 @@ class TaskDataAPITestCase(ApiTestBase):
 
     def _run_api_v2_tasks_id_data_post(self, tid, user, data, *, headers=None):
         with ForceLogin(user, self.client):
-            response = self.client.post(
-                "/api/tasks/{}/data".format(tid),
-                data=data,
-                **{"HTTP_" + k: v for k, v in (headers or {}).items()},
-            )
+            response = self.client.post(f"/api/tasks/{tid}/data", data=data, headers=headers)
 
         return response
 
     def _get_task_creation_status(self, tid, user, *, headers=None):
         with ForceLogin(user, self.client):
-            response = self.client.get(
-                "/api/tasks/{}/status".format(tid),
-                **{"HTTP_" + k: v for k, v in (headers or {}).items()},
-            )
+            response = self.client.get(f"/api/tasks/{tid}/status", headers=headers)
 
         return response
 
@@ -4131,7 +4092,7 @@ class TaskDataAPITestCase(ApiTestBase):
 
     def _get_task(self, user, tid):
         with ForceLogin(user, self.client):
-            return self.client.get("/api/tasks/{}".format(tid))
+            return self.client.get(f"/api/tasks/{tid}")
 
     def _run_api_v2_task_id_data_get(
         self, tid, user, data_type, data_quality=None, data_number=None
@@ -4142,10 +4103,10 @@ class TaskDataAPITestCase(ApiTestBase):
         if data_number is not None:
             query_params["number"] = data_number
         with ForceLogin(user, self.client):
-            return self.client.get("/api/tasks/{}/data".format(tid), query_params=query_params)
+            return self.client.get(f"/api/tasks/{tid}/data", query_params=query_params)
 
     def _get_preview(self, tid, user):
-        url = "/api/tasks/{}/preview".format(tid)
+        url = f"/api/tasks/{tid}/preview"
         with ForceLogin(user, self.client):
             return self.client.get(url)
 
@@ -5956,7 +5917,7 @@ class JobAnnotationAPITestCase(ApiTestBase):
                     "image_quality": 100,
                 }
 
-            response = self.client.post("/api/tasks/{}/data".format(tid), data=images)
+            response = self.client.post(f"/api/tasks/{tid}/data", data=images)
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
             rq_id = response.data["rq_id"]
@@ -5964,7 +5925,7 @@ class JobAnnotationAPITestCase(ApiTestBase):
             rqjob_status, msg = response.data["status"], response.data["message"]
             self.assertEqual(rqjob_status, "finished", f"Message: {msg}")
 
-            response = self.client.get("/api/tasks/{}".format(tid))
+            response = self.client.get(f"/api/tasks/{tid}")
             task = response.data
 
             if 200 <= response.status_code < 400:
@@ -6009,28 +5970,26 @@ class JobAnnotationAPITestCase(ApiTestBase):
 
     def _put_api_v2_jobs_id_data(self, jid, user, data):
         with ForceLogin(user, self.client):
-            response = self.client.put(
-                "/api/jobs/{}/annotations".format(jid), data=data, format="json"
-            )
+            response = self.client.put(f"/api/jobs/{jid}/annotations", data=data, format="json")
 
         return response
 
     def _get_api_v2_jobs_id_data(self, jid, user):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/jobs/{}/annotations".format(jid))
+            response = self.client.get(f"/api/jobs/{jid}/annotations")
 
         return response
 
     def _delete_api_v2_jobs_id_data(self, jid, user):
         with ForceLogin(user, self.client):
-            response = self.client.delete("/api/jobs/{}/annotations".format(jid), format="json")
+            response = self.client.delete(f"/api/jobs/{jid}/annotations", format="json")
 
         return response
 
     def _patch_api_v2_jobs_id_data(self, jid, user, action, data):
         with ForceLogin(user, self.client):
             response = self.client.patch(
-                "/api/jobs/{}/annotations".format(jid),
+                f"/api/jobs/{jid}/annotations",
                 query_params={"action": action},
                 data=data,
                 format="json",
@@ -6454,28 +6413,26 @@ class JobAnnotationAPITestCase(ApiTestBase):
 class TaskAnnotationAPITestCase(ExportApiTestBase, ImportApiTestBase, JobAnnotationAPITestCase):
     def _put_api_v2_tasks_id_annotations(self, pk, user, data):
         with ForceLogin(user, self.client):
-            response = self.client.put(
-                "/api/tasks/{}/annotations".format(pk), data=data, format="json"
-            )
+            response = self.client.put(f"/api/tasks/{pk}/annotations", data=data, format="json")
 
         return response
 
     def _get_api_v2_tasks_id_annotations(self, pk, user):
         with ForceLogin(user, self.client):
-            response = self.client.get("/api/tasks/{}/annotations".format(pk))
+            response = self.client.get(f"/api/tasks/{pk}/annotations")
 
         return response
 
     def _delete_api_v2_tasks_id_annotations(self, pk, user):
         with ForceLogin(user, self.client):
-            response = self.client.delete("/api/tasks/{}/annotations".format(pk), format="json")
+            response = self.client.delete(f"/api/tasks/{pk}/annotations", format="json")
 
         return response
 
     def _patch_api_v2_tasks_id_annotations(self, pk, user, action, data):
         with ForceLogin(user, self.client):
             response = self.client.patch(
-                "/api/tasks/{}/annotations".format(pk),
+                f"/api/tasks/{pk}/annotations",
                 query_params={"action": action},
                 data=data,
                 format="json",
@@ -7600,7 +7557,7 @@ class TaskAnnotationAPITestCase(ExportApiTestBase, ImportApiTestBase, JobAnnotat
                 ]
                 annotations["shapes"] += skeleton_wo_attrs
             else:
-                raise Exception("Unknown format {}".format(annotation_format))
+                raise Exception(f"Unknown format {annotation_format}")
 
             return annotations
 
@@ -7983,9 +7940,9 @@ class ServerShareDifferentTypesAPITestCase(ApiTestBase):
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             tid = response.data["id"]
 
-            response = self.client.post("/api/tasks/%s/data" % tid, data=image_data)
+            response = self.client.post(f"/api/tasks/{tid}/data", data=image_data)
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
-            response = self.client.get("/api/tasks/%s" % tid)
+            response = self.client.get(f"/api/tasks/{tid}")
             task = response.data
 
         return task
@@ -8009,7 +7966,7 @@ class ServerShareDifferentTypesAPITestCase(ApiTestBase):
         shared_images = [img for img in shared_images if os.path.dirname(img) != "data1/subdir"]
         shared_images.append("data1/subdir/")
         shared_images.append("data1/")
-        remote_files = {"server_files[%d]" % i: shared_images[i] for i in range(len(shared_images))}
+        remote_files = {f"server_files[{i}]": shared_images[i] for i in range(len(shared_images))}
 
         task = {
             "name": "task combined image and directory extractors",
@@ -8034,7 +7991,7 @@ class ServerShareDifferentTypesAPITestCase(ApiTestBase):
         image_data.update(remote_files)
         # create task with server
         task = self._create_task(task, image_data)
-        response = self._get_request("/api/tasks/%s/data/meta" % task["id"], self.user)
+        response = self._get_request(f"/api/tasks/{task['id']}/data/meta", self.user)
         self.assertEqual(len(response.data["frames"]), images_count)
 
 
@@ -8061,10 +8018,10 @@ class TaskAnnotation2DContext(ApiTestBase):
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             tid = response.data["id"]
 
-            response = self.client.post("/api/tasks/%s/data" % tid, data=image_data)
+            response = self.client.post(f"/api/tasks/{tid}/data", data=image_data)
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
-            response = self.client.get("/api/tasks/%s" % tid)
+            response = self.client.get(f"/api/tasks/{tid}")
             task = response.data
 
         return task
@@ -8102,7 +8059,7 @@ class TaskAnnotation2DContext(ApiTestBase):
 
                 task_id = task["id"]
 
-                response = self._get_request("/api/tasks/%s/data/meta" % task_id, self.admin)
+                response = self._get_request(f"/api/tasks/{task_id}/data/meta", self.admin)
                 for frame in response.data["frames"]:
                     self.assertEqual(context_img_data[frame["name"]], frame["has_related_context"])
 
@@ -8124,7 +8081,7 @@ class TaskAnnotation2DContext(ApiTestBase):
             task_id = task["id"]
             query_params = {"quality": "original", "type": "context_image", "number": 0}
             response = self._get_request(
-                "/api/tasks/%s/data" % task_id, self.admin, query_params=query_params
+                f"/api/tasks/{task_id}/data", self.admin, query_params=query_params
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/cvat/apps/engine/tests/test_rest_api_3D.py
+++ b/cvat/apps/engine/tests/test_rest_api_3D.py
@@ -55,20 +55,20 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
 
     def _put_api_v2_task_id_annotations(self, tid, data):
         with ForceLogin(self.admin, self.client):
-            response = self.client.put("/api/tasks/%s/annotations" % tid, data=data, format="json")
+            response = self.client.put(f"/api/tasks/{tid}/annotations", data=data, format="json")
 
         return response
 
     def _put_api_v2_job_id_annotations(self, jid, data):
         with ForceLogin(self.admin, self.client):
-            response = self.client.put("/api/jobs/%s/annotations" % jid, data=data, format="json")
+            response = self.client.put(f"/api/jobs/{jid}/annotations", data=data, format="json")
 
         return response
 
     def _patch_api_v2_task_id_annotations(self, tid, data, action, user):
         with ForceLogin(user, self.client):
             response = self.client.patch(
-                "/api/tasks/{}/annotations".format(tid),
+                f"/api/tasks/{tid}/annotations",
                 query_params={"action": action},
                 data=data,
                 format="json",
@@ -79,7 +79,7 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
     def _patch_api_v2_job_id_annotations(self, jid, data, action, user):
         with ForceLogin(user, self.client):
             response = self.client.patch(
-                "/api/jobs/{}/annotations".format(jid),
+                f"/api/jobs/{jid}/annotations",
                 query_params={"action": action},
                 data=data,
                 format="json",
@@ -93,7 +93,7 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
             assert response.status_code == status.HTTP_201_CREATED, response.status_code
             tid = response.data["id"]
 
-            response = self.client.post("/api/tasks/%s/data" % tid, data=image_data)
+            response = self.client.post(f"/api/tasks/{tid}/data", data=image_data)
             assert response.status_code == status.HTTP_202_ACCEPTED, response.status_code
             rq_id = response.json()["rq_id"]
 
@@ -101,7 +101,7 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
             assert response.status_code == status.HTTP_200_OK, response.status_code
             assert response.json()["status"] == "finished", response.json().get("status")
 
-            response = self.client.get("/api/tasks/%s" % tid)
+            response = self.client.get(f"/api/tasks/{tid}")
 
             if 200 <= response.status_code < 400:
                 labels_response = list(
@@ -166,7 +166,7 @@ class _DbTestBase(ExportApiTestBase, ImportApiTestBase):
         return response
 
     def _delete_task(self, tid):
-        response = self._delete_request("/api/tasks/{}".format(tid), self.admin)
+        response = self._delete_request(f"/api/tasks/{tid}", self.admin)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         return response
 

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -188,17 +188,17 @@ class _LambdaTestCaseBase(ApiTestBase):
         with ForceLogin(owner or self.admin, self.client):
             response = self.client.post(
                 "/api/tasks",
+                query_params={"org_id": org_id} if org_id is not None else None,
                 data=task_spec,
                 format="json",
-                QUERY_STRING=f"org_id={org_id}" if org_id is not None else None,
             )
             assert response.status_code == status.HTTP_201_CREATED, response.status_code
             tid = response.data["id"]
 
             response = self.client.post(
-                "/api/tasks/%s/data" % tid,
+                f"/api/tasks/{tid}/data",
+                query_params={"org_id": org_id} if org_id is not None else None,
                 data=data,
-                QUERY_STRING=f"org_id={org_id}" if org_id is not None else None,
             )
             assert response.status_code == status.HTTP_202_ACCEPTED, response.status_code
             rq_id = response.json()["rq_id"]
@@ -208,17 +208,15 @@ class _LambdaTestCaseBase(ApiTestBase):
             assert response.json()["status"] == "finished", response.json().get("status")
 
             response = self.client.get(
-                "/api/tasks/%s" % tid,
-                QUERY_STRING=f"org_id={org_id}" if org_id is not None else None,
+                f"/api/tasks/{tid}",
+                query_params={"org_id": org_id} if org_id is not None else None,
             )
             task = response.data
 
         return task
 
     def _generate_task_images(self, count):  # pylint: disable=no-self-use
-        images = {
-            "client_files[%d]" % i: generate_image_file("image_%d.jpg" % i) for i in range(count)
-        }
+        images = {f"client_files[{i}]": generate_image_file(f"image_{i}.jpg") for i in range(count)}
         images["image_quality"] = 75
         return images
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
* Replace %-formatting and str.format calls with f-strings.
* Use `query_params` and `headers` instead of raw WSGI environ variables.
* Collapse redundant `**{...}` constructs.

This improves consistency and readability.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
