### PR TITLE
Add audio interval annotation models

### DIFF
--- a/cvat-core/src/annotations-collection.ts
+++ b/cvat-core/src/annotations-collection.ts
@@ -8,10 +8,10 @@ import {
     MaskShape, BasicInjection, SkeletonShape,
     SkeletonTrack, PolygonShape, CuboidShape,
     RectangleShape, PolylineShape, PointsShape, EllipseShape,
-    InterpolationNotPossibleError,
+    InterpolationNotPossibleError, AudioInterval,
 } from './annotations-objects';
 import {
-    SerializedCollection, SerializedShape, SerializedTrack, SerializedInterval,
+    SerializedCollection, SerializedShape, SerializedTrack,
 } from './server-response-types';
 import AnnotationsFilter from './annotations-filter';
 import { checkObjectType } from './common';
@@ -103,7 +103,7 @@ export default class Collection {
     private shapes: Record<number, Shape[]>;
     private tags: Record<number, Tag[]>;
     private tracks: Track[];
-    private intervals: SerializedInterval[];
+    private intervals: AudioInterval[];
     private objects: Record<number, AnnotationObject>;
     private groupsInfo: BasicInjection['groupsInfo'];
     private injection: BasicInjection;
@@ -253,7 +253,7 @@ export default class Collection {
         tags: Tag[];
         shapes: Shape[];
         tracks: Track[];
-        intervals: SerializedInterval[];
+        intervals: AudioInterval[];
     } {
         const result = {
             tags: [],
@@ -296,8 +296,11 @@ export default class Collection {
         }
 
         for (const interval of data.intervals ?? []) {
-            this.intervals.push(interval);
-            result.intervals.push(interval);
+            const clientID = this.injection.nextClientID();
+            const color = colors[clientID % colors.length];
+            const intervalModel = new AudioInterval(interval, clientID, color, this.injection);
+            this.intervals.push(intervalModel);
+            result.intervals.push(intervalModel);
         }
 
         return result;
@@ -361,8 +364,8 @@ export default class Collection {
         );
     }
 
-    public getAllIntervals(): SerializedInterval[] {
-        return this.intervals.map((interval) => ({ ...interval }));
+    public getAllIntervals(): ReturnType<AudioInterval['get']>[] {
+        return this.intervals.map((interval) => interval.get());
     }
 
     public export(): Pick<SerializedCollection, 'shapes' | 'tags' | 'tracks'> {

--- a/cvat-core/src/annotations-objects/annotation-common.ts
+++ b/cvat-core/src/annotations-objects/annotation-common.ts
@@ -3,17 +3,16 @@
 // SPDX-License-Identifier: MIT
 
 import ObjectState from '../object-state';
-import { Label } from '../labels';
+import { type Label } from '../labels';
 import {
     colors, Source, HistoryActions, JobType,
 } from '../enums';
-import type { SerializedShape, SerializedTrack, SerializedTag } from '../server-response-types';
 import { AnnotationContext } from './annotation-context';
 import type { AnnotationInjection } from './types';
 import { computeNewSource, defaultGroupColor, deserializeAttributes } from './utils';
 
 // Stores common annotation identity/state and field history mutations.
-export abstract class AnnotationBase extends AnnotationContext {
+export class AnnotationBase extends AnnotationContext {
     private _removed: boolean;
 
     protected _serverId?: number;
@@ -29,6 +28,7 @@ export abstract class AnnotationBase extends AnnotationContext {
     public group: number;
     public label: Label;
     public lock: boolean;
+    public hidden: boolean;
     public source: Source;
     public updated: number;
     public attributes: Map<number, string>;
@@ -67,6 +67,7 @@ export abstract class AnnotationBase extends AnnotationContext {
         this.group = data.group;
         this.label = this.labels[data.label_id];
         this.lock = false;
+        this.hidden = false;
         this.source = injection.jobType === JobType.GROUND_TRUTH ? Source.GT : data.source;
         this.updated = Date.now();
         this.attributes = deserializeAttributes(data.attributes);
@@ -95,6 +96,27 @@ export abstract class AnnotationBase extends AnnotationContext {
         );
 
         this.lock = lock;
+    }
+
+    protected saveHidden(hidden: boolean, frame: number | null): void {
+        const undoHidden = this.hidden;
+        const redoHidden = hidden;
+
+        this.history.do(
+            HistoryActions.CHANGED_HIDDEN,
+            () => {
+                this.hidden = undoHidden;
+                this.updated = Date.now();
+            },
+            () => {
+                this.hidden = redoHidden;
+                this.updated = Date.now();
+            },
+            [this.clientID],
+            frame,
+        );
+
+        this.hidden = hidden;
     }
 
     protected saveColor(color: string, frame: number | null): void {
@@ -183,10 +205,6 @@ export abstract class AnnotationBase extends AnnotationContext {
 
     public clearServerId(): void {
         this._serverId = undefined;
-    }
-
-    public updateFromServerResponse(body: SerializedShape | SerializedTag | SerializedTrack): void {
-        this._serverId = body.id;
     }
 
     protected updateTimestamp(updated: ObjectState['updateFlags']): void {

--- a/cvat-core/src/annotations-objects/audio-interval.ts
+++ b/cvat-core/src/annotations-objects/audio-interval.ts
@@ -1,0 +1,46 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import type { SerializedInterval } from '../server-response-types';
+import { ObjectType } from '../enums';
+import { AnnotationBase } from './annotation-common';
+import type { AnnotationInjection, AudioIntervalState } from './types';
+import { ScoredMixin } from './scored';
+
+const ScoredAnnotationBase = ScoredMixin(AnnotationBase);
+
+export class AudioInterval extends ScoredAnnotationBase {
+    public start: number;
+    public stop: number | null;
+
+    constructor(data: SerializedInterval, clientID: number, color: string, injection: AnnotationInjection) {
+        super(data, clientID, color, injection);
+        this.start = data.start;
+        this.stop = data.stop;
+    }
+
+    public get(): AudioIntervalState {
+        return {
+            objectType: ObjectType.INTERVAL,
+            clientID: this.clientID,
+            serverID: this._serverId ?? null,
+            label: this.label,
+            start: this.start,
+            stop: this.stop,
+            group: this.groupObject,
+            color: this.color,
+            lock: this.lock,
+            hidden: this.hidden,
+            updated: this.updated,
+            source: this.source,
+            score: this.score,
+            votes: this.votes,
+            attributes: Object.fromEntries(this.attributes),
+        };
+    }
+
+    public updateFromServerResponse(body: { id: number }): void {
+        this._serverId = body.id;
+    }
+}

--- a/cvat-core/src/annotations-objects/drawn.ts
+++ b/cvat-core/src/annotations-objects/drawn.ts
@@ -16,14 +16,12 @@ import { isChildObject } from './utils';
 
 export class Drawn extends ImageObject {
     protected descriptions: string[];
-    public hidden: boolean;
     protected pinned: boolean;
     public shapeType: ShapeType;
 
     constructor(data, clientID: number, color: string, injection: AnnotationInjection) {
         super(data, clientID, color, injection);
         this.descriptions = data.descriptions || [];
-        this.hidden = false;
         this.pinned = true;
         this.shapeType = null;
     }
@@ -51,27 +49,6 @@ export class Drawn extends ImageObject {
         );
 
         this.pinned = pinned;
-    }
-
-    protected saveHidden(hidden: boolean, frame: number): void {
-        const undoHidden = this.hidden;
-        const redoHidden = hidden;
-
-        this.history.do(
-            HistoryActions.CHANGED_HIDDEN,
-            () => {
-                this.hidden = undoHidden;
-                this.updated = Date.now();
-            },
-            () => {
-                this.hidden = redoHidden;
-                this.updated = Date.now();
-            },
-            [this.clientID],
-            frame,
-        );
-
-        this.hidden = hidden;
     }
 
     private fitPoints(points: number[], rotation: number, maxX: number, maxY: number): number[] {

--- a/cvat-core/src/annotations-objects/image-object.ts
+++ b/cvat-core/src/annotations-objects/image-object.ts
@@ -17,15 +17,10 @@ export class InterpolationNotPossibleError extends Error {}
 
 export class ImageObject extends AnnotationBase {
     public frame: number;
-    public score: number;
-    public votes: number;
 
     constructor(data, clientID: number, color: string, injection: AnnotationInjection) {
         super(data, clientID, color, injection);
         this.frame = data.frame;
-        this.score = data.score;
-        this.votes = injection.replicasCount !== undefined ?
-            Math.round(this.score * injection.replicasCount) : 0;
     }
 
     protected withContext(_: number): {

--- a/cvat-core/src/annotations-objects/index.ts
+++ b/cvat-core/src/annotations-objects/index.ts
@@ -26,12 +26,14 @@ import { PointsTrack } from './points-track';
 import { CuboidTrack } from './cuboid-track';
 // eslint-disable-next-line import/no-cycle
 import { SkeletonTrack } from './skeleton-track';
+import { AudioInterval } from './audio-interval';
 
 export type { BasicInjection, InterpolatedPosition } from './types';
 export { InterpolationNotPossibleError } from './image-object';
 export { Shape };
 export { Track };
 export { Tag } from './tag';
+export { AudioInterval };
 export {
     RectangleShape, EllipseShape, PolygonShape, PolylineShape, PointsShape,
     CuboidShape, SkeletonShape, MaskShape,

--- a/cvat-core/src/annotations-objects/mask-shape.ts
+++ b/cvat-core/src/annotations-objects/mask-shape.ts
@@ -44,10 +44,8 @@ export class MaskShape extends Shape {
     public removeUnderlyingPixels(frame: number):
     {
         clientIDs: number[],
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-        undo: Function,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-        redo: Function,
+        undo: () => void,
+        redo: () => void,
         emptyMaskOccurred: boolean,
     } {
         if (frame !== this.frame) {

--- a/cvat-core/src/annotations-objects/scored.ts
+++ b/cvat-core/src/annotations-objects/scored.ts
@@ -1,0 +1,30 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import { AnnotationContext } from './annotation-context';
+
+type Constructor<T = object> = new (...args: any[]) => T;
+type AnnotationContextConstructor = Constructor<AnnotationContext>;
+
+export type Scored = {
+    score: number;
+    votes: number;
+};
+
+export function ScoredMixin<TBase extends AnnotationContextConstructor>(
+    Base: TBase,
+): TBase & Constructor<InstanceType<TBase> & Scored> {
+    return class ScoredAnnotation extends Base {
+        public score: number;
+        public votes: number;
+
+        constructor(...args: any[]) {
+            super(...args);
+            const [data] = args as [{ score: number }];
+            const { replicasCount } = this;
+            this.score = data.score ?? 1;
+            this.votes = replicasCount !== undefined ? Math.round(this.score * replicasCount) : 0;
+        }
+    } as TBase & Constructor<InstanceType<TBase> & Scored>;
+}

--- a/cvat-core/src/annotations-objects/shape.ts
+++ b/cvat-core/src/annotations-objects/shape.ts
@@ -11,8 +11,9 @@ import type { SerializedShape } from '../server-response-types';
 import { computeNewSource, isChildObject, serializeAttributes } from './utils';
 import { Drawn } from './drawn';
 import type { AnnotationInjection } from './types';
+import { ScoredMixin } from './scored';
 
-export class Shape extends Drawn {
+export class Shape extends ScoredMixin(Drawn) {
     public points: number[];
     public occluded: boolean;
     public outside: boolean;
@@ -110,6 +111,10 @@ export class Shape extends Drawn {
         }
 
         return result;
+    }
+
+    public updateFromServerResponse(body: { id: number }): void {
+        this._serverId = body.id;
     }
 
     protected saveRotation(rotation: number, frame: number): void {

--- a/cvat-core/src/annotations-objects/skeleton-shape.ts
+++ b/cvat-core/src/annotations-objects/skeleton-shape.ts
@@ -174,11 +174,17 @@ export class SkeletonShape extends Shape {
         };
     }
 
-    public updateFromServerResponse(body: SerializedShape): void {
+    public updateFromServerResponse(
+        body: Parameters<typeof Shape.prototype.updateFromServerResponse>[0] & {
+            elements?: { id: number, label_id: number }[];
+        },
+    ): void {
         Shape.prototype.updateFromServerResponse.call(this, body);
-        for (const element of body.elements) {
-            const context = this.elements.find((_element: Shape) => _element.label.id === element.label_id);
-            context.updateFromServerResponse(element);
+        if ('elements' in body) {
+            for (const element of body.elements) {
+                const context = this.elements.find((_element: Shape) => _element.label.id === element.label_id);
+                context.updateFromServerResponse(element);
+            }
         }
     }
 

--- a/cvat-core/src/annotations-objects/skeleton-track.ts
+++ b/cvat-core/src/annotations-objects/skeleton-track.ts
@@ -73,11 +73,20 @@ export class SkeletonTrack extends Track {
         }).filter(Boolean).sort((a: ImageObject, b: ImageObject) => a.label.id - b.label.id);
     }
 
-    public updateFromServerResponse(body: SerializedTrack): void {
+    public updateFromServerResponse(body: Parameters<typeof Track.prototype.updateFromServerResponse>[0] & {
+        elements?: {
+            id: number;
+            frame: number;
+            label_id: number;
+            shapes: SerializedTrack['shapes'];
+        }[];
+    }): void {
         Track.prototype.updateFromServerResponse.call(this, body);
-        for (const element of body.elements) {
-            const context = this.elements.find((_element: Track) => _element.label.id === element.label_id);
-            context.updateFromServerResponse(element);
+        if ('elements' in body) {
+            for (const element of body.elements) {
+                const context = this.elements.find((_element: Track) => _element.label.id === element.label_id);
+                context.updateFromServerResponse(element);
+            }
         }
     }
 
@@ -182,7 +191,7 @@ export class SkeletonTrack extends Track {
         return result;
     }
 
-    public get(frame: number): Required<SerializedData> {
+    public get(frame: number): Omit<Required<SerializedData>, 'score' | 'votes'> {
         const { prev, next } = this.boundedKeyframes(frame);
         const position = this.getPosition(frame, prev, next);
         const elements = this.elements.map((element) => ({
@@ -216,8 +225,6 @@ export class SkeletonTrack extends Track {
             occluded: elements.every((el) => el.occluded),
             lock: elements.every((el) => el.lock),
             hidden: elements.every((el) => el.hidden),
-            score: this.score,
-            votes: this.votes,
             __internal: this.withContext(frame),
         };
     }

--- a/cvat-core/src/annotations-objects/tag.ts
+++ b/cvat-core/src/annotations-objects/tag.ts
@@ -43,7 +43,7 @@ export class Tag extends ImageObject {
     public get(frame: number): Omit<Required<SerializedData>,
     'elements' | 'occluded' | 'outside' | 'rotation' | 'zOrder' |
     'points' | 'hidden' | 'pinned' | 'keyframe' | 'shapeType' |
-    'parentID' | 'descriptions' | 'keyframes'
+    'parentID' | 'descriptions' | 'keyframes' | 'score' | 'votes'
     > {
         if (frame !== this.frame) {
             throw new ScriptingError('Received frame is not equal to the frame of the shape');
@@ -61,10 +61,12 @@ export class Tag extends ImageObject {
             updated: this.updated,
             frame,
             source: this.source,
-            score: this.score,
-            votes: this.votes,
             __internal: this.withContext(frame),
         };
+    }
+
+    public updateFromServerResponse(body: { id: number }): void {
+        this._serverId = body.id;
     }
 
     public save(frame: number, data: ObjectState): ObjectState {

--- a/cvat-core/src/annotations-objects/track.ts
+++ b/cvat-core/src/annotations-objects/track.ts
@@ -88,7 +88,7 @@ export class Track extends Drawn {
         return result;
     }
 
-    public get(frame: number): Omit<Required<SerializedData>, 'elements'> {
+    public get(frame: number): Omit<Required<SerializedData>, 'elements' | 'score' | 'votes'> {
         const {
             prev, next, first, last,
         } = this.boundedKeyframes(frame);
@@ -117,8 +117,6 @@ export class Track extends Drawn {
             },
             frame,
             source: this.source,
-            score: this.score,
-            votes: this.votes,
             __internal: this.withContext(frame),
         };
     }
@@ -184,14 +182,16 @@ export class Track extends Drawn {
         return result;
     }
 
-    public updateFromServerResponse(body: SerializedTrack | SerializedTrack['elements'][0]): void {
+    public updateFromServerResponse(body: {
+        id: number;
+        frame: number;
+        shapes: SerializedTrack['shapes'];
+    }): void {
         this._serverId = body.id;
         this.frame = body.frame;
-        const updatedShapes = {};
-        for (const shape of body.shapes) {
-            updatedShapes[shape.frame] = convertTrackedShape(shape);
-        }
-        this.shapes = updatedShapes;
+        this.shapes = Object.fromEntries(
+            body.shapes.map((shape) => [shape.frame, convertTrackedShape(shape)]),
+        );
     }
 
     public clearServerId(): void {

--- a/cvat-core/src/annotations-objects/types.ts
+++ b/cvat-core/src/annotations-objects/types.ts
@@ -5,7 +5,9 @@
 
 import type AnnotationHistory from '../annotations-history';
 import type { Label } from '../labels';
-import type { DimensionType, JobType } from '../enums';
+import type {
+    DimensionType, JobType, ObjectType, Source,
+} from '../enums';
 import type { MaskShape } from './shape-models';
 
 export type FrameInfo = {
@@ -60,3 +62,24 @@ export interface Point2D {
     x: number;
     y: number;
 }
+
+export type AudioIntervalState = Readonly<{
+    objectType: ObjectType.INTERVAL;
+    clientID: number;
+    serverID: number | null;
+    label: Label;
+    start: number;
+    stop: number | null;
+    group: {
+        readonly color: string;
+        readonly id: number;
+    };
+    color: string;
+    lock: boolean;
+    updated: number;
+    source: Source;
+    score: number;
+    votes: number;
+    hidden: boolean;
+    attributes: Record<number, string>;
+}>;

--- a/cvat-core/src/annotations.ts
+++ b/cvat-core/src/annotations.ts
@@ -14,7 +14,6 @@ import { Task, Job } from './session';
 import { ArgumentError } from './exceptions';
 import { getFramesMeta, getJobFramesMetaSync } from './frames';
 import { JobType } from './enums';
-import { SerializedInterval } from './server-response-types';
 
 const jobCollectionCache = new WeakMap<Task | Job, { collection: AnnotationsCollection; saver: AnnotationsSaver; }>();
 const taskCollectionCache = new WeakMap<Task | Job, { collection: AnnotationsCollection; saver: AnnotationsSaver; }>();
@@ -154,7 +153,7 @@ export async function getAnnotations(
     }
 }
 
-export async function getAllIntervals(session: Job | Task): Promise<SerializedInterval[]> {
+export async function getAllIntervals(session: Job | Task): Promise<ReturnType<AnnotationsCollection['getAllIntervals']>> {
     try {
         return getCollection(session).getAllIntervals();
     } catch (error) {

--- a/cvat-core/src/session.ts
+++ b/cvat-core/src/session.ts
@@ -16,9 +16,10 @@ import { Label } from './labels';
 import User from './user';
 import { FieldUpdateTrigger } from './common';
 import {
-    SerializedCollection, SerializedJob, SerializedInterval,
+    SerializedCollection, SerializedJob,
     SerializedLabel, SerializedTask,
 } from './server-response-types';
+import { type AudioIntervalState } from './annotations-objects/types';
 import AnnotationGuide from './guide';
 import { FrameData, FramesMetaData } from './frames';
 import Statistics from './statistics';
@@ -381,7 +382,7 @@ function buildDuplicatedAPI(prototype) {
 export class Session {
     public annotations: {
         get: (frame: number, allTracks: boolean, filters: object[]) => Promise<ObjectState[]>;
-        intervals: () => Promise<SerializedInterval[]>;
+        intervals: () => Promise<AudioIntervalState[]>;
         put: (objectStates: ObjectState[]) => Promise<number[]>;
         merge: (objectStates: ObjectState[]) => Promise<void>;
         split: (objectState: ObjectState, frame: number) => Promise<void>;

--- a/cvat-ui/src/actions/audio-actions.ts
+++ b/cvat-ui/src/actions/audio-actions.ts
@@ -148,7 +148,7 @@ export function loadAudioAnnotationsAsync(): ThunkAction {
         }
 
         try {
-            const intervals: SerializedInterval[] = await jobInstance.annotations.intervals();
+            const intervals = await jobInstance.annotations.intervals();
 
             const regions: AudioRegion[] = intervals.reduce<AudioRegion[]>((acc, interval) => {
                 const startSec = interval.start / 1000;
@@ -158,20 +158,17 @@ export function loadAudioAnnotationsAsync(): ThunkAction {
                     return acc;
                 }
                 acc.push({
-                    id: `server-${interval.id}`,
+                    id: `server-${interval.clientID}`,
                     start: startSec,
                     end: endSec,
-                    labelId: interval.label_id,
-                    attributes: interval.attributes.reduce<Record<number, string>>(
-                        (attrs, attr) => ({ ...attrs, [attr.spec_id]: attr.value }),
-                        {},
-                    ),
-                    serverId: interval.id,
+                    labelId: interval.label.id!,
+                    attributes: interval.attributes,
+                    serverId: interval.serverID ?? undefined,
                     source: String(interval.source),
-                    group: interval.group,
+                    group: interval.group.id,
                     color: pickInstanceColor(acc),
-                    locked: false,
-                    hidden: false,
+                    locked: interval.lock,
+                    hidden: interval.hidden,
                 });
                 return acc;
             }, []);

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/controls-side-bar/interval-region-control.tsx
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/controls-side-bar/interval-region-control.tsx
@@ -75,6 +75,7 @@ function IntervalRegionControl(props: Props): JSX.Element {
         onSetActiveLabel,
         onExtendRegion,
     } = props;
+
     const { keyMap } = useSelector((state: CombinedState) => state.shortcuts);
     const [popoverOpen, setPopoverOpen] = useState(false);
     const [selectedLabelId, setSelectedLabelId] = useState<number | null>(


### PR DESCRIPTION
Title: Add audio interval annotation models

### Motivation and context

This PR introduces a core annotation object model for audio intervals instead of storing raw serialized interval payloads in the annotations collection.

Main changes:
- Add `AudioInterval`, backed by `AnnotationBase`, for interval identity, attributes, lock, hidden, score, votes, source, group, and color state.
- Add `AudioIntervalState` as the core return type for `annotations.intervals()`, while keeping `SerializedInterval` as the server payload type.
- Store audio intervals as annotation objects in `AnnotationsCollection` and expose them through `getAllIntervals()`.
- Add `ScoredMixin` so score/votes logic can be reused by shapes and intervals without moving it into all annotation objects.
- Move `hidden` state/history logic from `Drawn` to `AnnotationBase`.
- Update the audio UI load adapter to consume the new interval state shape.

Next steps:

- Add IntervalState class to save changes and undo/redo via cvat-core
- Incremental save via AnnotationCollection & existing AnnotationsSaver
- Updated Collection.put, Collection.export, Collection.commit, Collection.statistics, Collection.clear to support intervals

### How has this been tested?

Ran:

```bash
yarn --cwd cvat_enterprise/cvat/cvat-core run type-check
yarn --cwd cvat_enterprise/cvat/cvat-ui eslint src/actions/audio-actions.ts src/audio/components/annotation-page/audio-workspace/controls-side-bar/interval-region-control.tsx
git -C cvat_enterprise/cvat diff --cached --check
```

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- [ ] ~~I have updated the documentation accordingly~~
- [ ] ~~I have added tests to cover my changes~~
- [ ] ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.