### PR TITLE
Add editable audio interval state support

### DIFF
--- a/cvat-core/src/annotations-objects/annotation-common.ts
+++ b/cvat-core/src/annotations-objects/annotation-common.ts
@@ -2,13 +2,12 @@
 //
 // SPDX-License-Identifier: MIT
 
-import type ObjectState from '../object-state';
 import { type Label } from '../labels';
 import {
     colors, Source, HistoryActions, JobType,
 } from '../enums';
 import { AnnotationContext } from './annotation-context';
-import type { AnnotationInjection } from './types';
+import type { AnnotationInjection, CommonUpdateFlags } from './types';
 import { computeNewSource, defaultGroupColor, deserializeAttributes } from './utils';
 
 // Stores common annotation identity/state and field history mutations.
@@ -207,14 +206,14 @@ export class AnnotationBase extends AnnotationContext {
         this._serverId = undefined;
     }
 
-    protected updateTimestamp(updated: ObjectState['updateFlags']): void {
-        const anyChanges = Object.keys(updated).some((key) => !!updated[key]);
+    protected updateTimestamp<T extends CommonUpdateFlags>(updated: T): void {
+        const anyChanges = Object.values(updated).some((value) => value);
         if (anyChanges) {
             this.updated = Date.now();
         }
     }
 
-    protected withContext(_: number): {
+    protected withContext(): {
         delete: AnnotationBase['delete'];
     } {
         return {

--- a/cvat-core/src/annotations-objects/audio-interval-state.ts
+++ b/cvat-core/src/annotations-objects/audio-interval-state.ts
@@ -1,0 +1,310 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import PluginRegistry from '../plugins';
+import { ArgumentError } from '../exceptions';
+import { Label } from '../labels';
+import { ObjectType, Source } from '../enums';
+import type { SerializedInterval } from '../server-response-types';
+import type { AudioIntervalUpdateFlags } from './types';
+
+export interface SerializedAudioIntervalState {
+    objectType: ObjectType.INTERVAL;
+    label: Label;
+    clientID: number;
+    serverID: number | null;
+    start: number;
+    stop: number | null;
+    color: string;
+    lock: boolean;
+    updated: number;
+    source: Source;
+    score: number;
+    votes: number;
+    hidden: boolean;
+    attributes: Record<number, string>;
+    __internal: {
+        save: (audioIntervalState: AudioIntervalState) => AudioIntervalState;
+        delete: (frame: number | null, force: boolean) => boolean;
+        export: () => SerializedInterval;
+    };
+}
+
+export class AudioIntervalState {
+    private readonly __internal: SerializedAudioIntervalState['__internal'];
+
+    public readonly updateFlags: AudioIntervalUpdateFlags;
+    public readonly objectType: ObjectType.INTERVAL;
+    public readonly source: Source;
+    public readonly clientID: number;
+    public readonly serverID: number | null;
+    public readonly updated: number;
+    public readonly score: number;
+    public readonly votes: number;
+    public label: Label;
+    public start: number;
+    public stop: number | null;
+    public color: string;
+    public hidden: boolean;
+    public lock: boolean;
+    public attributes: Record<number, string>;
+
+    constructor(serialized: SerializedAudioIntervalState) {
+        if (serialized.objectType !== ObjectType.INTERVAL) {
+            throw new ArgumentError(
+                `AudioIntervalState must be provided correct ObjectType (INTERVAL), got ${serialized.objectType}`,
+            );
+        }
+
+        if (!(serialized.label instanceof Label)) {
+            throw new ArgumentError(
+                `AudioIntervalState must be provided correct Label, got wrong value ${serialized.label}`,
+            );
+        }
+
+        if (typeof serialized.start !== 'number') {
+            throw new ArgumentError(
+                `AudioIntervalState must be provided correct start, got wrong value ${serialized.start}`,
+            );
+        }
+
+        if (serialized.stop !== null && typeof serialized.stop !== 'number') {
+            throw new ArgumentError(
+                `AudioIntervalState must be provided correct stop, got wrong value ${serialized.stop}`,
+            );
+        }
+
+        const updateFlags: AudioIntervalUpdateFlags = {
+            reset() {
+                delete this.label;
+                delete this.attributes;
+                delete this.position;
+                delete this.lock;
+                delete this.color;
+                delete this.hidden;
+            },
+        };
+
+        Object.defineProperty(updateFlags, 'reset', {
+            enumerable: false,
+            writable: false,
+        });
+
+        const data = {
+            label: serialized.label,
+            attributes: {},
+            start: serialized.start,
+            stop: serialized.stop,
+            lock: serialized.lock,
+            color: serialized.color,
+            hidden: serialized.hidden,
+            source: serialized.source,
+            updated: serialized.updated,
+            clientID: serialized.clientID,
+            serverID: serialized.serverID,
+            objectType: serialized.objectType,
+            updateFlags,
+            score: serialized.score,
+            votes: serialized.votes,
+        };
+
+        Object.defineProperties(
+            this,
+            Object.freeze({
+                updateFlags: {
+                    get: () => data.updateFlags,
+                },
+                objectType: {
+                    get: () => data.objectType,
+                },
+                source: {
+                    get: () => data.source,
+                },
+                score: {
+                    get: () => data.score,
+                },
+                votes: {
+                    get: () => data.votes,
+                },
+                clientID: {
+                    get: () => data.clientID,
+                },
+                serverID: {
+                    get: () => data.serverID,
+                },
+                label: {
+                    get: () => data.label,
+                    set: (label) => {
+                        data.updateFlags.label = true;
+                        if (!(label instanceof Label)) {
+                            throw new ArgumentError(
+                                `Label must be an instance of Label class, got ${typeof label}`,
+                            );
+                        }
+
+                        if (label.id! === data.label.id) {
+                            return;
+                        }
+
+                        data.label = label;
+                    },
+                },
+                start: {
+                    get: () => data.start,
+                    set: (start) => {
+                        if (typeof start !== 'number') {
+                            throw new ArgumentError('Start is expected to be a number.');
+                        }
+
+                        if (start === data.start) {
+                            return;
+                        }
+
+                        data.updateFlags.position = true;
+                        data.start = start;
+                    },
+                },
+                stop: {
+                    get: () => data.stop,
+                    set: (stop) => {
+                        if (stop !== null && typeof stop !== 'number') {
+                            throw new ArgumentError('Stop is expected to be a number or null.');
+                        }
+
+                        if (stop === data.stop) {
+                            return;
+                        }
+
+                        data.updateFlags.position = true;
+                        data.stop = stop;
+                    },
+                },
+                color: {
+                    get: () => data.color,
+                    set: (color) => {
+                        data.updateFlags.color = true;
+                        data.color = color;
+                    },
+                },
+                hidden: {
+                    get: () => data.hidden,
+                    set: (hidden) => {
+                        if (typeof hidden !== 'boolean') {
+                            throw new ArgumentError('Hidden is expected to be a boolean.');
+                        }
+
+                        if (hidden === data.hidden) {
+                            return;
+                        }
+
+                        data.updateFlags.hidden = true;
+                        data.hidden = hidden;
+                    },
+                },
+                lock: {
+                    get: () => data.lock,
+                    set: (lock) => {
+                        if (typeof lock !== 'boolean') {
+                            throw new ArgumentError('Lock is expected to be a boolean.');
+                        }
+
+                        if (lock === data.lock) {
+                            return;
+                        }
+
+                        data.updateFlags.lock = true;
+                        data.lock = lock;
+                    },
+                },
+                updated: {
+                    get: () => data.updated,
+                },
+                attributes: {
+                    get: () => data.attributes,
+                    set: (attributes) => {
+                        if (typeof attributes !== 'object') {
+                            throw new ArgumentError(
+                                'Attributes are expected to be an object ' +
+                                    `but got ${
+                                        typeof attributes === 'object' ?
+                                            attributes.constructor.name :
+                                            typeof attributes
+                                    }`,
+                            );
+                        }
+
+                        for (const attrID of Object.keys(attributes)) {
+                            data.updateFlags.attributes = true;
+                            data.attributes[attrID] = attributes[attrID];
+                        }
+                    },
+                },
+            }),
+        );
+
+        if (typeof serialized.hidden === 'boolean') {
+            data.hidden = serialized.hidden;
+        }
+        if (typeof serialized.color === 'string') {
+            data.color = serialized.color;
+        }
+        if (typeof serialized.attributes === 'object') {
+            data.attributes = serialized.attributes;
+        }
+
+        /* eslint-disable-next-line no-underscore-dangle */
+        if (serialized.__internal) {
+            /* eslint-disable-next-line no-underscore-dangle */
+            this.__internal = serialized.__internal;
+        }
+    }
+
+    async save(): Promise<AudioIntervalState> {
+        const result = await PluginRegistry.apiWrapper.call(this, AudioIntervalState.prototype.save);
+        return result;
+    }
+
+    async delete(force = false): Promise<boolean> {
+        const result = await PluginRegistry.apiWrapper.call(this, AudioIntervalState.prototype.delete, force);
+        return result;
+    }
+
+    async export(): Promise<SerializedInterval> {
+        const result = await PluginRegistry.apiWrapper.call(this, AudioIntervalState.prototype.export);
+        return result;
+    }
+}
+
+Object.defineProperty(AudioIntervalState.prototype.save, 'implementation', {
+    value: function saveImplementation(): AudioIntervalState {
+        if (this.__internal && this.__internal.save) {
+            return this.__internal.save(this);
+        }
+
+        throw new Error('Could not save audio interval state. Context is not provided.');
+    },
+    writable: false,
+});
+
+Object.defineProperty(AudioIntervalState.prototype.export, 'implementation', {
+    value: function exportImplementation(): SerializedInterval | AudioIntervalState {
+        if (this.__internal && this.__internal.export) {
+            return this.__internal.export();
+        }
+
+        throw new Error('Could not export audio interval state. Context is not provided.');
+    },
+    writable: false,
+});
+
+Object.defineProperty(AudioIntervalState.prototype.delete, 'implementation', {
+    value: function deleteImplementation(force: boolean): boolean {
+        if (this.__internal && this.__internal.delete) {
+            return this.__internal.delete(null, force);
+        }
+
+        throw new Error('Could not delete audio interval state. Context is not provided.');
+    },
+    writable: false,
+});

--- a/cvat-core/src/annotations-objects/audio-interval.ts
+++ b/cvat-core/src/annotations-objects/audio-interval.ts
@@ -3,10 +3,12 @@
 // SPDX-License-Identifier: MIT
 
 import type { SerializedInterval } from '../server-response-types';
-import { ObjectType } from '../enums';
+import { HistoryActions, ObjectType } from '../enums';
 import { AnnotationBase } from './annotation-common';
-import type { AnnotationInjection, AudioIntervalState } from './types';
+import { AudioIntervalState } from './audio-interval-state';
+import type { AnnotationInjection } from './types';
 import { ScoredMixin } from './scored';
+import { serializeAttributes } from './utils';
 
 export class AudioInterval extends ScoredMixin(AnnotationBase) {
     public start: number;
@@ -18,15 +20,67 @@ export class AudioInterval extends ScoredMixin(AnnotationBase) {
         this.stop = data.stop;
     }
 
-    public get(): AudioIntervalState {
+    protected withContext(): ReturnType<AnnotationBase['withContext']> & {
+        save: (data: AudioIntervalState) => AudioIntervalState;
+        export: () => SerializedInterval;
+    } {
         return {
+            delete: this.delete.bind(this),
+            save: this.save.bind(this),
+            export: this.toJSON.bind(this),
+        };
+    }
+
+    protected savePosition(start: number, stop: number | null): void {
+        const undoStart = this.start;
+        const undoStop = this.stop;
+        this.start = start;
+        this.stop = stop;
+
+        this.history.do(
+            HistoryActions.CHANGED_AUDIO_POSITION,
+            () => {
+                this.start = undoStart;
+                this.stop = undoStop;
+                this.updated = Date.now();
+            },
+            () => {
+                this.start = start;
+                this.stop = stop;
+                this.updated = Date.now();
+            },
+            [this.clientID],
+            null,
+        );
+    }
+
+    public toJSON(): SerializedInterval {
+        const result: SerializedInterval = {
+            clientID: this.clientID,
+            label_id: this.label.id,
+            start: this.start,
+            stop: this.stop,
+            group: this.groupObject.id,
+            source: this.source,
+            score: this.score,
+            attributes: serializeAttributes(this.attributes),
+        };
+
+        if (typeof this._serverId === 'number') {
+            result.id = this._serverId;
+        }
+
+        return result;
+    }
+
+    public get(): AudioIntervalState {
+        return new AudioIntervalState({
             objectType: ObjectType.INTERVAL,
             clientID: this.clientID,
             serverID: this._serverId ?? null,
             label: this.label,
             start: this.start,
             stop: this.stop,
-            group: this.groupObject,
             color: this.color,
             lock: this.lock,
             hidden: this.hidden,
@@ -35,10 +89,53 @@ export class AudioInterval extends ScoredMixin(AnnotationBase) {
             score: this.score,
             votes: this.votes,
             attributes: Object.fromEntries(this.attributes),
-        };
+            __internal: this.withContext(),
+        });
     }
 
     public updateFromServerResponse(body: { id: number }): void {
         this._serverId = body.id;
+    }
+
+    public save(data: AudioIntervalState): AudioIntervalState {
+        if (this.lock && data.lock) {
+            return this.get();
+        }
+
+        const updated = data.updateFlags;
+        for (const readOnlyField of this.readOnlyFields) {
+            delete updated[readOnlyField];
+        }
+
+        // this.validateStateBeforeSave(data, updated);
+
+        if (updated.label) {
+            this.saveLabel(data.label, null);
+        }
+
+        if (updated.attributes) {
+            this.saveAttributes(data.attributes, null);
+        }
+
+        if (updated.lock) {
+            this.saveLock(data.lock, null);
+        }
+
+        if (updated.color) {
+            this.saveColor(data.color, null);
+        }
+
+        if (updated.position) {
+            this.savePosition(data.start, data.stop);
+        }
+
+        if (updated.hidden) {
+            this.saveHidden(data.hidden, null);
+        }
+
+        this.updateTimestamp(updated);
+        updated.reset();
+
+        return this.get();
     }
 }

--- a/cvat-core/src/annotations-objects/shape.ts
+++ b/cvat-core/src/annotations-objects/shape.ts
@@ -34,14 +34,14 @@ export class Shape extends ScoredMixin(Drawn) {
         this.zOrder = data.z_order;
     }
 
-    protected withContext(frame: number): ReturnType<Drawn['withContext']> & {
+    protected withContext(): ReturnType<Drawn['withContext']> & {
         save: (data: ObjectState) => ObjectState;
         export: () => SerializedShape;
     } {
         return {
-            ...super.withContext(frame),
-            save: this.save.bind(this, frame),
-            export: this.toJSON.bind(this) as () => SerializedShape,
+            ...super.withContext(),
+            save: this.save.bind(this),
+            export: this.toJSON.bind(this),
         };
     }
 
@@ -103,7 +103,7 @@ export class Shape extends ScoredMixin(Drawn) {
             source: this.source,
             score: this.score,
             votes: this.votes,
-            __internal: this.withContext(frame),
+            __internal: this.withContext(),
         };
 
         if (typeof this.outside !== 'undefined') {
@@ -258,7 +258,7 @@ export class Shape extends ScoredMixin(Drawn) {
 
         const updated = data.updateFlags;
         for (const readOnlyField of this.readOnlyFields) {
-            updated[readOnlyField] = false;
+            delete updated[readOnlyField];
         }
 
         const fittedPoints = this.validateStateBeforeSave(data, updated, frame);

--- a/cvat-core/src/annotations-objects/skeleton-shape.ts
+++ b/cvat-core/src/annotations-objects/skeleton-shape.ts
@@ -170,7 +170,7 @@ export class SkeletonShape extends Shape {
             source: this.source,
             score: this.score,
             votes: this.votes,
-            __internal: this.withContext(frame),
+            __internal: this.withContext(),
         };
     }
 

--- a/cvat-core/src/annotations-objects/skeleton-track.ts
+++ b/cvat-core/src/annotations-objects/skeleton-track.ts
@@ -225,7 +225,7 @@ export class SkeletonTrack extends Track {
             occluded: elements.every((el) => el.occluded),
             lock: elements.every((el) => el.lock),
             hidden: elements.every((el) => el.hidden),
-            __internal: this.withContext(frame),
+            __internal: this.withContext(),
         };
     }
 

--- a/cvat-core/src/annotations-objects/tag.ts
+++ b/cvat-core/src/annotations-objects/tag.ts
@@ -11,14 +11,14 @@ import { ImageObject } from './image-object';
 import { serializeAttributes } from './utils';
 
 export class Tag extends ImageObject {
-    protected withContext(frame: number): ReturnType<ImageObject['withContext']> & {
+    protected withContext(): ReturnType<ImageObject['withContext']> & {
         save: (data: ObjectState) => ObjectState;
         export: () => SerializedTag;
     } {
         return {
-            ...super.withContext(frame),
-            save: this.save.bind(this, frame),
-            export: this.toJSON.bind(this) as () => SerializedTag,
+            ...super.withContext(),
+            save: this.save.bind(this),
+            export: this.toJSON.bind(this),
         };
     }
 
@@ -61,7 +61,7 @@ export class Tag extends ImageObject {
             updated: this.updated,
             frame,
             source: this.source,
-            __internal: this.withContext(frame),
+            __internal: this.withContext(),
         };
     }
 
@@ -80,7 +80,7 @@ export class Tag extends ImageObject {
 
         const updated = data.updateFlags;
         for (const readOnlyField of this.readOnlyFields) {
-            updated[readOnlyField] = false;
+            delete updated[readOnlyField];
         }
 
         this.validateStateBeforeSave(data, updated);

--- a/cvat-core/src/annotations-objects/track.ts
+++ b/cvat-core/src/annotations-objects/track.ts
@@ -28,14 +28,14 @@ export class Track extends Drawn {
         this.shapes = deserializeTrackedShapes(data.shapes);
     }
 
-    protected withContext(frame: number): ReturnType<Drawn['withContext']> & {
+    protected withContext(): ReturnType<Drawn['withContext']> & {
         save: (data: ObjectState) => ObjectState;
         export: () => SerializedTrack;
     } {
         return {
-            ...super.withContext(frame),
-            save: this.save.bind(this, frame),
-            export: this.toJSON.bind(this) as () => SerializedTrack,
+            ...super.withContext(),
+            save: this.save.bind(this),
+            export: this.toJSON.bind(this),
         };
     }
 
@@ -114,7 +114,7 @@ export class Track extends Drawn {
             },
             frame,
             source: this.source,
-            __internal: this.withContext(frame),
+            __internal: this.withContext(),
         };
     }
 
@@ -484,7 +484,7 @@ export class Track extends Drawn {
 
         const updated = data.updateFlags;
         for (const readOnlyField of this.readOnlyFields) {
-            updated[readOnlyField] = false;
+            delete updated[readOnlyField];
         }
 
         const fittedPoints = this.validateStateBeforeSave(data, updated, frame);

--- a/cvat-core/src/annotations-objects/types.ts
+++ b/cvat-core/src/annotations-objects/types.ts
@@ -5,9 +5,7 @@
 
 import type AnnotationHistory from '../annotations-history';
 import type { Label } from '../labels';
-import type {
-    DimensionType, JobType, ObjectType, Source,
-} from '../enums';
+import type { DimensionType, JobType } from '../enums';
 import type { MaskShape } from './mask-shape';
 
 export type FrameInfo = {
@@ -63,23 +61,27 @@ export interface Point2D {
     y: number;
 }
 
-export type AudioIntervalState = Readonly<{
-    objectType: ObjectType.INTERVAL;
-    clientID: number;
-    serverID: number | null;
-    label: Label;
-    start: number;
-    stop: number | null;
-    group: {
-        readonly color: string;
-        readonly id: number;
-    };
-    color: string;
-    lock: boolean;
-    updated: number;
-    source: Source;
-    score: number;
-    votes: number;
-    hidden: boolean;
-    attributes: Record<number, string>;
-}>;
+export interface CommonUpdateFlags {
+    label?: boolean;
+    attributes?: boolean;
+    lock?: boolean;
+    color?: boolean;
+    hidden?: boolean;
+    reset: () => void;
+}
+
+export interface UpdateFlags extends CommonUpdateFlags {
+    description?: boolean;
+    points?: boolean;
+    rotation?: boolean;
+    outside?: boolean;
+    occluded?: boolean;
+    keyframe?: boolean;
+    zOrder?: boolean;
+    pinned?: boolean;
+    descriptions?: boolean;
+}
+
+export interface AudioIntervalUpdateFlags extends CommonUpdateFlags {
+    position?: boolean;
+}

--- a/cvat-core/src/enums.ts
+++ b/cvat-core/src/enums.ts
@@ -151,6 +151,7 @@ export enum HistoryActions {
     CHANGED_COLOR = 'Changed color',
     CHANGED_HIDDEN = 'Changed hidden',
     CHANGED_SOURCE = 'Changed source',
+    CHANGED_AUDIO_POSITION = 'Changed audio position',
     MERGED_OBJECTS = 'Merged objects',
     JOINED_OBJECTS = 'Joined objects',
     SLICED_OBJECT = 'Sliced object',

--- a/cvat-core/src/object-state.ts
+++ b/cvat-core/src/object-state.ts
@@ -11,24 +11,7 @@ import { isEnum } from './common';
 import {
     SerializedShape, SerializedTag, SerializedTrack,
 } from './server-response-types';
-
-interface UpdateFlags {
-    label: boolean;
-    attributes: boolean;
-    description: boolean;
-    points: boolean;
-    rotation: boolean;
-    outside: boolean;
-    occluded: boolean;
-    keyframe: boolean;
-    zOrder: boolean;
-    pinned: boolean;
-    lock: boolean;
-    color: boolean;
-    hidden: boolean;
-    descriptions: boolean;
-    reset: () => void;
-}
+import type { UpdateFlags } from './annotations-objects/types';
 
 export interface SerializedData {
     objectType: ObjectType;
@@ -128,29 +111,28 @@ export default class ObjectState {
             );
         }
 
-        const updateFlags: UpdateFlags = {} as UpdateFlags;
-        // Shows whether any properties updated since the object initialization
-        Object.defineProperty(updateFlags, 'reset', {
-            value: function reset() {
-                this.label = false;
-                this.attributes = false;
-                this.descriptions = false;
+        const updateFlags: UpdateFlags = {
+            reset() {
+                delete this.label;
+                delete this.attributes;
+                delete this.descriptions;
 
-                this.points = false;
-                this.rotation = false;
-                this.outside = false;
-                this.occluded = false;
-                this.keyframe = false;
+                delete this.points;
+                delete this.rotation;
+                delete this.outside;
+                delete this.occluded;
+                delete this.keyframe;
 
-                this.zOrder = false;
-                this.pinned = false;
-                this.lock = false;
-                this.color = false;
-                this.hidden = false;
-                this.descriptions = false;
-
-                return reset;
+                delete this.zOrder;
+                delete this.pinned;
+                delete this.lock;
+                delete this.color;
+                delete this.hidden;
+                delete this.descriptions;
             },
+        };
+
+        Object.defineProperty(updateFlags, 'reset', {
             writable: false,
             enumerable: false,
         });
@@ -582,10 +564,10 @@ export default class ObjectState {
 Object.defineProperty(ObjectState.prototype.save, 'implementation', {
     value: function saveImplementation(): ObjectState {
         if (this.__internal && this.__internal.save) {
-            return this.__internal.save(this);
+            return this.__internal.save(this.frame, this);
         }
 
-        return this;
+        throw new Error('Could not save object state. Context is not provided.');
     },
     writable: false,
 });
@@ -596,7 +578,7 @@ Object.defineProperty(ObjectState.prototype.export, 'implementation', {
             return this.__internal.export(this);
         }
 
-        return this;
+        throw new Error('Could not export object state. Context is not provided.');
     },
     writable: false,
 });
@@ -611,7 +593,7 @@ Object.defineProperty(ObjectState.prototype.delete, 'implementation', {
             return this.__internal.delete(frame, force);
         }
 
-        return false;
+        throw new Error('Could not delete object state. Context is not provided.');
     },
     writable: false,
 });

--- a/cvat-core/src/session.ts
+++ b/cvat-core/src/session.ts
@@ -19,7 +19,7 @@ import {
     SerializedCollection, SerializedJob,
     SerializedLabel, SerializedTask,
 } from './server-response-types';
-import { type AudioIntervalState } from './annotations-objects/types';
+import { type AudioIntervalState } from './annotations-objects/audio-interval-state';
 import AnnotationGuide from './guide';
 import { FrameData, FramesMetaData } from './frames';
 import Statistics from './statistics';

--- a/cvat-ui/src/actions/audio-actions.ts
+++ b/cvat-ui/src/actions/audio-actions.ts
@@ -165,7 +165,6 @@ export function loadAudioAnnotationsAsync(): ThunkAction {
                     attributes: interval.attributes,
                     serverId: interval.serverID ?? undefined,
                     source: String(interval.source),
-                    group: interval.group.id,
                     color: interval.color,
                     locked: interval.lock,
                     hidden: interval.hidden,
@@ -203,7 +202,7 @@ export function saveAudioAnnotationsAsync(): ThunkAction {
                     label_id: region.labelId as number,
                     start: startMs,
                     stop: stopMs,
-                    group: region.group || 0,
+                    group: 0,
                     source: (region.source || 'manual') as Source,
                     attributes: Object.entries(region.attributes || {}).map(([specId, value]) => ({
                         spec_id: Number(specId),

--- a/cvat-ui/src/reducers/audio-reducer.ts
+++ b/cvat-ui/src/reducers/audio-reducer.ts
@@ -21,7 +21,7 @@ function regionsEqual(a: AudioRegion, b: AudioRegion): boolean {
         a.start !== b.start || a.end !== b.end ||
         a.labelId !== b.labelId ||
         a.locked !== b.locked || a.hidden !== b.hidden ||
-        a.color !== b.color || a.group !== b.group ||
+        a.color !== b.color ||
         a.source !== b.source || a.serverId !== b.serverId
     ) return false;
     const aKeys = Object.keys(a.attributes);

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -28,7 +28,6 @@ export interface AudioRegion {
     attributes: Record<number, string>;
     serverId?: number;
     source?: string;
-    group?: number;
     color?: string;
     hidden?: boolean;
     locked?: boolean;
@@ -829,7 +828,6 @@ export enum ActiveControl {
     DRAW_CUBOID = 'draw_cuboid',
     DRAW_SKELETON = 'draw_skeleton',
     MERGE = 'merge',
-    GROUP = 'group',
     JOIN = 'join',
     SPLIT = 'split',
     SLICE = 'slice',

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -827,6 +827,7 @@ export enum ActiveControl {
     DRAW_MASK = 'draw_mask',
     DRAW_CUBOID = 'draw_cuboid',
     DRAW_SKELETON = 'draw_skeleton',
+    GROUP = 'group',
     MERGE = 'merge',
     JOIN = 'join',
     SPLIT = 'split',


### PR DESCRIPTION
**PR Description**

### Motivation and context

This PR adds runtime state support for audio intervals, similar to object annotation states. `AudioIntervalState` now provides plugin-wrapped `save`, `delete`, and `export` methods, allowing audio interval edits to flow through the same core state pattern used by shapes, tracks, and tags.

Audio intervals can now serialize back to server payloads, save label/attribute/lock/color/hidden changes, and record start/stop edits through a dedicated `CHANGED_AUDIO_POSITION` history action.

The change also simplifies annotation object context handling by removing frame capture from `withContext()`. Object saves now use the readonly frame already stored on `ObjectState`.

### How has this been tested?

Ran:

```bash
../node_modules/.bin/tsc --noEmit --project tsconfig.json
```

from `cvat-core`.

### Checklist

- [x] I submit my changes into the `develop` branch
- [ ] ~~I have created a changelog fragment~~
- [ ] ~~I have updated the documentation accordingly~~
- [ ] ~~I have added tests to cover my changes~~
- [ ] ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.