### PR TITLE
[DEV-952] updated hrnet32 download paths

### DIFF
--- a/serverless/pytorch/mmpose/hrnet32/nuclio/function.yaml
+++ b/serverless/pytorch/mmpose/hrnet32/nuclio/function.yaml
@@ -191,10 +191,9 @@ spec:
         - kind: RUN
           value: git clone -b v1.2.0 --depth=1 https://github.com/open-mmlab/mmpose.git
         - kind: ADD
-          value: https://download.openmmlab.com/mmpose/v1/wholebody_2d_keypoint/ubody/td-hm_hrnet-w32_8xb64-210e_ubody-coco-256x192-7c227391_20230807.pth ./
+          value: https://mmassets.onedl.ai/mmpose/v1/projects/rtmpose/rtmdet_nano_8xb32-100e_coco-obj365-person-05d8511e.pth ./
         - kind: ADD
-          value: https://download.openmmlab.com/mmpose/v1/projects/rtmpose/rtmdet_nano_8xb32-100e_coco-obj365-person-05d8511e.pth ./
-
+          value: https://mmassets.onedl.ai/mmpose/v1/wholebody_2d_keypoint/ubody/td-hm_hrnet-w32_8xb64-210e_ubody-coco-256x192-7c227391_20230807.pth ./
   triggers:
     myHttpTrigger:
       numWorkers: 2


### PR DESCRIPTION
Old repo is not available anymore.

There was a small problem:

To check file sizes i have used checksum but wayback machine returns just 1048576 bytes for td-hm_hrnet-w32_8xb64-210e_ubody-coco-256x192-7c227391_20230807.pth, however checksum for a file  from a new repo starts exactly with 7c227391 which (most likely) means that the files are identical.


- [x] I submit my changes into the `develop` branch


### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
