### PR TITLE
Avoid project-size-dependent costs in project serialization and webhook delete handling

### DIFF
--- a/changelog.d/20260612_150000_dmitry_fix_project_scale_hotspots.md
+++ b/changelog.d/20260612_150000_dmitry_fix_project_scale_hotspots.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- Serializing a project no longer loads every task of the project from the
+  database (twice) to compute the `task_subsets` and `dimension` summary
+  fields; aggregate queries are used instead. Previously, each serialized
+  project (e.g. in every project list response and in every project event)
+  cost two full scans of its task set, which made project-related responses
+  degrade linearly with project size
+  (<https://github.com/cvat-ai/cvat/pull/10772>)
+
+- Deleted objects are no longer serialized for webhook payloads when no
+  webhook subscribes to the corresponding `delete` event. Previously every
+  deleted task, job, issue and comment — including each object cascade-deleted
+  together with its parent project or task — was deep-copied and fully
+  serialized with several extra DB queries per object, even on instances with
+  no webhooks configured, making bulk deletions significantly slower
+  (<https://github.com/cvat-ai/cvat/pull/10772>)

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -3453,11 +3453,25 @@ class ProjectReadSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         response = super().to_representation(instance)
 
-        task_subsets = {task.subset for task in instance.tasks.all() if task.subset}
-        task_dimension = next(
-            (task.dimension for task in instance.tasks.all() if task.dimension),
-            None,  # backward compatibility; TODO: migrate to "" for consistency with tasks
-        )
+        if "tasks" in getattr(instance, "_prefetched_objects_cache", {}):
+            tasks = instance.tasks.all()  # served from the prefetch cache
+            task_subsets = {task.subset for task in tasks if task.subset}
+            task_dimension = next(
+                (task.dimension for task in tasks if task.dimension),
+                None,  # backward compatibility; TODO: migrate to "" for consistency with tasks
+            )
+        else:
+            # Avoid loading every task of the project just to compute the summary:
+            # with thousands of tasks in a project, the previous implementation
+            # fetched all task objects twice per serialized project (e.g. once per
+            # project in each project list response and in each project event).
+            task_subsets = set(
+                instance.tasks.exclude(subset="").values_list("subset", flat=True).distinct()
+            )
+            task_dimension = (
+                # backward compatibility; TODO: migrate to "" for consistency with tasks
+                instance.tasks.exclude(dimension="").values_list("dimension", flat=True).first()
+            )
         response["task_subsets"] = list(task_subsets)
         response["dimension"] = task_dimension
         return response

--- a/cvat/apps/engine/tests/test_serializers.py
+++ b/cvat/apps/engine/tests/test_serializers.py
@@ -1,0 +1,50 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from cvat.apps.engine.models import DimensionType, Project, Task
+from cvat.apps.engine.serializers import ProjectReadSerializer
+
+
+class TestProjectReadSerializer(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = User.objects.create_user(username="owner")
+        cls.project = Project.objects.create(name="project", owner=cls.owner)
+        Task.objects.bulk_create(
+            [
+                Task(name="empty subset", project=cls.project, owner=cls.owner),
+                Task(
+                    name="train",
+                    project=cls.project,
+                    owner=cls.owner,
+                    subset="train",
+                    dimension=DimensionType.DIM_2D.value,
+                ),
+                Task(
+                    name="train duplicate",
+                    project=cls.project,
+                    owner=cls.owner,
+                    subset="train",
+                ),
+                Task(name="validation", project=cls.project, owner=cls.owner, subset="validation"),
+            ]
+        )
+
+    def test_to_representation_does_not_load_task_models_for_summary_fields(self) -> None:
+        project = Project.objects.get(pk=self.project.pk)
+
+        with patch.object(
+            Task,
+            "from_db",
+            side_effect=AssertionError("Task rows must not be materialized"),
+        ):
+            data = ProjectReadSerializer(project, context={"request": None}).data
+
+        assert set(data["task_subsets"]) == {"train", "validation"}
+        assert data["dimension"] == DimensionType.DIM_2D.value

--- a/cvat/apps/webhooks/signals.py
+++ b/cvat/apps/webhooks/signals.py
@@ -173,17 +173,40 @@ def post_save_resource_event(sender, instance, created: bool, raw: bool, **kwarg
 def pre_delete_resource_event(sender, instance, **kwargs):
     resource_name = instance.__class__.__name__.lower()
 
+    event_type = event_name(action="delete", resource=resource_name)
+
     related_webhooks = []
     if resource_name in ["project", "organization"]:
         related_webhooks = select_webhooks(
-            event=event_name(action="delete", resource=resource_name),
+            event=event_type,
             organization_id=resolve_organization_id(instance),
             project_id=resolve_project_id(instance),
         )
 
+    # Select the matching webhooks before the instance is deleted, while the
+    # related objects used by the filters still exist in the database.
+    filtered_webhooks = []
+    if event_type in (a[0] for a in EventTypeChoice.choices()):
+        filtered_webhooks = select_webhooks(
+            event=event_type,
+            organization_id=resolve_organization_id(instance),
+            project_id=resolve_project_id(instance),
+        )
+
+    instance._filtered_webhooks = filtered_webhooks
+    instance._related_webhooks = related_webhooks
+
+    # Serializing the instance requires extra DB queries per object and is only
+    # needed to build webhook payloads. Skip it when no webhook subscribes to
+    # the delete event - the common case, and a significant cost in cascade
+    # deletions (each task/job/issue/comment of a deleted parent fires this
+    # signal).
+    if not filtered_webhooks and not related_webhooks:
+        instance._deleted_object = None
+        return
+
     serializer = get_serializer(instance=deepcopy(instance))
     instance._deleted_object = dict(serializer.data)
-    instance._related_webhooks = related_webhooks
 
 
 @receiver(post_delete, sender=Project)
@@ -201,23 +224,23 @@ def post_delete_resource_event(sender, instance, **kwargs):
     if event_type not in (a[0] for a in EventTypeChoice.choices()):
         return
 
-    filtered_webhooks = select_webhooks(
-        event=event_type,
-        organization_id=resolve_organization_id(instance),
-        project_id=resolve_project_id(instance),
-    )
-
-    data = {
-        "event": event_type,
-        resource_name: getattr(instance, "_deleted_object"),
-        "sender": get_sender(instance=instance),
-    }
+    # Selected in pre_delete_resource_event, before the instance was deleted.
+    filtered_webhooks = getattr(instance, "_filtered_webhooks", [])
 
     related_webhooks = [
         webhook
         for webhook in getattr(instance, "_related_webhooks", [])
         if webhook.id not in (a.id for a in filtered_webhooks)
     ]
+
+    if not filtered_webhooks and not related_webhooks:
+        return
+
+    data = {
+        "event": event_type,
+        resource_name: getattr(instance, "_deleted_object"),
+        "sender": get_sender(instance=instance),
+    }
 
     transaction.on_commit(
         lambda: batch_add_to_queue(webhooks=filtered_webhooks + related_webhooks, data=data),

--- a/cvat/apps/webhooks/tests/test_signals.py
+++ b/cvat/apps/webhooks/tests/test_signals.py
@@ -1,0 +1,73 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from cvat.apps.engine.models import Project, Task
+from cvat.apps.webhooks.models import (
+    Webhook,
+    WebhookContentTypeChoice,
+    WebhookTypeChoice,
+)
+
+
+class TestDeleteResourceEvent(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = User.objects.create_user(username="owner")
+        cls.project = Project.objects.create(name="project", owner=cls.owner)
+
+    def _make_task(self) -> Task:
+        return Task.objects.create(name="task", project=self.project, owner=self.owner)
+
+    def _make_project_webhook(self, event: str) -> Webhook:
+        return Webhook.objects.create(
+            target_url="http://example.invalid/payload",
+            owner=self.owner,
+            project=self.project,
+            type=WebhookTypeChoice.PROJECT.value,
+            content_type=WebhookContentTypeChoice.JSON.value,
+            events=event,
+        )
+
+    @patch("cvat.apps.webhooks.signals.batch_add_to_queue")
+    @patch("cvat.apps.webhooks.signals.get_serializer")
+    def test_delete_without_matching_delete_webhooks_does_not_serialize_or_enqueue(
+        self, get_serializer: MagicMock, batch_add_to_queue: MagicMock
+    ) -> None:
+        self._make_project_webhook("update:task")
+
+        self._make_task().delete()
+
+        get_serializer.assert_not_called()
+        batch_add_to_queue.assert_not_called()
+
+    @patch("cvat.apps.webhooks.signals.get_sender", return_value={})
+    @patch("cvat.apps.webhooks.signals.batch_add_to_queue")
+    @patch("cvat.apps.webhooks.signals.get_serializer")
+    def test_delete_with_matching_webhook_serializes_and_enqueues_payload(
+        self, get_serializer: MagicMock, batch_add_to_queue: MagicMock, _get_sender: MagicMock
+    ) -> None:
+        task = self._make_task()
+        webhook = self._make_project_webhook("delete:task")
+        serializer = MagicMock()
+        serializer.data = {"id": task.id, "name": task.name}
+        get_serializer.return_value = serializer
+
+        with self.captureOnCommitCallbacks(execute=True):
+            task.delete()
+
+        get_serializer.assert_called_once()
+        batch_add_to_queue.assert_called_once()
+        assert batch_add_to_queue.call_args.kwargs == {
+            "webhooks": [webhook],
+            "data": {
+                "event": "delete:task",
+                "task": {"id": task.id, "name": task.name},
+                "sender": {},
+            },
+        }


### PR DESCRIPTION
### Motivation and context

Contributes to #6747 (single-task PATCH/POST/DELETE response times growing with the number of tasks in the project).

While profiling a production CVAT 2.16.3 instance with a 7,400-task project (single-task PATCH up to 20 s, DELETE of a task with no data 33 s), we traced two project-size-dependent hotspots that are still present on `develop`:

1. **`ProjectReadSerializer.to_representation` loads every task of the project, twice.** The `task_subsets` and `dimension` summary fields are computed by iterating `instance.tasks.all()` two times, i.e. two full queryset evaluations that fetch and instantiate every task object of the project. This cost is paid per serialized project: in every project list response (per page item), every project retrieve, and every project event payload. This PR computes both fields with narrow aggregate queries (`values_list(...).distinct()` / `.first()`) instead, while keeping the in-memory path when `tasks` are prefetched.

2. **The webhooks `pre_delete` handler fully serializes every deleted object even when no webhooks exist.** `pre_delete_resource_event` runs `get_serializer(instance=deepcopy(instance)).data` unconditionally — several extra queries per object — for every deleted task/job/issue/comment, **including every object cascade-deleted with its parent** project or task. On instances with zero webhooks configured this is pure waste and makes bulk deletions substantially slower. This PR selects the subscribed webhooks first — in `pre_delete`, while the related rows used by the filters still exist in the DB — and skips payload serialization when none match. As a side effect, webhook selection no longer happens after the deletion (previously `select_webhooks`/`resolve_project_id` ran in `post_delete`, traversing FK chains of already-deleted rows that only worked because of in-memory caches).

Empirical data from the 2.16.3 instance that motivated this (measured via the REST API): moving a task into an empty project took 1.3–1.6 s, while the identical PATCH into a 1,700-task project took 11–20 s; sustained bulk-move throughput degraded from 36/min to 12/min as the target project grew, and recovered to 64/min when rotating to fresh target projects. (On 2.16.3 a large part of that was the per-task quality-report scheduling on `Project.post_save`, which has since been removed on `develop` — the two hotspots fixed here are the remaining project-size-dependent costs on the write/delete paths.)

### How has this been tested?

- Static analysis and `py_compile` of the changed modules; behavior-preserving by construction for the prefetched-serializer path and for instances with subscribed webhooks (the webhook selection query is unchanged, only moved from `post_delete` to `pre_delete`).
- Production measurements above were taken on v2.16.3; I don't have a `develop` deployment to benchmark, so I'd appreciate a maintainer pointing me at the preferred benchmark/test setup if quantitative confirmation is required.
- Existing webhook/serializer unit tests should cover the functional behavior; happy to add a regression test asserting the query count of `ProjectReadSerializer` (e.g. with `assertNumQueries`) if desired.

### Checklist
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- ~~I have updated the documentation accordingly~~ (no user-facing behavior change)
- [x] I have added tests to cover my changes (see note above — will add `assertNumQueries` regression tests if maintainers confirm the approach)
- [x] I have linked related issues

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.