### PR TITLE
Fix 10470: preserver query params for empty filters

### DIFF
--- a/changelog.d/20260615_234209_vsbrute_10470_back_navigation_pagination.md
+++ b/changelog.d/20260615_234209_vsbrute_10470_back_navigation_pagination.md
@@ -1,6 +1,4 @@
 ### Fixed
 
-- Pagination state on the projects and project pages is no longer reset to the
-  first page when a filter is cleared, so the current page is preserved on back
-  navigation
+- Current page on projects/tasks/jobs pages is no longer reset after backward navigation from a resource page
   (<https://github.com/cvat-ai/cvat/pull/10777>)

--- a/changelog.d/20260615_234209_vsbrute_10470_back_navigation_pagination.md
+++ b/changelog.d/20260615_234209_vsbrute_10470_back_navigation_pagination.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Pagination state on the projects and project pages is no longer reset to the
+  first page when a filter is cleared, so the current page is preserved on back
+  navigation
+  (<https://github.com/cvat-ai/cvat/pull/10777>)

--- a/cvat-ui/src/components/project-page/project-page.tsx
+++ b/cvat-ui/src/components/project-page/project-page.tsx
@@ -62,6 +62,7 @@ export default function ProjectPageComponent(): JSX.Element {
     const history = useHistory();
     const [projectInstance, setProjectInstance] = useState<Project | null>(null);
     const [fechingProject, setFetchingProject] = useState(true);
+    const [isMounted, setIsMounted] = useState(false);
     const mounted = useRef(false);
 
     const {
@@ -98,6 +99,7 @@ export default function ProjectPageComponent(): JSX.Element {
                     if (project && mounted.current) {
                         dispatch(getProjectTasksAsync({ ...updatedQuery, projectId: id }));
                         setProjectInstance(project);
+                        setIsMounted(true);
                     }
                 }).catch((error: Error) => {
                     if (mounted.current) {
@@ -126,9 +128,11 @@ export default function ProjectPageComponent(): JSX.Element {
     }, []);
 
     useEffect(() => {
-        history.replace({
-            search: updateHistoryFromQuery(tasksQuery),
-        });
+        if (isMounted) {
+            history.replace({
+                search: updateHistoryFromQuery(tasksQuery),
+            });
+        }
     }, [tasksQuery]);
 
     useEffect(() => {

--- a/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
@@ -165,7 +165,7 @@ export default function ResourceFilterHOC(
                 setSearchTree(tree);
                 return {
                     recent: recentFilters[value] ?? null,
-                    predefined: splitFilterIntoPredefined(Object.values(predefinedFilters), value),
+                    predefined: splitFilterIntoPredefined(Object.values(predefinedFilters ?? {}), value),
                     built: JSON.stringify(QbUtils.jsonLogicFormat(tree, config).logic),
                 };
             } catch {

--- a/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
@@ -199,7 +199,7 @@ export default function ResourceFilterHOC(
             }
 
             if (appliedFilter.predefined?.length) {
-                const predefinedFilterToApply = unite(appliedFilter.predefined)
+                const predefinedFilterToApply = unite(appliedFilter.predefined);
                 if (value === predefinedFilterToApply) {
                     return;
                 }
@@ -229,7 +229,7 @@ export default function ResourceFilterHOC(
                 onApplyFilter(null);
                 setState(defaultTree);
             }
-        }, [appliedFilter, value]);
+        }, [appliedFilter, value, isMounted]);
 
         const renderBuilder = (builderProps: any): JSX.Element => (
             <div className='query-builder-container'>

--- a/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
@@ -130,6 +130,16 @@ export default function ResourceFilterHOC(
         return result;
     }
 
+    function getSearchTreeFromFilterValue(filterValue: string | null): ImmutableTree {
+        if (!filterValue || filterValue === '{}') return defaultTree;
+        try {
+            const tree = QbUtils.loadFromJsonLogic(JSON.parse(filterValue), config);
+            return (tree && isValidTree(tree)) ? tree : defaultTree;
+        } catch {
+            return defaultTree;
+        }
+    }
+
     function ResourceFilterComponent(props: ResourceFilterProps): JSX.Element {
         const {
             predefinedVisible, builderVisible, recentVisible, value,
@@ -139,7 +149,8 @@ export default function ResourceFilterHOC(
 
         const user = useSelector((state: CombinedState) => state.auth.user);
         const [recentFilters, setRecentFilters] = useState<Record<string, string>>({});
-        const [searchTree, setSearchTree] = useState<ImmutableTree>(defaultTree);
+        const [prevValue, setPrevValue] = useState(value);
+        const [searchTree, setSearchTree] = useState<ImmutableTree>(() => getSearchTreeFromFilterValue(value));
 
         const predefinedFilters = getPredefinedFilters(user);
 
@@ -147,32 +158,27 @@ export default function ResourceFilterHOC(
             setRecentFilters(receiveRecentFilters());
         }, []);
 
-        const appliedFilter = useMemo(() => {
-            const innerAppliedFilter = { ...defaultAppliedFilter };
+        const { appliedFilter, searchTreeFromValue } = useMemo(() => {
+            const tree = getSearchTreeFromFilterValue(value);
 
-            if (!value || value === '{}') {
-                setSearchTree(defaultTree);
-                return innerAppliedFilter;
+            if (tree === defaultTree) {
+                return { appliedFilter: { ...defaultAppliedFilter }, searchTreeFromValue: defaultTree };
             }
 
-            try {
-                const tree = QbUtils.loadFromJsonLogic(JSON.parse(value), config);
-
-                if (!tree || !isValidTree(tree)) {
-                    return innerAppliedFilter;
-                }
-
-                setSearchTree(tree);
-                return {
-                    recent: recentFilters[value] ?? null,
-                    predefined: splitFilterIntoPredefined(Object.values(predefinedFilters ?? {}), value),
+            return {
+                appliedFilter: {
+                    recent: recentFilters[value!] ?? null,
+                    predefined: splitFilterIntoPredefined(Object.values(predefinedFilters ?? {}), value!),
                     built: JSON.stringify(QbUtils.jsonLogicFormat(tree, config).logic),
-                };
-            } catch {
-                // leave default for broken input value
-                return innerAppliedFilter;
-            }
+                },
+                searchTreeFromValue: tree,
+            };
         }, [value, recentFilters]);
+
+        if (prevValue !== value) {
+            setPrevValue(value);
+            setSearchTree(searchTreeFromValue);
+        }
 
         useEffect(() => {
             const listener = (event: MouseEvent): void => {
@@ -196,14 +202,6 @@ export default function ResourceFilterHOC(
         const handlePredefinedFilterChange = (predefinedFilter: string[]): void => {
             const predefinedFilterToApply = unite(predefinedFilter);
             onApplyFilter(predefinedFilterToApply);
-        };
-
-        const handleRecentFilterChange = (recentFilter: string): void => {
-            onApplyFilter(recentFilter);
-            const tree = QbUtils.loadFromJsonLogic(JSON.parse(recentFilter), config);
-            if (tree && isValidTree(tree)) {
-                setSearchTree(tree);
-            }
         };
 
         const handleApplyFilter = (filter: string): void => {
@@ -306,7 +304,7 @@ export default function ResourceFilterHOC(
                                                                 if (appliedFilter.recent === key) {
                                                                     handleClearFilter();
                                                                 } else {
-                                                                    handleRecentFilterChange(key);
+                                                                    handleApplyFilter(key);
                                                                 }
                                                             }}
                                                         >
@@ -346,7 +344,7 @@ export default function ResourceFilterHOC(
                                     disabled={!QbUtils.queryString(searchTree, config)}
                                     size='small'
                                     onClick={() => {
-                                        setSearchTree(defaultTree);
+                                        handleClearFilter();
                                     }}
                                 >
                                     Reset
@@ -367,7 +365,9 @@ export default function ResourceFilterHOC(
                                             return;
                                         }
 
-                                        handleApplyFilter(stringified);
+                                        if (stringified !== appliedFilter.built) {
+                                            handleApplyFilter(stringified);
+                                        }
                                     }}
                                 >
                                     Apply

--- a/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
     Builder, Config, AntdConfig, ImmutableTree, Query, Utils as QbUtils,
 } from '@react-awesome-query-builder/antd';
@@ -138,40 +138,41 @@ export default function ResourceFilterHOC(
         } = props;
 
         const user = useSelector((state: CombinedState) => state.auth.user);
-        const [isMounted, setIsMounted] = useState<boolean>(false);
         const [recentFilters, setRecentFilters] = useState<Record<string, string>>({});
-        const [appliedFilter, setAppliedFilter] = useState(defaultAppliedFilter);
-        const [state, setState] = useState<ImmutableTree>(defaultTree);
+        const [searchTree, setSearchTree] = useState<ImmutableTree>(defaultTree);
 
         const predefinedFilters = getPredefinedFilters(user);
 
         useEffect(() => {
             setRecentFilters(receiveRecentFilters());
-            setIsMounted(true);
+        }, []);
+
+        const appliedFilter = useMemo(() => {
+            const innerAppliedFilter = { ...defaultAppliedFilter };
+
+            if (!value || value === '{}') {
+                setSearchTree(defaultTree);
+                return innerAppliedFilter;
+            }
 
             try {
-                if (value && value !== '{}') {
-                    const tree = QbUtils.loadFromJsonLogic(JSON.parse(value), config);
-                    if (tree && isValidTree(tree)) {
-                        setAppliedFilter({
-                            ...appliedFilter,
-                            predefined: splitFilterIntoPredefined(Object.values(predefinedFilters), value),
-                            built: JSON.stringify(QbUtils.jsonLogicFormat(tree, config).logic),
-                        });
-                        setState(tree);
-                    }
-                } else {
-                    setState(defaultTree);
-                    setAppliedFilter({
-                        ...appliedFilter,
-                        predefined: null,
-                        built: null,
-                    });
+                const tree = QbUtils.loadFromJsonLogic(JSON.parse(value), config);
+
+                if (!tree || !isValidTree(tree)) {
+                    return innerAppliedFilter;
                 }
-            } catch (_: any) {
-                // nothing to do
+
+                setSearchTree(tree);
+                return {
+                    recent: recentFilters[value] ?? null,
+                    predefined: splitFilterIntoPredefined(Object.values(predefinedFilters), value),
+                    built: JSON.stringify(QbUtils.jsonLogicFormat(tree, config).logic),
+                };
+            } catch {
+                // leave default for broken input value
+                return innerAppliedFilter;
             }
-        }, [value]);
+        }, [value, recentFilters]);
 
         useEffect(() => {
             const listener = (event: MouseEvent): void => {
@@ -198,7 +199,7 @@ export default function ResourceFilterHOC(
         };
 
         const handleRecentFilterChange = (recentFilter: string): void => {
-            onApplyFilter(appliedFilter.recent);
+            onApplyFilter(recentFilter);
             const tree = QbUtils.loadFromJsonLogic(JSON.parse(recentFilter), config);
             if (tree && isValidTree(tree)) {
                 setSearchTree(tree);
@@ -213,40 +214,6 @@ export default function ResourceFilterHOC(
             onApplyFilter(null);
             setSearchTree(defaultTree);
         };
-
-        useEffect(() => {
-            if (!isMounted) {
-                // do not request resources until on mount hook is done
-                return;
-            }
-
-            if (appliedFilter.predefined?.length) {
-                // TODO: should be removed in next step
-                const predefinedFilterToApply = unite(predefinedFilter);
-                if (value === predefinedFilterToApply) {
-                    return;
-                }
-
-                handlePredefinedFilterChange(appliedFilter.predefined);
-            } else if (appliedFilter.recent) {
-                if (value === appliedFilter.recent) {
-                    return;
-                }
-                handleRecentFilterChange(appliedFilter.recent);
-            } else if (appliedFilter.built) {
-                if (value === appliedFilter.built) {
-                    return;
-                }
-
-                handleApplyFilter(appliedFilter.built);
-            } else {
-                if (value === null) {
-                    return;
-                }
-
-                handleClearFilter();
-            }
-        }, [appliedFilter, value]);
 
         const renderBuilder = (builderProps: any): JSX.Element => (
             <div className='query-builder-container'>
@@ -271,7 +238,7 @@ export default function ResourceFilterHOC(
                                         <Checkbox
                                             checked={appliedFilter.predefined?.includes(predefinedFilters[key])}
                                             onChange={(event: CheckboxChangeEvent) => {
-                                                let updatedValue: string[] | null = appliedFilter.predefined || [];
+                                                let updatedValue: string[] = appliedFilter.predefined || [];
                                                 if (event.target.checked) {
                                                     updatedValue.push(predefinedFilters[key]);
                                                 } else {
@@ -281,20 +248,18 @@ export default function ResourceFilterHOC(
                                                         ));
                                                 }
 
-                                                if (!updatedValue.length) {
-                                                    updatedValue = null;
+                                                if (updatedValue.length === 0) {
+                                                    handleClearFilter();
+                                                    return;
                                                 }
 
-                                                setAppliedFilter({
-                                                    ...defaultAppliedFilter,
-                                                    predefined: updatedValue,
-                                                });
+                                                handlePredefinedFilterChange(updatedValue);
                                             }}
                                             key={key}
                                         >
                                             {key}
                                         </Checkbox>
-                                    )) }
+                                    ))}
                                 </div>
                             )}
                         >
@@ -339,12 +304,9 @@ export default function ResourceFilterHOC(
                                                             key={key}
                                                             onClick={() => {
                                                                 if (appliedFilter.recent === key) {
-                                                                    setAppliedFilter(defaultAppliedFilter);
+                                                                    handleClearFilter();
                                                                 } else {
-                                                                    setAppliedFilter({
-                                                                        ...defaultAppliedFilter,
-                                                                        recent: key,
-                                                                    });
+                                                                    handleRecentFilterChange(key);
                                                                 }
                                                             }}
                                                         >
@@ -373,23 +335,18 @@ export default function ResourceFilterHOC(
                             <Query
                                 {...config}
                                 onChange={(tree: ImmutableTree) => {
-                                    setState(tree);
+                                    setSearchTree(tree);
                                 }}
-                                value={state}
+                                value={searchTree}
                                 renderBuilder={renderBuilder}
                             />
                             <Space className='cvat-resource-page-filters-space'>
                                 <Button
                                     className='cvat-reset-filters-button'
-                                    disabled={!QbUtils.queryString(state, config)}
+                                    disabled={!QbUtils.queryString(searchTree, config)}
                                     size='small'
                                     onClick={() => {
-                                        setState(defaultTree);
-                                        setAppliedFilter({
-                                            ...appliedFilter,
-                                            recent: null,
-                                            built: null,
-                                        });
+                                        setSearchTree(defaultTree);
                                     }}
                                 >
                                     Reset
@@ -399,16 +356,18 @@ export default function ResourceFilterHOC(
                                     size='small'
                                     type='primary'
                                     onClick={() => {
-                                        const filter = QbUtils.jsonLogicFormat(state, config).logic;
+                                        const filter = QbUtils.jsonLogicFormat(searchTree, config).logic;
                                         const stringified = JSON.stringify(filter);
                                         keepFilterInLocalStorage(stringified);
                                         setRecentFilters(receiveRecentFilters());
                                         onBuilderVisibleChange(false);
-                                        setAppliedFilter({
-                                            predefined: null,
-                                            recent: null,
-                                            built: stringified,
-                                        });
+
+                                        if (!stringified || stringified === '{}') {
+                                            handleClearFilter();
+                                            return;
+                                        }
+
+                                        handleApplyFilter(stringified);
                                     }}
                                 >
                                     Apply
@@ -434,7 +393,7 @@ export default function ResourceFilterHOC(
                     disabled={!(appliedFilter.built || appliedFilter.predefined || appliedFilter.recent) || disabled}
                     size='small'
                     type='link'
-                    onClick={() => { setAppliedFilter({ ...defaultAppliedFilter }); }}
+                    onClick={handleClearFilter}
                 >
                     Clear filters
                 </Button>

--- a/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
@@ -192,6 +192,28 @@ export default function ResourceFilterHOC(
             return () => window.removeEventListener('click', listener);
         }, [builderVisible, predefinedVisible]);
 
+        const handlePredefinedFilterChange = (predefinedFilter: string[]): void => {
+            const predefinedFilterToApply = unite(predefinedFilter);
+            onApplyFilter(predefinedFilterToApply);
+        };
+
+        const handleRecentFilterChange = (recentFilter: string): void => {
+            onApplyFilter(appliedFilter.recent);
+            const tree = QbUtils.loadFromJsonLogic(JSON.parse(recentFilter), config);
+            if (tree && isValidTree(tree)) {
+                setSearchTree(tree);
+            }
+        };
+
+        const handleApplyFilter = (filter: string): void => {
+            onApplyFilter(filter);
+        };
+
+        const handleClearFilter = (): void => {
+            onApplyFilter(null);
+            setSearchTree(defaultTree);
+        };
+
         useEffect(() => {
             if (!isMounted) {
                 // do not request resources until on mount hook is done
@@ -199,37 +221,32 @@ export default function ResourceFilterHOC(
             }
 
             if (appliedFilter.predefined?.length) {
-                const predefinedFilterToApply = unite(appliedFilter.predefined);
+                // TODO: should be removed in next step
+                const predefinedFilterToApply = unite(predefinedFilter);
                 if (value === predefinedFilterToApply) {
                     return;
                 }
 
-                onApplyFilter(predefinedFilterToApply);
+                handlePredefinedFilterChange(appliedFilter.predefined);
             } else if (appliedFilter.recent) {
                 if (value === appliedFilter.recent) {
                     return;
                 }
-
-                onApplyFilter(appliedFilter.recent);
-                const tree = QbUtils.loadFromJsonLogic(JSON.parse(appliedFilter.recent), config);
-                if (tree && isValidTree(tree)) {
-                    setState(tree);
-                }
+                handleRecentFilterChange(appliedFilter.recent);
             } else if (appliedFilter.built) {
                 if (value === appliedFilter.built) {
                     return;
                 }
 
-                onApplyFilter(appliedFilter.built);
+                handleApplyFilter(appliedFilter.built);
             } else {
                 if (value === null) {
                     return;
                 }
 
-                onApplyFilter(null);
-                setState(defaultTree);
+                handleClearFilter();
             }
-        }, [appliedFilter, value, isMounted]);
+        }, [appliedFilter, value]);
 
         const renderBuilder = (builderProps: any): JSX.Element => (
             <div className='query-builder-container'>

--- a/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
@@ -199,22 +199,37 @@ export default function ResourceFilterHOC(
             }
 
             if (appliedFilter.predefined?.length) {
-                onApplyFilter(unite(appliedFilter.predefined));
+                const predefinedFilterToApply = unite(appliedFilter.predefined)
+                if (value === predefinedFilterToApply) {
+                    return;
+                }
+
+                onApplyFilter(predefinedFilterToApply);
             } else if (appliedFilter.recent) {
+                if (value === appliedFilter.recent) {
+                    return;
+                }
+
                 onApplyFilter(appliedFilter.recent);
                 const tree = QbUtils.loadFromJsonLogic(JSON.parse(appliedFilter.recent), config);
                 if (tree && isValidTree(tree)) {
                     setState(tree);
                 }
             } else if (appliedFilter.built) {
-                if (value !== appliedFilter.built) {
-                    onApplyFilter(appliedFilter.built);
+                if (value === appliedFilter.built) {
+                    return;
                 }
+
+                onApplyFilter(appliedFilter.built);
             } else {
+                if (value === null) {
+                    return;
+                }
+
                 onApplyFilter(null);
                 setState(defaultTree);
             }
-        }, [appliedFilter]);
+        }, [appliedFilter, value]);
 
         const renderBuilder = (builderProps: any): JSX.Element => (
             <div className='query-builder-container'>

--- a/tests/cypress/e2e/issues_prs/issue_10470_back_navigation_pagination.js
+++ b/tests/cypress/e2e/issues_prs/issue_10470_back_navigation_pagination.js
@@ -1,0 +1,94 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { defaultTaskSpec } from '../../support/default-specs';
+
+const issueId = '10470';
+const PROJECTS_COUNT = 15; // projects pageSize=12 — page 2 exists
+const TASKS_COUNT = 11; // single-project tasks pageSize=10 — page 2 exists
+const projectPrefix = `issue-${issueId}-project`;
+const taskPrefix = `issue-${issueId}-task`;
+
+context(`Issue ${issueId} - Pagination state is preserved on page reload`, () => {
+    const projectIds = [];
+    let hostProjectId = null;
+
+    before(() => {
+        cy.visit('/auth/login');
+        cy.headlessLogin();
+    });
+
+    after(() => {
+        projectIds.forEach(cy.headlessDeleteProject);
+        if (hostProjectId !== null) {
+            cy.headlessDeleteProject(hostProjectId);
+        }
+        cy.headlessLogout();
+    });
+
+    describe('Projects page', () => {
+        before(() => {
+            for (let i = 1; i <= PROJECTS_COUNT; i++) {
+                cy.headlessCreateProject({
+                    name: `${projectPrefix}-${i}`,
+                    labels: [],
+                }).then(({ projectId }) => projectIds.push(projectId));
+            }
+
+            cy.visit('/projects');
+            cy.get('.cvat-spinner').should('not.exist');
+        });
+
+        it('Navigate to page 2 via bottom pagination', () => {
+            cy.get('.ant-pagination-item-2').should('be.visible').click();
+            cy.get('.ant-pagination-item-active').should('have.text', '2');
+        });
+
+        it('Page 2 is preserved after page reload', () => {
+            cy.reload();
+            cy.get('.cvat-spinner').should('not.exist');
+            cy.get('.ant-pagination-item-active').should('have.text', '2');
+        });
+    });
+
+    describe('Single project page (tasks)', () => {
+        before(() => {
+            cy.headlessCreateProject({
+                name: `${projectPrefix}-tasks-host`,
+                labels: [{ name: 'label' }],
+            }).then(({ projectId }) => {
+                hostProjectId = projectId;
+
+                for (let i = 1; i <= TASKS_COUNT; i++) {
+                    const { taskSpec, dataSpec, extras } = defaultTaskSpec({
+                        projectId: hostProjectId,
+                        taskName: `${taskPrefix}-${i}`,
+                        labelName: 'label',
+                        serverFiles: ['smallArchive.zip'],
+                    });
+                    delete taskSpec.labels; // task in a project inherits project labels
+                    cy.headlessCreateTask(taskSpec, dataSpec, extras);
+                }
+            }).then(() => {
+                cy.visit(`/projects/${hostProjectId}`);
+                cy.get('.cvat-spinner').should('not.exist');
+            });
+        });
+
+        it('Navigate to page 2 via tasks pagination', () => {
+            cy.get('.cvat-project-tasks-pagination .ant-pagination-item-2', { log: false }).click();
+            cy.get('.cvat-project-tasks-pagination .ant-pagination-item-active', { log: false })
+                .invoke('text').should('eq', '2');
+        });
+
+        it('Page 2 is preserved after page reload', () => {
+            cy.reload();
+            cy.get('.cvat-spinner').should('not.exist');
+            cy.get('.cvat-project-tasks-pagination .ant-pagination-item-active', { log: false })
+                .invoke('text').should('eq', '2');
+        });
+    });
+});

--- a/tests/cypress/e2e/issues_prs/issue_10470_back_navigation_pagination.js
+++ b/tests/cypress/e2e/issues_prs/issue_10470_back_navigation_pagination.js
@@ -4,91 +4,81 @@
 
 /// <reference types="cypress" />
 
-import { defaultTaskSpec } from '../../support/default-specs';
-
 const issueId = '10470';
 const PROJECTS_COUNT = 15; // projects pageSize=12 — page 2 exists
-const TASKS_COUNT = 11; // single-project tasks pageSize=10 — page 2 exists
 const projectPrefix = `issue-${issueId}-project`;
-const taskPrefix = `issue-${issueId}-task`;
 
-context(`Issue ${issueId} - Pagination state is preserved on page reload`, () => {
+context(`Issue ${issueId} - Pagination state is preserved on navigation`, () => {
     const projectIds = [];
-    let hostProjectId = null;
+
+    // Open the projects list and wait until the first page has fully settled.
+    // The list request must complete before interacting, otherwise a still
+    // in-flight initial fetch can override the subsequent page switch (this only
+    // surfaces on warm headless runs where the page loads fast).
+    function openSettledProjectsList() {
+        cy.intercept('GET', '/api/projects?*').as('getProjects');
+        cy.visit('/projects');
+        cy.wait('@getProjects');
+        cy.get('.cvat-spinner').should('not.exist');
+        cy.get('.cvat-projects-project-item-card').should('have.length', 12);
+        cy.get('.ant-pagination-item-active').should('have.text', '1');
+    }
 
     before(() => {
         cy.visit('/auth/login');
         cy.headlessLogin();
+
+        for (let i = 1; i <= PROJECTS_COUNT; i++) {
+            cy.headlessCreateProject({
+                name: `${projectPrefix}-${i}`,
+                labels: [],
+            }).then(({ projectId }) => projectIds.push(projectId));
+        }
     });
 
     after(() => {
         projectIds.forEach(cy.headlessDeleteProject);
-        if (hostProjectId !== null) {
-            cy.headlessDeleteProject(hostProjectId);
-        }
         cy.headlessLogout();
     });
 
-    describe('Projects page', () => {
+    describe('Projects page with back navigation', () => {
         before(() => {
-            for (let i = 1; i <= PROJECTS_COUNT; i++) {
-                cy.headlessCreateProject({
-                    name: `${projectPrefix}-${i}`,
-                    labels: [],
-                }).then(({ projectId }) => projectIds.push(projectId));
-            }
-
-            cy.visit('/projects');
-            cy.get('.cvat-spinner').should('not.exist');
+            openSettledProjectsList();
         });
 
         it('Navigate to page 2 via bottom pagination', () => {
             cy.get('.ant-pagination-item-2').should('be.visible').click();
+            cy.get('.cvat-spinner').should('not.exist');
             cy.get('.ant-pagination-item-active').should('have.text', '2');
         });
 
-        it('Page 2 is preserved after page reload', () => {
-            cy.reload();
+        it('Open the first project on page 2', () => {
+            cy.get('.cvat-projects-project-item-title').first().click();
+            cy.get('.cvat-project-details').should('exist');
+        });
+
+        it('Page 2 is preserved after browser back navigation', () => {
+            cy.go('back');
             cy.get('.cvat-spinner').should('not.exist');
             cy.get('.ant-pagination-item-active').should('have.text', '2');
         });
     });
 
-    describe('Single project page (tasks)', () => {
+    describe('Projects page with page refresh', () => {
         before(() => {
-            cy.headlessCreateProject({
-                name: `${projectPrefix}-tasks-host`,
-                labels: [{ name: 'label' }],
-            }).then(({ projectId }) => {
-                hostProjectId = projectId;
-
-                for (let i = 1; i <= TASKS_COUNT; i++) {
-                    const { taskSpec, dataSpec, extras } = defaultTaskSpec({
-                        projectId: hostProjectId,
-                        taskName: `${taskPrefix}-${i}`,
-                        labelName: 'label',
-                        serverFiles: ['smallArchive.zip'],
-                    });
-                    delete taskSpec.labels; // task in a project inherits project labels
-                    cy.headlessCreateTask(taskSpec, dataSpec, extras);
-                }
-            }).then(() => {
-                cy.visit(`/projects/${hostProjectId}`);
-                cy.get('.cvat-spinner').should('not.exist');
-            });
+            openSettledProjectsList();
         });
 
-        it('Navigate to page 2 via tasks pagination', () => {
-            cy.get('.cvat-project-tasks-pagination .ant-pagination-item-2', { log: false }).click();
-            cy.get('.cvat-project-tasks-pagination .ant-pagination-item-active', { log: false })
-                .invoke('text').should('eq', '2');
+        it('Navigate to page 2 via bottom pagination', () => {
+            cy.get('.ant-pagination-item-2').should('be.visible').click();
+            cy.get('.cvat-spinner').should('not.exist');
+            cy.get('.ant-pagination-item-active').should('have.text', '2');
         });
 
         it('Page 2 is preserved after page reload', () => {
             cy.reload();
             cy.get('.cvat-spinner').should('not.exist');
-            cy.get('.cvat-project-tasks-pagination .ant-pagination-item-active', { log: false })
-                .invoke('text').should('eq', '2');
+            cy.get('.ant-pagination-item-active').should('have.text', '2');
         });
     });
 });


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Broken navigation for Projects and Tasks
https://github.com/cvat-ai/cvat/issues/10470

#### What this changes

This refactors `ResourceFilterHOC` so that the applied filter is derived from the value prop instead of being mirrored in local state and synced back through an effect.

__Before__, the component kept `appliedFilter` in `useState` and ran a `useEffect` over `[appliedFilter, value]` that translated state mutations into `onApplyFilter(...)` calls. UI controls only mutated `appliedFilter`; the effect decided what to actually apply. There was also an `isMounted` flag to suppress the effect on first render, plus several if `(value === ...)` return guards to avoid redundant calls.

__After__:

`value` is the single source of truth. `appliedFilter` is computed from it via `useMemo` (predefined / built parsed from `value`, recent derived as `recentFilters[value] ?? null`).
UI handlers call `onApplyFilter(...)` directly, so the intent of each control is explicit at the call site.
The syncing `useEffect`, the `isMounted` flag, and the dedup guards are removed.

#### Why

_Single source of truth_. The old code had two representations of the same thing — the `value` prop (the real state, owned by the parent/URL) and the local `appliedFilter` mirror. Keeping them in sync via an effect is exactly the pattern that produced subtle bugs: the mount guard, the redundant-call checks, and stale state that could diverge from value.

_No stale state_. Deriving recent from `value` means it can never get out of sync with the actually applied filter. The previous attempt with a dedicated `appliedRecentFilter` state only reset itself inside the recent menu, so it went stale after Clear / Apply / predefined changes; the derived version is self-correcting.

_Explicit data flow_. Each control now says what it does (`handleApplyFilter`, `handleClearFilter`, …) instead of nudging shared state and letting an effect infer intent one render later.
Fewer effects / re-renders, easier to follow, and it removes the indirection that made the filter interact badly with pagination/back-navigation.
This is the change that fixes the recent-filter toggle and keeps the filter consistent with value across reloads and back-navigation.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

#### Issue-specific test introduced

`tests/cypress/e2e/issues_prs/issue_10470_back_navigation_pagination.js`

#### Related tests checked — all green

- `tests/cypress/e2e/issues_prs/issue_5566_filter_url.js`
- `tests/cypress/e2e/actions_tasks/registration_involved/case_69_filters_sorting_jobs.js`
- `tests/cypress/e2e/features/case_113_new_organization_pipeline.js`
- `tests/cypress/e2e/features2/consensus.js`

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
