### PR TITLE
Prepare the UI for agent-based interactors

### DIFF
--- a/cvat-core/src/lambda-manager.ts
+++ b/cvat-core/src/lambda-manager.ts
@@ -6,15 +6,18 @@
 import serverProxy from './server-proxy';
 import { ArgumentError } from './exceptions';
 import MLModel from './ml-model';
-import {
-    ModelKind, RQStatus, ShapeType, Source,
-} from './enums';
-import { SerializedCollection, SerializedShape, SerializedFunctionRequest } from './server-response-types';
+import { ModelKind, RQStatus, ShapeType } from './enums';
+import { SerializedCollection, SerializedFunctionRequest } from './server-response-types';
 import { mask2Rle } from './rle-utils';
 
-type InteractorShape = Pick<SerializedShape, 'group' | 'source' | 'attributes' | 'occluded' | 'rotation' | 'type'> & {
-    points: Int32Array;
-};
+export interface MinimalShape {
+    type: ShapeType;
+    points: number[];
+}
+
+interface InteractorShape extends MinimalShape {
+    attributes?: { spec_id: number; value: string }[]
+}
 
 // This type is compatible with our SerializedCollection, however the client only supports it partly
 // The idea behind is to let us extend it in the future by necessary
@@ -23,11 +26,6 @@ type InteractorShape = Pick<SerializedShape, 'group' | 'source' | 'attributes' |
 export type InteractorResults = {
     shapes: InteractorShape[];
 };
-
-export interface MinimalShape {
-    type: ShapeType;
-    points: number[];
-}
 
 export interface TrackerResults {
     states: any[];
@@ -102,39 +100,20 @@ class LambdaManager {
                 } else {
                     rle.push(0, 0, maskWidth - 1, maskHeight - 1);
                 }
-                return {
-                    shapes: [{
-                        points: Int32Array.from(rle),
-                        group: 0,
-                        source: Source.SEMI_AUTO,
-                        attributes: [],
-                        occluded: false,
-                        rotation: 0,
-                        type: ShapeType.MASK,
-                    }],
-                };
+                return { shapes: [{ points: rle, type: ShapeType.MASK }] };
             }
 
             if (Array.isArray(result.shapes)) {
-                // perhaps already returned object according to the new interface
-                // in this case we just skip shapes which are not supported on client
                 return {
                     shapes: (result as InteractorResults).shapes.map((item) => ({
-                        points: Int32Array.from(item.points),
-                        group: typeof item.group === 'number' ? item.group : 0,
-                        source: Source.SEMI_AUTO,
-                        attributes: Array.isArray(item.attributes) && item.attributes.every((attr) => {
-                            if (typeof attr !== 'object') {
-                                return false;
-                            }
-                            return typeof attr === 'object' &&
+                        points: item.points,
+                        attributes: Array.isArray(item.attributes) && item.attributes.every(
+                            (attr) => typeof attr === 'object' &&
                                 typeof attr.spec_id === 'number' &&
-                                typeof attr.value === 'string';
-                        }) ? item.attributes : [],
-                        occluded: typeof item.occluded === 'boolean' ? item.occluded : false,
-                        rotation: typeof item.rotation === 'number' ? item.rotation : 0,
+                                typeof attr.value === 'string',
+                        ) ? item.attributes : undefined,
                         type: item.type ?? ShapeType.MASK,
-                    })).filter((item) => item.type === ShapeType.MASK),
+                    })),
                 };
             }
         }

--- a/cvat-core/src/lambda-manager.ts
+++ b/cvat-core/src/lambda-manager.ts
@@ -16,7 +16,7 @@ export interface MinimalShape {
 }
 
 interface InteractorShape extends MinimalShape {
-    attributes?: { spec_id: number; value: string }[]
+    attributes: { spec_id: number; value: string }[]
 }
 
 // This type is compatible with our SerializedCollection, however the client only supports it partly
@@ -100,7 +100,7 @@ class LambdaManager {
                 } else {
                     rle.push(0, 0, maskWidth - 1, maskHeight - 1);
                 }
-                return { shapes: [{ points: rle, type: ShapeType.MASK }] };
+                return { shapes: [{ points: rle, type: ShapeType.MASK, attributes: [] }] };
             }
 
             if (Array.isArray(result.shapes)) {
@@ -111,7 +111,7 @@ class LambdaManager {
                             (attr) => typeof attr === 'object' &&
                                 typeof attr.spec_id === 'number' &&
                                 typeof attr.value === 'string',
-                        ) ? item.attributes : undefined,
+                        ) ? item.attributes : [],
                         type: item.type ?? ShapeType.MASK,
                     })),
                 };

--- a/cvat-ui/plugins/sam/src/ts/index.tsx
+++ b/cvat-ui/plugins/sam/src/ts/index.tsx
@@ -271,7 +271,7 @@ const samPlugin: SAMPlugin = {
 
                                                 plugin.data.lowResMasks.set(key, maskInput);
                                                 return {
-                                                    points: Int32Array.from(rle),
+                                                    points: rle,
                                                     group: 0,
                                                     source: Source.SEMI_AUTO,
                                                     occluded: false,

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
@@ -447,7 +447,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                     }
 
                     const approximated = this.approximateResponsePoints(polygonPoints!);
-                    const confidenceAttr = item.attributes?.find((attr) => attr.spec_id === 0);
+                    const confidenceAttr = item.attributes.find((attr) => attr.spec_id === 0);
                     const confidence = confidenceAttr ? +confidenceAttr.value : 1;
                     showConfidenceControl = showConfidenceControl || !!confidenceAttr;
                     latestResponse.push({

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
@@ -427,7 +427,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                 const response = await core.lambda.call(
                     jobInstance.taskId,
                     interactor,
-                    { ...data, job: jobInstance.id },
+                    { ...data, type: 'interact', job: jobInstance.id },
                 ) as InteractorResults;
 
                 if (this.interaction.id !== interactionId || this.interaction.isAborted) {
@@ -438,17 +438,20 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                 const latestResponse: ToolsControlComponent['interaction']['latestResponse'] = [];
                 let showConfidenceControl = false;
                 for (const item of response.shapes) {
-                    const polygonPoints = this.receivePointsFromMask(item.points);
+                    if (item.type !== ShapeType.MASK) continue;
+
+                    const points = Int32Array.from(item.points);
+                    const polygonPoints = this.receivePointsFromMask(points);
                     if (polygonPoints.length < 3) {
                         continue;
                     }
 
                     const approximated = this.approximateResponsePoints(polygonPoints!);
-                    const confidenceAttr = item.attributes.find((attr) => attr.spec_id === 0);
+                    const confidenceAttr = item.attributes?.find((attr) => attr.spec_id === 0);
                     const confidence = confidenceAttr ? +confidenceAttr.value : 1;
                     showConfidenceControl = showConfidenceControl || !!confidenceAttr;
                     latestResponse.push({
-                        rle: item.points,
+                        rle: points,
                         points: polygonPoints,
                         approximatedPoints: approximated,
                         confidence,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This involves two changes:

* Pass an annotation request type when invoking lambda functions.

* Move certain AR response postprocessing logic to `ToolsControlComponent`, so that it still works when `LambdaManager.call` is overridden by a plugin. In particular, the conversion of points to an `Int32Array` and the dropping of unsupported shape types.

Also, to simplify the code, drop the keys from `InteractorShape` that the code doesn't actually do anything with.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I have manually tested with with IOG, SAM, and SAM2.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
