### PR TITLE
Fix handling of `GET /api/quality/reports` with inaccessible `parent_id`s

### DIFF
--- a/changelog.d/20260619_141337_roman_parent_report_check.md
+++ b/changelog.d/20260619_141337_roman_parent_report_check.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Fixed incorrect responses being returned from the `GET
+  /api/quality/reports` endpoint when the `parent_id` parameter
+  refers to a report inaccessible by the current user
+  (<https://github.com/cvat-ai/cvat/pull/10807>)
+
+### Security
+
+- Fixed a bug allowing a user to determine whether an inaccessible
+  quality report is located in an organization they are not a member of
+  or elsewhere
+  (<https://github.com/cvat-ai/cvat/pull/10807>)

--- a/cvat/apps/quality_control/permissions.py
+++ b/cvat/apps/quality_control/permissions.py
@@ -42,7 +42,7 @@ class QualityReportPermission(OpenPolicyAgentPermission):
             report = get_or_404(QualityReport, report)
 
         if not iam_context and request:
-            iam_context = get_iam_context(request, None)
+            iam_context = get_iam_context(request, report)
 
         return cls(**iam_context, scope=cls.Scopes.VIEW, obj=report)
 
@@ -54,6 +54,8 @@ class QualityReportPermission(OpenPolicyAgentPermission):
         for scope in cls.get_scopes(request, view, obj):
             if scope == Scopes.VIEW:
                 permissions.append(cls.create_scope_view(request, obj, iam_context=iam_context))
+            elif scope == Scopes.LIST and isinstance(obj, QualityReport):
+                permissions.append(QualityReportPermission.create_scope_view(request, obj))
             elif scope == Scopes.LIST and isinstance(obj, Job):
                 permissions.append(JobPermission.create_scope_view(request, obj))
             elif scope == Scopes.LIST and isinstance(obj, Task):

--- a/cvat/apps/quality_control/views.py
+++ b/cvat/apps/quality_control/views.py
@@ -216,6 +216,7 @@ class QualityReportViewSet(
             # NOTE: the parent_id filter requires a different queryset
             if parent_id := self.request.query_params.get("parent_id", None):
                 parent_report = get_or_404(QualityReport, parent_id)
+                self.check_object_permissions(self.request, parent_report)
                 iam_context = get_iam_context(self.request, parent_report)
 
                 # For m2m relations this is actually "in"

--- a/tests/python/rest_api/test_quality_control.py
+++ b/tests/python/rest_api/test_quality_control.py
@@ -426,6 +426,41 @@ class TestListQualityReports(_PermissionTestBase):
         else:
             self._test_list_reports_403(**list_kwargs)
 
+    @pytest.mark.usefixtures("restore_db_per_function")
+    @pytest.mark.parametrize(*_PermissionTestBase._default_sandbox_cases)
+    def test_user_list_reports_by_parent_id_in_sandbox(
+        self,
+        is_staff,
+        allow,
+        admin_user,
+        find_sandbox_task_without_gt,
+    ):
+        task, user = find_sandbox_task_without_gt(is_staff)
+        self.create_gt_job(admin_user, task["id"])
+        report = self.create_quality_report(user=admin_user, task_id=task["id"])
+        if allow:
+            self._test_list_reports_200(user=user["username"], parent_id=report["id"])
+        else:
+            self._test_list_reports_403(user=user["username"], parent_id=report["id"])
+
+    @pytest.mark.usefixtures("restore_db_per_function")
+    @pytest.mark.parametrize(*_PermissionTestBase._default_org_cases)
+    def test_user_list_reports_by_parent_id_in_org(
+        self,
+        find_org_task_without_gt,
+        org_role,
+        is_staff,
+        allow,
+        admin_user,
+    ):
+        task, user = find_org_task_without_gt(is_staff, org_role)
+        self.create_gt_job(admin_user, task["id"])
+        report = self.create_quality_report(user=admin_user, task_id=task["id"])
+        if allow:
+            self._test_list_reports_200(user=user["username"], parent_id=report["id"])
+        else:
+            self._test_list_reports_403(user=user["username"], parent_id=report["id"])
+
 
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestGetQualityReports(_PermissionTestBase):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Currently this either returns 200 and an empty list (if the parent quality report is in an accessible organization or a personal workspace), or 500 (if the parent is in an inaccessible organization). This is inconsistent with all other resource-based filters, where the endpoint returns 403 if the resource is inaccessible (and obviously we should never return a 500 status regardless). It's also a (very minor) security problem, since it lets an attacker learn some information about a quality report they can't access.

The cause is that we don't explicitly check that the user has permissions to view the parent, so do that.

Thanks to @geo-chen for the report.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
REST API tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
