### PR TITLE
Added unit tests to cover ROI for nuclio functions

### DIFF
--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+import base64
+import io
 import json
 import os
 from collections import Counter
@@ -10,6 +12,7 @@ from itertools import groupby
 from unittest import mock, skip
 
 import requests
+from PIL import Image
 from django.contrib.auth.models import Group, User
 from django.core.signing import TimestampSigner
 from django.http import HttpResponseNotFound, HttpResponseServerError
@@ -239,6 +242,20 @@ class _LambdaTestCaseBase(ApiTestBase):
     def _delete_lambda_request(self, request_id: str, user: User | None = None) -> None:
         response = self._delete_request(f"{LAMBDA_REQUESTS_PATH}/{request_id}", user or self.admin)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def _wait_lambda_request(self, request_id: str, user: User | None = None) -> str:
+        request_status = "started"
+        while request_status != "finished" and request_status != "failed":
+            response = self._get_request(f"{LAMBDA_REQUESTS_PATH}/{request_id}", user or self.admin)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            request_status = response.json().get("status")
+
+        return request_status
+
+    def _get_payload_image_size(self, payload: dict) -> tuple[int, int]:
+        image_data = base64.b64decode(payload["image"])
+        with Image.open(io.BytesIO(image_data)) as image:
+            return image.size
 
 
 class LambdaTestCases(_LambdaTestCaseBase):
@@ -676,6 +693,132 @@ class LambdaTestCases(_LambdaTestCaseBase):
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    def test_api_v2_lambda_functions_create_detector_with_roi(self):
+        roi = [11, 13, 31, 43]
+
+        def invoke_detector_with_roi(func, payload):
+            self.assertEqual(func.id, id_function_detector)
+            self.assertEqual(self._get_payload_image_size(payload), (20, 30))
+            return [
+                {
+                    "confidence": "0.9959098",
+                    "label": "car",
+                    "points": [1, 2, 5, 6],
+                    "type": "rectangle",
+                },
+            ]
+
+        data = {
+            "task": self.main_task["id"],
+            "frame": 0,
+            "mapping": {
+                "car": {"name": "car"},
+            },
+            "roi": roi,
+        }
+
+        with mock.patch(
+            "cvat.apps.lambda_manager.views.LambdaGateway.invoke",
+            side_effect=invoke_detector_with_roi,
+        ):
+            response = self._post_request(
+                f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}", self.admin, data=data
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.json()["shapes"][0]["points"], [12.0, 15.0, 16.0, 19.0])
+
+    def test_api_v2_lambda_requests_create_detector_with_roi(self):
+        roi = [10, 20, 30, 50]
+
+        def invoke_detector_with_roi(func, payload):
+            self.assertEqual(func.id, id_function_detector)
+            self.assertEqual(self._get_payload_image_size(payload), (20, 30))
+            return [
+                {
+                    "confidence": "0.9959098",
+                    "label": "car",
+                    "points": [3, 4, 15, 16],
+                    "type": "rectangle",
+                },
+            ]
+
+        data = {
+            "function": id_function_detector,
+            "task": self.main_task["id"],
+            "cleanup": True,
+            "mapping": {
+                "car": {"name": "car"},
+            },
+            "roi": roi,
+        }
+
+        with mock.patch(
+            "cvat.apps.lambda_manager.views.LambdaGateway.invoke",
+            side_effect=invoke_detector_with_roi,
+        ) as mock_invoke:
+            response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+            request_id = response.data["id"]
+
+            request_status = self._wait_lambda_request(request_id)
+            self.assertEqual(request_status, "finished")
+
+        self.assertEqual(mock_invoke.call_count, 3)
+        self._delete_lambda_request(request_id)
+
+        response = self._get_request(f'/api/tasks/{self.main_task["id"]}/annotations', self.admin)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        shapes = response.json()["shapes"]
+        self.assertEqual(len(shapes), 3)
+        for shape in shapes:
+            self.assertEqual(shape["points"], [13.0, 24.0, 25.0, 36.0])
+
+    def test_api_v2_lambda_functions_detector_invalid_roi(self):
+        invalid_rois = {
+            "too_few_coordinates": [0, 0, 10],
+            "too_many_coordinates": [0, 0, 10, 10, 10],
+            "negative_coordinate": [-1, 0, 10, 10],
+            "zero_width": [10, 10, 10, 20],
+            "zero_height": [10, 10, 20, 10],
+            "outside_image": [0, 0, 101, 100],
+        }
+
+        with mock.patch("cvat.apps.lambda_manager.views.LambdaGateway.invoke") as mock_invoke:
+            for name, roi in invalid_rois.items():
+                with self.subTest(path="request", roi=name):
+                    response = self._post_request(
+                        LAMBDA_REQUESTS_PATH,
+                        self.admin,
+                        data={
+                            "function": id_function_detector,
+                            "task": self.main_task["id"],
+                            "mapping": {
+                                "car": {"name": "car"},
+                            },
+                            "roi": roi,
+                        },
+                    )
+                    self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+                with self.subTest(path="call", roi=name):
+                    response = self._post_request(
+                        f"{LAMBDA_FUNCTIONS_PATH}/{id_function_detector}",
+                        self.admin,
+                        data={
+                            "task": self.main_task["id"],
+                            "frame": 0,
+                            "mapping": {
+                                "car": {"name": "car"},
+                            },
+                            "roi": roi,
+                        },
+                    )
+                    self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+            mock_invoke.assert_not_called()
+
     @skip(
         "Fail: expected result != actual result"
     )  # TODO move test to test_api_v2_lambda_functions_create
@@ -744,6 +887,44 @@ class LambdaTestCases(_LambdaTestCaseBase):
             f"{LAMBDA_FUNCTIONS_PATH}/{id_function_interactor}", None, data=data_main_task
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_api_v2_lambda_functions_create_interactor_with_roi(self):
+        roi = [10, 20, 30, 50]
+
+        def invoke_interactor_with_roi(func, payload):
+            self.assertEqual(func.id, id_function_interactor)
+            self.assertEqual(self._get_payload_image_size(payload), (20, 30))
+            self.assertEqual(payload["pos_points"], [[2, 3], [19, 29]])
+            self.assertEqual(payload["neg_points"], [[1, 2]])
+            self.assertEqual(payload["obj_bbox"], [[0, 0], [20, 30]])
+            return {
+                "shapes": [
+                    {
+                        "type": "polygon",
+                        "points": [1, 2, 3, 4, 5, 6],
+                    },
+                ],
+            }
+
+        data = {
+            "task": self.main_task["id"],
+            "frame": 0,
+            "pos_points": [[12, 23], [29, 49]],
+            "neg_points": [[11, 22]],
+            "obj_bbox": [[10, 20], [30, 50]],
+            "roi": roi,
+        }
+
+        with mock.patch(
+            "cvat.apps.lambda_manager.views.LambdaGateway.invoke",
+            side_effect=invoke_interactor_with_roi,
+        ):
+            response = self._post_request(
+                f"{LAMBDA_FUNCTIONS_PATH}/{id_function_interactor}", self.admin, data=data
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.json()["shapes"][0]["points"], [11, 22, 13, 24, 15, 26])
 
     def test_api_v2_lambda_functions_create_tracker(self):
         for id_func in [

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -12,10 +12,10 @@ from itertools import groupby
 from unittest import mock, skip
 
 import requests
-from PIL import Image
 from django.contrib.auth.models import Group, User
 from django.core.signing import TimestampSigner
 from django.http import HttpResponseNotFound, HttpResponseServerError
+from PIL import Image
 from rest_framework import status
 
 from cvat.apps.engine.tests.utils import (


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
