### PR TITLE
Add TwelveLabs Pegasus video auto-annotation helper to the SDK

### DIFF
--- a/changelog.d/20260625_000000_mohit_twelvelabs_pegasus.md
+++ b/changelog.d/20260625_000000_mohit_twelvelabs_pegasus.md
@@ -1,0 +1,7 @@
+### Added
+
+- \[SDK\] A new opt-in auto-annotation helper,
+  `cvat_sdk.auto_annotation.functions.twelvelabs_pegasus`,
+  that uses the TwelveLabs Pegasus video-understanding model to label a video
+  task's frames with the events detected in the video
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/cvat-sdk/cvat_sdk/auto_annotation/functions/twelvelabs_pegasus.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/functions/twelvelabs_pegasus.py
@@ -1,0 +1,206 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Video auto-annotation using the TwelveLabs Pegasus video-understanding model.
+
+Unlike the torchvision detection functions in this package, Pegasus is a
+*video* model: it reasons about a whole clip rather than individual frames.
+It is therefore not exposed as a per-frame ``DetectionFunction`` (which the
+``annotate_task`` driver applies image by image), but as a task-level helper.
+
+The helper sends the task's source video to Pegasus, asks it to enumerate the
+distinct events in the video together with their timestamps, and turns each
+event into a CVAT *tag* placed on the frame that corresponds to the event's
+start time. The event label is matched to a task label by name, following the
+same name-based matching used elsewhere in this package.
+
+This is an opt-in integration; nothing here runs unless you call it explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+import cvat_sdk.models as models
+
+if TYPE_CHECKING:
+    from cvat_sdk.core import Client
+
+# The schema Pegasus is asked to fill in. Kept here so it is easy to audit and
+# so the prompt and the parsing stay in sync.
+_EVENT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "events": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "start_time": {
+                        "type": "number",
+                        "description": "Start time of the event, in seconds.",
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "Short label naming the event (a few words).",
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "One-sentence description of the event.",
+                    },
+                },
+                "required": ["start_time", "label"],
+            },
+        }
+    },
+    "required": ["events"],
+}
+
+_DEFAULT_PROMPT = (
+    "Watch the video and identify the distinct events that occur in it. "
+    "For each event, report the start time in seconds, a short label naming "
+    "the event, and a one-sentence description."
+)
+
+
+class TwelveLabsPegasusFunction:
+    """
+    Task-level auto-annotation backed by TwelveLabs Pegasus.
+
+    The source video must be reachable by the TwelveLabs API. Provide it as a
+    public HTTP(S) URL (``video_url``) or as the id of an asset you have already
+    uploaded to TwelveLabs (``asset_id``).
+    """
+
+    def __init__(
+        self,
+        *,
+        video_url: str | None = None,
+        asset_id: str | None = None,
+        api_key: str | None = None,
+        model_name: str = "pegasus1.5",
+        prompt: str = _DEFAULT_PROMPT,
+        max_tokens: int = 2048,
+        default_label: str = "event",
+    ) -> None:
+        if (video_url is None) == (asset_id is None):
+            raise ValueError("exactly one of video_url and asset_id must be provided")
+
+        api_key = api_key or os.getenv("TWELVELABS_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "a TwelveLabs API key must be supplied via the api_key argument"
+                " or the TWELVELABS_API_KEY environment variable"
+            )
+
+        # Imported lazily so that the rest of the SDK does not depend on the
+        # twelvelabs package being installed.
+        from twelvelabs import TwelveLabs
+        from twelvelabs.types.video_context import (
+            VideoContext_AssetId,
+            VideoContext_Url,
+        )
+
+        self._client = TwelveLabs(api_key=api_key)
+        self._model_name = model_name
+        self._prompt = prompt
+        self._max_tokens = max_tokens
+        self._default_label = default_label
+
+        if video_url is not None:
+            self._video = VideoContext_Url(url=video_url)
+        else:
+            self._video = VideoContext_AssetId(asset_id=asset_id)
+
+    def _analyze(self) -> Sequence[dict[str, Any]]:
+        from twelvelabs.types.sync_response_format import SyncResponseFormat
+
+        response = self._client.analyze(
+            model_name=self._model_name,
+            video=self._video,
+            prompt=self._prompt,
+            response_format=SyncResponseFormat(type="json_schema", json_schema=_EVENT_SCHEMA),
+            max_tokens=self._max_tokens,
+        )
+
+        import json
+
+        data = json.loads(response.data)
+        events = data.get("events", [])
+        if not isinstance(events, list):
+            raise ValueError("Pegasus returned an unexpected response (no event list)")
+        return events
+
+    def annotate_task(
+        self,
+        client: Client,
+        task_id: int,
+        *,
+        fps: float | None = None,
+        clear_existing: bool = False,
+    ) -> None:
+        """
+        Annotate the CVAT task with the given id using Pegasus.
+
+        Each event reported by Pegasus becomes a tag on the frame matching its
+        start time. The event's label is matched to a task label by name; events
+        whose label has no matching task label fall back to ``default_label``,
+        and are skipped if that label is not present in the task either.
+
+        ``fps`` is the frame rate of the task's video and is used to convert
+        event timestamps (in seconds) to frame indices. If it is omitted, all
+        tags are placed on the first frame (frame 0), since the CVAT API does
+        not expose the video frame rate.
+
+        If ``clear_existing`` is true, existing annotations are replaced;
+        otherwise the new tags are appended.
+        """
+        task = client.tasks.retrieve(task_id)
+        label_ids = {label.name: label.id for label in task.get_labels()}
+        size = task.get_meta().size
+
+        tags: list[models.LabeledImageRequest] = []
+
+        for event in self._analyze():
+            name = event.get("label") or self._default_label
+            label_id = label_ids.get(name)
+            if label_id is None:
+                label_id = label_ids.get(self._default_label)
+            if label_id is None:
+                client.logger.info(
+                    "Skipping event %r: no matching task label and no %r label",
+                    name,
+                    self._default_label,
+                )
+                continue
+
+            if fps is not None:
+                frame = round(float(event.get("start_time", 0)) * fps)
+                frame = max(0, min(frame, size - 1))
+            else:
+                frame = 0
+
+            tags.append(models.LabeledImageRequest(label_id=label_id, frame=frame, source="auto"))
+
+        client.logger.info("Uploading %d tag(s) to task %d...", len(tags), task_id)
+
+        if clear_existing:
+            client.tasks.api.update_annotations(
+                task_id,
+                labeled_data_request=models.LabeledDataRequest(tags=tags),
+            )
+        else:
+            client.tasks.api.partial_update_annotations(
+                "create",
+                task_id,
+                patched_labeled_data_request=models.PatchedLabeledDataRequest(tags=tags),
+            )
+
+        client.logger.info("Upload complete")
+
+
+create = TwelveLabsPegasusFunction

--- a/cvat-sdk/pyproject.toml
+++ b/cvat-sdk/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 [project.optional-dependencies]
 masks = ["numpy>=2"]
 pytorch = ["torch", "torchvision", "scikit-image>=0.24", "cvat_sdk[masks]"]
+twelvelabs = ["twelvelabs>=1.2.8"]
 
 [project.urls]
 homepage = "https://github.com/cvat-ai/cvat"

--- a/site/content/en/docs/api_sdk/sdk/auto-annotation.md
+++ b/site/content/en/docs/api_sdk/sdk/auto-annotation.md
@@ -476,6 +476,58 @@ This AA function uses torchvision's keypoint detection models.
 It produces skeleton annotations.
 Keypoints which the model marks as invisible will be marked as occluded in CVAT.
 
+## Video auto-annotation with TwelveLabs Pegasus
+
+This layer also includes a task-level helper that uses the
+[TwelveLabs](https://twelvelabs.io) Pegasus video-understanding model
+to annotate a video task.
+
+Unlike the torchvision functions above, Pegasus reasons about a whole video
+rather than individual frames, so it is not a per-frame detection function and
+is not used via `annotate_task` or the CLI `auto-annotate` command. Instead, it
+exposes its own `annotate_task` method that sends the task's source video to the
+TwelveLabs API, asks Pegasus to enumerate the distinct events in the video
+together with their timestamps, and turns each event into a tag placed on the
+corresponding frame. Event labels are matched to task labels by name, the same
+way as for the detection functions.
+
+To use it, install CVAT SDK with the `twelvelabs` extra and
+[get a TwelveLabs API key](https://twelvelabs.io) (there is a free tier):
+
+```
+$ pip install "cvat-sdk[twelvelabs]"
+$ export TWELVELABS_API_KEY=<your key>
+```
+
+Then, from Python:
+
+```python
+from cvat_sdk import make_client
+from cvat_sdk.auto_annotation.functions.twelvelabs_pegasus import create as create_pegasus
+
+# The video must be reachable by the TwelveLabs API, e.g. as a public URL.
+func = create_pegasus(video_url="https://example.com/my-video.mp4")
+
+with make_client("http://localhost", credentials=("user", "password")) as client:
+    # fps is used to map event timestamps to frame numbers; if omitted, all
+    # tags are placed on the first frame.
+    func.annotate_task(client, 12345, fps=30)
+```
+
+`create` accepts the following parameters:
+
+- `video_url` (`str`) - a public HTTP(S) URL to the task's source video.
+- `asset_id` (`str`) - the id of a video asset already uploaded to TwelveLabs.
+  Exactly one of `video_url` and `asset_id` must be provided.
+- `api_key` (`str`) - the TwelveLabs API key.
+  Defaults to the `TWELVELABS_API_KEY` environment variable.
+- `model_name` (`str`) - the Pegasus model to use. Defaults to `pegasus1.5`.
+- `prompt` (`str`) - the prompt used to extract events. A sensible default is
+  provided.
+- `max_tokens` (`int`) - the maximum number of output tokens. Defaults to 2048.
+- `default_label` (`str`) - the label to fall back to for events whose label
+  does not match any task label. Defaults to `event`.
+
 ## Additional AA functions
 
 The CVAT source repository contains additional predefined auto-annotation functions

--- a/tests/python/sdk/test_twelvelabs_pegasus.py
+++ b/tests/python/sdk/test_twelvelabs_pegasus.py
@@ -1,0 +1,204 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+# Unit tests for the TwelveLabs Pegasus auto-annotation helper.
+#
+# These tests do not require a running CVAT server or network access: both the
+# TwelveLabs client and the CVAT client are replaced with lightweight fakes, so
+# only the helper's own logic (event parsing, label matching, timestamp-to-frame
+# mapping) is exercised.
+
+import json
+import sys
+import types
+from logging import getLogger
+
+import pytest
+
+cvat_sdk_models = pytest.importorskip("cvat_sdk.models")
+
+
+def _install_fake_twelvelabs(monkeypatch, events):
+    """Install a fake ``twelvelabs`` package that returns the given events."""
+
+    tl = types.ModuleType("twelvelabs")
+
+    class _FakeAnalyzeResponse:
+        def __init__(self, data):
+            self.data = data
+
+    class _FakeClient:
+        last_kwargs = None
+
+        def __init__(self, *, api_key):
+            assert api_key  # the helper must pass a key through
+
+        def analyze(self, **kwargs):
+            _FakeClient.last_kwargs = kwargs
+            return _FakeAnalyzeResponse(json.dumps({"events": events}))
+
+    tl.TwelveLabs = _FakeClient
+
+    video_context = types.ModuleType("twelvelabs.types.video_context")
+
+    class _Url:
+        def __init__(self, *, url):
+            self.url = url
+
+    class _AssetId:
+        def __init__(self, *, asset_id):
+            self.asset_id = asset_id
+
+    video_context.VideoContext_Url = _Url
+    video_context.VideoContext_AssetId = _AssetId
+
+    sync_response_format = types.ModuleType("twelvelabs.types.sync_response_format")
+
+    class _SyncResponseFormat:
+        def __init__(self, *, type, json_schema):
+            self.type = type
+            self.json_schema = json_schema
+
+    sync_response_format.SyncResponseFormat = _SyncResponseFormat
+
+    types_pkg = types.ModuleType("twelvelabs.types")
+
+    monkeypatch.setitem(sys.modules, "twelvelabs", tl)
+    monkeypatch.setitem(sys.modules, "twelvelabs.types", types_pkg)
+    monkeypatch.setitem(sys.modules, "twelvelabs.types.video_context", video_context)
+    monkeypatch.setitem(sys.modules, "twelvelabs.types.sync_response_format", sync_response_format)
+    return _FakeClient
+
+
+class _FakeLabel:
+    def __init__(self, name, id):
+        self.name = name
+        self.id = id
+
+
+class _FakeTask:
+    def __init__(self, labels, size):
+        self._labels = labels
+        self._size = size
+
+    def get_labels(self):
+        return self._labels
+
+    def get_meta(self):
+        return types.SimpleNamespace(size=self._size)
+
+
+class _FakeAnnotationsApi:
+    def __init__(self):
+        self.created = None
+        self.replaced = None
+
+    def partial_update_annotations(self, action, task_id, *, patched_labeled_data_request):
+        self.created = (task_id, patched_labeled_data_request)
+
+    def update_annotations(self, task_id, *, labeled_data_request):
+        self.replaced = (task_id, labeled_data_request)
+
+
+class _FakeClient:
+    def __init__(self, labels, size):
+        self.logger = getLogger("test")
+        self._task = _FakeTask(labels, size)
+        self.tasks = types.SimpleNamespace(
+            retrieve=lambda task_id: self._task,
+            api=_FakeAnnotationsApi(),
+        )
+
+
+def _make_function(monkeypatch, events, **kwargs):
+    _install_fake_twelvelabs(monkeypatch, events)
+    from cvat_sdk.auto_annotation.functions.twelvelabs_pegasus import create
+
+    kwargs.setdefault("video_url", "https://example.com/v.mp4")
+    kwargs.setdefault("api_key", "fake-key")
+    return create(**kwargs)
+
+
+def test_requires_exactly_one_source(monkeypatch):
+    _install_fake_twelvelabs(monkeypatch, [])
+    from cvat_sdk.auto_annotation.functions.twelvelabs_pegasus import create
+
+    with pytest.raises(ValueError, match="exactly one"):
+        create(api_key="k")
+    with pytest.raises(ValueError, match="exactly one"):
+        create(api_key="k", video_url="u", asset_id="a")
+
+
+def test_requires_api_key(monkeypatch):
+    _install_fake_twelvelabs(monkeypatch, [])
+    monkeypatch.delenv("TWELVELABS_API_KEY", raising=False)
+    from cvat_sdk.auto_annotation.functions.twelvelabs_pegasus import create
+
+    with pytest.raises(ValueError, match="API key"):
+        create(video_url="u")
+
+
+def test_events_mapped_to_frames_by_fps(monkeypatch):
+    events = [
+        {"start_time": 0.0, "label": "intro"},
+        {"start_time": 2.0, "label": "intro"},
+    ]
+    fn = _make_function(monkeypatch, events)
+    client = _FakeClient([_FakeLabel("intro", 7)], size=100)
+
+    fn.annotate_task(client, 42, fps=30.0)
+
+    task_id, req = client.tasks.api.created
+    assert task_id == 42
+    frames = sorted(tag.frame for tag in req.tags)
+    assert frames == [0, 60]
+    assert all(tag.label_id == 7 for tag in req.tags)
+    assert all(tag.source == "auto" for tag in req.tags)
+
+
+def test_frame_clamped_to_task_size(monkeypatch):
+    fn = _make_function(monkeypatch, [{"start_time": 1000.0, "label": "intro"}])
+    client = _FakeClient([_FakeLabel("intro", 7)], size=10)
+
+    fn.annotate_task(client, 1, fps=30.0)
+
+    (tag,) = client.tasks.api.created[1].tags
+    assert tag.frame == 9  # size - 1
+
+
+def test_no_fps_puts_everything_on_frame_zero(monkeypatch):
+    fn = _make_function(monkeypatch, [{"start_time": 5.0, "label": "intro"}])
+    client = _FakeClient([_FakeLabel("intro", 7)], size=100)
+
+    fn.annotate_task(client, 1)
+
+    (tag,) = client.tasks.api.created[1].tags
+    assert tag.frame == 0
+
+
+def test_unmatched_label_falls_back_then_skips(monkeypatch):
+    events = [{"start_time": 0.0, "label": "unknown-thing"}]
+
+    # No "event" fallback label present -> skipped.
+    fn = _make_function(monkeypatch, events)
+    client = _FakeClient([_FakeLabel("intro", 7)], size=100)
+    fn.annotate_task(client, 1)
+    assert client.tasks.api.created[1].tags == []
+
+    # "event" fallback label present -> used.
+    fn = _make_function(monkeypatch, events)
+    client = _FakeClient([_FakeLabel("event", 9)], size=100)
+    fn.annotate_task(client, 1)
+    (tag,) = client.tasks.api.created[1].tags
+    assert tag.label_id == 9
+
+
+def test_clear_existing_uses_replace(monkeypatch):
+    fn = _make_function(monkeypatch, [{"start_time": 0.0, "label": "intro"}])
+    client = _FakeClient([_FakeLabel("intro", 7)], size=100)
+
+    fn.annotate_task(client, 1, fps=30.0, clear_existing=True)
+
+    assert client.tasks.api.created is None
+    assert client.tasks.api.replaced is not None


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds an opt-in auto-annotation helper to the CVAT SDK that uses the [TwelveLabs](https://twelvelabs.io) Pegasus video-understanding model to pre-label video tasks.

### Motivation and context

CVAT's predefined auto-annotation functions (the torchvision ones in `cvat_sdk/auto_annotation/functions/`) operate per-frame, which is a great fit for image models. Video understanding is a different problem: a model that reasons about a whole clip can describe *what happens and when*, which is useful for bootstrapping temporal/event annotations on video tasks.

This adds `cvat_sdk.auto_annotation.functions.twelvelabs_pegasus`, which sends a video task's source video to Pegasus, asks it to enumerate the distinct events with their start times, and writes each event as a tag on the matching frame. Event labels are matched to task labels by name, reusing the same name-based matching the existing functions rely on.

Because Pegasus is a video model rather than a per-frame one, it is intentionally *not* wired into the `annotate_task` driver / CLI `auto-annotate` command (those apply a `DetectionFunction` image-by-image and explicitly support image tasks only). Instead the helper exposes its own task-level `annotate_task` method, mirroring the SDK's annotation-upload conventions.

It is fully opt-in and non-breaking: it lives behind a new `cvat-sdk[twelvelabs]` extra, nothing imports `twelvelabs` unless you call the helper, and no existing defaults or behavior change.

### How has this been tested?

- No-network unit tests (`tests/python/sdk/test_twelvelabs_pegasus.py`) covering event parsing, label-by-name matching with fallback, timestamp→frame mapping via `fps`, frame clamping to task size, and the `clear_existing` path. They fake both the TwelveLabs and CVAT clients, so they need no server or network. All 7 pass locally.
- The TwelveLabs side of the contract was verified end-to-end against the live API with `twelvelabs==1.2.8`: `analyze(model_name="pegasus1.5", video=..., response_format=json_schema, ...)` returns structured events for a public sample video.

### A note on process

The contributing guide suggests opening an issue first for larger changes — I went straight to a PR since this is small, additive, and behind an optional extra, but I'm very happy to move the discussion to an issue if you'd prefer that.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

### Checklist
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] ~~I have linked related issues~~ (no related issue)

### License
- [x] I submit my code changes under the same MIT License that covers the project.
