### PR TITLE
Update test packages to enable running tests with Python 3.14

### DIFF
--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -1,21 +1,16 @@
 allure-pytest==2.14.2
 av==16.0.1
-pytest==6.2.5
-pytest-cases==3.8.6
-pytest-timeout==2.1.0
-pytest-cov==4.1.0
-pytest-xdist==3.5.0
+pytest==9.0.3
+pytest-cases==3.10.1
+pytest-timeout==2.4.0
+pytest-cov==7.1.0
+pytest-xdist==3.8.0
 requests==2.33.0
 deepdiff==8.6.2
 boto3==1.35.95
 Pillow==12.2.0
 python-dateutil==2.8.2
-pyyaml==6.0.2
-numpy==2.0.0
+pyyaml==6.0.3
+numpy==2.3.2; python_version >= "3.14"
+numpy==2.0.0; python_version < "3.14"
 librosa==0.11.0
-
-# a librosa dep, Higher versions conflict with coverage,
-# https://github.com/numba/numba/issues/10239
-numba==0.61
-
-# TODO: update pytest to 7.0.0 and pytest-timeout to 2.3.1 (better debug in vscode)

--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -1,6 +1,6 @@
 allure-pytest==2.14.2
 av==16.0.1
-pytest==9.0.3
+pytest==9.0.3  # https://github.com/smarie/python-pytest-cases/issues/385
 pytest-cases==3.10.1
 pytest-timeout==2.4.0
 pytest-cov==7.1.0


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Our Helm tests currently use the default Python version in `ubuntu-latest`, which will become 3.14 once `ubuntu-latest` becomes Ubuntu 26.04. We should make sure the tests are ready for that.

Some notes:

* The `numba` pin should not be necessary anymore, since the problem it works around was fixed in coverage 7.6.1, and I've already updated coverage to 7.14.0 in 76e15a01e0.

* There is no version of NumPy that supports both 3.10 and 3.14. I've elected to use the lowest version that supports each, since it helps ensure that we didn't make the SDK dependent on a newer version by accident.

* pytest 9.0.3 is not the latest version, but the newest one is currently incompatible with pytest-cases.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
