### PR TITLE
CLI: move more function kind-specific logic into drivers

### DIFF
--- a/cvat-cli/src/cvat_cli/_internal/agent_driver.py
+++ b/cvat-cli/src/cvat_cli/_internal/agent_driver.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Protocol, TypeVar
 
 import cvat_sdk.auto_annotation as cvataa
 import cvat_sdk.datasets as cvatds
@@ -47,10 +47,13 @@ class CheckInCallback(Protocol):
         """
 
 
-class AgentFunctionDriver:
+SpecT = TypeVar("SpecT")
+
+
+class AgentFunctionDriver(Generic[SpecT]):
     FUNCTION_KIND: ClassVar[str]
 
-    def __init__(self, client: Client, executor: RecoverableExecutor, function_spec: object):
+    def __init__(self, client: Client, executor: RecoverableExecutor, function_spec: SpecT) -> None:
         self._client = client
         self._executor = executor
         self._function_spec = function_spec
@@ -58,6 +61,10 @@ class AgentFunctionDriver:
     @classmethod
     def init_worker(cls, state_id_generator: TrackingStateIdGenerator) -> None:
         pass
+
+    @classmethod
+    def get_remote_function_fields(cls, spec: SpecT) -> dict[str, Any]:
+        raise NotImplementedError
 
     def validate_function_compatibility(self, remote_function: dict) -> None:
         raise NotImplementedError

--- a/cvat-cli/src/cvat_cli/_internal/agent_driver_detection.py
+++ b/cvat-cli/src/cvat_cli/_internal/agent_driver_detection.py
@@ -30,9 +30,45 @@ def _worker_job_detect(
     return current_function.detect(context, image)
 
 
-class AgentDetectionFunctionDriver(AgentFunctionDriver):
+class AgentDetectionFunctionDriver(AgentFunctionDriver[cvataa.DetectionFunctionSpec]):
     FUNCTION_KIND = "detector"
-    _function_spec: cvataa.DetectionFunctionSpec
+
+    @staticmethod
+    def _dump_sublabel_spec(
+        sl_spec: models.SublabelRequest | models.PatchedLabelRequest,
+    ) -> dict:
+        result = {
+            "name": sl_spec.name,
+            "attributes": [
+                {
+                    "name": attribute_spec.name,
+                    "input_type": attribute_spec.input_type,
+                    "values": attribute_spec.values,
+                }
+                for attribute_spec in getattr(sl_spec, "attributes", [])
+            ],
+        }
+
+        if getattr(sl_spec, "type", "any") != "any":
+            # Add the type conditionally, to stay compatible with older
+            # CVAT versions when the function doesn't define label types.
+            result["type"] = sl_spec.type
+
+        return result
+
+    @classmethod
+    def get_remote_function_fields(cls, spec: cvataa.DetectionFunctionSpec) -> dict[str, Any]:
+        labels_v2 = []
+
+        for label_spec in spec.labels:
+            labels_v2.append(cls._dump_sublabel_spec(label_spec))
+
+            if sublabels := getattr(label_spec, "sublabels", None):
+                labels_v2[-1]["sublabels"] = [
+                    cls._dump_sublabel_spec(sublabel) for sublabel in sublabels
+                ]
+
+        return {"labels_v2": labels_v2}
 
     def _validate_sublabel_compatibility(
         self, remote_sl: dict, sl: models.Sublabel | None, sl_desc: str

--- a/cvat-cli/src/cvat_cli/_internal/agent_driver_tracking.py
+++ b/cvat-cli/src/cvat_cli/_internal/agent_driver_tracking.py
@@ -146,9 +146,8 @@ class _TrackingFunctionShapeContextImpl(cvataa.TrackingFunctionShapeContext):
     original_shape_type: str
 
 
-class AgentTrackingFunctionDriver(AgentFunctionDriver):
+class AgentTrackingFunctionDriver(AgentFunctionDriver[cvataa.TrackingFunctionSpec]):
     FUNCTION_KIND = "tracker"
-    _function_spec: cvataa.TrackingFunctionSpec
 
     @classmethod
     def init_worker(cls, state_id_generator: TrackingStateIdGenerator) -> None:
@@ -157,6 +156,10 @@ class AgentTrackingFunctionDriver(AgentFunctionDriver):
 
         global _tracking_state_id_generator
         _tracking_state_id_generator = state_id_generator
+
+    @classmethod
+    def get_remote_function_fields(cls, spec: cvataa.TrackingFunctionSpec) -> dict[str, Any]:
+        return {"supported_shape_types": sorted(spec.supported_shape_types)}
 
     def validate_function_compatibility(self, remote_function: dict) -> None:
         remote_supported_shape_types = frozenset(remote_function["supported_shape_types"])

--- a/cvat-cli/src/cvat_cli/_internal/commands_functions.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_functions.py
@@ -8,12 +8,9 @@ import textwrap
 from collections.abc import Sequence
 from typing import Any
 
-import cvat_sdk.auto_annotation as cvataa
-from cvat_sdk import Client, models
+from cvat_sdk import Client
 
-from .agent import FUNCTION_PROVIDER_NATIVE, run_agent
-from .agent_driver_detection import AgentDetectionFunctionDriver
-from .agent_driver_tracking import AgentTrackingFunctionDriver
+from .agent import FUNCTION_PROVIDER_NATIVE, get_function_driver_class, run_agent
 from .command_base import CommandGroup
 from .common import FunctionLoader, configure_function_implementation_arguments
 
@@ -40,29 +37,6 @@ class FunctionCreateNative:
 
         configure_function_implementation_arguments(parser)
 
-    @staticmethod
-    def _dump_sublabel_spec(
-        sl_spec: models.SublabelRequest | models.PatchedLabelRequest,
-    ) -> dict:
-        result = {
-            "name": sl_spec.name,
-            "attributes": [
-                {
-                    "name": attribute_spec.name,
-                    "input_type": attribute_spec.input_type,
-                    "values": attribute_spec.values,
-                }
-                for attribute_spec in getattr(sl_spec, "attributes", [])
-            ],
-        }
-
-        if getattr(sl_spec, "type", "any") != "any":
-            # Add the type conditionally, to stay compatible with older
-            # CVAT versions when the function doesn't define label types.
-            result["type"] = sl_spec.type
-
-        return result
-
     def execute(
         self,
         client: Client,
@@ -72,31 +46,15 @@ class FunctionCreateNative:
         function_loader: FunctionLoader,
     ) -> None:
         function = function_loader.load()
+        driver_class = get_function_driver_class(function.spec)
 
         remote_function: dict[str, Any] = {
             "provider": FUNCTION_PROVIDER_NATIVE,
             "name": name,
             "visibility": visibility,
+            "kind": driver_class.FUNCTION_KIND,
+            **driver_class.get_remote_function_fields(function.spec),
         }
-
-        spec = function.spec
-
-        if isinstance(spec, cvataa.DetectionFunctionSpec):
-            remote_function["kind"] = AgentDetectionFunctionDriver.FUNCTION_KIND
-            remote_function["labels_v2"] = []
-
-            for label_spec in spec.labels:
-                remote_function["labels_v2"].append(self._dump_sublabel_spec(label_spec))
-
-                if sublabels := getattr(label_spec, "sublabels", None):
-                    remote_function["labels_v2"][-1]["sublabels"] = [
-                        self._dump_sublabel_spec(sublabel) for sublabel in sublabels
-                    ]
-        elif isinstance(spec, cvataa.TrackingFunctionSpec):
-            remote_function["kind"] = AgentTrackingFunctionDriver.FUNCTION_KIND
-            remote_function["supported_shape_types"] = sorted(spec.supported_shape_types)
-        else:
-            raise cvataa.BadFunctionError(f"Unsupported function spec type: {type(spec).__name__}")
 
         _, response = client.api_client.call_api(
             "/api/functions",


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This is a continuation (and probably conclusion) of d06c0a33.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I manually ran the CLI tests from the private repo.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
