### PR TITLE
Skip empty masks on dataset import (#7458)

### DIFF
--- a/changelog.d/20260630_140217_farus-hub.empty_mask_import.md
+++ b/changelog.d/20260630_140217_farus-hub.empty_mask_import.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Importing a dataset that contains an empty (zero-area) mask no longer
+  creates a degenerate mask (and no longer crashes on older Datumaro
+  versions); such masks are now skipped on import
+  (<https://github.com/cvat-ai/cvat/pull/10847>)

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -2455,6 +2455,13 @@ def import_dm_annotations(dm_dataset: dm.Dataset, instance_data: ProjectData | C
                 if hasattr(ann, "label") and ann.label is None:
                     raise CvatImportError("annotation has no label")
 
+                # Skip empty (zero-area) masks. Such masks can be produced on
+                # export or by external tools; importing them yields a
+                # degenerate 1x1 mask (and crashes get_bbox() on older
+                # datumaro). See https://github.com/cvat-ai/cvat/issues/7458
+                if ann.type == dm.AnnotationType.mask and ann.get_area() == 0:
+                    continue
+
                 score = ann.attributes.pop("score", None)
                 if score is None:
                     score = 1

--- a/cvat/apps/dataset_manager/tests/test_formats.py
+++ b/cvat/apps/dataset_manager/tests/test_formats.py
@@ -19,7 +19,12 @@ from rest_framework import status
 
 import cvat.apps.dataset_manager as dm
 from cvat.apps.dataset_manager.annotation import AnnotationIR
-from cvat.apps.dataset_manager.bindings import CvatDataExtractor, TaskData, find_dataset_root
+from cvat.apps.dataset_manager.bindings import (
+    CvatDataExtractor,
+    TaskData,
+    find_dataset_root,
+    import_dm_annotations,
+)
 from cvat.apps.dataset_manager.task import TaskAnnotation
 from cvat.apps.dataset_manager.tests.utils import (
     ensure_extractors_efficiency,
@@ -1094,6 +1099,50 @@ class TaskAnnotationsImportTest(_DbTestBase):
 
             dm.task.import_task_annotations(dataset_path, task["id"], format_name, True)
             self._test_can_import_annotations(task, format_name)
+
+    def test_can_import_dataset_with_empty_mask(self):
+        # https://github.com/cvat-ai/cvat/issues/7458
+        # An empty (zero-area) mask must be dropped on import, while a valid
+        # mask on the same image survives.
+        valid_mask = np.zeros((5, 7), dtype=np.uint8)
+        valid_mask[1:3, 2:4] = 1
+        empty_mask = np.zeros((5, 7), dtype=np.uint8)
+
+        source_dataset = Dataset.from_iterable(
+            [
+                DatasetItem(
+                    id="image_0",
+                    annotations=[
+                        Mask(valid_mask, label=0),
+                        Mask(empty_mask, label=0),
+                    ],
+                )
+            ],
+            categories=["label_0"],
+        )
+
+        images = self._generate_task_images(1, size=(5, 7))
+        task = {
+            "name": "test empty mask import",
+            "overlap": 0,
+            "segment_size": 100,
+            "labels": [{"name": "label_0"}],
+        }
+        task = self._create_task(task, images)
+
+        task_ann = TaskAnnotation(task["id"])
+        task_ann.init_from_db()
+        task_data = TaskData(task_ann.ir_data, Task.objects.get(pk=task["id"]))
+
+        # Must not raise, and the empty mask must be skipped
+        import_dm_annotations(source_dataset, task_data)
+
+        shapes = task_ann.ir_data.shapes
+        self.assertEqual(len(shapes), 1)
+        self.assertEqual(shapes[0]["type"], "mask")
+        # The surviving shape is the valid mask: the CVAT RLE ends with
+        # [left, top, right, bottom], i.e. the tight bbox of valid_mask.
+        self.assertEqual([int(p) for p in shapes[0]["points"][-4:]], [2, 1, 3, 2])
 
     def _make_coco_annotation_without_iscrowd(
         self, format_name: str = "COCO 1.0", has_segmentation: bool = True


### PR DESCRIPTION
<!-- Skip empty masks on dataset import (#7458) -->

### Motivation and context

Fixes #7458.

`import_dm_annotations()` converts every Datumaro mask with `MaskConverter.dm_mask_to_cvat_rle()`, which calls `dm_mask.get_bbox()`. An empty (all-zero, `area == 0`) mask has no pixels:

- On older Datumaro, `get_bbox()` raised `ValueError: zero-size array to reduction operation minimum which has no identity` — the original crash in the issue.
- On the currently pinned Datumaro (`find_mask_bbox` hardened to return a zero bbox), it no longer crashes but silently produces a **degenerate 1×1 mask at the origin**.

Either way an empty mask should not be imported. This skips masks with `get_area() == 0` in the import loop, matching the maintainer's suggested workaround in the issue thread. The misleading "disconnected instances" framing is a red herring — CVAT imports multiple masks of one class fine; the trigger is empty masks.

### How has this been tested?

Added `TaskAnnotationsImportTest.test_can_import_dataset_with_empty_mask`: builds a Datumaro dataset with one valid and one empty `Mask` on the same image, runs it through `import_dm_annotations`, and asserts (a) no exception, (b) exactly one shape is imported, (c) the survivor is the valid mask (its CVAT RLE bbox matches). Mirrors the existing MOTS mask test's fixtures.

_I was unable to run the backend unit suite locally (no provisioned CVAT container stack), so I'm relying on CI to exercise it. The conversion/bbox math and the import read-back path were verified statically._

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- ~~I have updated the documentation accordingly~~ <!-- not applicable -->
- [x] I have added tests to cover my changes
- [x] I have linked related issues

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
