### PR TITLE
Fix `cannot read properties of undefined (reading 'drawcircles')`

### DIFF
--- a/changelog.d/20260630_123848_klakhov_fix_draw_circles_undefined.md
+++ b/changelog.d/20260630_123848_klakhov_fix_draw_circles_undefined.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Client error `cannot read properties of undefined (reading 'drawcircles')`
+  (<https://github.com/cvat-ai/cvat/pull/10848>)

--- a/changelog.d/20260630_123848_klakhov_fix_draw_circles_undefined.md
+++ b/changelog.d/20260630_123848_klakhov_fix_draw_circles_undefined.md
@@ -1,4 +1,4 @@
 ### Fixed
 
-- Client error `cannot read properties of undefined (reading 'drawcircles')`
+- Fix snap to contour crashes when drawing stops (drawCircles of undefined / array of null)
   (<https://github.com/cvat-ai/cvat/pull/10848>)

--- a/cvat-canvas/src/typescript/autoborderHandler.ts
+++ b/cvat-canvas/src/typescript/autoborderHandler.ts
@@ -211,10 +211,14 @@ export class AutoborderHandlerImpl implements AutoborderHandler {
     }
 
     private replaceCurrentShapePoints(points: number[][]): void {
+        const paintHandler = this.currentShape.remember('_paintHandler');
+        if (!paintHandler) {
+            return;
+        }
+
         const lastPoint = (this.currentShape as any).array().valueOf().slice(-1)[0];
         (this.currentShape as any).plot([...points, lastPoint]);
 
-        const paintHandler = this.currentShape.remember('_paintHandler');
         paintHandler.drawCircles();
         paintHandler.set.members.forEach((el: SVG.Circle): void => {
             el.attr('stroke-width', 1 / this.scale).attr('r', 2.5 / this.scale);

--- a/cvat-canvas/src/typescript/autoborderHandler.ts
+++ b/cvat-canvas/src/typescript/autoborderHandler.ts
@@ -211,7 +211,7 @@ export class AutoborderHandlerImpl implements AutoborderHandler {
     }
 
     private replaceCurrentShapePoints(points: number[][]): void {
-        const paintHandler = this.currentShape.remember('_paintHandler');
+        const paintHandler = this.currentShape?.remember('_paintHandler');
         if (!paintHandler) {
             return;
         }


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
When drawing a polygon/polyline with autoborder enabled, the canvas could crash with:


`Cannot read properties of undefined (reading 'drawCircles')`
The crash originated in `AutoborderHandlerImpl.replaceCurrentShapePoints`, which retrieved the SVG paint handler via `this.currentShape.remember('_paintHandler')` and immediately called `paintHandler.drawCircles()` without checking that it exists.

`_paintHandler` is owned by svg.draw.js and only lives during the active drawing window — it is created lazily on the first drawstart and forgotten on `stop()` (done/cancel/single-point finish). replaceCurrentShapePoints has four callers, but only the mousedown handler bootstraps the handler first. The three other paths — the onContainerMouseMove revert, the onContainerMouseMove preview, and the undopoint listener — could reach it when the handler is absent (e.g. a mouse move or undo processed just after drawing stopped but before autoborder(false) tears the listeners down), throwing on undefined.

This fix makes `replaceCurrentShapePoints` defensive at a single point instead of relying on every caller to pre-warm the handler: it reads _paintHandler first and returns early (a no-op) when drawing isn't active, before mutating the shape. This closes all three unguarded paths at once and leaves the normal first-click flow unchanged.

To reproduce:

1. Have an existing polygon on the frame; enable snap to contour.
2. Start a new polygon, place one point.
3. Click one of the existing shape's autoborder markers, then sweep the mouse along its border to build a curve preview.
4. Finish the shape while still moving the mouse fast (e.g. complete it and keep dragging).
5. Start drawing again using `N`

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
