### PR TITLE
Fix `Cannot read properties of null (reading 'toLowerCase')` on requests page

### DIFF
--- a/changelog.d/20260630_000000_klakhov_fix_request_null_status.md
+++ b/changelog.d/20260630_000000_klakhov_fix_request_null_status.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - Requests API no longer returns a `null` status when a job's status cannot be
-  read from Redis (e.g. the job expired)
+  read from Redis (e.g. the job expired) (<https://github.com/cvat-ai/cvat/pull/10849>)

--- a/changelog.d/20260630_000000_klakhov_fix_request_null_status.md
+++ b/changelog.d/20260630_000000_klakhov_fix_request_null_status.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Requests API no longer returns a `null` status when a job's status cannot be
+  read from Redis (e.g. the job expired)

--- a/cvat/apps/redis_handler/serializers.py
+++ b/cvat/apps/redis_handler/serializers.py
@@ -34,6 +34,16 @@ class RequestStatus(TextChoices):
     FINISHED = "finished"
 
 
+class RequestStatusField(serializers.ChoiceField):
+    def get_attribute(self, instance: CustomRQJob) -> str | None:
+        # Reuse the status loaded when the job was fetched instead of re-reading it from
+        # Redis. A fresh read (get_status(refresh=True)) is racy: the job hash may expire
+        # between fetching the job and serializing it, in which case Redis returns None and
+        # the client receives a null status. The view guarantees the status is not None by
+        # the time it reaches the serializer.
+        return instance.get_status(refresh=False)
+
+
 class RqIdSerializer(serializers.Serializer):
     rq_id = serializers.CharField(help_text="Request id")
 
@@ -83,7 +93,7 @@ class RequestSerializer(serializers.Serializer):
     # Marking them as read_only leads to generating type as allOf with one reference to RequestStatus component.
     # The client generated using openapi-generator from such a schema contains wrong type like:
     # status (bool, date, datetime, dict, float, int, list, str, none_type): [optional]
-    status = serializers.ChoiceField(source="get_status", choices=RequestStatus.choices)
+    status = RequestStatusField(choices=RequestStatus.choices)
     message = serializers.SerializerMethodField()
     id = serializers.CharField()
     operation = RequestDataOperationSerializer(source="*")
@@ -139,7 +149,7 @@ class RequestSerializer(serializers.Serializer):
     @extend_schema_field(serializers.CharField(allow_blank=True))
     def get_message(self, rq_job: CustomRQJob) -> str:
         assert self._base_rq_job_meta
-        rq_job_status = rq_job.get_status()
+        rq_job_status = rq_job.get_status(refresh=False)
         message = ""
 
         if RQJobStatus.STARTED == rq_job_status:

--- a/cvat/apps/redis_handler/serializers.py
+++ b/cvat/apps/redis_handler/serializers.py
@@ -34,6 +34,15 @@ class RequestStatus(TextChoices):
     FINISHED = "finished"
 
 
+class RequestStatusField(serializers.ChoiceField):
+    def get_attribute(self, instance: CustomRQJob) -> str | None:
+        # Reuse the status loaded when the job was fetched instead of re-reading it from
+        # Redis. A fresh read (get_status(refresh=True)) is racy: the job hash may expire
+        # between fetching the job and serializing it, in which case Redis returns None and
+        # the client receives a null status.
+        return instance.get_status(refresh=False)
+
+
 class RqIdSerializer(serializers.Serializer):
     rq_id = serializers.CharField(help_text="Request id")
 
@@ -79,7 +88,11 @@ class RequestDataOperationSerializer(serializers.Serializer):
 
 
 class RequestSerializer(serializers.Serializer):
-    status = serializers.SerializerMethodField()
+    # SerializerMethodField is not used here to mark "status" field as required and fix schema generation.
+    # Marking them as read_only leads to generating type as allOf with one reference to RequestStatus component.
+    # The client generated using openapi-generator from such a schema contains wrong type like:
+    # status (bool, date, datetime, dict, float, int, list, str, none_type): [optional]
+    status = RequestStatusField(choices=RequestStatus.choices)
     message = serializers.SerializerMethodField()
     id = serializers.CharField()
     operation = RequestDataOperationSerializer(source="*")
@@ -131,15 +144,6 @@ class RequestSerializer(serializers.Serializer):
             return expiry_date.replace(tzinfo=timezone.utc)
 
         return None
-
-    @extend_schema_field(serializers.ChoiceField(choices=RequestStatus.choices))
-    def get_status(self, rq_job: CustomRQJob) -> str | None:
-        # Reuse the status loaded when the job was fetched instead of re-reading it from
-        # Redis. A fresh read (get_status(refresh=True)) is racy: the job hash may expire
-        # between fetching the job and serializing it, in which case Redis returns None and
-        # the client receives a null status. The view guarantees the status is not None by
-        # the time it reaches the serializer.
-        return rq_job.get_status(refresh=False)
 
     @extend_schema_field(serializers.CharField(allow_blank=True))
     def get_message(self, rq_job: CustomRQJob) -> str:

--- a/cvat/apps/redis_handler/serializers.py
+++ b/cvat/apps/redis_handler/serializers.py
@@ -34,16 +34,6 @@ class RequestStatus(TextChoices):
     FINISHED = "finished"
 
 
-class RequestStatusField(serializers.ChoiceField):
-    def get_attribute(self, instance: CustomRQJob) -> str | None:
-        # Reuse the status loaded when the job was fetched instead of re-reading it from
-        # Redis. A fresh read (get_status(refresh=True)) is racy: the job hash may expire
-        # between fetching the job and serializing it, in which case Redis returns None and
-        # the client receives a null status. The view guarantees the status is not None by
-        # the time it reaches the serializer.
-        return instance.get_status(refresh=False)
-
-
 class RqIdSerializer(serializers.Serializer):
     rq_id = serializers.CharField(help_text="Request id")
 
@@ -89,11 +79,7 @@ class RequestDataOperationSerializer(serializers.Serializer):
 
 
 class RequestSerializer(serializers.Serializer):
-    # SerializerMethodField is not used here to mark "status" field as required and fix schema generation.
-    # Marking them as read_only leads to generating type as allOf with one reference to RequestStatus component.
-    # The client generated using openapi-generator from such a schema contains wrong type like:
-    # status (bool, date, datetime, dict, float, int, list, str, none_type): [optional]
-    status = RequestStatusField(choices=RequestStatus.choices)
+    status = serializers.SerializerMethodField()
     message = serializers.SerializerMethodField()
     id = serializers.CharField()
     operation = RequestDataOperationSerializer(source="*")
@@ -145,6 +131,15 @@ class RequestSerializer(serializers.Serializer):
             return expiry_date.replace(tzinfo=timezone.utc)
 
         return None
+
+    @extend_schema_field(serializers.ChoiceField(choices=RequestStatus.choices))
+    def get_status(self, rq_job: CustomRQJob) -> str | None:
+        # Reuse the status loaded when the job was fetched instead of re-reading it from
+        # Redis. A fresh read (get_status(refresh=True)) is racy: the job hash may expire
+        # between fetching the job and serializing it, in which case Redis returns None and
+        # the client receives a null status. The view guarantees the status is not None by
+        # the time it reaches the serializer.
+        return rq_job.get_status(refresh=False)
 
     @extend_schema_field(serializers.CharField(allow_blank=True))
     def get_message(self, rq_job: CustomRQJob) -> str:

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -10897,7 +10897,9 @@ components:
       type: object
       properties:
         status:
-          $ref: '#/components/schemas/RequestStatus'
+          allOf:
+          - $ref: '#/components/schemas/RequestStatus'
+          readOnly: true
         message:
           type: string
           readOnly: true
@@ -10943,7 +10945,6 @@ components:
       - created_date
       - id
       - operation
-      - status
     RequestDataOperation:
       type: object
       properties:

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -10897,9 +10897,7 @@ components:
       type: object
       properties:
         status:
-          allOf:
-          - $ref: '#/components/schemas/RequestStatus'
-          readOnly: true
+          $ref: '#/components/schemas/RequestStatus'
         message:
           type: string
           readOnly: true
@@ -10945,6 +10943,7 @@ components:
       - created_date
       - id
       - operation
+      - status
     RequestDataOperation:
       type: object
       properties:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The Requests API (GET /api/requests/{id} and GET /api/requests) could return a request with status: null. On the client this crashed the UI with:


`Cannot read properties of null (reading 'toLowerCase')`
at Request.status in cvat-core/src/request.ts, because the getter does this.#status.toLowerCase().

Root cause: RequestSerializer.status resolved its value via source="get_status", which calls RQ's Job.get_status() with the default refresh=True — a fresh hget(key, 'status') against Redis at serialization time. The job is fetched once in the view (so its status is already loaded), but the serializer then re-reads it. If the job's Redis hash loses its status field in that window — most plausibly a TTL-expiry race for a finished/failed job near the end of its result_ttl/failure_ttl, or a partially-evicted hash — the read returns None, which serializes to null.

Fix (server, primary):

Added a RequestStatusField(ChoiceField) that overrides get_attribute to call get_status(refresh=False), reusing the status already loaded when the job was fetched instead of issuing a second, racy Redis read. It remains a ChoiceField, so the generated OpenAPI/SDK schema is unchanged.
get_message likewise switched to get_status(refresh=False).

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
