### PR TITLE
Remove PATCH /api/invitations/{key} endpoint

### DIFF
--- a/changelog.d/20260701_170000_andrei_remove_invitation_patch.md
+++ b/changelog.d/20260701_170000_andrei_remove_invitation_patch.md
@@ -1,0 +1,4 @@
+### Removed
+
+- Removed the unused `PATCH /api/invitations/{key}` Server API operation.
+  (<https://github.com/cvat-ai/cvat/pull/10850>)

--- a/cvat/apps/organizations/permissions.py
+++ b/cvat/apps/organizations/permissions.py
@@ -100,9 +100,6 @@ class InvitationPermission(OpenPolicyAgentPermission):
                 "list": Scopes.LIST,
                 "create": Scopes.CREATE,
                 "destroy": Scopes.DELETE,
-                "partial_update": (
-                    Scopes.ACCEPT if "accepted" in request.query_params else Scopes.RESEND
-                ),
                 "retrieve": Scopes.VIEW,
                 "accept": Scopes.ACCEPT,
                 "decline": Scopes.DECLINE,

--- a/cvat/apps/organizations/rules/tests/configs/invitations.csv
+++ b/cvat/apps/organizations/rules/tests/configs/invitations.csv
@@ -6,11 +6,11 @@ create,Invitation,Organization,N/A,"resource[""role""] != ""owner""",POST,/invit
 view,Invitation,Sandbox,None,,GET,/invitations/{id},Admin,N/A
 view,Invitation,N/A,"Owner, Invitee",,GET,/invitations/{id},None,N/A
 view,Invitation,Organization,None,,GET,/invitations/{id},User,Maintainer
-resend,Invitation,Sandbox,"None, Invitee",,PATCH,/invitations/{id},Admin,N/A
-resend,Invitation,N/A,Owner,,PATCH,/invitations/{id},Worker,N/A
-resend,Invitation,Organization,"None, Invitee",,PATCH,/invitations/{id},User,Maintainer
+resend,Invitation,Sandbox,"None, Invitee",,POST,/invitations/{id}/resend,Admin,N/A
+resend,Invitation,N/A,Owner,,POST,/invitations/{id}/resend,Worker,N/A
+resend,Invitation,Organization,"None, Invitee",,POST,/invitations/{id}/resend,User,Maintainer
 delete,Invitation,Sandbox,"None, Invitee",,DELETE,/invitations/{id},Admin,N/A
 delete,Invitation,N/A,Owner,,DELETE,/invitations/{id},Worker,N/A
 delete,Invitation,Organization,"None, Invitee",,DELETE,/invitations/{id},User,Maintainer
-accept,Invitation,N/A,None,,PATCH,/invitations/{id},Admin,N/A
-accept,Invitation,N/A,Invitee,,PATCH,/invitations/{id},None,N/A
+accept,Invitation,N/A,None,,POST,/invitations/{id}/accept,Admin,N/A
+accept,Invitation,N/A,Invitee,,POST,/invitations/{id}/accept,None,N/A

--- a/cvat/apps/organizations/serializers.py
+++ b/cvat/apps/organizations/serializers.py
@@ -139,15 +139,12 @@ class InvitationWriteSerializer(serializers.ModelSerializer):
 
         return invitation
 
-    def update(self, instance, validated_data):
-        return super().update(instance, {})
-
-    def save(self, request=None, **kwargs):
+    def save(self, request, **kwargs):
         invitation = super().save(**kwargs)
         _, regular_user = get_dummy_or_regular_user(invitation.membership.user.email)
         if not to_bool(settings.ORG_INVITATION_CONFIRM) and regular_user:
             invitation.accept()
-        elif request is not None:
+        else:
             invitation.send(request)
 
         return invitation

--- a/cvat/apps/organizations/serializers.py
+++ b/cvat/apps/organizations/serializers.py
@@ -142,12 +142,12 @@ class InvitationWriteSerializer(serializers.ModelSerializer):
     def update(self, instance, validated_data):
         return super().update(instance, {})
 
-    def save(self, request, **kwargs):
+    def save(self, request=None, **kwargs):
         invitation = super().save(**kwargs)
         _, regular_user = get_dummy_or_regular_user(invitation.membership.user.email)
         if not to_bool(settings.ORG_INVITATION_CONFIRM) and regular_user:
             invitation.accept()
-        else:
+        elif request is not None:
             invitation.send(request)
 
         return invitation

--- a/cvat/apps/organizations/views.py
+++ b/cvat/apps/organizations/views.py
@@ -195,13 +195,6 @@ class MembershipViewSet(
             "200": InvitationReadSerializer(many=True),
         },
     ),
-    partial_update=extend_schema(
-        summary="Update an invitation",
-        request=InvitationWriteSerializer(partial=True),
-        responses={
-            "200": InvitationReadSerializer,  # check InvitationWriteSerializer.to_representation
-        },
-    ),
     create=extend_schema(
         summary="Create an invitation",
         request=InvitationWriteSerializer,
@@ -249,12 +242,11 @@ class InvitationViewSet(
     viewsets.GenericViewSet,
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
-    PartialUpdateModelMixin,
     mixins.CreateModelMixin,
     mixins.DestroyModelMixin,
 ):
     queryset = Invitation.objects.all()
-    http_method_names = ["get", "post", "patch", "delete", "head", "options"]
+    http_method_names = ["get", "post", "delete", "head", "options"]
     iam_supports_organization_params = True
     iam_permission_class = InvitationPermission
 
@@ -308,12 +300,6 @@ class InvitationViewSet(
             organization=self.request.iam_context["organization"],
             request=self.request,
         )
-
-    def perform_update(self, serializer):
-        if "accepted" in self.request.query_params:
-            serializer.instance.accept()
-        else:
-            super().perform_update(serializer)
 
     @transaction.atomic
     @action(detail=True, methods=["POST"], url_path="accept")

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -1784,37 +1784,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/InvitationRead'
           description: ''
-    patch:
-      operationId: invitations_partial_update
-      summary: Update an invitation
-      parameters:
-      - in: path
-        name: key
-        schema:
-          type: string
-        description: A unique value identifying this invitation.
-        required: true
-      tags:
-      - invitations
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedInvitationWriteRequest'
-      security:
-      - tokenAuth: []
-      - accessTokenAuth: []
-      - sessionAuth: []
-        csrfAuth: []
-        csrfHeaderAuth: []
-      - basicAuth: []
-      responses:
-        '200':
-          content:
-            application/vnd.cvat+json:
-              schema:
-                $ref: '#/components/schemas/InvitationRead'
-          description: ''
     delete:
       operationId: invitations_destroy
       summary: Delete an invitation
@@ -9854,15 +9823,6 @@ components:
         cloud_storage_id:
           type: integer
           nullable: true
-    PatchedInvitationWriteRequest:
-      type: object
-      properties:
-        role:
-          $ref: '#/components/schemas/RoleEnum'
-        email:
-          type: string
-          format: email
-          minLength: 1
     PatchedIssueWriteRequest:
       type: object
       properties:

--- a/tests/python/rest_api/test_invitations.py
+++ b/tests/python/rest_api/test_invitations.py
@@ -162,13 +162,3 @@ class TestGetInvitations:
 
         source_inv["owner"] = None
         assert DeepDiff(source_inv, fetched_inv, ignore_order=True) == {}
-
-
-@pytest.mark.usefixtures("restore_db_per_class")
-class TestUpdateInvitations:
-    def test_patch_invitation_endpoint_is_not_allowed(self, admin_user, invitations):
-        invitation = invitations[0]
-
-        response = patch_method(admin_user, f"invitations/{invitation['key']}", {})
-
-        assert response.status_code == HTTPStatus.METHOD_NOT_ALLOWED, response.content

--- a/tests/python/rest_api/test_invitations.py
+++ b/tests/python/rest_api/test_invitations.py
@@ -10,7 +10,7 @@ import pytest
 from cvat_sdk.api_client.api_client import ApiClient, Endpoint
 from deepdiff import DeepDiff
 
-from shared.utils.config import get_method, make_api_client, patch_method, post_method
+from shared.utils.config import get_method, make_api_client, post_method
 
 from .utils import CollectionSimpleFilterTestBase
 

--- a/tests/python/rest_api/test_invitations.py
+++ b/tests/python/rest_api/test_invitations.py
@@ -10,7 +10,7 @@ import pytest
 from cvat_sdk.api_client.api_client import ApiClient, Endpoint
 from deepdiff import DeepDiff
 
-from shared.utils.config import get_method, make_api_client, post_method
+from shared.utils.config import get_method, make_api_client, patch_method, post_method
 
 from .utils import CollectionSimpleFilterTestBase
 
@@ -162,3 +162,13 @@ class TestGetInvitations:
 
         source_inv["owner"] = None
         assert DeepDiff(source_inv, fetched_inv, ignore_order=True) == {}
+
+
+@pytest.mark.usefixtures("restore_db_per_class")
+class TestUpdateInvitations:
+    def test_patch_invitation_endpoint_is_not_allowed(self, admin_user, invitations):
+        invitation = invitations[0]
+
+        response = patch_method(admin_user, f"invitations/{invitation['key']}", {})
+
+        assert response.status_code == HTTPStatus.METHOD_NOT_ALLOWED, response.content


### PR DESCRIPTION
### Motivation and context
The endpoint is removed because it's not used and duplicated by `/api/invitations/{key}/accept` endpoint. Moreover, it contains security leak regarding accessing outdated organizations.
#### What happens

  A `PATCH /api/invitations/{key}` request from Postman (without the `?accepted` query parameter) returns 500 Internal Server Error with the stack trace ending at:
```python
  File "/opt/venv/lib/python3.10/site-packages/rest_framework/mixins.py", line 78, in perform_update
      serializer.save()
  TypeError: InvitationWriteSerializer.save() missing 1 required positional argument: 'request'
```

#### Why it happens

  `InvitationWriteSerializer.save()` (cvat/apps/organizations/serializers.py:145) overrides DRF's default with a required positional argument:
```python
  def save(self, request, **kwargs):
      invitation = super().save(**kwargs)
      ...
      invitation.send(request)   # needs request to build the absolute invitation URL
```
  This works for `POST` because I`nvitationViewSet.perform_create()` (views.py:304) explicitly forwards it:
```python
  serializer.save(
      owner=self.request.user,
      key=get_random_string(length=64),
      organization=self.request.iam_context["organization"],
      request=self.request,
  )
```
  But for `PATCH`, the call chain is:

  1. `InvitationViewSet.perform_update()` (views.py:312) only handles the ?accepted branch:
  ```python
  def perform_update(self, serializer):
      if "accepted" in self.request.query_params:
          serializer.instance.accept()
      else:
          super().perform_update(serializer)   # ← falls here without ?accepted
 ```
  2. super().perform_update() resolves to _UpdateMixin.perform_update() in cvat/apps/engine/mixins.py:293, which delegates to DRF's UpdateModelMixin.perform_update().
  3. DRF's default implementation simply calls serializer.save() with no kwargs — so request is missing and Python raises TypeError before the body of save() runs.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
