### PR TITLE
Fix broken range downloading implementation for Azure Blob Storage

### DIFF
--- a/changelog.d/20260630_162121_roman.md
+++ b/changelog.d/20260630_162121_roman.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Fixed task creation from images hosted on Azure Blob Storage when
+  at least one image's header doesn't fit into 2047 bytes
+  (<https://github.com/cvat-ai/cvat/pull/10851>)

--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -977,7 +977,9 @@ class AzureBlobCloudStorage(AbstractCloudStorage):
         storage_stream_downloader.readinto(stream)
 
     def _download_range_of_bytes(self, key: str, /, *, stop_byte: int, start_byte: int) -> bytes:
-        return self._client.download_blob(blob=key, offset=start_byte, length=stop_byte).readall()
+        return self._client.download_blob(
+            blob=key, offset=start_byte, length=stop_byte - start_byte + 1
+        ).readall()
 
     @property
     def supported_actions(self):

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -1895,7 +1895,7 @@ class _CloudStorageTestBase(ApiTestBase):
                 return Status.AVAILABLE if key in self._files else Status.NOT_FOUND
 
             def _download_range_of_bytes(self, key: str, /, *, stop_byte: int, start_byte: int):
-                return self._files[key][start_byte:stop_byte]
+                return self._files[key][start_byte : stop_byte + 1]
 
             def _download_fileobj_to_stream(self, key: str, stream: BinaryIO, /):
                 stream.write(self._files[key])


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Currently we pass the end byte index as the length, which is obviously incorrect. In many cases this doesn't actually cause any problems; however, the problems start when we try to use `HeaderFirstDownloader` to download an image whose header doesn't fit in 2048 bytes. In this case what happens is this:

* `HeaderFirstDownloader` calls `download_range_of_bytes(key, start_byte=0, stop_byte=2047)`.
* `AzureBlobCloudStorage` calls `download_blob(blob=key, offset=0, length=2047)`. This returns a bytestring of length 2047.
* Since 2047 < 2048, `HeaderFirstDownloader` assumes that it has downloaded the entire file, and returns the bytestring.
* When we later open the downloaded file with Pillow, it fails.

The fix is trivial, just calculate the length properly.

While investigating, I saw that `MockS3` in the tests implements this incorrectly too. This hasn't caused any problems so far, but fix it anyway.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
