### PR TITLE
Cancel "Open an issue" mode when switching out of the review workspace

### DIFF
--- a/changelog.d/20260701_000000_adhavan_fix_9813.md
+++ b/changelog.d/20260701_000000_adhavan_fix_9813.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Switching out of the review workspace no longer leaves the "Open an issue"
+  control active, so the next click is not misinterpreted as issue creation
+  (<https://github.com/cvat-ai/cvat/pull/10852>)

--- a/cvat-ui/src/actions/annotation-actions.ts
+++ b/cvat-ui/src/actions/annotation-actions.ts
@@ -1300,6 +1300,15 @@ export function changeWorkspaceAsync(workspace: Workspace): ThunkAction {
 
         if (currentWorkspace === Workspace.REVIEW && workspace !== Workspace.REVIEW) {
             userUnlockedInReviewMode.clear();
+
+            // The "Open an issue" control puts the canvas into select-region mode. Leaving the
+            // review workspace must cancel it, otherwise the next canvas click in another
+            // workspace is still interpreted as issue creation (see #9813).
+            const { instance: canvasInstance, activeControl } = state.annotation.canvas;
+            if (activeControl === ActiveControl.OPEN_ISSUE && canvasInstance instanceof Canvas) {
+                canvasInstance.selectRegion(false);
+                dispatch(updateActiveControl(ActiveControl.CURSOR));
+            }
         }
 
         dispatch(changeWorkspace(workspace));


### PR DESCRIPTION
### Motivation and context

Fixes #9813.

In the review workspace the **Open an issue** control (`CreateIssueControl`) puts the canvas into select-region mode via `canvasInstance.selectRegion(true)` and sets `ActiveControl.OPEN_ISSUE`. Switching to another workspace (e.g. Standard) through `changeWorkspaceAsync` did not clear this state — it only cleared `userUnlockedInReviewMode` and re-fetched annotations. The canvas therefore stayed in select-region mode after the switch, so the next click on the image was interpreted as creating an issue instead of a normal annotation action.

This change resets the control when leaving the review workspace (`selectRegion(false)` and `activeControl → CURSOR`), mirroring the toggle-off already implemented in `CreateIssueControl` itself. The reset is guarded by `activeControl === ActiveControl.OPEN_ISSUE` and a `canvasInstance instanceof Canvas` check (the 2D canvas that exposes `selectRegion`), so it is a no-op in every other case.

### How has this been tested?

Manually, following the reproduction in #9813:

1. Open a job and switch to the **Review** workspace.
2. Click the **Open an issue** control on the left panel (it becomes active and the cursor enters select-region mode).
3. Switch to the **Standard** workspace without drawing an issue.
4. Click on the image.

Before this change, step 4 was still handled as issue creation (the select-region handler was left active). After this change the control is reset when the workspace changes, so the click behaves normally.

Note: I was not able to run the Cypress e2e suite locally (it needs a running CVAT deployment), so I have not included an automated test in this PR. I'd be glad to add a regression test under `tests/cypress/` — the review-pipeline helpers (`cy.changeWorkspace`, the `.cvat-issue-control` control, and the `.cvat-create-issue-dialog` assertion) already cover the building blocks — if you'd like one; just let me know your preferred placement.

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- [ ] ~~I have updated the documentation accordingly~~ — no user-facing documentation is affected
- [ ] ~~I have added tests to cover my changes~~ — see the testing note above; happy to add a Cypress regression test on request
- [x] I have linked related issues
- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
