### PR TITLE
Fix pagination being reset when refreshing or going "back" to a resources page

### DIFF
--- a/changelog.d/20260702_131449_aleksey.zinovyev_pagination_reset.md
+++ b/changelog.d/20260702_131449_aleksey.zinovyev_pagination_reset.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fix pagination being reset when refreshing or going "back" to a resources page
+  (<https://github.com/cvat-ai/cvat/pull/10858>)

--- a/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
@@ -210,7 +210,7 @@ export default function ResourceFilterHOC(
                 if (value !== appliedFilter.built) {
                     onApplyFilter(appliedFilter.built);
                 }
-            } else {
+            } else if (value !== null) {
                 onApplyFilter(null);
                 setState(defaultTree);
             }


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Resolved https://github.com/cvat-ai/cvat/issues/10470

For a resources page that is displaying not the first page of items when refreshing it or going "back" to it pagination is reset.

It is caused by an empty filter being unnecessarily applied on mount which effectively resets the pagination.

This change prevents extra empty filter application fixing the aforementioned problem. 

Additionally, it fixes duplicate API request when clearing an existing filter.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Manually tested

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [X] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
