### PR TITLE
Make loading previews on project/job cards clickable

### DIFF
--- a/changelog.d/20260702_140645_aleksey.zinovyev_clickable_loading_preview.md
+++ b/changelog.d/20260702_140645_aleksey.zinovyev_clickable_loading_preview.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Make loading previews on project/job cards clickable to allow opening the resource regardless of the preview state
+  (<https://github.com/cvat-ai/cvat/pull/10859>)

--- a/cvat-ui/src/components/common/preview.tsx
+++ b/cvat-ui/src/components/common/preview.tsx
@@ -92,7 +92,7 @@ export default function Preview(props: Readonly<Props>): JSX.Element {
 
     if (!preview || preview?.fetching) {
         return (
-            <div ref={ref} className={loadingClassName || ''} aria-hidden>
+            <div ref={ref} className={loadingClassName || ''} onClick={onClick} aria-hidden>
                 <Spin size='default' />
             </div>
         );

--- a/cvat-ui/src/components/projects-page/styles.scss
+++ b/cvat-ui/src/components/projects-page/styles.scss
@@ -129,6 +129,7 @@
             }
 
             .cvat-projects-project-item-title {
+                width: 100%;
                 cursor: pointer;
             }
 


### PR DESCRIPTION
Make loading previews on cards clickable to allow opening resource regardless of the preview state

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Sometimes preview loading for a project/job takes noticeable time and it's not convenient that it doesn't allow to open the resource by clicking on the preview until it is loaded.

This change handles the click on loading preview and allows opening the resource regardless of the loading state.

Additionally, extends the width of the title on a project card to full width of the card allowing opening the project clicking anywhere on the project title row regardless of the actual title text width.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Tested manually.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [X] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
