### PR TITLE
Fix AI tools tracking for multiple drawn rectangles

### DIFF
--- a/changelog.d/20260702_000000_codex_track_multiple_rectangles.md
+++ b/changelog.d/20260702_000000_codex_track_multiple_rectangles.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - Fixed AI tools tracking when starting tracking from multiple drawn rectangles
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/10860>)

--- a/changelog.d/20260702_000000_codex_track_multiple_rectangles.md
+++ b/changelog.d/20260702_000000_codex_track_multiple_rectangles.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed AI tools tracking when starting tracking from multiple drawn rectangles
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
@@ -624,7 +624,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
             isActivated, jobInstance, frame, curZOrder, fetchAnnotations,
         } = this.props;
 
-        if (!isActivated || !activeLabelID) {
+        if (!isActivated || !activeLabelID || !activeTracker) {
             return;
         }
 
@@ -635,34 +635,37 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
             return;
         }
 
-        // TODO: support more rectangles at the same time
-        // OR: drop this tracking method
+        const { shapes } = (e as CustomEvent<{ shapes: InteractionResult[] | null }>).detail;
+        if (!Array.isArray(shapes) || !shapes.length) {
+            return;
+        }
 
         try {
-            const { points } = (e as CustomEvent).detail.shapes[0];
-            const state = new core.classes.ObjectState({
-                shapeType: ShapeType.RECTANGLE,
-                objectType: ObjectType.TRACK,
-                source: core.enums.Source.SEMI_AUTO,
-                zOrder: curZOrder,
-                label,
-                points,
-                frame,
-                occluded: false,
-                attributes: {},
-                descriptions: [`Trackable (${activeTracker?.name})`],
-            });
+            const states = shapes.map(({ points }) => (
+                new core.classes.ObjectState({
+                    shapeType: ShapeType.RECTANGLE,
+                    objectType: ObjectType.TRACK,
+                    source: core.enums.Source.SEMI_AUTO,
+                    zOrder: curZOrder,
+                    label,
+                    points,
+                    frame,
+                    occluded: false,
+                    attributes: {},
+                    descriptions: [`Trackable (${activeTracker.name})`],
+                })
+            ));
 
-            const [clientID] = await jobInstance.annotations.put([state]);
+            const clientIDs = await jobInstance.annotations.put(states);
             this.setState({
                 trackedShapes: [
                     ...trackedShapes,
-                    {
+                    ...clientIDs.map((clientID: number, index: number): TrackedShape => ({
                         clientID,
                         serverlessState: null,
-                        shapePoints: points,
-                        trackerModel: activeTracker as MLModel,
-                    },
+                        shapePoints: states[index].points!,
+                        trackerModel: activeTracker,
+                    })),
                 ],
             });
 
@@ -685,11 +688,11 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
             return;
         }
 
-        if (!activeInteractor) {
-            return;
-        }
-
         if (mode === 'interaction') {
+            if (!activeInteractor) {
+                return;
+            }
+
             const { shapes, finished } = (e as CustomEvent<{ shapes: InteractionResult[], finished: boolean }>).detail;
 
             if (finished) {


### PR DESCRIPTION
### Motivation and context

AI tools tracking had two related issues. First, tracker-only setups could fail because the shared canvas interaction listener returned early when no interactor was selected, even though tracking does not require an interactor. Second, tracking initialization only used the first drawn rectangle, so drawing multiple rectangles before finishing setup created only one tracked object.

This change scopes the `activeInteractor` guard to interaction mode, restoring tracking in tracker-only configurations. It also adds support for initializing tracking from multiple drawn rectangles by creating one track per rectangle and registering all returned client IDs in `trackedShapes`, allowing the existing batched tracker flow to continue tracking them together.

### How has this been tested?

Manually

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- [ ] ~~I have updated the documentation accordingly~~
- [ ] ~~I have added tests to cover my changes~~
- [ ] ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.