### PR TITLE
Fix request card layout

### DIFF
--- a/changelog.d/20260702_171804_aleksey.zinovyev_request_card_layout.md
+++ b/changelog.d/20260702_171804_aleksey.zinovyev_request_card_layout.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Prevent requests cards content overflow
+  (<https://github.com/cvat-ai/cvat/pull/10862>)

--- a/cvat-ui/src/components/requests-page/request-card.tsx
+++ b/cvat-ui/src/components/requests-page/request-card.tsx
@@ -65,6 +65,10 @@ function constructName(operation: Request['operation']): string | null {
     return null;
 }
 
+function constructTypeText(type: string): string {
+    return type.split(':').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
+}
+
 function constructTimestamps(request: Request): JSX.Element {
     const started = dayjs(request.startedDate).format('MMM Do YY, H:mm');
     const finished = dayjs(request.finishedDate).format('MMM Do YY, H:mm');
@@ -137,7 +141,7 @@ const dimensions = {
     md: 8,
     lg: 8,
     xl: 8,
-    xxl: 6,
+    xxl: 7,
 };
 
 function RequestCard(props: Readonly<Props>): JSX.Element {
@@ -151,6 +155,7 @@ function RequestCard(props: Readonly<Props>): JSX.Element {
     const linkToEntity = constructLink(request);
     const percent = request.status === RQStatus.FINISHED ? 100 : (request.progress ?? 0) * 100;
     const timestamps = constructTimestamps(request);
+    const typeText = constructTypeText(type);
 
     const name = constructName(operation);
 
@@ -172,10 +177,10 @@ function RequestCard(props: Readonly<Props>): JSX.Element {
         >
             <Row justify='space-between'>
                 <Col span={12}>
-                    <Row style={{ paddingBottom: [RQStatus.FAILED].includes(request.status) ? '10px' : '0' }}>
+                    <Row style={{ paddingBottom: [RQStatus.FAILED].includes(request.status) ? '10px' : '0' }} gutter={8}>
                         <Col className='cvat-requests-type' {...dimensions}>
-                            <Text>
-                                {type.split(':').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
+                            <Text ellipsis={{ tooltip: typeText }}>
+                                {typeText}
                                 {' '}
                             </Text>
                         </Col>

--- a/cvat-ui/src/components/requests-page/request-card.tsx
+++ b/cvat-ui/src/components/requests-page/request-card.tsx
@@ -13,6 +13,7 @@ import Progress from 'antd/lib/progress';
 import { MoreOutlined } from '@ant-design/icons';
 import Button from 'antd/lib/button';
 import { MenuProps } from 'antd/lib/menu';
+import { BaseType } from 'antd/lib/typography/Base';
 
 import { RQStatus, Request } from 'cvat-core-wrapper';
 import { useContextMenuClick } from 'utils/hooks';
@@ -69,6 +70,14 @@ function constructTypeText(type: string): string {
     return type.split(':').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
 }
 
+function renderEllipsisText(text: string, type?: BaseType): JSX.Element {
+    return (
+        <Text ellipsis={{ tooltip: text }} type={type}>
+            {text}
+        </Text>
+    );
+}
+
 function constructTimestamps(request: Request): JSX.Element {
     const started = dayjs(request.startedDate).format('MMM Do YY, H:mm');
     const finished = dayjs(request.finishedDate).format('MMM Do YY, H:mm');
@@ -83,7 +92,7 @@ function constructTimestamps(request: Request): JSX.Element {
                 return (
                     <>
                         <Row>
-                            <Text type='secondary'>{`Started by ${request.owner.username} on ${started}`}</Text>
+                            {renderEllipsisText(`Started by ${request.owner.username} on ${started}`, 'secondary')}
                         </Row>
                         <Row>
                             <Text type='secondary'>{`Expires on ${expired}`}</Text>
@@ -94,7 +103,7 @@ function constructTimestamps(request: Request): JSX.Element {
             return (
                 <>
                     <Row>
-                        <Text type='secondary'>{`Started by ${request.owner.username} on ${started}`}</Text>
+                        {renderEllipsisText(`Started by ${request.owner.username} on ${started}`, 'secondary')}
                     </Row>
                     <Row>
                         <Text type='secondary'>{`Finished on ${finished}`}</Text>
@@ -105,11 +114,11 @@ function constructTimestamps(request: Request): JSX.Element {
         case RQStatus.FAILED: {
             return (request.startedDate ? (
                 <Row>
-                    <Text type='secondary'>{`Started by ${request.owner.username} on ${started}`}</Text>
+                    {renderEllipsisText(`Started by ${request.owner.username} on ${started}`, 'secondary')}
                 </Row>
             ) : (
                 <Row>
-                    <Text type='secondary'>{`Enqueued by ${request.owner.username} on ${created}`}</Text>
+                    {renderEllipsisText(`Enqueued by ${request.owner.username} on ${created}`, 'secondary')}
                 </Row>
             ));
         }
@@ -117,7 +126,7 @@ function constructTimestamps(request: Request): JSX.Element {
             return (
                 <>
                     <Row>
-                        <Text type='secondary'>{`Enqueued by ${request.owner.username} on ${created}`}</Text>
+                        {renderEllipsisText(`Enqueued by ${request.owner.username} on ${created}`, 'secondary')}
                     </Row>
                     <Row>
                         <Text type='secondary'>{`Started on ${started}`}</Text>
@@ -128,7 +137,7 @@ function constructTimestamps(request: Request): JSX.Element {
         default: {
             return (
                 <Row>
-                    <Text type='secondary'>{`Enqueued by ${request.owner.username} on ${created}`}</Text>
+                    {renderEllipsisText(`Enqueued by ${request.owner.username} on ${created}`, 'secondary')}
                 </Row>
             );
         }
@@ -179,10 +188,7 @@ function RequestCard(props: Readonly<Props>): JSX.Element {
                 <Col span={12}>
                     <Row style={{ paddingBottom: [RQStatus.FAILED].includes(request.status) ? '10px' : '0' }} gutter={8}>
                         <Col className='cvat-requests-type' {...dimensions}>
-                            <Text ellipsis={{ tooltip: typeText }}>
-                                {typeText}
-                                {' '}
-                            </Text>
+                            {renderEllipsisText(typeText)}
                         </Col>
                         {name && (
                             <Col className='cvat-requests-name'>
@@ -225,7 +231,7 @@ function RequestCard(props: Readonly<Props>): JSX.Element {
                             {operation?.format && (
                                 <Row>
                                     <Col className='cvat-format-name'>
-                                        <Text type='secondary'>{operation.format}</Text>
+                                        {renderEllipsisText(operation.format, 'secondary')}
                                     </Col>
                                 </Row>
                             )}


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Resolves https://github.com/cvat-ai/cvat/issues/10158

On the smallest responsive breakpoint the request title wraps on the next line pushing other details beyond the card boundaries. I assume that possibly it could affect other sizes if it fails to process the resize events and detects wrong responsive breakpoint in certain scenario as shown in the related issue.

This change updates the layout so the request type is never wrapped but rather displayed with an ellipsis if there's not enough space. The reasoning behind this fix is that the card height is fixed and we never want the request type text to occupy more height as it leads to the content overflow. Also, we cannot fix this by just increasing the width because the request type text can be of different width and even if we adjust it for all the existing options longer ones might be eventually introduced causing the same issue.

Before:
<img width="735" height="295" alt="requests_layout_before" src="https://github.com/user-attachments/assets/93fc5bc3-b1dd-4abe-bc5e-7c0c862cdafd" />

After:
<img width="764" height="228" alt="requests_layout_after" src="https://github.com/user-attachments/assets/c72332c2-677d-4a3d-88cd-ebc97cabe43b" />

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Tested manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [X] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
