### PR TITLE
Optimize track annotation initialization

### DIFF
--- a/changelog.d/20260703_105329_andrey_optimize_init_tracks_from_db.md
+++ b/changelog.d/20260703_105329_andrey_optimize_init_tracks_from_db.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed slow annotation loading for tasks with tracks by avoiding an expensive joined query during track initialization.
+  (<https://github.com/cvat-ai/cvat/pull/10867>)

--- a/changelog.d/20260703_105329_andrey_optimize_init_tracks_from_db.md
+++ b/changelog.d/20260703_105329_andrey_optimize_init_tracks_from_db.md
@@ -1,4 +1,4 @@
 ### Fixed
 
-- Fixed slow annotation loading for tasks with tracks by avoiding an expensive joined query during track initialization.
+- Improved performance of annotation responses.
   (<https://github.com/cvat-ai/cvat/pull/10867>)

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -827,26 +827,27 @@ class JobAnnotation:
         for db_track in db_tracks:
             db_track.shapes = []
 
-        db_shapes = (
-            models.TrackedShape.objects.filter(track_id__in=list(tracks_by_id))
-            .values(
-                "track_id",
-                "type",
-                "occluded",
-                "z_order",
-                "rotation",
-                "points",
-                "id",
-                "frame",
-                "outside",
+        for track_ids_chunk in take_by(sorted(tracks_by_id), 1000):
+            db_shapes = (
+                models.TrackedShape.objects.filter(track_id__in=track_ids_chunk)
+                .values(
+                    "track_id",
+                    "type",
+                    "occluded",
+                    "z_order",
+                    "rotation",
+                    "points",
+                    "id",
+                    "frame",
+                    "outside",
+                )
+                .order_by("track_id", "frame")
+                .iterator(chunk_size=settings.DEFAULT_DB_ANNO_CHUNK_SIZE)
             )
-            .order_by("track_id", "frame")
-            .iterator(chunk_size=settings.DEFAULT_DB_ANNO_CHUNK_SIZE)
-        )
 
-        for db_shape in db_shapes:
-            track_id = db_shape.pop("track_id")
-            tracks_by_id[track_id].shapes.append(dotdict(db_shape))
+            for db_shape in db_shapes:
+                track_id = db_shape.pop("track_id")
+                tracks_by_id[track_id].shapes.append(dotdict(db_shape))
 
         labeledtrack_attributes = _receive_attributes_from_db(
             self.db_job.labeledtrackattributeval_set,

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -805,45 +805,48 @@ class JobAnnotation:
             self.ir_data.shapes = list(generate_shapes())
 
     def _init_tracks_from_db(self):
-        # NOTE: do not use .prefetch_related() with .values() since it's useless:
-        # https://github.com/cvat-ai/cvat/pull/7748#issuecomment-2063695007
-        db_tracks = (
-            self.db_job.labeledtrack_set.values(
+        db_tracks = [
+            dotdict(row)
+            for row in self.db_job.labeledtrack_set.values(
                 "id",
                 "frame",
                 "label_id",
                 "group",
                 "source",
                 "parent",
-                "shape__type",
-                "shape__occluded",
-                "shape__z_order",
-                "shape__rotation",
-                "shape__points",
-                "shape__id",
-                "shape__frame",
-                "shape__outside",
             )
-            .order_by("id", "shape__frame")
+            .order_by("id")
+            .iterator(chunk_size=settings.DEFAULT_DB_ANNO_CHUNK_SIZE)
+        ]
+
+        if not db_tracks:
+            self.ir_data.tracks = []
+            return
+
+        tracks_by_id = {db_track.id: db_track for db_track in db_tracks}
+        for db_track in db_tracks:
+            db_track.shapes = []
+
+        db_shapes = (
+            models.TrackedShape.objects.filter(track_id__in=list(tracks_by_id))
+            .values(
+                "track_id",
+                "type",
+                "occluded",
+                "z_order",
+                "rotation",
+                "points",
+                "id",
+                "frame",
+                "outside",
+            )
+            .order_by("track_id", "frame")
             .iterator(chunk_size=settings.DEFAULT_DB_ANNO_CHUNK_SIZE)
         )
 
-        db_tracks = merge_table_rows(
-            rows=db_tracks,
-            keys_for_merge={
-                "shapes": [
-                    "shape__type",
-                    "shape__occluded",
-                    "shape__z_order",
-                    "shape__points",
-                    "shape__rotation",
-                    "shape__id",
-                    "shape__frame",
-                    "shape__outside",
-                ],
-            },
-            field_id="id",
-        )
+        for db_shape in db_shapes:
+            track_id = db_shape.pop("track_id")
+            tracks_by_id[track_id].shapes.append(dotdict(db_shape))
 
         labeledtrack_attributes = _receive_attributes_from_db(
             self.db_job.labeledtrackattributeval_set,


### PR DESCRIPTION
Local benchmarks were run on three synthetic tasks where the old joined query selected a 'bad' planner path.

Empty task, 10 jobs, no tracks:
before: 20.02s avg
after: 0.11s avg

Small tracks task, 1 job, 50 tracks / 5000 shapes:
before: 2.14s avg
after: 0.18s avg

Large tracks task, 1 job, 1000 tracks / 1,000,000 shapes:
before: 22.03s avg
after: 16.65s avg

### Motivation and context
Slow `/api/tasks/id/annotations` on empty tasks

### How has this been tested?
Tested on synthetic data covering empty annotations, a small tracks workload, and a large tracks workload to compare the old joined query with the new split-query initialization path.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
