### PR TITLE
Introduce annotation guide local drafts

### DIFF
--- a/cvat-ui/src/components/md-guide/annotation-guide-page.tsx
+++ b/cvat-ui/src/components/md-guide/annotation-guide-page.tsx
@@ -19,6 +19,12 @@ import { getCore, AnnotationGuide } from 'cvat-core-wrapper';
 import CVATLoadingSpinner from 'components/common/loading-spinner';
 import GoBackButton from 'components/common/go-back-button';
 import dimensions from 'utils/dimensions';
+import {
+    clearGuideDraft,
+    readGuideDraft,
+    saveGuideDraft,
+    shouldRestoreGuideDraft,
+} from './guide-drafts';
 
 const core = getCore();
 
@@ -30,6 +36,7 @@ function AnnotationGuidePage(): JSX.Element {
     const id = +useParams<{ id: string }>().id;
     const [guide, setGuide] = useState<AnnotationGuide | null>(null);
     const [fetching, setFetching] = useState(true);
+    const guideId = guide?.id;
 
     useEffect(() => {
         const promise = instanceType === 'project' ? core.projects.get({ id }) : core.tasks.get({ id });
@@ -45,7 +52,20 @@ function AnnotationGuidePage(): JSX.Element {
 
                 return existingGuide;
             }).then((guideInstance: AnnotationGuide) => {
-                setValue(guideInstance.markdown);
+                const guideInstanceId = guideInstance.id;
+                const draft = guideInstanceId !== undefined ? readGuideDraft(guideInstanceId) : null;
+                const shouldRestoreDraft = draft && shouldRestoreGuideDraft(draft, guideInstance);
+
+                if (shouldRestoreDraft) {
+                    setValue(draft.markdown);
+                    notification.info({ message: 'Your unsaved annotation guide changes were restored' });
+                } else {
+                    if (draft && guideInstanceId !== undefined) {
+                        clearGuideDraft(guideInstanceId);
+                    }
+                    setValue(guideInstance.markdown);
+                }
+
                 setGuide(guideInstance);
             }).catch((error: unknown) => {
                 notification.error({
@@ -57,13 +77,29 @@ function AnnotationGuidePage(): JSX.Element {
             });
     }, []);
 
-    const submit = useCallback((updatedValue: string) => {
+    const saveDraft = useCallback((updatedValue: string): void => {
+        if (guideId) {
+            saveGuideDraft(guideId, updatedValue);
+        }
+    }, [guideId]);
+
+    const updateValue = useCallback((updatedValue: string): void => {
+        setValue(updatedValue);
+        saveDraft(updatedValue);
+    }, [saveDraft]);
+
+    const submit = useCallback((updatedValue: string): Promise<void> => {
         if (guide) {
             guide.markdown = updatedValue;
             setFetching(true);
-            guide.save().then((result: AnnotationGuide) => {
+            return guide.save().then((result: AnnotationGuide) => {
+                const savedGuideId = result.id;
+
                 setValue(result.markdown);
                 setGuide(result);
+                if (savedGuideId) {
+                    clearGuideDraft(savedGuideId);
+                }
                 notification.info({ message: 'Annotation guide was saved successfully' });
             }).catch((error: unknown) => {
                 notification.error({
@@ -74,6 +110,8 @@ function AnnotationGuidePage(): JSX.Element {
                 setFetching(false);
             });
         }
+
+        return Promise.resolve();
     }, [guide]);
 
     const handleInsertFiles = useCallback(async (files: FileList): Promise<void> => {
@@ -125,9 +163,11 @@ function AnnotationGuidePage(): JSX.Element {
                 setFetching(false);
             }
 
-            await submit(computeNewValue());
+            const finalValue = computeNewValue();
+            saveDraft(finalValue);
+            await submit(finalValue);
         }
-    }, [guide, value]);
+    }, [guide, saveDraft, submit]);
 
     return (
         <Row
@@ -148,7 +188,7 @@ function AnnotationGuidePage(): JSX.Element {
                         ref={mdEditorRef}
                         value={value}
                         onChange={(val: string | undefined) => {
-                            setValue(val || '');
+                            updateValue(val || '');
                         }}
                         onPaste={(event: React.ClipboardEvent) => {
                             const { clipboardData } = event;

--- a/cvat-ui/src/components/md-guide/guide-drafts.ts
+++ b/cvat-ui/src/components/md-guide/guide-drafts.ts
@@ -1,0 +1,75 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import { AnnotationGuide } from 'cvat-core-wrapper';
+
+interface AnnotationGuideDraft {
+    markdown: string;
+    updatedAt: number;
+}
+
+function getGuideDraftStorageKey(guideId: number): string {
+    // guide id is unique across orgs so we don't need to scope to org id in the key
+    // if it changes later it needs to be included here
+    return `drafts/guides/${guideId}`;
+}
+
+export function clearGuideDraft(guideId: number): void {
+    try {
+        localStorage.removeItem(getGuideDraftStorageKey(guideId));
+    } catch {
+        // Ignore errors.
+    }
+}
+
+export function readGuideDraft(guideId: number): AnnotationGuideDraft | null {
+    try {
+        const serializedDraft = localStorage.getItem(getGuideDraftStorageKey(guideId));
+
+        if (!serializedDraft) {
+            return null;
+        }
+
+        const parsedDraft = JSON.parse(serializedDraft) as Partial<AnnotationGuideDraft>;
+        if (typeof parsedDraft.markdown === 'string' && typeof parsedDraft.updatedAt === 'number') {
+            return {
+                markdown: parsedDraft.markdown,
+                updatedAt: parsedDraft.updatedAt,
+            };
+        }
+
+        clearGuideDraft(guideId);
+    } catch {
+        clearGuideDraft(guideId);
+    }
+
+    return null;
+}
+
+export function saveGuideDraft(guideId: number, markdown: string): void {
+    try {
+        const draft: AnnotationGuideDraft = {
+            markdown,
+            updatedAt: Date.now(),
+        };
+
+        localStorage.setItem(getGuideDraftStorageKey(guideId), JSON.stringify(draft));
+    } catch {
+        // Best-effort approach. Ignore errors.
+    }
+}
+
+export function shouldRestoreGuideDraft(draft: AnnotationGuideDraft, guide: AnnotationGuide): boolean {
+    if (!guide.updatedDate) {
+        return false;
+    }
+
+    const guideUpdatedAt = Date.parse(guide.updatedDate);
+
+    if (Number.isNaN(guideUpdatedAt)) {
+        return false;
+    }
+
+    return guideUpdatedAt < draft.updatedAt;
+}


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Resolves https://github.com/cvat-ai/cvat/issues/10303

Unsaved changes in the annotation guide editor are lost when navigating away or closing the tab. There's no warning that the changes will be lost.

This PR adds basic best-effort local draft persistence for annotation guides so unsaved changes can survive page reloads and navigation away from the editor.

Changes:

* Saves markdown edits to localStorage using guide-specific keys.
* Restores a local draft on opening. Notifies that the local draft is restored.
<img width="499" height="164" alt="image" src="https://github.com/user-attachments/assets/5aa61ef5-9982-4874-82be-718c28e472f4" />

* Restores a local draft only when its updatedAt is newer than the guide’s server updatedDate.
* Clears the local draft after a successful guide save or if the newer guide version comes from the backend.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Tested manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
