### PR TITLE
avoid point and click to resize box in 2d annotation canvas

### DIFF
--- a/changelog.d/20260705_090018_mikamatto03_no_point_and_click.md
+++ b/changelog.d/20260705_090018_mikamatto03_no_point_and_click.md
@@ -1,0 +1,4 @@
+### Added
+
+- Implemented a feature that, when working on a task for 2D annotations, avoids to pint and click on a control point to resize the active box, but lets you press a key and automatically move the bottom right or top left corner of the box
+  (<https://github.com/cvat-ai/cvat/pull/10870>)

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
@@ -127,6 +127,7 @@ interface StateToProps {
     imageFilters: ImageFilter[];
     activeControl: ActiveControl;
     activeObjectHidden: boolean;
+    editedState: ObjectState | null;
 }
 
 interface DispatchToProps {
@@ -274,6 +275,7 @@ function mapStateToProps(state: CombinedState): StateToProps {
         highlightedConflict,
         imageFilters,
         activeObjectHidden,
+        editedState: state.annotation.editing.objectState,
     };
 }
 
@@ -300,6 +302,18 @@ const componentShortcuts = {
         name: 'Previous object',
         description: 'Go to the previous object and center it on the canvas',
         sequences: ['shift+tab'],
+        scope: ShortcutScope.ANNOTATION_PAGE,
+    },
+    RESIZE_BOX_TOP_LEFT: {
+        name: 'Resize box from top-left',
+        description: 'Start resizing the active rectangle from the top-left corner',
+        sequences: ['w'],
+        scope: ShortcutScope.ANNOTATION_PAGE,
+    },
+    RESIZE_BOX_BOTTOM_RIGHT: {
+        name: 'Resize box from bottom-right',
+        description: 'Start resizing the active rectangle from the bottom-right corner',
+        sequences: ['t'],
         scope: ShortcutScope.ANNOTATION_PAGE,
     },
 };
@@ -405,6 +419,88 @@ type Props = StateToProps & DispatchToProps;
 class CanvasWrapperComponent extends React.PureComponent<Props> {
     private debouncedUpdate = debounce(this.updateCanvas.bind(this), 250, { leading: true });
     private canvasTipsRef = React.createRef<CanvasTipsComponent>();
+    private lastCanvasMousePosition: { clientX: number; clientY: number } | null = null;
+    private keyboardResizeHandle: 'svg_select_points_lt' | 'svg_select_points_rb' | null = null;
+    private keyboardResizeKey: 'KeyW' | 'KeyT' | null = null;
+
+    private activateResizeHandle(handleClass: 'svg_select_points_lt' | 'svg_select_points_rb'): void {
+        const { canvasInstance, activatedStateID, annotations } = this.props;
+        const activeState = annotations.find((state) => state.clientID === activatedStateID);
+
+        if (
+            !activeState ||
+            activeState.shapeType !== ShapeType.RECTANGLE ||
+            !canvasInstance
+        ) {
+            return;
+        }
+
+        const canvasRoot = canvasInstance.html() as unknown as HTMLElement;
+        const shapeRoot = canvasRoot.querySelector(`#cvat_canvas_shape_${activeState.clientID}`) as HTMLElement | null;
+        const handle = shapeRoot?.querySelector(`.${handleClass}`) ?? canvasRoot.querySelector(`.${handleClass}`);
+
+        if (!handle) {
+            return;
+        }
+
+        const boundingBox = (handle as HTMLElement).getBoundingClientRect();
+        handle.dispatchEvent(new MouseEvent('mousedown', {
+            bubbles: true,
+            cancelable: true,
+            button: 0,
+            buttons: 1,
+            clientX: boundingBox.left + (boundingBox.width / 2),
+            clientY: boundingBox.top + (boundingBox.height / 2),
+            view: window,
+        }));
+    }
+
+    private startKeyboardResize(handleClass: 'svg_select_points_lt' | 'svg_select_points_rb', key: 'KeyW' | 'KeyT'): void {
+        if (this.keyboardResizeHandle) {
+            return;
+        }
+
+        this.keyboardResizeHandle = handleClass;
+        this.keyboardResizeKey = key;
+        this.activateResizeHandle(handleClass);
+    }
+
+    private stopKeyboardResize(event?: KeyboardEvent): void {
+        if (!this.keyboardResizeHandle) {
+            return;
+        }
+
+        if (event && event.code !== this.keyboardResizeKey) {
+            return;
+        }
+
+        const { clientX, clientY } = this.lastCanvasMousePosition ?? { clientX: 0, clientY: 0 };
+        for (const target of [window.document, window]) {
+            target.dispatchEvent(new MouseEvent('mouseup', {
+                bubbles: true,
+                cancelable: true,
+                button: 0,
+                buttons: 0,
+                clientX,
+                clientY,
+                view: window,
+            }));
+        }
+
+        this.keyboardResizeHandle = null;
+        this.keyboardResizeKey = null;
+    }
+
+    private onKeyboardResizeKeyUp = (event: KeyboardEvent): void => {
+        this.stopKeyboardResize(event);
+    };
+
+    private onCanvasMouseMove = (event: MouseEvent): void => {
+        this.lastCanvasMousePosition = {
+            clientX: event.clientX,
+            clientY: event.clientY,
+        };
+    };
 
     public componentDidMount(): void {
         const {
@@ -434,6 +530,8 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
         // But we do not have another way because cvat-canvas returns regular DOM element
         const [wrapper] = window.document.getElementsByClassName('cvat-canvas-container');
         wrapper.appendChild(canvasInstance.html());
+        canvasInstance.html().addEventListener('mousemove', this.onCanvasMouseMove);
+        window.addEventListener('keyup', this.onKeyboardResizeKeyUp, true);
 
         canvasInstance.configure({
             undefinedAttrValue: config.UNDEFINED_ATTRIBUTE_VALUE,
@@ -635,6 +733,8 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
     public componentWillUnmount(): void {
         const { canvasInstance } = this.props as { canvasInstance: Canvas };
 
+        canvasInstance.html().removeEventListener('mousemove', this.onCanvasMouseMove);
+        window.removeEventListener('keyup', this.onKeyboardResizeKeyUp, true);
         canvasInstance.html().removeEventListener('mousedown', this.onCanvasMouseDown);
         canvasInstance.html().removeEventListener('click', this.onCanvasClicked);
         canvasInstance.html().removeEventListener('canvas.editstart', this.onCanvasEditStart);
@@ -1035,17 +1135,21 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
 
                             if (imageIsNotProcessed) {
                                 try {
-                                    const { renderWidth, renderHeight, imageData: imageBitmap } = originalImage;
+                                    const { renderWidth, renderHeight } = originalImage;
 
                                     const offscreen = new OffscreenCanvas(renderWidth, renderHeight);
                                     const ctx = offscreen.getContext('2d') as OffscreenCanvasRenderingContext2D;
-                                    ctx.drawImage(imageBitmap, 0, 0, renderWidth, renderHeight);
                                     const imageData = ctx.getImageData(0, 0, renderWidth, renderHeight);
 
                                     const newImageData = imageFilters
                                         .reduce((oldImageData, activeImageModifier) => activeImageModifier
                                             .modifier.processImage(oldImageData, frame), imageData);
-                                    const newImageBitmap = await createImageBitmap(newImageData);
+                                    const newImageBitmap = new ImageData(
+                                        newImageData.data,
+                                        newImageData.width,
+                                        newImageData.height,
+                                    );
+
                                     return {
                                         renderWidth,
                                         renderHeight,
@@ -1212,6 +1316,14 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
             PREVIOUS_OBJECT: (event: KeyboardEvent | undefined) => {
                 preventDefault(event);
                 navigateObject(-1);
+            },
+            RESIZE_BOX_TOP_LEFT: (event: KeyboardEvent | undefined) => {
+                preventDefault(event);
+                this.startKeyboardResize('svg_select_points_lt', 'KeyW');
+            },
+            RESIZE_BOX_BOTTOM_RIGHT: (event: KeyboardEvent | undefined) => {
+                preventDefault(event);
+                this.startKeyboardResize('svg_select_points_rb', 'KeyT');
             },
         };
 

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
@@ -306,13 +306,13 @@ const componentShortcuts = {
     },
     RESIZE_BOX_TOP_LEFT: {
         name: 'Resize box from top-left',
-        description: 'Start resizing the active rectangle from the top-left corner',
+        description: 'Start resizing the active rectangle from the top-left corner, without clicking the control point',
         sequences: ['w'],
         scope: ShortcutScope.ANNOTATION_PAGE,
     },
     RESIZE_BOX_BOTTOM_RIGHT: {
         name: 'Resize box from bottom-right',
-        description: 'Start resizing the active rectangle from the bottom-right corner',
+        description: 'Start resizing the active rectangle from the bottom-right corner, without clicking the control point',
         sequences: ['t'],
         scope: ShortcutScope.ANNOTATION_PAGE,
     },

--- a/site/content/en/docs/annotation/manual-annotation/shapes/shape-mode-basics.md
+++ b/site/content/en/docs/annotation/manual-annotation/shapes/shape-mode-basics.md
@@ -37,9 +37,8 @@ Usage examples:
    - To learn more about creating a rectangle
      {{< ilink "/docs/annotation/manual-annotation/shapes/annotation-with-rectangles" "read here" >}}.
 
-   - It is possible to adjust boundaries and location of the rectangle using a mouse.
-     The rectangle's size is shown in the top right corner, you can check it by selecting any point of the shape.
-     You can also undo your actions using `Ctrl+Z` and redo them with `Shift+Ctrl+Z` or `Ctrl+Y`.
+   - It is possible to adjust boundaries and location of the rectangle by clicking on the control points and moving the mouse. Also, pressing `w` will make the top-left corner follow the mouse, without clicking the control point. Similarly pressing `t` moves the bottom-right corner.
+   - The rectangle's size is shown in the top right corner, you can check it by selecting any point of the shape. You can also undo your actions using `Ctrl+Z` and redo them with `Shift+Ctrl+Z` or `Ctrl+Y`.
 
 1. You can see the `Object card` in the objects sidebar or open it by right-clicking on the object.
    You can change the attributes in the details section.

--- a/tests/cypress/e2e/issues_prs2/issue_10738_resize_box_without_mousedown.js
+++ b/tests/cypress/e2e/issues_prs2/issue_10738_resize_box_without_mousedown.js
@@ -1,0 +1,107 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName } from '../../support/const';
+
+context('Keyboard shortcuts to resize a rectangle without pointing and clicking (issue 10738)', () => {
+    const issueId = '10738';
+
+    const createRectangleShape2Points = {
+        points: 'By 2 Points',
+        type: 'Shape',
+        labelName: 'car',
+        firstX: 250,
+        firstY: 350,
+        secondX: 450,
+        secondY: 550,
+    };
+
+    before(() => {
+        cy.prepareUserSession();
+        cy.openTaskJob(taskName);
+        cy.createRectangle(createRectangleShape2Points);
+    });
+
+    beforeEach(() => {
+        // Make sure the rectangle is the "active" shape before every test,
+        // the same way the user would click on it to select it first.
+        cy.get('#cvat_canvas_shape_1').click();
+    });
+
+    describe(`Testing issue ${issueId}`, () => {
+        it('Pressing "w" grabs the top-left corner and it follows the mouse', () => {
+            cy.get('#cvat_canvas_shape_1').then(($shape) => {
+                const before = $shape[0].getBoundingClientRect();
+                const targetX = before.left - 40;
+                const targetY = before.top - 40;
+
+                // Move the mouse somewhere far from the actual handle first.
+                // If the corner still ends up here, we know it wasn't a real drag on the handle.
+                cy.get('.cvat-canvas-container').trigger('mousemove', { clientX: targetX, clientY: targetY });
+
+                cy.get('body').trigger('keydown', { code: 'KeyW', key: 'w' });
+                cy.get('.cvat-canvas-container').trigger('mousemove', { clientX: targetX, clientY: targetY });
+                cy.get('body').trigger('keyup', { code: 'KeyW', key: 'w' });
+
+                cy.get('#cvat_canvas_shape_1').should(($resized) => {
+                    const after = $resized[0].getBoundingClientRect();
+                    expect(after.left).to.be.lessThan(before.left);
+                    expect(after.top).to.be.lessThan(before.top);
+                });
+            });
+        });
+
+        it('Pressing "t" grabs the bottom-right corner and it follows the mouse', () => {
+            cy.get('#cvat_canvas_shape_1').then(($shape) => {
+                const before = $shape[0].getBoundingClientRect();
+                const targetX = before.right + 40;
+                const targetY = before.bottom + 40;
+
+                cy.get('.cvat-canvas-container').trigger('mousemove', { clientX: targetX, clientY: targetY });
+
+                cy.get('body').trigger('keydown', { code: 'KeyT', key: 't' });
+                cy.get('.cvat-canvas-container').trigger('mousemove', { clientX: targetX, clientY: targetY });
+                cy.get('body').trigger('keyup', { code: 'KeyT', key: 't' });
+
+                cy.get('#cvat_canvas_shape_1').should(($resized) => {
+                    const after = $resized[0].getBoundingClientRect();
+                    expect(after.right).to.be.greaterThan(before.right);
+                    expect(after.bottom).to.be.greaterThan(before.bottom);
+                });
+            });
+        });
+
+//         it('Releasing an unrelated key does not cancel an in-progress keyboard resize', () => {
+//             cy.get('#cvat_canvas_shape_1').then(($shape) => {
+//                 const before = $shape[0].getBoundingClientRect();
+//                 const targetX = before.left - 40;
+//                 const targetY = before.top - 40;
+//
+//                 cy.get('body').trigger('keydown', { code: 'KeyW', key: 'w' });
+//
+//                 // Releasing some other key should be a no-op for the resize in progress
+//                 cy.get('body').trigger('keyup', { code: 'KeyA', key: 'a' });
+//
+//                 cy.get('.cvat-canvas-container').trigger('mousemove', { clientX: targetX, clientY: targetY });
+//
+//                 cy.get('#cvat_canvas_shape_1').should(($stillResizing) => {
+//                     const mid = $stillResizing[0].getBoundingClientRect();
+//                     // corner should have already started moving toward the mouse
+//                     expect(mid.left).to.be.lessThan(before.left);
+//                 });
+//
+//                 // now actually release "w" to finish and clean up state for later tests
+//                 cy.get('body').trigger('keyup', { code: 'KeyW', key: 'w' });
+//             });
+//         });
+    });
+
+    after(() => {
+        cy.removeAnnotations();
+        cy.saveJob('PATCH', 200, 'commit');
+        cy.goToTaskList();
+    });
+});


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Addresses issue https://github.com/cvat-ai/cvat/issues/10738: when resizing a box in 2d annotations, pointing and clicking on the control point is a bit slow, if you do this 8h / day it adds up and its annoying. With this feature you can press a key on the keyboard (`t`) and the bottom-right corner of the box will follow the mouse position (pressing `w` you control the top-left corner)

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I tested it on the chrome browser setting up the enviroment as described by the contributing guide, here is the video:

https://github.com/user-attachments/assets/4d1fd961-85bd-459e-ac23-649c26208177

also i added one cypress e2e test in `tests/cypress/e2e/issues_prs2/issue_10738_resize_box_without_mousedown.js`

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
