### PR TITLE
Fix mask bounding box not shrinking after removing underlying pixels

### DIFF
--- a/changelog.d/20260706_175017_nikborovets_fix_mask_bbox_underlying_pixels.md
+++ b/changelog.d/20260706_175017_nikborovets_fix_mask_bbox_underlying_pixels.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed mask bounding box not shrinking after removing underlying pixels
+  when another mask overlaps it with the "Remove underlying pixels" option enabled

--- a/changelog.d/20260706_175017_nikborovets_fix_mask_bbox_underlying_pixels.md
+++ b/changelog.d/20260706_175017_nikborovets_fix_mask_bbox_underlying_pixels.md
@@ -2,3 +2,4 @@
 
 - Fixed mask bounding box not shrinking after removing underlying pixels
   when another mask overlaps it with the "Remove underlying pixels" option enabled
+  (<https://github.com/cvat-ai/cvat/pull/10872>)

--- a/cvat-core/src/annotations-objects/mask-shape.ts
+++ b/cvat-core/src/annotations-objects/mask-shape.ts
@@ -91,16 +91,28 @@ export class MaskShape extends Shape {
         const wrapper = {
             stashedPoints: Object.values(updatedObjects).map((object) => object.points),
             stashedRemoved: Object.values(updatedObjects).map((object) => object.removed),
+            stashedBoxes: Object.values(updatedObjects).map((object) => ({
+                left: object.left, top: object.top, right: object.right, bottom: object.bottom,
+            })),
         };
 
+        const { width: frameWidth, height: frameHeight } = this.framesInfo[frame];
         let emptyMaskOccurred = false;
         for (const object of Object.values(updatedObjects)) {
-            const points = mask2Rle(masks[object.clientID]);
-            if (points.length < 2) {
+            const rle = mask2Rle(masks[object.clientID]);
+            if (rle.length < 2) {
                 object.removed = true;
                 emptyMaskOccurred = true;
             } else {
-                object.points = points;
+                const croppedPoints = cropMask([
+                    ...rle, object.left, object.top, object.right, object.bottom,
+                ], frameWidth, frameHeight);
+                const [left, top, right, bottom] = croppedPoints.splice(-4, 4);
+                object.points = croppedPoints;
+                object.left = left;
+                object.top = top;
+                object.right = right;
+                object.bottom = bottom;
                 object.updated = Date.now();
             }
         }
@@ -109,13 +121,22 @@ export class MaskShape extends Shape {
         const undo = (): void => {
             const updatedStashedPoints = Object.values(updatedObjects).map((object) => object.points);
             const updatedStashedRemoved = Object.values(updatedObjects).map((object) => object.removed);
+            const updatedStashedBoxes = Object.values(updatedObjects).map((object) => ({
+                left: object.left, top: object.top, right: object.right, bottom: object.bottom,
+            }));
             for (const [index, object] of Object.values(updatedObjects).entries()) {
                 object.points = wrapper.stashedPoints[index];
                 object.removed = wrapper.stashedRemoved[index];
+                const box = wrapper.stashedBoxes[index];
+                object.left = box.left;
+                object.top = box.top;
+                object.right = box.right;
+                object.bottom = box.bottom;
                 object.updated = Date.now();
             }
             wrapper.stashedPoints = updatedStashedPoints;
             wrapper.stashedRemoved = updatedStashedRemoved;
+            wrapper.stashedBoxes = updatedStashedBoxes;
         };
 
         const redo = undo;


### PR DESCRIPTION
### Motivation and context

When the "Remove underlying pixels" option is enabled and a mask is drawn/edited
over another overlapping mask, `removeUnderlyingPixels` only updated the RLE
of the overlapped masks, leaving their `left/top/right/bottom` bounding box
stale (i.e. not shrunk to the remaining visible pixels). As a result, the
selection/bounding box shown for the overlapped mask stayed the same size
even though part of it was erased.

This PR recomputes the bounding box via the existing `cropMask` helper
(already used elsewhere for the same purpose) right after the underlying
pixels are removed, and keeps the undo/redo stash in sync with the new box
so history navigation stays consistent.

### How has this been tested?

- Verified TypeScript compiles cleanly (`tsc --noEmit`) and ESLint reports
  no issues for the changed file.
- Ran `python3 dev/check_changelog_fragments.py` — no issues reported.
- Manually tested in a locally built CVAT instance
  (`docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build`):
  created two overlapping masks with "Remove underlying pixels" enabled,
  edited/erased one mask over the other, and confirmed the overlapped
  mask's bounding box now shrinks to the remaining visible pixels.
  Also verified undo/redo restores the correct bounding box.

### Checklist
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- ~~I have updated the documentation accordingly~~
- [ ] I have added tests to cover my changes
- ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.