### PR TITLE
fix timeouts in rq rest api tests

### DIFF
--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -323,6 +323,7 @@ REDIS_INMEM_SETTINGS = {
     "PASSWORD": redis_inmem_password,
     "REDIS_CLIENT_KWARGS": {
         "socket_timeout": None,
+        # workaround for RQ 2.0: https://github.com/rq/rq/pull/2120
     },
 }
 

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -321,6 +321,9 @@ REDIS_INMEM_SETTINGS = {
     "PORT": redis_inmem_port,
     "DB": REDIS_INMEM_DATABASES.RQ,
     "PASSWORD": redis_inmem_password,
+    "REDIS_CLIENT_KWARGS": {
+        "socket_timeout": None,
+    },
 }
 
 RQ_QUEUES = {

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -322,8 +322,10 @@ REDIS_INMEM_SETTINGS = {
     "DB": REDIS_INMEM_DATABASES.RQ,
     "PASSWORD": redis_inmem_password,
     "REDIS_CLIENT_KWARGS": {
+        # Work around an RQ < 2.0 bug where Redis socket timeouts can be too short
+        # for blocking operations such as BLPOP. Fixed upstream in RQ 2.0:
+        # https://github.com/rq/rq/pull/2120
         "socket_timeout": None,
-        # workaround for RQ 2.0: https://github.com/rq/rq/pull/2120
     },
 }
 

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -322,7 +322,7 @@ REDIS_INMEM_SETTINGS = {
     "DB": REDIS_INMEM_DATABASES.RQ,
     "PASSWORD": redis_inmem_password,
     "REDIS_CLIENT_KWARGS": {
-        "socket_timeout": 600,
+        "socket_timeout": None,
         "socket_connect_timeout": 30,
         "health_check_interval": 30,
     },

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -322,7 +322,9 @@ REDIS_INMEM_SETTINGS = {
     "DB": REDIS_INMEM_DATABASES.RQ,
     "PASSWORD": redis_inmem_password,
     "REDIS_CLIENT_KWARGS": {
-        "socket_timeout": None,
+        "socket_timeout": 600,
+        "socket_connect_timeout": 30,
+        "health_check_interval": 30,
     },
 }
 

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -323,8 +323,6 @@ REDIS_INMEM_SETTINGS = {
     "PASSWORD": redis_inmem_password,
     "REDIS_CLIENT_KWARGS": {
         "socket_timeout": None,
-        "socket_connect_timeout": 30,
-        "health_check_interval": 30,
     },
 }
 


### PR DESCRIPTION

We've recently had many blocking failures of rest api tests and performance tests

### Root Cause
Redis library bump 4.6.0 → 8.0.1 (PR #10760) changed socket_timeout semantics.

### Before upgrade:

- Workers sent blocking requests to Redis waiting for new jobs
- Request lifetime: 405 seconds (derived from DEFAULT_WORKER_TTL = 420, timeout = TTL - 15)
- If no job arrived, request timed out gracefully, new request sent
- Normal behavior in prod logs:
```
[2026-07-07 17:10:28] DEBUG rq.worker: Dequeueing jobs on queues quality_reports and timeout 405
[2026-07-07 17:17:13] DEBUG rq.worker: Sent heartbeat to prevent worker timeout. Next one should arrive in 480 seconds.
```
### After upgrade:

- Redis library introduces default request timeout
- Workers still send blocking requests, but they terminate after ~1 minute
- Exception unhandled → worker killed
- Worker restarts follow

Example from REST API tests:

```
[2026-07-03 10:15:37] DEBUG rq.worker: Dequeueing jobs on queues quality_reports and timeout 405
[2026-07-03 10:16:29] DEBUG rq.worker: Got signal SIGTERM
[2026-07-03 10:16:29] INFO rq.worker: warm shut down requested
```

### Impact
- Workers and server containers share cpu_set
- During restarts, CPU load spikes
- Performance tests degrade due to noise from frequent restarts
Fix: Restore previous behavior for Redis in-memory connections

Although, just setting `{'socket_timeout': None}` didn't work (tests red with rq failures), so with help of ChatGPT I added extra timeouts


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
