### PR TITLE
Prevent RQ worker Redis socket timeouts

### DIFF
--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -321,6 +321,9 @@ REDIS_INMEM_SETTINGS = {
     "PORT": redis_inmem_port,
     "DB": REDIS_INMEM_DATABASES.RQ,
     "PASSWORD": redis_inmem_password,
+    "REDIS_CLIENT_KWARGS": {
+        "socket_timeout": None,
+    },
 }
 
 RQ_QUEUES = {


### PR DESCRIPTION
### Motivation and context

Redis-py 8 changed connection timeout behavior, which can interrupt RQ workers while they are waiting on blocking Redis dequeue commands such as `BLMOVE` / `BLPOP`.

In CVAT, idle RQ workers use Redis blocking reads with RQ’s dequeue timeout. With the newer Redis client defaults, workers can exit early with Redis connection timeout errors, then get restarted by supervisor. This creates Redis connection churn and extra worker overhead, which can affect API performance under load.

This change restores the expected blocking queue-consumer behavior for RQ Redis connections by setting `socket_timeout` to `None` in `REDIS_INMEM_SETTINGS`.

### How has this been tested?

Manually

### Checklist

- [x] I submit my changes into the `develop` branch
- [ ] ~~I have created a changelog fragment~~
- [ ] ~~I have updated the documentation accordingly~~
- [ ] ~~I have added tests to cover my changes~~
- [ ] ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.