### PR TITLE
Change skeleton control points to be visually distinguishable from annotation

### DIFF
--- a/changelog.d/20260708_151521_aleksey.zinovyev_skeleton_cp_visual_change.md
+++ b/changelog.d/20260708_151521_aleksey.zinovyev_skeleton_cp_visual_change.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Change skeleton control points display to be visually distinguishable from the annotation points
+  (<https://github.com/cvat-ai/cvat/pull/10879>)

--- a/cvat-canvas/src/scss/canvas.scss
+++ b/cvat-canvas/src/scss/canvas.scss
@@ -328,14 +328,7 @@ g.cvat_canvas_shape_occluded {
     // wrapping rect must not apply transform attribute from selectize.js
     // otherwise it rotated twice, because we apply the same rotation value to parent element (skeleton itself)
     transform: none !important;
-}
-
-.cvat_canvas_shape > .cvat_canvas_skeleton_wrapping_rect {
     visibility: hidden;
-}
-
-.cvat_canvas_shape.cvat_canvas_shape_activated > .cvat_canvas_skeleton_wrapping_rect {
-    visibility: initial;
 }
 
 .cvat_canvas_pixelized {

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -1290,13 +1290,16 @@ export class CanvasViewImpl implements CanvasView, Listener {
     }
 
     private refreshSkeletonControlPointDecorators(): void {
-        // there can be only one selection on canvas so we handle first element only
-        const [element] = window.document.getElementsByClassName('cvat_canvas_skeleton_select_wrapper');
-        if (!element) {
+        const { clientID } = this.activeElement;
+        if (clientID === null || this.drawnStates[clientID]?.shapeType !== 'skeleton') {
             return;
         }
 
-        const selectContainer = (element as SVG.LinkedHTMLElement).instance as SVG.Container;
+        const skeleton = this.svgShapes[clientID] as SVG.G;
+        const wrappingRect = skeleton.children().find((child: SVG.Element): boolean => (
+            child.hasClass('cvat_canvas_skeleton_wrapping_rect')
+        ));
+        const selectContainer = wrappingRect?.remember('_selectHandler')?.nested as SVG.Container | undefined;
         if (!selectContainer) {
             return;
         }
@@ -1504,7 +1507,6 @@ export class CanvasViewImpl implements CanvasView, Listener {
         if (handler && handler.nested) {
             handler.nested.fill(shape.attr('fill'));
             if (value && isSkeletonRect) {
-                handler.nested.addClass('cvat_canvas_skeleton_select_wrapper');
                 this.setupSkeletonControlPointViews(handler.nested);
             }
         }

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -91,7 +91,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
     private snapToAngleResize: number;
     private draggableShape: SVG.Shape | null;
     private resizableShape: SVG.Shape | null;
-    private skeletonControlPointDecoratorsRefreshRequest: number | null;
+    private skeletonResizerRefreshRequest: number | null;
     private ctrlPressed: boolean;
     private innerObjectsFlags: {
         drawHidden: Record<number, boolean>;
@@ -887,7 +887,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
         this.regionSelector.transform(this.geometry);
 
         this.refreshRotationPointView();
-        this.refreshSkeletonControlPointDecorators();
+        this.refreshSkeletonResizer();
     }
 
     private resizeCanvas(): void {
@@ -1110,7 +1110,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
         pathElement.dmove(-pathElement.width() / 2, -pathElement.height() / 2);
     }
 
-    private static getSkeletonResizeHandle(point: SVG.Element): string | null {
+    private static getSkeletonResizerHandle(point: SVG.Element): string | null {
         const handles = ['lt', 'rt', 'rb', 'lb', 't', 'r', 'b', 'l'];
         return handles.find((handle: string): boolean => point.hasClass(`svg_select_points_${handle}`)) ?? null;
     }
@@ -1119,12 +1119,12 @@ export class CanvasViewImpl implements CanvasView, Listener {
         return size / this.geometry.scale;
     }
 
-    private updateSkeletonControlPointDecoratorView(element: Element, hovered: boolean): void {
-        const isOuterStroke = element.classList.contains('cvat_canvas_skeleton_control_point_decorator_outer');
+    private updateSkeletonResizerView(element: Element, hovered: boolean): void {
+        const isOuterStroke = element.classList.contains('cvat_canvas_skeleton_resizer_outer');
         const strokeWidth =
             isOuterStroke && hovered ? consts.POINTS_SELECTED_STROKE_WIDTH : 2 * consts.POINTS_STROKE_WIDTH;
 
-        element.classList.toggle('cvat_canvas_skeleton_control_point_decorator_hovered', hovered);
+        element.classList.toggle('cvat_canvas_skeleton_resizer_hovered', hovered);
         element.setAttribute('stroke-opacity', hovered ? '1' : '0.8');
         element.setAttribute(
             'stroke-width',
@@ -1132,8 +1132,8 @@ export class CanvasViewImpl implements CanvasView, Listener {
         );
     }
 
-    private toggleSkeletonControlPointDecorator(point: SVG.Element, hovered: boolean): void {
-        const handle = CanvasViewImpl.getSkeletonResizeHandle(point);
+    private toggleSkeletonResizer(point: SVG.Element, hovered: boolean): void {
+        const handle = CanvasViewImpl.getSkeletonResizerHandle(point);
         if (!handle) {
             return;
         }
@@ -1143,14 +1143,14 @@ export class CanvasViewImpl implements CanvasView, Listener {
             return;
         }
 
-        for (const decorator of parent.getElementsByClassName(
-            `cvat_canvas_skeleton_control_point_decorator_${handle}`,
+        for (const resizer of parent.getElementsByClassName(
+            `cvat_canvas_skeleton_resizer_${handle}`,
         )) {
-            this.updateSkeletonControlPointDecoratorView(decorator, hovered);
+            this.updateSkeletonResizerView(resizer, hovered);
         }
     }
 
-    private setupSkeletonControlPointViews(container: SVG.Container): void {
+    private setupSkeletonResizer(container: SVG.Container): void {
         const boundingRect = container.children().find((element: SVG.Element): boolean => (
             element.hasClass('svg_select_boundingRect')
         ));
@@ -1165,7 +1165,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
         const boundingRectWidth = Math.max(boundingRect.width(), controlPointDiameter);
         const boundingRectHeight = Math.max(boundingRect.height(), controlPointDiameter);
         // we don't want it to be smaller than 3x width of the stroke we're using so it's a minimum size
-        // we aim towards 1.7 of the controlPoint (hitbox) but we don't want decorators to cover
+        // we aim towards 1.7 of the controlPoint (hitbox) but we don't want resizers to cover
         // full width or full height so we limit their size with width/3 or height/3
         // so they take up to 2/3 of the size length max
         const cornerLength = Math.max(
@@ -1179,7 +1179,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
         );
         const innerStrokeOffset = this.screenToCanvasSize(2 * consts.POINTS_STROKE_WIDTH);
 
-        const decoratorPath = (handle: string, cx: number, cy: number, inset = 0): string => {
+        const resizerPath = (handle: string, cx: number, cy: number, inset = 0): string => {
             switch (handle) {
                 case 'lt':
                     return `M ${cx + inset} ${cy + cornerLength}
@@ -1214,11 +1214,11 @@ export class CanvasViewImpl implements CanvasView, Listener {
             }
         };
 
-        // clean previous decorators
-        for (const decorator of Array.from(
-            container.node.getElementsByClassName('cvat_canvas_skeleton_control_point_decorator'),
+        // clean previous resizers
+        for (const resizer of Array.from(
+            container.node.getElementsByClassName('cvat_canvas_skeleton_resizer'),
         )) {
-            decorator.parentNode?.removeChild(decorator);
+            resizer.parentNode?.removeChild(resizer);
         }
 
         const controlPoints = container.children().filter((point: SVG.Element): boolean => (
@@ -1226,14 +1226,14 @@ export class CanvasViewImpl implements CanvasView, Listener {
             (point.hasClass('svg_select_points') || point.hasClass('svg_select_points_rot'))
         ));
 
-        // ensure control points attrs and create fresh decorators
+        // ensure control points attrs and create a fresh resizer
         for (const point of controlPoints) {
             const isRotationPoint = point.hasClass('svg_select_points_rot');
             // we keep control points other than the rotation point invisible as hitboxes
-            // and they define decorators positions.
-            // we do not replace them with decorators directly because svg.select manages
+            // and they define resizer positions.
+            // we do not replace them with resizers directly because svg.select manages
             // these controls as circles positioning their center and using radius
-            // passing not round decorators directly causes weird calculations and requires ugly code
+            // passing non-round resizers directly causes weird calculations and requires ugly code
             if (!point.hasClass('cvat_canvas_skeleton_control_point')) {
                 point
                     .addClass('cvat_canvas_skeleton_control_point')
@@ -1255,41 +1255,41 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 continue;
             }
 
-            const handle = CanvasViewImpl.getSkeletonResizeHandle(point);
+            const handle = CanvasViewImpl.getSkeletonResizerHandle(point);
             if (!handle) {
                 continue;
             }
 
             const isHovered = point.hasClass('cvat_canvas_selected_point');
-            const outerPath = decoratorPath(handle, point.cx(), point.cy());
-            const innerPath = decoratorPath(handle, point.cx(), point.cy(), innerStrokeOffset);
-            const outerDecorator = container
+            const outerPath = resizerPath(handle, point.cx(), point.cy());
+            const innerPath = resizerPath(handle, point.cx(), point.cy(), innerStrokeOffset);
+            const outerResizer = container
                 .path(outerPath)
-                .addClass('cvat_canvas_skeleton_control_point_decorator')
-                .addClass('cvat_canvas_skeleton_control_point_decorator_outer')
-                .addClass(`cvat_canvas_skeleton_control_point_decorator_${handle}`)
+                .addClass('cvat_canvas_skeleton_resizer')
+                .addClass('cvat_canvas_skeleton_resizer_outer')
+                .addClass(`cvat_canvas_skeleton_resizer_${handle}`)
                 .attr({
                     fill: 'none',
                     stroke: 'black',
                     'pointer-events': 'none',
                 });
-            const innerDecorator = container
+            const innerResizer = container
                 .path(innerPath)
-                .addClass('cvat_canvas_skeleton_control_point_decorator')
-                .addClass('cvat_canvas_skeleton_control_point_decorator_inner')
-                .addClass(`cvat_canvas_skeleton_control_point_decorator_${handle}`)
+                .addClass('cvat_canvas_skeleton_resizer')
+                .addClass('cvat_canvas_skeleton_resizer_inner')
+                .addClass(`cvat_canvas_skeleton_resizer_${handle}`)
                 .attr({
                     fill: 'none',
                     stroke: 'white',
                     'pointer-events': 'none',
                 });
 
-            this.updateSkeletonControlPointDecoratorView(outerDecorator.node, isHovered);
-            this.updateSkeletonControlPointDecoratorView(innerDecorator.node, isHovered);
+            this.updateSkeletonResizerView(outerResizer.node, isHovered);
+            this.updateSkeletonResizerView(innerResizer.node, isHovered);
         }
     }
 
-    private refreshSkeletonControlPointDecorators(): void {
+    private refreshSkeletonResizer(): void {
         const { clientID } = this.activeElement;
         if (clientID === null || this.drawnStates[clientID]?.shapeType !== 'skeleton') {
             return;
@@ -1304,20 +1304,20 @@ export class CanvasViewImpl implements CanvasView, Listener {
             return;
         }
 
-        this.setupSkeletonControlPointViews(selectContainer);
+        this.setupSkeletonResizer(selectContainer);
     }
 
-    private scheduleSkeletonControlPointDecoratorsRefresh(): void {
-        if (this.skeletonControlPointDecoratorsRefreshRequest !== null) {
+    private scheduleSkeletonResizerRefresh(): void {
+        if (this.skeletonResizerRefreshRequest !== null) {
             return;
         }
 
         // we need to delay the refresh to the next frame during resize as otherwise
         // select handles are not yet updated if handled synchronously
         // also, potentially batches swift resize updates so its not recalculated multiple times per frame
-        this.skeletonControlPointDecoratorsRefreshRequest = window.requestAnimationFrame((): void => {
-            this.skeletonControlPointDecoratorsRefreshRequest = null;
-            this.refreshSkeletonControlPointDecorators();
+        this.skeletonResizerRefreshRequest = window.requestAnimationFrame((): void => {
+            this.skeletonResizerRefreshRequest = null;
+            this.refreshSkeletonResizer();
         });
     }
 
@@ -1435,12 +1435,12 @@ export class CanvasViewImpl implements CanvasView, Listener {
             const getGeometry = (): Geometry => this.geometry;
             const getController = (): CanvasController => this.controller;
             const getActiveElement = (): ActiveElement => this.activeElement;
-            const toggleSkeletonControlPointDecorator = (point: SVG.Element, hovered: boolean): void => {
+            const toggleSkeletonResizer = (point: SVG.Element, hovered: boolean): void => {
                 if (!isSkeletonRect) {
                     return;
                 }
 
-                this.toggleSkeletonControlPointDecorator(point, hovered);
+                this.toggleSkeletonResizer(point, hovered);
             };
             (shape as any).selectize(value, {
                 deepSelect: true,
@@ -1480,7 +1480,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         circle.on('mousedown', mousedownHandler);
                         circle.on('contextmenu', contextMenuHandler);
                         circle.addClass('cvat_canvas_selected_point');
-                        toggleSkeletonControlPointDecorator(circle, true);
+                        toggleSkeletonResizer(circle, true);
                     });
 
                     circle.on('mouseleave', (): void => {
@@ -1492,7 +1492,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         circle.off('mousedown', mousedownHandler);
                         circle.off('contextmenu', contextMenuHandler);
                         circle.removeClass('cvat_canvas_selected_point');
-                        toggleSkeletonControlPointDecorator(circle, false);
+                        toggleSkeletonResizer(circle, false);
                     });
                     return circle;
                 },
@@ -1507,7 +1507,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
         if (handler && handler.nested) {
             handler.nested.fill(shape.attr('fill'));
             if (value && isSkeletonRect) {
-                this.setupSkeletonControlPointViews(handler.nested);
+                this.setupSkeletonResizer(handler.nested);
             }
         }
 
@@ -1791,7 +1791,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         resized = true;
                         skeletonSVGTemplate = skeletonSVGTemplate ?? makeSVGFromTemplate(state.label.structure.svg);
                         setupSkeletonEdges(shape as SVG.G, skeletonSVGTemplate);
-                        this.scheduleSkeletonControlPointDecoratorsRefresh();
+                        this.scheduleSkeletonResizerRefresh();
                     }
                 })
                 .on('resizedone', (): void => {
@@ -2021,7 +2021,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
         gridRect.setAttribute('fill', 'url(#cvat_canvas_grid_pattern)');
 
         // setup skeletons supplementary state
-        this.skeletonControlPointDecoratorsRefreshRequest = null;
+        this.skeletonResizerRefreshRequest = null;
 
         // Setup content
         this.text.setAttribute('id', 'cvat_canvas_text_content');

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -91,6 +91,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
     private snapToAngleResize: number;
     private draggableShape: SVG.Shape | null;
     private resizableShape: SVG.Shape | null;
+    private skeletonControlPointDecoratorsRefreshRequest: number | null;
     private ctrlPressed: boolean;
     private innerObjectsFlags: {
         drawHidden: Record<number, boolean>;
@@ -884,6 +885,9 @@ export class CanvasViewImpl implements CanvasView, Listener {
         this.autoborderHandler.transform(this.geometry);
         this.interactionHandler.transform(this.geometry);
         this.regionSelector.transform(this.geometry);
+
+        this.refreshRotationPointView();
+        this.refreshSkeletonControlPointDecorators();
     }
 
     private resizeCanvas(): void {
@@ -1106,7 +1110,239 @@ export class CanvasViewImpl implements CanvasView, Listener {
         pathElement.dmove(-pathElement.width() / 2, -pathElement.height() / 2);
     }
 
+    private getSkeletonResizeHandle(point: SVG.Element): string | null {
+        const handles = ['lt', 'rt', 'rb', 'lb', 't', 'r', 'b', 'l'];
+        return handles.find((handle: string): boolean => point.hasClass(`svg_select_points_${handle}`)) ?? null;
+    }
+
+    private screenToCanvasSize(size: number): number {
+        return size / this.geometry.scale;
+    }
+
+    private updateSkeletonControlPointDecoratorView(element: Element, hovered: boolean): void {
+        const isOuterStroke = element.classList.contains('cvat_canvas_skeleton_control_point_decorator_outer');
+        const strokeWidth =
+            isOuterStroke && hovered ? consts.POINTS_SELECTED_STROKE_WIDTH : 2 * consts.POINTS_STROKE_WIDTH;
+
+        element.classList.toggle('cvat_canvas_skeleton_control_point_decorator_hovered', hovered);
+        element.setAttribute('stroke-opacity', hovered ? '1' : '0.8');
+        element.setAttribute(
+            'stroke-width',
+            `${this.screenToCanvasSize(strokeWidth)}`,
+        );
+    }
+
+    private toggleSkeletonControlPointDecorator(point: SVG.Element, hovered: boolean): void {
+        const handle = this.getSkeletonResizeHandle(point);
+        if (!handle) {
+            return;
+        }
+
+        const parent = point.node.parentElement;
+        if (!parent) {
+            return;
+        }
+
+        for (const decorator of parent.getElementsByClassName(
+            `cvat_canvas_skeleton_control_point_decorator_${handle}`,
+        )) {
+            this.updateSkeletonControlPointDecoratorView(decorator, hovered);
+        }
+    }
+
+    private setupSkeletonControlPointViews(container: SVG.Container): void {
+        const boundingRect = container.children().find((element: SVG.Element): boolean => (
+            element.hasClass('svg_select_boundingRect')
+        ));
+        if (!boundingRect) {
+            return;
+        }
+
+        const strokeWidth = this.screenToCanvasSize(consts.POINTS_STROKE_WIDTH);
+        const controlPointRadius = this.screenToCanvasSize(this.configuration.controlPointsSize);
+        const controlPointDiameter = 2 * controlPointRadius;
+        // For tiny BBs use controlPoint diameter as base for calculations
+        const boundingRectWidth = Math.max(boundingRect.width(), controlPointDiameter);
+        const boundingRectHeight = Math.max(boundingRect.height(), controlPointDiameter);
+        // we don't want it to be smaller than 3x width of the stroke we're using so it's a minimum size
+        // we aim towards 1.7 of the controlPoint (hitbox) but we don't want decorators to cover
+        // full width or full height so we limit their size with width/3 or height/3
+        // so they take up to 2/3 of the size length max
+        const cornerLength = Math.max(
+            strokeWidth * 3,
+            Math.min(controlPointRadius * 1.7, boundingRectWidth / 4, boundingRectHeight / 4),
+        );
+        // similar idea but we aim side segment to be a bit logner than corner segment
+        const segmentLength = Math.max(
+            strokeWidth * 4,
+            Math.min(controlPointRadius * 2.2, boundingRectWidth / 3, boundingRectHeight / 3),
+        );
+        const innerStrokeOffset = this.screenToCanvasSize(2 * consts.POINTS_STROKE_WIDTH);
+
+        const decoratorPath = (handle: string, cx: number, cy: number, inset = 0): string => {
+            switch (handle) {
+                case 'lt':
+                    return `M ${cx + inset} ${cy + cornerLength}
+                            L ${cx + inset} ${cy + inset}
+                            L ${cx + cornerLength} ${cy + inset}`;
+                case 'rt':
+                    return `M ${cx - cornerLength} ${cy + inset}
+                            L ${cx - inset} ${cy + inset}
+                            L ${cx - inset} ${cy + cornerLength}`;
+                case 'rb':
+                    return `M ${cx - inset} ${cy - cornerLength}
+                            L ${cx - inset} ${cy - inset}
+                            L ${cx - cornerLength} ${cy - inset}`;
+                case 'lb':
+                    return `M ${cx + cornerLength} ${cy - inset}
+                            L ${cx + inset} ${cy - inset}
+                            L ${cx + inset} ${cy - cornerLength}`;
+                case 't':
+                    return `M ${cx - segmentLength / 2} ${cy + inset}
+                            L ${cx + segmentLength / 2} ${cy + inset}`;
+                case 'b':
+                    return `M ${cx - segmentLength / 2} ${cy - inset}
+                            L ${cx + segmentLength / 2} ${cy - inset}`;
+                case 'r':
+                    return `M ${cx - inset} ${cy - segmentLength / 2}
+                            L ${cx - inset} ${cy + segmentLength / 2}`;
+                case 'l':
+                    return `M ${cx + inset} ${cy - segmentLength / 2}
+                            L ${cx + inset} ${cy + segmentLength / 2}`;
+                default:
+                    return '';
+            }
+        };
+
+        // clean previous decorators
+        for (const decorator of Array.from(
+            container.node.getElementsByClassName('cvat_canvas_skeleton_control_point_decorator'),
+        )) {
+            decorator.parentNode?.removeChild(decorator);
+        }
+
+        const controlPoints = container.children().filter((point: SVG.Element): boolean => (
+            point.type === 'circle' &&
+            (point.hasClass('svg_select_points') || point.hasClass('svg_select_points_rot'))
+        ));
+
+        // ensure control points attrs and create fresh decorators
+        for (const point of controlPoints) {
+            const isRotationPoint = point.hasClass('svg_select_points_rot');
+            // we keep control points other than the rotation point invisible as hitboxes
+            // and they define decorators positions.
+            // we do not replace them with decorators directly because svg.select manages
+            // these controls as circles positioning their center and using radius
+            // passing not round decorators directly causes weird calculations and requires ugly code
+            if (!point.hasClass('cvat_canvas_skeleton_control_point')) {
+                point
+                    .addClass('cvat_canvas_skeleton_control_point')
+                    .attr({
+                        fill: 'white',
+                        'fill-opacity': isRotationPoint ? 1 : 0,
+                        stroke: 'black',
+                        'stroke-opacity': isRotationPoint ? 1 : 0,
+                        'pointer-events': 'all',
+                    });
+            }
+
+            point.attr({
+                'stroke-width': strokeWidth,
+                r: controlPointRadius,
+            });
+
+            if (isRotationPoint) {
+                continue;
+            }
+
+            const handle = this.getSkeletonResizeHandle(point);
+            if (!handle) {
+                continue;
+            }
+
+            const isHovered = point.hasClass('cvat_canvas_selected_point');
+            const outerPath = decoratorPath(handle, point.cx(), point.cy());
+            const innerPath = decoratorPath(handle, point.cx(), point.cy(), innerStrokeOffset);
+            const outerDecorator = container
+                .path(outerPath)
+                .addClass('cvat_canvas_skeleton_control_point_decorator')
+                .addClass('cvat_canvas_skeleton_control_point_decorator_outer')
+                .addClass(`cvat_canvas_skeleton_control_point_decorator_${handle}`)
+                .attr({
+                    fill: 'none',
+                    stroke: 'black',
+                    'pointer-events': 'none',
+                });
+            const innerDecorator = container
+                .path(innerPath)
+                .addClass('cvat_canvas_skeleton_control_point_decorator')
+                .addClass('cvat_canvas_skeleton_control_point_decorator_inner')
+                .addClass(`cvat_canvas_skeleton_control_point_decorator_${handle}`)
+                .attr({
+                    fill: 'none',
+                    stroke: 'white',
+                    'pointer-events': 'none',
+                });
+
+            this.updateSkeletonControlPointDecoratorView(outerDecorator.node, isHovered);
+            this.updateSkeletonControlPointDecoratorView(innerDecorator.node, isHovered);
+        }
+    }
+
+    private refreshSkeletonControlPointDecorators(): void {
+        // there can be only one selection on canvas so we handle first element only
+        const [element] = window.document.getElementsByClassName('cvat_canvas_skeleton_select_wrapper');
+        if (!element) {
+            return;
+        }
+
+        const selectContainer = (element as SVG.LinkedHTMLElement).instance as SVG.Container;
+        if (!selectContainer) {
+            return;
+        }
+
+        this.setupSkeletonControlPointViews(selectContainer);
+    }
+
+    private scheduleSkeletonControlPointDecoratorsRefresh(): void {
+        if (this.skeletonControlPointDecoratorsRefreshRequest !== null) {
+            return;
+        }
+
+        // we need to delay the refresh to the next frame during resize as otherwise
+        // select handles are not yet updated if handled synchronously
+        // also, potentially batches swift resize updates so its not recalculated multiple times per frame
+        this.skeletonControlPointDecoratorsRefreshRequest = window.requestAnimationFrame((): void => {
+            this.skeletonControlPointDecoratorsRefreshRequest = null;
+            this.refreshSkeletonControlPointDecorators();
+        });
+    }
+
+    private refreshRotationPointView(): void {
+        // there can be only one selection on canvas so we handle first element only
+        const [rotationPoint] = window.document.getElementsByClassName('svg_select_points_rot');
+        const [topPoint] = window.document.getElementsByClassName('svg_select_points_t');
+        if (!rotationPoint) {
+            return;
+        }
+
+        if (topPoint) {
+            const rotY = +rotationPoint.getAttribute('cy');
+            const topY = +topPoint.getAttribute('cy');
+            const rotationPointOffset = this.screenToCanvasSize(2 * this.configuration.controlPointsSize + 5);
+            (rotationPoint as SVGElement).style.transform =
+                `translate(0px, -${rotY - topY + rotationPointOffset}px)`;
+        }
+
+        if (!rotationPoint.children.length) {
+            const title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+            title.textContent = 'Hold Shift to snap angle';
+            rotationPoint.appendChild(title);
+        }
+    }
+
     private selectize(value: boolean, shape: SVG.Element): void {
+        const isSkeletonRect = shape.hasClass('cvat_canvas_skeleton_wrapping_rect');
         const mousedownHandler = (e: MouseEvent): void => {
             if (e.button !== 0) return;
             e.preventDefault();
@@ -1196,6 +1432,13 @@ export class CanvasViewImpl implements CanvasView, Listener {
             const getGeometry = (): Geometry => this.geometry;
             const getController = (): CanvasController => this.controller;
             const getActiveElement = (): ActiveElement => this.activeElement;
+            const toggleSkeletonControlPointDecorator = (point: SVG.Element, hovered: boolean): void => {
+                if (!isSkeletonRect) {
+                    return;
+                }
+
+                this.toggleSkeletonControlPointDecorator(point, hovered);
+            };
             (shape as any).selectize(value, {
                 deepSelect: true,
                 pointSize: (2 * this.configuration.controlPointsSize) / this.geometry.scale,
@@ -1211,6 +1454,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                             'fill-opacity': 1,
                             'stroke-width': consts.POINTS_STROKE_WIDTH / getGeometry().scale,
                         });
+
                     circle.on('mouseenter', (e: MouseEvent): void => {
                         const activeElement = getActiveElement();
                         if (activeElement !== null && (e.altKey || e.ctrlKey)) {
@@ -1233,6 +1477,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         circle.on('mousedown', mousedownHandler);
                         circle.on('contextmenu', contextMenuHandler);
                         circle.addClass('cvat_canvas_selected_point');
+                        toggleSkeletonControlPointDecorator(circle, true);
                     });
 
                     circle.on('mouseleave', (): void => {
@@ -1244,6 +1489,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         circle.off('mousedown', mousedownHandler);
                         circle.off('contextmenu', contextMenuHandler);
                         circle.removeClass('cvat_canvas_selected_point');
+                        toggleSkeletonControlPointDecorator(circle, false);
                     });
                     return circle;
                 },
@@ -1257,21 +1503,13 @@ export class CanvasViewImpl implements CanvasView, Listener {
         const handler = shape.remember('_selectHandler');
         if (handler && handler.nested) {
             handler.nested.fill(shape.attr('fill'));
-        }
-
-        const [rotationPoint] = window.document.getElementsByClassName('svg_select_points_rot');
-        const [topPoint] = window.document.getElementsByClassName('svg_select_points_t');
-        if (rotationPoint && !rotationPoint.children.length) {
-            if (topPoint) {
-                const rotY = +(rotationPoint as SVGEllipseElement).getAttribute('cy');
-                const topY = +(topPoint as SVGEllipseElement).getAttribute('cy');
-                (rotationPoint as SVGCircleElement).style.transform = `translate(0px, -${rotY - topY + 20}px)`;
+            if (value && isSkeletonRect) {
+                handler.nested.addClass('cvat_canvas_skeleton_select_wrapper');
+                this.setupSkeletonControlPointViews(handler.nested);
             }
-
-            const title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
-            title.textContent = 'Hold Shift to snap angle';
-            rotationPoint.appendChild(title);
         }
+
+        this.refreshRotationPointView();
 
         if (value && shape.type === 'image') {
             const [boundingRect] = window.document.getElementsByClassName('svg_select_boundingRect');
@@ -1551,6 +1789,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         resized = true;
                         skeletonSVGTemplate = skeletonSVGTemplate ?? makeSVGFromTemplate(state.label.structure.svg);
                         setupSkeletonEdges(shape as SVG.G, skeletonSVGTemplate);
+                        this.scheduleSkeletonControlPointDecoratorsRefresh();
                     }
                 })
                 .on('resizedone', (): void => {
@@ -1778,6 +2017,9 @@ export class CanvasViewImpl implements CanvasView, Listener {
         gridRect.setAttribute('width', '100%');
         gridRect.setAttribute('height', '100%');
         gridRect.setAttribute('fill', 'url(#cvat_canvas_grid_pattern)');
+
+        // setup skeletons supplementary state
+        this.skeletonControlPointDecoratorsRefreshRequest = null;
 
         // Setup content
         this.text.setAttribute('id', 'cvat_canvas_text_content');

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -1110,7 +1110,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
         pathElement.dmove(-pathElement.width() / 2, -pathElement.height() / 2);
     }
 
-    private getSkeletonResizeHandle(point: SVG.Element): string | null {
+    private static getSkeletonResizeHandle(point: SVG.Element): string | null {
         const handles = ['lt', 'rt', 'rb', 'lb', 't', 'r', 'b', 'l'];
         return handles.find((handle: string): boolean => point.hasClass(`svg_select_points_${handle}`)) ?? null;
     }
@@ -1133,7 +1133,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
     }
 
     private toggleSkeletonControlPointDecorator(point: SVG.Element, hovered: boolean): void {
-        const handle = this.getSkeletonResizeHandle(point);
+        const handle = CanvasViewImpl.getSkeletonResizeHandle(point);
         if (!handle) {
             return;
         }
@@ -1255,7 +1255,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 continue;
             }
 
-            const handle = this.getSkeletonResizeHandle(point);
+            const handle = CanvasViewImpl.getSkeletonResizeHandle(point);
             if (!handle) {
                 continue;
             }

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -1172,7 +1172,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
             strokeWidth * 3,
             Math.min(controlPointRadius * 1.7, boundingRectWidth / 4, boundingRectHeight / 4),
         );
-        // similar idea but we aim side segment to be a bit logner than corner segment
+        // similar idea but we aim side segment to be a bit longer than corner segment
         const segmentLength = Math.max(
             strokeWidth * 4,
             Math.min(controlPointRadius * 2.2, boundingRectWidth / 3, boundingRectHeight / 3),

--- a/tests/cypress/e2e/actions_objects2/case_108_rotated_bounding_boxes.js
+++ b/tests/cypress/e2e/actions_objects2/case_108_rotated_bounding_boxes.js
@@ -68,8 +68,8 @@ context('Rotated bounding boxes.', () => {
 
     describe(`Testing case "${caseId}"`, () => {
         it('Check that bounding boxes can be rotated.', () => {
-            cy.shapeRotate('#cvat_canvas_shape_1', '15.7');
-            cy.shapeRotate('#cvat_canvas_shape_2', '15.7');
+            cy.shapeRotate('#cvat_canvas_shape_1', '17.3');
+            cy.shapeRotate('#cvat_canvas_shape_2', '17.3');
         });
 
         it('Check interpolation, merging/splitting rotated shapes.', () => {
@@ -87,7 +87,7 @@ context('Rotated bounding boxes.', () => {
                 }
             });
 
-            cy.shapeRotate('#cvat_canvas_shape_2', '29.8');
+            cy.shapeRotate('#cvat_canvas_shape_2', '32.2');
 
             // Comparison of the values of the shape attribute of the current frame with the previous frame
             testCompareRotate('cvat_canvas_shape_2', 0);
@@ -112,7 +112,7 @@ context('Rotated bounding boxes.', () => {
             cy.get('#cvat_canvas_shape_4').should('be.visible');
             cy.goCheckFrameNumber(9);
 
-            cy.shapeRotate('#cvat_canvas_shape_4', '15.7');
+            cy.shapeRotate('#cvat_canvas_shape_4', '17.3');
 
             // Comparison of the values of the shape attribute of the current frame with the previous frame
             testCompareRotate('cvat_canvas_shape_4', 2);

--- a/tests/cypress/e2e/actions_objects2/case_115_ellipse_shape_track_label.js
+++ b/tests/cypress/e2e/actions_objects2/case_115_ellipse_shape_track_label.js
@@ -75,7 +75,7 @@ context('Actions on ellipse.', () => {
         it('Ellipse rotation/interpolation.', () => {
             Cypress.config('scrollBehavior', false);
             cy.get('.cvat-player-last-button').click();
-            cy.shapeRotate('#cvat_canvas_shape_4', '19.7');
+            cy.shapeRotate('#cvat_canvas_shape_4', '21.8');
             testCompareRotate('cvat_canvas_shape_4', 0);
             // Rotation with shift
             cy.shapeRotate('#cvat_canvas_shape_4', '15.0', true);

--- a/tests/cypress/e2e/features/skeletons_pipeline.js
+++ b/tests/cypress/e2e/features/skeletons_pipeline.js
@@ -133,7 +133,7 @@ context('Manipulations with skeletons', { scrollBehavior: false }, () => {
             cy.get(selector).should('not.exist');
         }
 
-        it('Wrapping bounding box for a skeleton is visible only when skeleton is activated', () => {
+        it('Wrapping bounding box for a skeleton is not visible regardless of activation state', () => {
             createSkeletonObject('shape');
 
             cy.get('body').click();
@@ -141,8 +141,23 @@ context('Manipulations with skeletons', { scrollBehavior: false }, () => {
                 cy.get('.cvat_canvas_skeleton_wrapping_rect').should('exist').and('not.be.visible');
                 cy.wrap($el).trigger('mousemove');
                 cy.wrap($el).should('have.class', 'cvat_canvas_shape_activated');
-                cy.get('.cvat_canvas_skeleton_wrapping_rect').should('exist').and('be.visible');
+                cy.get('.cvat_canvas_skeleton_wrapping_rect').should('exist').and('not.be.visible');
             });
+
+            cy.removeAnnotations();
+        });
+
+        it('Control points for a skeleton exist only when skeleton is activated', () => {
+            createSkeletonObject('shape');
+
+            cy.get('body').click();
+
+            cy.get('.cvat_canvas_skeleton_control_point').should('not.exist');
+
+            cy.get('#cvat_canvas_shape_1').trigger('mousemove');
+            cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
+
+            cy.get('.cvat_canvas_skeleton_control_point').should('have.length', 9);
 
             cy.removeAnnotations();
         });


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Skeleton control points look very similar to the points of the annotation itself. It sometimes causes confusion why the control points are not part of the annotation.

1. This change visually differentiates skeleton control points from the annotation points so it's not confusing anymore.

Before:
<img width="311" height="498" alt="old_skeleton_cp" src="https://github.com/user-attachments/assets/c1faf50e-8489-438c-bb38-e1ded577fbbc" />


After:
<img width="301" height="503" alt="new_skeleton_cp" src="https://github.com/user-attachments/assets/61fe6c19-4775-4a63-9f7a-3899c91a44b5" />

Note: this change affects only skeleton control points display. It doesn't affect the behavior. Also, rect annotations are unaffected as well.

2. Rotation control point offset calculation is changed for all shapes where applicable. Instead of static number it now:
- Depends on the control point size setting
- Compensates current scale factor 

It prevents the rotation control point from overlapping with other control points of a shape.

Before:
<img width="310" height="205" alt="ellipse_rot_old" src="https://github.com/user-attachments/assets/175492af-c313-45be-81a1-e4274620f5dd" />

After:
<img width="303" height="191" alt="ellipse_rot_new" src="https://github.com/user-attachments/assets/8a67d9ee-9922-47d5-b827-010ce9f13c46" />

Note: change of the offset affects the rotation speed in a freeform rotation hence expected rotation values had to be adjusted in tests.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Tested manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
