### PR TITLE
retry e2e tests on server image download fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,16 +160,7 @@ jobs:
           python-version: '3.10'
 
       - name: Download CVAT server image
-        id: download
-        continue-on-error: true
         uses: actions/download-artifact@v8
-        with:
-          name: cvat_server
-          path: /tmp/cvat_server/
-
-      - name: Download CVAT server image (retry)
-        if: steps.download.outcome == 'failure'
-        uses: actions/download-artifact@v4
         with:
           name: cvat_server
           path: /tmp/cvat_server/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,6 @@ jobs:
         with:
           name: cvat_server_nonexistent # should fail
           path: /tmp/cvat_server/
-        timeout-minutes: 5
 
       - name: Download CVAT server image (retry)
         if: steps.download.outcome == 'failure'
@@ -174,7 +173,6 @@ jobs:
         with:
           name: cvat_server
           path: /tmp/cvat_server/
-        timeout-minutes: 5
 
       - name: Download CVAT UI images
         uses: actions/download-artifact@v8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,6 +166,7 @@ jobs:
         with:
           name: cvat_server_nonexistent # should fail
           path: /tmp/cvat_server/
+        timeout-minutes: 5
 
       - name: Download CVAT server image (retry)
         if: steps.download.outcome == 'failure'
@@ -173,6 +174,7 @@ jobs:
         with:
           name: cvat_server
           path: /tmp/cvat_server/
+        timeout-minutes: 5
 
       - name: Download CVAT UI images
         uses: actions/download-artifact@v8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -334,10 +334,21 @@ jobs:
             # https://nodejs.org/docs/v22.18.0/api/corepack.html#corepack
 
       - name: Download CVAT server image
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@v8
+        with:
+          name: cvat_server_nonexistent # should fail
+          path: /tmp/cvat_server/
+        timeout-minutes: 5
+
+      - name: Download CVAT server image (retry)
+        if: steps.download.outcome == 'failure'
+        uses: actions/download-artifact@v4
         with:
           name: cvat_server
           path: /tmp/cvat_server/
+        timeout-minutes: 5
 
       - name: Download CVAT UI image
         uses: actions/download-artifact@v8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: cvat_server
+          name: cvat_server_nonexistent # should fail
           path: /tmp/cvat_server/
 
       - name: Download CVAT server image (retry)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,7 +160,16 @@ jobs:
           python-version: '3.10'
 
       - name: Download CVAT server image
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@v8
+        with:
+          name: cvat_server
+          path: /tmp/cvat_server/
+
+      - name: Download CVAT server image (retry)
+        if: steps.download.outcome == 'failure'
+        uses: actions/download-artifact@v4
         with:
           name: cvat_server
           path: /tmp/cvat_server/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: cvat_server_nonexistent # should fail
+          name: cvat_server
           path: /tmp/cvat_server/
 
       - name: Download CVAT server image (retry)


### PR DESCRIPTION
This provides a retry mechanism with timeout for e2e tests in case when server image was not downloaded
Prevents e2e matrix jobs from running without healthy images and from bottlenecking the access to log artifacts

### Checklist

- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
