### PR TITLE
Fix django-rq admin 500 on Python 3.12

### DIFF
--- a/changelog.d/20260707_000000_mzhiltsov_fix_django_rq_admin_enum_500.md
+++ b/changelog.d/20260707_000000_mzhiltsov_fix_django_rq_admin_enum_500.md
@@ -2,4 +2,4 @@
 
 - The 500 error (`EnumType.__call__() missing 1 required positional argument: 'value'`)
   when opening an RQ job details in the `/django-rq/` admin panel
-  (<https://github.com/cvat-ai/cvat/pull/PLACEHOLDER>)
+  (<https://github.com/cvat-ai/cvat/pull/10890>)

--- a/changelog.d/20260707_000000_zm_fix_django_rq_admin_enum_500.md
+++ b/changelog.d/20260707_000000_zm_fix_django_rq_admin_enum_500.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- The 500 error (`EnumType.__call__() missing 1 required positional argument: 'value'`)
+  when opening an RQ job details in the `/django-rq/` admin panel
+  (<https://github.com/cvat-ai/cvat/pull/PLACEHOLDER>)

--- a/cvat/apps/redis_handler/apps.py
+++ b/cvat/apps/redis_handler/apps.py
@@ -68,10 +68,30 @@ def initialize_mappings():
                     )
 
 
+def _patch_rq_result_type_for_templates() -> None:
+    # A workaround for a django-rq admin template crash on Python 3.12.
+    # Fixed in the upstream django-rq 3.x: https://github.com/rq/django-rq/issues/678.
+    # TODO: remove after upgrading to django-rq 3.x
+
+    # With django-rq 2.x and Python 3.12, a job in the ``/django-rq/`` admin
+    # (``job_detail`` view) returns HTTP 500 with::
+    #
+    #     TypeError: EnumType.__call__() missing 1 required positional argument: 'value'
+    #
+    # for any job that has a stored RQ ``Result`` (i.e. any finished/failed job).
+    # The fix follows the recipe from https://code.djangoproject.com/ticket/31154.
+
+    from rq.results import Result
+
+    Result.Type.do_not_call_in_templates = True
+
+
 class RedisHandlerConfig(AppConfig):
     name = "cvat.apps.redis_handler"
 
     def ready(self) -> None:
+        _patch_rq_result_type_for_templates()
+
         from cvat.apps.iam.permissions import load_app_iam_rules
 
         load_app_iam_rules(self)


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Opening a job in the `/django-rq/` admin (`job_detail` view) returns a 500 error:
`TypeError: EnumType.__call__() missing 1 required positional argument: 'value'`

for any job that has a stored RQ ``Result`` (i.e. any finished/failed job, e.g. our
``chunks:prepare-item-*`` chunk/preview jobs).

#### Details

Root cause is a bug in the django-rq template `django_rq/job_detail.html` (present in
the pinned 2.10.3, see `django-rq>=2.10.1,<3` in requirements). Inside the results
loop it renders `{{ result.Type }}`, which resolves to the `rq.results.Result.Type`
*enum class* (not the instance's `result.type`) - almost certainly a copy/paste typo,
since the surrounding lines already render `result.type.name` and
`result.created_at` correctly. The Django template engine calls any callable it
resolves in `{{ }}` with no arguments, so it evaluates `Result.Type()`, which
requires a `value` argument and raises. Upstream django-rq has since removed this
template line in the 3.x/4.x update. Reported in
https://github.com/rq/django-rq/issues/678 (+ https://github.com/rq/django-rq/issues/685, https://github.com/rq/django-rq/issues/649).

Why this only started 500ing after the Ubuntu 24.04 / Python 3.12 upgrade (#10597),
and not from the recent redis/rq bumps: Django *does* guard against "callable that
needs arguments" in templates (fix for Django ticket [#31154](https://code.djangoproject.com/ticket/31154)) - on a TypeError it
inspects the callable's signature and only re-raises if `signature.bind()` succeeds
with no args. The `Result.Type` enum has existed since rq 1.12, but:

  * On Python <= 3.11 `inspect.signature(Result.Type)` reports the concrete
    `(value, names=None, ...)` signature, so `bind()` with no args fails and Django
    swallows the error (renders empty) - no 500.
  * On Python 3.12 the Enum metaclass `__call__` signature became variadic
    `(*values)`, so `bind()` with no args *succeeds*, Django's guard concludes the
    call was valid and re-raises the original TypeError - hence the 500.

Fix: mark the enum class with Django's `do_not_call_in_templates` so the template
engine renders it instead of trying to instantiate it, as [recommended in #31154](https://code.djangoproject.com/ticket/31154). 
It is a harmless no-op once django-rq is upgraded to 3.x (the offending template line is gone), 
so this patch can be dropped at that point.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
