### PR TITLE
Add filename search on task page to jump to a frame

### DIFF
--- a/changelog.d/20260713_180738_petrosilius_search_frame_by_filename_task_page.md
+++ b/changelog.d/20260713_180738_petrosilius_search_frame_by_filename_task_page.md
@@ -1,0 +1,5 @@
+### Added
+
+- Ability to search images by filename on the task page and jump directly to the
+  job and frame that contain them
+  (<https://github.com/cvat-ai/cvat/issues/5109>)

--- a/cvat-ui/src/components/annotation-page/top-bar/search-modal.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/search-modal.tsx
@@ -2,31 +2,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { shallowEqual } from 'utils/redux';
-import Modal from 'antd/lib/modal';
-import Text from 'antd/lib/typography/Text';
-import AutoComplete from 'antd/lib/auto-complete';
-import _ from 'lodash';
-import type { BaseSelectRef } from 'rc-select';
 
 import { CombinedState } from 'reducers';
 import { changeFrameAsync, switchShowSearchFramesModal } from 'actions/annotation-actions';
-import CvatTooltip from 'components/common/cvat-tooltip';
-
-interface SearchResult {
-    number: number;
-    name: string;
-}
-
-const SEARCH_LIMIT = 25;
-const SEARCH_DEBOUNCE_TIME = 100;
+import FrameSearchModal, { FrameSearchItem } from 'components/common/frame-search-modal';
 
 function SearchFramesModal(): JSX.Element {
     const dispatch = useDispatch();
-    const [searchTerm, setSearchTerm] = useState('');
-    const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
     const {
         visible,
         meta,
@@ -37,88 +22,32 @@ function SearchFramesModal(): JSX.Element {
         frameNumbers: state.annotation.job.frameNumbers,
     }), shallowEqual);
 
-    const [searchData, setSearchData] = useState<SearchResult[]>([]);
-    useEffect(() => {
-        if (meta) {
-            const newSearchData = meta.frames.map((frame: any, idx: number) => ({
-                name: frame.name,
-                number: frameNumbers[idx],
-            }));
-            setSearchData(newSearchData);
+    const searchData = useMemo<FrameSearchItem[]>(() => {
+        if (!meta) {
+            return [];
         }
-    }, [meta]);
+        return meta.frames.map((frame, idx) => ({
+            name: frame.name,
+            number: frameNumbers[idx],
+        }));
+    }, [meta, frameNumbers]);
 
     const onCancel = useCallback(() => {
         dispatch(switchShowSearchFramesModal(false));
-        setSearchTerm('');
-        setSearchResults([]);
     }, []);
 
-    const handleSearch = _.debounce((value: string) => {
-        let count = 0;
-        const searchResult = [];
-        for (const element of searchData) {
-            if (count >= SEARCH_LIMIT) break;
-            if (element.name.toLowerCase().includes(value.toLowerCase())) {
-                count++;
-                searchResult.push(element);
-            }
-        }
-        setSearchResults(searchResult);
-    }, SEARCH_DEBOUNCE_TIME);
-
-    const onSearch = useCallback((value: string) => {
-        setSearchTerm(value);
-        handleSearch(value);
-    }, [searchData]);
-
-    const onSelect = useCallback((frameNumber: string) => {
-        onCancel();
-        dispatch(changeFrameAsync(+frameNumber));
+    const onSelect = useCallback((frameNumber: number) => {
+        dispatch(switchShowSearchFramesModal(false));
+        dispatch(changeFrameAsync(frameNumber));
     }, []);
-
-    const autoCompleteRef = useCallback((node: BaseSelectRef | null) => {
-        if (node !== null && visible) {
-            node.focus();
-        }
-    }, [visible]);
 
     return (
-        <Modal
-            className='cvat-frame-search-modal'
-            open={visible}
-            footer={null}
+        <FrameSearchModal
+            visible={visible}
+            searchData={searchData}
+            onSelect={onSelect}
             onCancel={onCancel}
-            width={600}
-            destroyOnClose
-            closeIcon={null}
-            styles={{
-                mask: {
-                    backgroundColor: 'unset',
-                },
-            }}
-        >
-            <AutoComplete
-                ref={autoCompleteRef}
-                defaultValue={searchTerm}
-                placeholder='Type to search'
-                showSearch
-                onSearch={onSearch}
-                notFoundContent={searchTerm ? <Text>No frames found</Text> : null}
-                options={searchResults.map((item) => ({
-                    value: item.number,
-                    label: (
-                        <CvatTooltip title={item.name} className='cvat-frame-search-item'>
-                            <Text strong className='cvat-frame-search-item-number'>{`#${item.number} `}</Text>
-                            <Text className='cvat-frame-search-item-name'>{item.name}</Text>
-                        </CvatTooltip>
-                    ),
-                }))}
-                onSelect={onSelect}
-                allowClear
-                className='cvat-frame-search-selector'
-            />
-        </Modal>
+        />
     );
 }
 

--- a/cvat-ui/src/components/common/frame-search-modal.tsx
+++ b/cvat-ui/src/components/common/frame-search-modal.tsx
@@ -1,0 +1,109 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import React, { useCallback, useEffect, useState } from 'react';
+import Modal from 'antd/lib/modal';
+import Text from 'antd/lib/typography/Text';
+import AutoComplete from 'antd/lib/auto-complete';
+import _ from 'lodash';
+import type { BaseSelectRef } from 'rc-select';
+
+import CvatTooltip from 'components/common/cvat-tooltip';
+
+export interface FrameSearchItem {
+    number: number;
+    name: string;
+}
+
+interface Props {
+    visible: boolean;
+    searchData: FrameSearchItem[];
+    onSelect: (frameNumber: number) => void;
+    onCancel: () => void;
+}
+
+const SEARCH_LIMIT = 25;
+const SEARCH_DEBOUNCE_TIME = 100;
+
+// Presentational filename search modal shared by the annotation player and the task page.
+// It only knows about a flat list of { number, name } items and reports the selected
+// frame number back to the parent, which decides what to do with it.
+function FrameSearchModal(props: Readonly<Props>): JSX.Element {
+    const {
+        visible, searchData, onSelect, onCancel,
+    } = props;
+    const [searchTerm, setSearchTerm] = useState('');
+    const [searchResults, setSearchResults] = useState<FrameSearchItem[]>([]);
+
+    useEffect(() => {
+        if (!visible) {
+            setSearchTerm('');
+            setSearchResults([]);
+        }
+    }, [visible]);
+
+    const handleSearch = _.debounce((value: string) => {
+        let count = 0;
+        const searchResult: FrameSearchItem[] = [];
+        for (const element of searchData) {
+            if (count >= SEARCH_LIMIT) break;
+            if (element.name.toLowerCase().includes(value.toLowerCase())) {
+                count++;
+                searchResult.push(element);
+            }
+        }
+        setSearchResults(searchResult);
+    }, SEARCH_DEBOUNCE_TIME);
+
+    const onSearch = useCallback((value: string) => {
+        setSearchTerm(value);
+        handleSearch(value);
+    }, [searchData]);
+
+    const autoCompleteRef = useCallback((node: BaseSelectRef | null) => {
+        if (node !== null && visible) {
+            node.focus();
+        }
+    }, [visible]);
+
+    return (
+        <Modal
+            className='cvat-frame-search-modal'
+            open={visible}
+            footer={null}
+            onCancel={onCancel}
+            width={600}
+            destroyOnClose
+            closeIcon={null}
+            styles={{
+                mask: {
+                    backgroundColor: 'unset',
+                },
+            }}
+        >
+            <AutoComplete
+                ref={autoCompleteRef}
+                defaultValue={searchTerm}
+                placeholder='Type to search'
+                showSearch
+                onSearch={onSearch}
+                notFoundContent={searchTerm ? <Text>No frames found</Text> : null}
+                options={searchResults.map((item) => ({
+                    value: item.number,
+                    label: (
+                        <CvatTooltip title={item.name} className='cvat-frame-search-item'>
+                            <Text strong className='cvat-frame-search-item-number'>{`#${item.number} `}</Text>
+                            <Text className='cvat-frame-search-item-name'>{item.name}</Text>
+                        </CvatTooltip>
+                    ),
+                }))}
+                onSelect={(frameNumber: string) => onSelect(+frameNumber)}
+                allowClear
+                className='cvat-frame-search-selector'
+            />
+        </Modal>
+    );
+}
+
+export default React.memo(FrameSearchModal);

--- a/cvat-ui/src/components/task-page/frame-search.tsx
+++ b/cvat-ui/src/components/task-page/frame-search.tsx
@@ -1,0 +1,67 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { useHistory } from 'react-router';
+import Button from 'antd/lib/button';
+import { SearchOutlined } from '@ant-design/icons';
+
+import CVATTooltip from 'components/common/cvat-tooltip';
+import FrameSearchModal, { FrameSearchItem } from 'components/common/frame-search-modal';
+import { Task, FramesMetaData, JobType } from 'cvat-core-wrapper';
+
+interface Props {
+    task: Task;
+    taskMeta: FramesMetaData | null;
+}
+
+// Task-level filename search. Reuses the annotation player's search modal, but on select
+// it resolves which job contains the chosen frame and navigates straight into it.
+function FrameSearch(props: Readonly<Props>): JSX.Element {
+    const { task, taskMeta } = props;
+    const history = useHistory();
+    const [visible, setVisible] = useState(false);
+
+    const searchData = useMemo<FrameSearchItem[]>(() => {
+        if (!taskMeta) {
+            return [];
+        }
+        const frameNumbers = taskMeta.getDataFrameNumbers();
+        return taskMeta.frames.map((frame, idx) => ({
+            name: frame.name,
+            number: frameNumbers[idx],
+        }));
+    }, [taskMeta]);
+
+    const onSelect = useCallback((frame: number) => {
+        setVisible(false);
+        const jobsWithFrame = task.jobs.filter((job) => job.startFrame <= frame && frame <= job.stopFrame);
+        // The `?frame=` query parameter does not work for ground truth jobs, so prefer an annotation job.
+        const targetJob = jobsWithFrame.find((job) => job.type !== JobType.GROUND_TRUTH) ?? jobsWithFrame[0];
+        if (targetJob) {
+            history.push(`/tasks/${task.id}/jobs/${targetJob.id}?frame=${frame}`);
+        }
+    }, [task, history]);
+
+    return (
+        <>
+            <CVATTooltip title='Search image by filename'>
+                <Button
+                    className='cvat-task-search-frame-button'
+                    icon={<SearchOutlined />}
+                    disabled={!taskMeta}
+                    onClick={() => setVisible(true)}
+                />
+            </CVATTooltip>
+            <FrameSearchModal
+                visible={visible}
+                searchData={searchData}
+                onSelect={onSelect}
+                onCancel={() => setVisible(false)}
+            />
+        </>
+    );
+}
+
+export default React.memo(FrameSearch);

--- a/cvat-ui/src/components/task-page/job-list.tsx
+++ b/cvat-ui/src/components/task-page/job-list.tsx
@@ -15,8 +15,9 @@ import Pagination from 'antd/lib/pagination';
 import Empty from 'antd/lib/empty';
 import Button from 'antd/lib/button';
 import { PlusOutlined } from '@ant-design/icons';
-import { Task, Job } from 'cvat-core-wrapper';
+import { Task, Job, FramesMetaData } from 'cvat-core-wrapper';
 import JobItem from 'components/job-item/job-item';
+import FrameSearch from 'components/task-page/frame-search';
 import {
     SortingComponent, ResourceFilterHOC, defaultVisibility, updateHistoryFromQuery, ResourceSelectionInfo,
 } from 'components/resource-sorting-filtering';
@@ -34,6 +35,7 @@ const FilteringComponent = ResourceFilterHOC(
 
 interface Props {
     task: Task;
+    taskMeta: FramesMetaData | null;
     onJobUpdate(job: Job, data: Parameters<Job['save']>[0]): void;
 }
 
@@ -73,7 +75,7 @@ function setUpJobsList(jobs: Job[], newPage: number, pageSize: number): Job[] {
 }
 
 function JobListComponent(props: Readonly<Props>): JSX.Element {
-    const { task: taskInstance, onJobUpdate } = props;
+    const { task: taskInstance, taskMeta, onJobUpdate } = props;
     const [visibility, setVisibility] = useState(defaultVisibility);
 
     const history = useHistory();
@@ -128,10 +130,13 @@ function JobListComponent(props: Readonly<Props>): JSX.Element {
     return (
         <>
             <div className='cvat-jobs-list-wrapper'>
-                <Row>
+                <Row justify='space-between' align='middle'>
                     <Col>
                         <Text className='cvat-text-color cvat-jobs-header'> Jobs </Text>
                         <ResourceSelectionInfo selectedCount={selectedCount} onSelectAll={onSelectAll} />
+                    </Col>
+                    <Col>
+                        <FrameSearch task={taskInstance} taskMeta={taskMeta} />
                     </Col>
                 </Row>
                 <Row>

--- a/cvat-ui/src/components/task-page/task-page.tsx
+++ b/cvat-ui/src/components/task-page/task-page.tsx
@@ -150,7 +150,7 @@ function TaskPageComponent(): JSX.Element {
                         onUpdateTaskMeta={onUpdateTaskMeta}
                         labelsEditorProps={labelsEditorProps}
                     />
-                    <JobListComponent task={taskInstance} onJobUpdate={onJobUpdate} />
+                    <JobListComponent task={taskInstance} taskMeta={taskMeta} onJobUpdate={onJobUpdate} />
                 </Col>
             </Row>
             <ModelRunnerModal />

--- a/site/content/en/docs/workspace/tasks-page.md
+++ b/site/content/en/docs/workspace/tasks-page.md
@@ -126,6 +126,12 @@ to annotate the first images. Other frames will be loaded in the background.
 
 ![Example of user interface with task frames](/images/task-details-2.png)
 
+### Search a frame by filename
+
+Use the search (magnifier) button next to the **Jobs** header to find an image by
+filename across the whole task. Type a part of the filename and select a result to
+open the job that contains that frame, at the exact frame.
+
 ## How to create and configure an annotation task
 
 To start annotating in CVAT, you must create an annotation task and specify its parameters.

--- a/tests/cypress/e2e/actions_tasks/search_frame_by_filename_task_page.js
+++ b/tests/cypress/e2e/actions_tasks/search_frame_by_filename_task_page.js
@@ -1,0 +1,81 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { defaultTaskSpec } from '../../support/default-specs';
+
+context('Search frame by filename on the task page', () => {
+    const taskName = 'Search frame by filename task page';
+    const labelName = 'search_frame_label';
+    const imagesCount = 12;
+    const serverFiles = ['archive.zip'];
+    const fileIndices = Cypress._.range(1, imagesCount + 1);
+    const padValue = (val) => val.toString().padStart(2, '0');
+    const allFilenames = fileIndices.map((val) => `archive/${padValue(val)}.jpg`);
+
+    function filenamesThatContain(input) {
+        return allFilenames.filter((name) => name.includes(input));
+    }
+
+    let taskId = null;
+    let jobId = null;
+
+    before(() => {
+        cy.visit('/auth/login');
+        cy.headlessLogin();
+        const { taskSpec, dataSpec, extras } = defaultTaskSpec({
+            taskName, serverFiles, labelName,
+        });
+        cy.headlessCreateTask(taskSpec, dataSpec, extras).then(({ taskId: tid, jobIds: [jid] }) => {
+            [taskId, jobId] = [tid, jid];
+            cy.visit(`/tasks/${taskId}`);
+            cy.get('.cvat-task-details').should('be.visible');
+        });
+    });
+
+    after(() => {
+        cy.headlessDeleteTask(taskId);
+    });
+
+    describe('Open the search modal from the task page and navigate to a frame', () => {
+        beforeEach(() => {
+            // Every test starts from the task page with the modal opened and empty.
+            cy.visit(`/tasks/${taskId}`);
+            cy.get('.cvat-task-details').should('be.visible');
+            cy.get('.cvat-task-search-frame-button').should('be.visible').click();
+            cy.get('.cvat-frame-search-modal').should('be.visible')
+                .find('input')
+                .should('be.visible')
+                .should('be.focused');
+        });
+
+        it('search button opens the modal with a focused input', () => {
+            // Assertions already covered by beforeEach; this documents the entry point.
+            cy.get('.cvat-frame-search-modal').should('contain', 'Type to search');
+        });
+
+        it('typing a filename fragment lists the matching frames', () => {
+            const input = '0';
+            const expected = filenamesThatContain(input);
+
+            cy.get('.cvat-frame-search-modal').find('input').type(input);
+            cy.get('.cvat-frame-search-item').should('have.length', expected.length);
+        });
+
+        it('a filename that does not exist shows "No frames found"', () => {
+            cy.get('.cvat-frame-search-modal').find('input').type('does-not-exist');
+            cy.contains('No frames found').should('exist');
+        });
+
+        it('selecting a frame navigates to the job that contains it at the right frame', () => {
+            // 05.jpg is the 5th image after lexicographical sorting, i.e. absolute frame 4.
+            cy.get('.cvat-frame-search-modal').find('input').type('05.jpg');
+            cy.get('.cvat-frame-search-item').should('have.length', 1);
+            cy.realPress('ArrowDown');
+            cy.realPress('Enter');
+            cy.url().should('include', `/tasks/${taskId}/jobs/${jobId}?frame=4`);
+        });
+    });
+});


### PR DESCRIPTION
### Motivation and context

Tried to close #5109 as it was wished by many people. The PR changes to search images by filename from the task page and jump to the containing job/frame (`/tasks/<id>/jobs/<job>?frame=<n>`), without knowing the job up front. Currently only search within job is supported. I tried to reuse the existing job-based search functionality as best as possible.

How is it implemented:

- Extracted the annotation player's frame-search modal into a shared `components/common/frame-search-modal.tsx`.
- Annotation search modal now a thin redux wrapper over it (behavior unchanged).
- Task page: search button in the Jobs header opens the modal; on select resolves the non-GT job for the frame and navigates.

### How has this been tested?

- New Cypress e2e: `tests/cypress/e2e/actions_tasks/search_frame_by_filename_task_page.js` (open modal, list matches, no-match state, navigate to job+frame).
- Existing annotation search e2e still valid (markup/classes unchanged).

### Checklist
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- [x]  have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
