### PR TITLE
add correct guards to optional user fields

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -461,8 +461,12 @@ Cypress.Commands.add('headlessCreateUser', (userSpec) => {
             expect(response.statusCode).to.eq(201, response.body.username);
             expect(response.body.username).to.eq(userSpecSnake.username);
             expect(response.body.email).to.eq(userSpecSnake.email.toLowerCase());
-            expect(response.body.first_name).to.eq(userSpecSnake.first_name || '');
-            expect(response.body.last_name).to.eq(userSpecSnake.last_name || '');
+            if (userSpecSnake.first_name !== undefined) {
+                expect(response.body.first_name).to.eq(userSpecSnake.first_name);
+            }
+            if (userSpecSnake.last_name !== undefined) {
+                expect(response.body.last_name).to.eq(userSpecSnake.last_name);
+            }
         });
     }).as('registerRequest');
 


### PR DESCRIPTION
#10889 didn't correctly guard the user fields. In case of `undefined` it would compare `undefined` with `''` which is incorrect, hence the failure in https://github.com/cvat-ai/app.cvat.ai/actions/runs/29323245560/job/87055920948?pr=952


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
