### PR TITLE
Fix RQ registry cleanup outside main thread

### DIFF
--- a/changelog.d/20260721_084900_aleksei_sosov_fix_rq_cleanup_timeout.md
+++ b/changelog.d/20260721_084900_aleksei_sosov_fix_rq_cleanup_timeout.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- \[Server API\] Prevented `/api/requests` from failing while cleaning up
+  abandoned jobs
+  (<https://github.com/cvat-ai/cvat/pull/10904>)

--- a/cvat/rq_patching.py
+++ b/cvat/rq_patching.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import threading
 import traceback
 from datetime import datetime
 
@@ -11,6 +12,7 @@ from redis.client import Pipeline
 from rq.exceptions import AbandonedJobError, InvalidJobOperation, NoSuchJobError
 from rq.job import Job, JobStatus
 from rq.queue import Queue
+from rq.timeouts import TimerDeathPenalty
 from rq.utils import current_timestamp
 from rq.version import VERSION
 
@@ -48,8 +50,14 @@ def custom_started_job_registry_cleanup(self, timestamp: float | None = None):
                 except NoSuchJobError:
                     continue
 
+                death_penalty_class = self.death_penalty_class
+                # Registry cleanup can be triggered by an ASGI executor thread while listing jobs.
+                # UnixSignalDeathPenalty cannot install a signal handler outside the main thread.
+                if threading.current_thread() is not threading.main_thread():
+                    death_penalty_class = TimerDeathPenalty
+
                 job.execute_failure_callback(
-                    self.death_penalty_class,
+                    death_penalty_class,
                     AbandonedJobError,
                     AbandonedJobError(),
                     traceback.extract_stack(),


### PR DESCRIPTION
### Title
Fix RQ registry cleanup outside the main thread

### Body
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Reading `/api/requests` can trigger `StartedJobRegistry` cleanup from an ASGI executor thread. When cleanup executes a failure callback for an abandoned job, RQ tries to install a `SIGALRM` handler and raises `ValueError` because Python only permits this in the main thread. Use `TimerDeathPenalty` for cleanup outside the main thread while preserving the default death penalty in worker processes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [[GitHub docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.