### PR TITLE
fix: handle single-point skeletons in quality control matching

### DIFF
--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -1079,9 +1079,28 @@ def oks(a, b, sigma=0.1, bbox=None, scale=None, visibility_a=None, visibility_b=
 
 @define(kw_only=True)
 class KeypointsMatcher(datumaro.components.annotations.matcher.PointsMatcher):
+    img_h: int = 0
+    img_w: int = 0
+
     def distance(self, a: dm.Points, b: dm.Points) -> float:
         a_bbox = self.instance_map[id(a)][1]
         b_bbox = self.instance_map[id(b)][1]
+        a_area = a_bbox[2] * a_bbox[3]
+        b_area = b_bbox[2] * b_bbox[3]
+
+        if a_area == 0 and b_area == 0:
+            # Simple case: singular points / single-point skeletons without bbox
+            # match them in the image space
+            img_h, img_w = self.img_h, self.img_w
+            return oks(
+                a,
+                b,
+                sigma=self.sigma,
+                scale=img_h * img_w,
+                visibility_a=[v == dm.Points.Visibility.visible for v in a.visibility],
+                visibility_b=[v == dm.Points.Visibility.visible for v in b.visibility],
+            )
+
         if datumaro.util.annotation_util.bbox_iou(a_bbox, b_bbox) <= 0:
             return 0
 
@@ -1821,7 +1840,11 @@ class DistanceComparator(datumaro.components.comparator.DistanceComparator):
                 for ann in instance_group:
                     instance_map[id(ann)] = [instance_group, instance_bbox]
 
-        matcher = KeypointsMatcher(instance_map=instance_map, sigma=self.oks_sigma)
+        img_h, img_w = item_a.media_as(dm.Image).size
+
+        matcher = KeypointsMatcher(
+            instance_map=instance_map, sigma=self.oks_sigma, img_h=img_h, img_w=img_w
+        )
 
         results = self.match_segments(
             dm.AnnotationType.points,

--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -1081,6 +1081,7 @@ def oks(a, b, sigma=0.1, bbox=None, scale=None, visibility_a=None, visibility_b=
 class KeypointsMatcher(datumaro.components.annotations.matcher.PointsMatcher):
     img_h: int = 0
     img_w: int = 0
+    point_size_base: models.PointSizeBase = models.PointSizeBase.GROUP_BBOX_SIZE
 
     def distance(self, a: dm.Points, b: dm.Points) -> float:
         a_bbox = self.instance_map[id(a)][1]
@@ -1088,30 +1089,31 @@ class KeypointsMatcher(datumaro.components.annotations.matcher.PointsMatcher):
         a_area = a_bbox[2] * a_bbox[3]
         b_area = b_bbox[2] * b_bbox[3]
 
+        visibility_a = [v == dm.Points.Visibility.visible for v in a.visibility]
+        visibility_b = [v == dm.Points.Visibility.visible for v in b.visibility]
+
         if a_area == 0 and b_area == 0:
-            # Simple case: singular points / single-point skeletons without bbox
-            # match them in the image space
-            img_h, img_w = self.img_h, self.img_w
-            return oks(
-                a,
-                b,
-                sigma=self.sigma,
-                scale=img_h * img_w,
-                visibility_a=[v == dm.Points.Visibility.visible for v in a.visibility],
-                visibility_b=[v == dm.Points.Visibility.visible for v in b.visibility],
-            )
+            # Degenerate case: single-point or collinear skeletons produce
+            # zero-area bboxes. bbox_iou() always returns 0 for these, so the
+            # normal IoU guard would block even identical annotations.
+            if self.point_size_base == models.PointSizeBase.IMAGE_SIZE:
+                # Scale OKS by image area — mirrors match_points._distance
+                return oks(
+                    a, b, sigma=self.sigma,
+                    scale=self.img_h * self.img_w,
+                    visibility_a=visibility_a, visibility_b=visibility_b,
+                )
+            else:
+                # GROUP_BBOX_SIZE: skeletons must have a valid bbox to compare
+                return 0
 
         if datumaro.util.annotation_util.bbox_iou(a_bbox, b_bbox) <= 0:
             return 0
 
         bbox = datumaro.util.annotation_util.mean_bbox([a_bbox, b_bbox])
         return oks(
-            a,
-            b,
-            sigma=self.sigma,
-            bbox=bbox,
-            visibility_a=[v == dm.Points.Visibility.visible for v in a.visibility],
-            visibility_b=[v == dm.Points.Visibility.visible for v in b.visibility],
+            a, b, sigma=self.sigma, bbox=bbox,
+            visibility_a=visibility_a, visibility_b=visibility_b,
         )
 
 
@@ -1843,7 +1845,9 @@ class DistanceComparator(datumaro.components.comparator.DistanceComparator):
         img_h, img_w = item_a.media_as(dm.Image).size
 
         matcher = KeypointsMatcher(
-            instance_map=instance_map, sigma=self.oks_sigma, img_h=img_h, img_w=img_w
+            instance_map=instance_map, sigma=self.oks_sigma,
+            img_h=img_h, img_w=img_w,
+            point_size_base=self.point_size_base,
         )
 
         results = self.match_segments(

--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -1086,26 +1086,23 @@ class KeypointsMatcher(datumaro.components.annotations.matcher.PointsMatcher):
     def distance(self, a: dm.Points, b: dm.Points) -> float:
         a_bbox = self.instance_map[id(a)][1]
         b_bbox = self.instance_map[id(b)][1]
-        a_area = a_bbox[2] * a_bbox[3]
-        b_area = b_bbox[2] * b_bbox[3]
 
         visibility_a = [v == dm.Points.Visibility.visible for v in a.visibility]
         visibility_b = [v == dm.Points.Visibility.visible for v in b.visibility]
 
+        if self.point_size_base == models.PointSizeBase.IMAGE_SIZE:
+            return oks(
+                a, b, sigma=self.sigma,
+                scale=self.img_h * self.img_w,
+                visibility_a=visibility_a, visibility_b=visibility_b,
+            )
+
+        # GROUP_BBOX_SIZE: check bbox overlap first
+        a_area = a_bbox[2] * a_bbox[3]
+        b_area = b_bbox[2] * b_bbox[3]
+
         if a_area == 0 and b_area == 0:
-            # Degenerate case: single-point or collinear skeletons produce
-            # zero-area bboxes. bbox_iou() always returns 0 for these, so the
-            # normal IoU guard would block even identical annotations.
-            if self.point_size_base == models.PointSizeBase.IMAGE_SIZE:
-                # Scale OKS by image area — mirrors match_points._distance
-                return oks(
-                    a, b, sigma=self.sigma,
-                    scale=self.img_h * self.img_w,
-                    visibility_a=visibility_a, visibility_b=visibility_b,
-                )
-            else:
-                # GROUP_BBOX_SIZE: skeletons must have a valid bbox to compare
-                return 0
+            return 0
 
         if datumaro.util.annotation_util.bbox_iou(a_bbox, b_bbox) <= 0:
             return 0


### PR DESCRIPTION
## Description

Fixes skeleton and point group matching in quality control for corner cases where skeletons have zero-area bounding boxes (e.g. single-point skeletons).

### Problem

The `KeypointsMatcher.distance()` method always checked `bbox_iou(a_bbox, b_bbox) <= 0` as an early exit. For single-point skeletons, the bounding box has 0 width and 0 height, so `bbox_iou` is always 0, meaning these skeletons could **never** match during quality checks.

### Solution

Mirrors the existing logic in `match_points` (line 1680-1700): when both bboxes have zero area, compute OKS distance in the image space instead of the bbox space.

Changes:
- `KeypointsMatcher`: Added `img_h`/`img_w` attributes, added zero-area bbox fallback
- `match_skeletons`: Pass `img_h`/`img_w` to the matcher instance

### Example

```python
# Before: single-point skeletons never matched (distance always 0)
# After: they match correctly when close to each other
```

Closes #9957
