### PR TITLE
fix: register mangled image names to prevent export collisions

### DIFF
--- a/changelog.d/20260718_191447_maisto_fix_duplicate_image_export.md
+++ b/changelog.d/20260718_191447_maisto_fix_duplicate_image_export.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Project export could silently overwrite images across tasks when
+  filename collisions were resolved with a generated fallback name that
+  was never marked as taken
+  (<https://github.com/cvat-ai/cvat/pull/10915>)

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -2105,6 +2105,7 @@ def mangle_image_name(name: str, subset: str, names: defaultdict[tuple[str, str]
         image_name = f"{name}_{names[(subset, name)]}"
         if not names[(subset, image_name)]:
             names[(subset, name)] += 1
+            names[(subset, image_name)] += 1
             return osp.extsep.join([image_name, ext])
         else:
             i = 1
@@ -2112,6 +2113,7 @@ def mangle_image_name(name: str, subset: str, names: defaultdict[tuple[str, str]
                 new_image_name = f"{image_name}_{i}"
                 if not names[(subset, new_image_name)]:
                     names[(subset, name)] += 1
+                    names[(subset, new_image_name)] += 1
                     return osp.extsep.join([new_image_name, ext])
                 i += 1
     raise Exception("Cannot mangle image name")

--- a/tests/python/rest_api/test_projects.py
+++ b/tests/python/rest_api/test_projects.py
@@ -1055,6 +1055,49 @@ class TestImportExportDatasetProject:
                 annotations = json.load(anno_file)
                 assert sorted([a["file_name"] for a in annotations["images"]]) == image_names
 
+    @allure.issue(url="https://github.com/cvat-ai/cvat/issues/8076", name="GH-8076")
+    def test_export_project_with_duplicate_image_names_across_tasks(self, admin_user: str):
+        project_spec = {
+            "name": "Project with duplicate image names",
+            "labels": [{"name": "cat"}],
+        }
+
+        with make_api_client(admin_user) as api_client:
+            project, _ = api_client.projects_api.create(project_spec)
+
+        for task_name in ("task1", "task2"):
+            image_files = generate_image_files(1, filenames=["image.jpg"])
+            task_params = {
+                "name": task_name,
+                "segment_size": 1,
+                "project_id": project.id,
+            }
+            data_params = {
+                "image_quality": 70,
+                "client_files": image_files,
+            }
+            create_task(admin_user, spec=task_params, data=data_params)
+
+        dataset = export_project_dataset(
+            admin_user, save_images=True, id=project.id, format="COCO 1.0"
+        )
+
+        with zipfile.ZipFile(io.BytesIO(dataset)) as zip_file:
+            subset_path = "images/default"
+            exported_image_names = [
+                f[len(subset_path) + 1 :] for f in zip_file.namelist() if f.startswith(subset_path)
+            ]
+            # both tasks' images must be exported as distinct files: neither should be
+            # silently overwritten by the other because they share the same original name
+            assert len(exported_image_names) == 2
+            assert len(set(exported_image_names)) == 2
+
+            with zip_file.open("annotations/instances_default.json") as anno_file:
+                annotations = json.load(anno_file)
+                annotated_names = [a["file_name"] for a in annotations["images"]]
+                assert len(set(annotated_names)) == 2
+                assert sorted(annotated_names) == sorted(exported_image_names)
+
     @allure.description("Project annotations do not have tags for removed frames")
     @allure.issue(url="https://github.com/cvat-ai/cvat/issues/9918", name="GH-9918")
     def test_export_project_with_removed_frames(


### PR DESCRIPTION
Fixes #8076 
### Motivation and context

`mangle_image_name()` resolves filename collisions during project export by trying candidates like `image_1`, `image_1_1`, etc. When it finds a free candidate, it only increments the counter for the *original* name in the `names` tracking dict, never registering the candidate itself as taken.

If task order in the project causes the fallback names to be generated before the real files that happen to share those names are processed, the real files are later returned unchanged (since their name was never marked as taken) and silently overwrite the earlier export, exactly as described in the issue.

The fix registers every name actually handed out, not just the original name's counter, so a later real file with a colliding name gets re-mangled instead of overwriting an already-exported image.

### How has this been tested?

Added `test_export_project_with_duplicate_image_names_across_tasks` to `tests/python/rest_api/test_projects.py`, modeled on the existing `test_export_project_with_honeypots` test: creates a project with two tasks whose images share the same original filename, exports it, and asserts both survive as distinct files with matching annotation entries.

Verified the fix in isolation with a standalone script reproducing the collision scenario from the issue (5 tasks with a duplicate image.jpg, followed by a task with the real image_1.jpg to image_4.jpg): the current code produces 4 collisions, the fix produces 0.

I was not able to run the full test suite locally (no local CVAT dev/Docker environment set up), so I'd appreciate CI/reviewer confirmation that the added test passes.

### Checklist

I submit my changes into the develop branch. I have added a description of my changes into the CHANGELOG file (to follow up once this PR's number is known). I have updated the documentation accordingly (not applicable, internal helper function). I have added tests to cover my changes. Related issue is linked above via "Fixes #8076".

### License

I submit my code changes under the same MIT License that covers the project.