### PR TITLE
As/update webhook delivery logging in handle rq exception

### DIFF
--- a/changelog.d/20260722_140345_aleksei_sosov_fix_webhook_retry_handling.md
+++ b/changelog.d/20260722_140345_aleksei_sosov_fix_webhook_retry_handling.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Reduced misleading event log entries for webhook delivery failures by recording
+  an exception only after all retries are exhausted, and shortened the connection
+  timeout for unreachable webhook consumers
+  (<https://github.com/cvat-ai/cvat/pull/10921>)

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -38,6 +38,7 @@ from cvat.apps.engine.serializers import (
     ProjectReadSerializer,
     TaskReadSerializer,
 )
+from cvat.apps.events import utils
 from cvat.apps.organizations.models import Invitation, Membership, Organization
 from cvat.apps.organizations.serializers import (
     InvitationReadSerializer,
@@ -645,7 +646,10 @@ def handle_function_call(
     )
 
 
-def handle_rq_exception(rq_job, exc_type, exc_value, tb):
+def handle_rq_exception(rq_job: rq.job.Job, exc_type: type[Exception], exc_value: Exception, tb):
+    if utils.should_skip_rq_exception_event_recording(rq_job=rq_job, exc_value=exc_value):
+        return False
+
     rq_job_meta = BaseRQMeta.for_job(rq_job)
     oid = rq_job_meta.org_id
     oslug = rq_job_meta.org_slug

--- a/cvat/apps/events/utils.py
+++ b/cvat/apps/events/utils.py
@@ -5,10 +5,20 @@
 import datetime
 from contextlib import suppress
 
+import rq
 from django.db.models import Min
+
+from cvat.apps.webhooks.exceptions import WebhookDeliveryError
 
 from .cache import clear_cache
 from .const import COMPRESSED_EVENT_SCOPES, MAX_EVENT_DURATION
+
+
+def should_skip_rq_exception_event_recording(rq_job: rq.job.Job, exc_value: Exception) -> bool:
+    if isinstance(exc_value, WebhookDeliveryError):
+        return rq_job.get_status(refresh=False) != rq.job.JobStatus.FAILED
+
+    return False
 
 
 def _prepare_objects_to_delete(object_to_delete):

--- a/cvat/apps/webhooks/utils.py
+++ b/cvat/apps/webhooks/utils.py
@@ -19,7 +19,7 @@ from cvat.utils.http import PROXIES_FOR_UNTRUSTED_URLS, make_requests_session
 from .event_type import event_name
 from .models import Webhook
 
-_WEBHOOK_TIMEOUT = 10
+_WEBHOOK_TIMEOUT = (3, 10)
 _RESPONSE_SIZE_LIMIT = 1 * 1024 * 1024  # 1 MB
 
 


### PR DESCRIPTION
### Title
Reduce webhook retry noise and connection delays

### Body
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Retryable webhook delivery failures are raised intentionally to activate RQ retries, but the generic handler records each one as a `send:exception` event, creating misleading noise. Skip event recording while RQ retries remain, so failures continue to surface when no retries are left, and use separate 3-second connect and 10-second read timeouts to prevent unreachable consumers from occupying webhook workers unnecessarily.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [[GitHub docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword)](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.