### PR TITLE
Fix e2e dropdown flake in annotations actions tests

### DIFF
--- a/tests/cypress/support/commands_annotations_actions.js
+++ b/tests/cypress/support/commands_annotations_actions.js
@@ -39,7 +39,7 @@ Cypress.Commands.add('selectAnnotationsAction', (name) => {
     // Re-query before clicking because Ant Design may re-render the
     // dropdown and detach the option previously yielded by Cypress.
     getOption().should('be.visible');
-    getOption().click({force: true});
+    getOption().click({ force: true });
     cy.get('.cvat-action-runner-list .ant-select-selection-item')
         .should('contain', name);
 });

--- a/tests/cypress/support/commands_annotations_actions.js
+++ b/tests/cypress/support/commands_annotations_actions.js
@@ -29,14 +29,19 @@ Cypress.Commands.add('cancelAnnotationsAction', () => {
 });
 
 Cypress.Commands.add('selectAnnotationsAction', (name) => {
-    cy.get('.cvat-action-runner-list .ant-select').click();
-    cy.get('.ant-select-dropdown')
-        .not('.ant-select-dropdown-hidden').within(() => {
-            cy.get('.rc-virtual-list-holder')
-                .contains('.ant-select-item-option', name)
-                .click();
-        });
-    cy.get('.cvat-action-runner-list .ant-select-selection-item').should('contain', name);
+    const getOption = () => cy
+        .get('.ant-select-dropdown:visible')
+        .contains('.ant-select-item-option', name);
+
+    cy.get('.cvat-action-runner-list .ant-select')
+        .should('exist').and('be.visible')
+        .click();
+    // Re-query before clicking because Ant Design may re-render the
+    // dropdown and detach the option previously yielded by Cypress.
+    getOption().should('be.visible');
+    getOption().click({force: true});
+    cy.get('.cvat-action-runner-list .ant-select-selection-item')
+        .should('contain', name);
 });
 
 Cypress.Commands.add('waitAnnotationsAction', () => {


### PR DESCRIPTION
Fix flake from CI Nightly runs and re-runs from https://github.com/cvat-ai/app.cvat.ai/pull/991
At some point could reproduce every time, consistently blushing the CI. 

Hypothesis: root cause lies in somewhat overloaded UI. In cvat, these tests deal with 3 options in dropdown, while enterprise version loads much more with `enhanced_actions` plugin (which adds system trackers, converters etc.). This forces Ant to use the rolling virtual-list layer, which exacerbated the flake, making it more visible

### How has this been tested?

Added assertions
- ran with `cypress-repeat -n 5` to ensure passes every time 
- ran with /check
- ran on nightly three times


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
