### PR TITLE
Add multi-selection with move/copy/paste/delete functions

### DIFF
--- a/changelog.d/20260722_170000_multiselect_cursor.md
+++ b/changelog.d/20260722_170000_multiselect_cursor.md
@@ -1,0 +1,9 @@
+### Added
+
+- Rubber-band multi-selection of shapes in the annotation view: hold Shift
+  (rebindable to Ctrl/Alt in the shortcuts settings) and drag with the left mouse
+  button to select every shape intersecting the box. The selection is highlighted
+  on the canvas and in the objects sidebar, can be moved together (live group drag),
+  copied with Ctrl+C, pasted with Ctrl+V (relative geometry preserved, clipboard
+  survives frame changes) and removed with Delete. Group move, paste and delete
+  are each recorded as a single undo step

--- a/cvat-canvas/src/scss/canvas.scss
+++ b/cvat-canvas/src/scss/canvas.scss
@@ -82,6 +82,17 @@ polyline.cvat_shape_drawing_opacity {
     fill: #fcfbfc;
 }
 
+// persistent visual for shapes that are part of a multi-selection
+// (does not hide mask images, unlike .cvat_canvas_shape_selection)
+.cvat_canvas_shape_selected_object {
+    @extend .cvat_shape_action_dasharray;
+
+    stroke: #1890ff;
+
+    // glow makes the selection obvious at any zoom level and also works for masks
+    filter: drop-shadow(0 0 4px #1890ff) drop-shadow(0 0 10px #1890ff);
+}
+
 image.cvat_canvas_shape_selection {
     visibility: hidden;
 }

--- a/cvat-canvas/src/typescript/canvas.ts
+++ b/cvat-canvas/src/typescript/canvas.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import {
-    DrawData, MergeData, SplitData, GroupData,
+    DrawData, MergeData, SplitData, GroupData, SelectData,
     JoinData, SliceData, MasksEditData,
     InteractionData as _InteractionData,
     InteractionResult as _InteractionResult,
@@ -41,6 +41,8 @@ interface Canvas {
     split(splitData: SplitData): void;
     merge(mergeData: MergeData): void;
     select(objectState: any): void;
+    selectObjects(selectData: SelectData): void;
+    setSelectedObjects(clientIDs: number[]): void;
 
     fitCanvas(): void;
     bitmap(enable: boolean): void;
@@ -166,6 +168,14 @@ class CanvasImpl implements Canvas {
 
     public select(objectState: any): void {
         this.model.select(objectState);
+    }
+
+    public selectObjects(selectData: SelectData): void {
+        this.model.selectObjects(selectData);
+    }
+
+    public setSelectedObjects(clientIDs: number[]): void {
+        this.model.setSelectedObjects(clientIDs);
     }
 
     public mode(): Mode {

--- a/cvat-canvas/src/typescript/canvasController.ts
+++ b/cvat-canvas/src/typescript/canvasController.ts
@@ -13,6 +13,7 @@ import {
     MergeData,
     SplitData,
     GroupData,
+    SelectData,
     JoinData,
     SliceData,
     Mode,
@@ -37,6 +38,8 @@ export interface CanvasController {
     readonly mergeData: MergeData;
     readonly splitData: SplitData;
     readonly groupData: GroupData;
+    readonly selectData: SelectData;
+    readonly selectedObjects: number[];
     readonly joinData: JoinData;
     readonly sliceData: SliceData;
     readonly selected: any;
@@ -47,6 +50,7 @@ export interface CanvasController {
     zoom(x: number, y: number, deltaY: number): void;
     draw(drawData: DrawData): void;
     edit(editData: MasksEditData | PolyEditData): void;
+    selectObjects(selectData: SelectData): void;
     enableDrag(x: number, y: number): void;
     drag(x: number, y: number): void;
     disableDrag(): void;
@@ -101,6 +105,10 @@ export class CanvasControllerImpl implements CanvasController {
 
     public edit(editData: MasksEditData | PolyEditData): void {
         this.model.edit(editData);
+    }
+
+    public selectObjects(selectData: SelectData): void {
+        this.model.selectObjects(selectData);
     }
 
     public focus(clientID: number, padding: number): void {
@@ -161,6 +169,14 @@ export class CanvasControllerImpl implements CanvasController {
 
     public get groupData(): GroupData {
         return this.model.groupData;
+    }
+
+    public get selectData(): SelectData {
+        return this.model.selectData;
+    }
+
+    public get selectedObjects(): number[] {
+        return this.model.selectedObjects;
     }
 
     public get joinData(): JoinData {

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -79,9 +79,12 @@ export enum ColorBy {
     LABEL = 'Label',
 }
 
+export type MultiSelectModifier = 'shift' | 'ctrl' | 'alt' | 'meta';
+
 export interface Configuration {
     smoothImage?: boolean;
     autoborders?: boolean;
+    multiSelectModifier?: MultiSelectModifier;
     snapToPoint?: boolean;
     adaptiveZoom?: boolean;
     displayAllText?: boolean;
@@ -173,6 +176,10 @@ export interface GroupData {
     enabled: boolean;
 }
 
+export interface SelectData {
+    enabled: boolean;
+}
+
 export interface MergeData {
     enabled: boolean;
 }
@@ -221,6 +228,8 @@ export enum UpdateReasons {
     JOIN = 'join',
     SLICE = 'slice',
     SELECT = 'select',
+    SELECT_OBJECTS = 'select_objects',
+    SELECTED_OBJECTS_UPDATED = 'selected_objects_updated',
     CANCEL = 'cancel',
     BITMAP = 'bitmap',
     SELECT_REGION = 'select_region',
@@ -243,6 +252,7 @@ export enum Mode {
     JOIN = 'join',
     SLICE = 'slice',
     INTERACT = 'interact',
+    SELECT = 'select',
     SELECT_REGION = 'select_region',
     DRAG_CANVAS = 'drag_canvas',
     ZOOM_CANVAS = 'zoom_canvas',
@@ -267,6 +277,8 @@ export interface CanvasModel {
     readonly groupData: GroupData;
     readonly joinData: JoinData;
     readonly sliceData: SliceData;
+    readonly selectData: SelectData;
+    readonly selectedObjects: number[];
     readonly configuration: Configuration;
     readonly selected: any;
     geometry: Geometry;
@@ -293,6 +305,8 @@ export interface CanvasModel {
     split(splitData: SplitData): void;
     merge(mergeData: MergeData): void;
     select(objectState: any): void;
+    selectObjects(selectData: SelectData): void;
+    setSelectedObjects(clientIDs: number[]): void;
     interact(interactionData: InteractionData): void;
 
     fitCanvas(width: number, height: number): void;
@@ -321,6 +335,9 @@ const defaultData = {
         enabled: false,
     },
     groupData: {
+        enabled: false,
+    },
+    selectData: {
         enabled: false,
     },
     splitData: {
@@ -384,10 +401,12 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
         interactionData: InteractionData;
         mergeData: MergeData;
         groupData: GroupData;
+        selectData: SelectData;
         joinData: JoinData;
         sliceData: SliceData;
         splitData: SplitData;
         selected: any;
+        selectedObjects: number[];
         mode: Mode;
         exception: Error | null;
     };
@@ -434,6 +453,7 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
                 undefinedAttrValue: consts.DEFAULT_UNDEFINED_ATTR_VALUE,
                 hideEditedObject: false,
                 focusedObjectPadding: 50,
+                multiSelectModifier: 'shift',
             },
             imageBitmap: false,
             image: null,
@@ -461,6 +481,7 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
             left: 0,
             fittedScale: 0,
             selected: null,
+            selectedObjects: [],
             mode: Mode.IDLE,
             exception: null,
             ...defaultData,
@@ -893,6 +914,26 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
         this.notify(UpdateReasons.GROUP);
     }
 
+    public selectObjects(selectData: SelectData): void {
+        if (![Mode.IDLE, Mode.SELECT].includes(this.data.mode)) {
+            throw Error(`Canvas is busy. Action: ${this.data.mode}`);
+        }
+
+        if ((this.data.selectData.enabled && selectData.enabled) || (
+            !this.data.selectData.enabled && !selectData.enabled
+        )) {
+            return;
+        }
+
+        this.data.selectData = { ...selectData };
+        this.notify(UpdateReasons.SELECT_OBJECTS);
+    }
+
+    public setSelectedObjects(clientIDs: number[]): void {
+        this.data.selectedObjects = [...clientIDs];
+        this.notify(UpdateReasons.SELECTED_OBJECTS_UPDATED);
+    }
+
     public join(joinData: JoinData): void {
         if (![Mode.IDLE, Mode.JOIN].includes(this.data.mode)) {
             throw Error(`Canvas is busy. Action: ${this.data.mode}`);
@@ -992,6 +1033,10 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
         if (typeof configuration.smoothImage === 'boolean') {
             this.data.configuration.smoothImage = configuration.smoothImage;
         }
+        if (['shift', 'ctrl', 'alt', 'meta'].includes(configuration.multiSelectModifier)) {
+            this.data.configuration.multiSelectModifier = configuration.multiSelectModifier;
+        }
+
         if (typeof configuration.undefinedAttrValue === 'string') {
             this.data.configuration.undefinedAttrValue = configuration.undefinedAttrValue;
         }
@@ -1164,6 +1209,14 @@ export class CanvasModelImpl extends MasterImpl implements CanvasModel {
 
     public get groupData(): GroupData {
         return { ...this.data.groupData };
+    }
+
+    public get selectData(): SelectData {
+        return { ...this.data.selectData };
+    }
+
+    public get selectedObjects(): number[] {
+        return [...this.data.selectedObjects];
     }
 
     public get selected(): any {

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -21,6 +21,7 @@ import { MergeHandler, MergeHandlerImpl } from './mergeHandler';
 import { SplitHandler, SplitHandlerImpl } from './splitHandler';
 import { ObjectSelector, ObjectSelectorImpl } from './objectSelector';
 import { GroupHandler, GroupHandlerImpl } from './groupHandler';
+import { SelectHandler, SelectHandlerImpl } from './selectHandler';
 import { SliceHandler, SliceHandlerImpl } from './sliceHandler';
 import { RegionSelector, RegionSelectorImpl } from './regionSelector';
 import { ZoomHandler, ZoomHandlerImpl } from './zoomHandler';
@@ -41,7 +42,7 @@ import {
     CanvasModel, Geometry, UpdateReasons, FrameZoom, ActiveElement,
     DrawData, MergeData, SplitData, Mode, Size, Configuration,
     InteractionResult, InteractionData, ColorBy, HighlightedElements,
-    HighlightSeverity, GroupData, JoinData, CanvasHint,
+    HighlightSeverity, GroupData, SelectData, JoinData, CanvasHint,
 } from './canvasModel';
 
 export interface CanvasView {
@@ -79,6 +80,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
     private mergeHandler: MergeHandler;
     private splitHandler: SplitHandler;
     private groupHandler: GroupHandler;
+    private selectHandler: SelectHandler;
     private sliceHandler: SliceHandler;
     private regionSelector: RegionSelector;
     private objectSelector: ObjectSelector;
@@ -93,6 +95,8 @@ export class CanvasViewImpl implements CanvasView, Listener {
     private resizableShape: SVG.Shape | null;
     private skeletonResizerRefreshRequest: number | null;
     private ctrlPressed: boolean;
+    private pendingSelectionEvent: MouseEvent | null;
+    private selectedObjects: number[];
     private innerObjectsFlags: {
         drawHidden: Record<number, boolean>;
         editHidden: Record<number, boolean>;
@@ -415,35 +419,41 @@ export class CanvasViewImpl implements CanvasView, Listener {
         this.mode = Mode.EDIT;
     };
 
+    // Mark a drawn state as edited so the diff logic redraws it during the next objects setup.
+    // (points is set to an empty array on purpose — see the note below.)
+    private markStateEdited(state: any): void {
+        // we need to store "updated" and set "points" to an empty array
+        // as this information is used to define "updated" objects in diff logic during canvas objects setup
+        // if because of any reason updating was actually rejected somewhere, we must reset view inside this logic
+
+        // there is one more deeper issue:
+        // somewhere canvas updates drawn views and then sends request,
+        // updating internal CVAT state (e.g. drag, resize)
+        // somewhere, however, it just sends request to update internal CVAT state
+        // (e.g. remove point, edit polygon/polyline)
+        // if object view was not changed by canvas and points accepted as is without any changes
+        // the view will not be updated during objects setup if we just set points as is here
+        // that is why we need to set points to an empty array (something that can't normally come from CVAT)
+        // I do not think it can be easily fixed now, however in the future we should refactor code
+        if (Number.isInteger(state.parentID)) {
+            const { elements } = this.drawnStates[state.parentID];
+            const drawnElement = elements.find((el) => el.clientID === state.clientID);
+            drawnElement.updated = 0;
+            drawnElement.points = [];
+
+            this.drawnStates[state.parentID].updated = 0;
+            this.drawnStates[state.parentID].points = [];
+        } else {
+            this.drawnStates[state.clientID].updated = 0;
+            this.drawnStates[state.clientID].points = [];
+        }
+    }
+
     private onEditDone = (state: any, points: number[], rotation?: number): void => {
         this.canvas.style.cursor = '';
         this.mode = Mode.IDLE;
         if (state && points) {
-            // we need to store "updated" and set "points" to an empty array
-            // as this information is used to define "updated" objects in diff logic during canvas objects setup
-            // if because of any reason updating was actually rejected somewhere, we must reset view inside this logic
-
-            // there is one more deeper issue:
-            // somewhere canvas updates drawn views and then sends request,
-            // updating internal CVAT state (e.g. drag, resize)
-            // somewhere, however, it just sends request to update internal CVAT state
-            // (e.g. remove point, edit polygon/polyline)
-            // if object view was not changed by canvas and points accepted as is without any changes
-            // the view will not be updated during objects setup if we just set points as is here
-            // that is why we need to set points to an empty array (something that can't normally come from CVAT)
-            // I do not think it can be easily fixed now, however in the future we should refactor code
-            if (Number.isInteger(state.parentID)) {
-                const { elements } = this.drawnStates[state.parentID];
-                const drawnElement = elements.find((el) => el.clientID === state.clientID);
-                drawnElement.updated = 0;
-                drawnElement.points = [];
-
-                this.drawnStates[state.parentID].updated = 0;
-                this.drawnStates[state.parentID].points = [];
-            } else {
-                this.drawnStates[state.clientID].updated = 0;
-                this.drawnStates[state.clientID].points = [];
-            }
+            this.markStateEdited(state);
 
             const event: CustomEvent = new CustomEvent('canvas.edited', {
                 bubbles: false,
@@ -530,6 +540,23 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     this.joinMasks(objects, duration);
                 }
             }
+        } else {
+            this.dispatchCanceledEvent();
+        }
+    };
+
+    private onSelectObjectsDone = (objects?: any[]): void => {
+        this.mode = Mode.IDLE;
+        if (objects && objects.length) {
+            // visual persistence of the selection is handled by the consumer
+            // (cvat-ui calls canvasInstance.highlight() on the reported states)
+            this.canvas.dispatchEvent(new CustomEvent('canvas.selected', {
+                bubbles: false,
+                cancelable: true,
+                detail: {
+                    states: objects,
+                },
+            }));
         } else {
             this.dispatchCanceledEvent();
         }
@@ -1550,11 +1577,21 @@ export class CanvasViewImpl implements CanvasView, Listener {
             });
 
             let startCenter = null;
+            // live multi-selection drag: when a selected shape is dragged, the rest of the
+            // selection follows by the same delta
+            let groupDragging = false;
+            let groupSiblingIDs: number[] = [];
+            let groupLastCenter: { x: number; y: number } | null = null;
             draggableInstance.on('dragstart', (): void => {
                 onDragStart();
                 this.draggableShape = shape;
                 const { cx, cy } = shape.bbox();
                 startCenter = { x: cx, y: cy };
+                groupDragging = this.selectedObjects.length > 1 &&
+                    this.selectedObjects.includes(state.clientID);
+                groupSiblingIDs = groupDragging ?
+                    this.selectedObjects.filter((id) => id !== state.clientID) : [];
+                groupLastCenter = { x: cx, y: cy };
                 start = Date.now();
             }).on('dragmove', (e: CustomEvent): void => {
                 onDragMove();
@@ -1582,9 +1619,27 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     skeletonSVGTemplate = skeletonSVGTemplate ?? makeSVGFromTemplate(state.label.structure.svg);
                     setupSkeletonEdges(shape as SVG.G, skeletonSVGTemplate);
                 }
+
+                if (groupDragging && groupLastCenter) {
+                    const { cx, cy } = shape.bbox();
+                    const ddx = cx - groupLastCenter.x;
+                    const ddy = cy - groupLastCenter.y;
+                    if (ddx !== 0 || ddy !== 0) {
+                        for (const siblingID of groupSiblingIDs) {
+                            const siblingShape = this.svgShapes[siblingID];
+                            if (siblingShape) {
+                                (siblingShape as any).dmove(ddx, ddy);
+                            }
+                        }
+                        groupLastCenter = { x: cx, y: cy };
+                    }
+                }
             }).on('dragend', (): void => {
                 if (aborted) {
                     this.resetViewPosition(state.clientID);
+                    for (const siblingID of groupSiblingIDs) {
+                        this.resetViewPosition(siblingID);
+                    }
                     return;
                 }
 
@@ -1595,13 +1650,14 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 const dx2 = (startCenter.x - cx) ** 2;
                 const dy2 = (startCenter.y - cy) ** 2;
                 if (Math.sqrt(dx2 + dy2) > 0) {
+                    let draggedPoints: number[];
                     if (state.shapeType === 'mask') {
                         const { points } = state;
                         const x = Math.trunc(shape.x()) - this.geometry.offset;
                         const y = Math.trunc(shape.y()) - this.geometry.offset;
                         points.splice(-4);
                         points.push(x, y, x + shape.width() - 1, y + shape.height() - 1);
-                        this.onEditDone(state, points);
+                        draggedPoints = points;
                     } else if (state.shapeType === 'skeleton') {
                         const points = [];
                         state.elements.forEach((element: any) => {
@@ -1614,7 +1670,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                                 points.push(...this.translateFromCanvas(readPointsFromShape(elementShape)));
                             }
                         });
-                        this.onEditDone(state, points);
+                        draggedPoints = points;
                     } else {
                         // these points does not take into account possible transformations, applied on the element
                         // so, if any (like rotation) we need to map them to canvas coordinate space
@@ -1624,7 +1680,40 @@ export class CanvasViewImpl implements CanvasView, Listener {
                             points = this.translatePointsFromRotatedShape(shape, points);
                         }
 
-                        this.onEditDone(state, this.translateFromCanvas(points));
+                        draggedPoints = this.translateFromCanvas(points);
+                    }
+
+                    if (groupDragging) {
+                        // move the whole selection together and record it as a single change
+                        const totalDx = cx - startCenter.x;
+                        const totalDy = cy - startCenter.y;
+                        const movedStates = [{ state, points: draggedPoints }];
+                        for (const siblingID of groupSiblingIDs) {
+                            const sibling = this.controller.objects
+                                .find((obj: any) => obj.clientID === siblingID);
+                            if (sibling) {
+                                movedStates.push({
+                                    state: sibling,
+                                    points: this.translateStatePoints(sibling, totalDx, totalDy),
+                                });
+                            }
+                        }
+
+                        movedStates.forEach(({ state: movedState }) => this.markStateEdited(movedState));
+                        this.canvas.style.cursor = '';
+                        this.mode = Mode.IDLE;
+                        this.canvas.dispatchEvent(
+                            new CustomEvent('canvas.groupmoved', {
+                                bubbles: false,
+                                cancelable: true,
+                                detail: {
+                                    states: movedStates,
+                                    duration: Date.now() - start,
+                                },
+                            }),
+                        );
+                    } else {
+                        this.onEditDone(state, draggedPoints);
                     }
 
                     this.canvas.dispatchEvent(
@@ -1870,6 +1959,37 @@ export class CanvasViewImpl implements CanvasView, Listener {
         }
     }
 
+    // the modifier key (default shift) + left mouse button starts a rubber-band multi-selection
+    private isMultiSelectModifierPressed(event: MouseEvent): boolean {
+        const modifier = this.configuration.multiSelectModifier || 'shift';
+        return {
+            shift: event.shiftKey,
+            ctrl: event.ctrlKey,
+            alt: event.altKey,
+            meta: event.metaKey,
+        }[modifier];
+    }
+
+    private onContentMouseDown = (event: MouseEvent): void => {
+        const onBackground = !(event.target as Element)?.closest?.('.cvat_canvas_shape');
+        if (event.button === 0 && this.isMultiSelectModifierPressed(event) &&
+            this.mode === Mode.IDLE && onBackground) {
+            this.pendingSelectionEvent = event;
+            this.controller.selectObjects({ enabled: true });
+            this.pendingSelectionEvent = null;
+
+            const onDocumentMouseUp = (): void => {
+                window.document.removeEventListener('mouseup', onDocumentMouseUp);
+                if (this.mode === Mode.SELECT) {
+                    this.controller.selectObjects({ enabled: false });
+                }
+            };
+            // registered after objectSelector's own mouseup listener, so it runs
+            // once the intersecting shapes have already been collected
+            window.document.addEventListener('mouseup', onDocumentMouseUp);
+        }
+    };
+
     private onKeyDown = (e: KeyboardEvent): void => {
         if (e.repeat) {
             return;
@@ -1949,6 +2069,8 @@ export class CanvasViewImpl implements CanvasView, Listener {
         this.mode = Mode.IDLE;
         this.snapToAngleResize = consts.SNAP_TO_ANGLE_RESIZE_DEFAULT;
         this.ctrlPressed = false;
+        this.pendingSelectionEvent = null;
+        this.selectedObjects = [];
         this.innerObjectsFlags = {
             drawHidden: {},
             editHidden: {},
@@ -2090,6 +2212,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
             this.adoptedContent,
         );
         this.groupHandler = new GroupHandlerImpl(this.onSelectDone, this.objectSelector);
+        this.selectHandler = new SelectHandlerImpl(this.onSelectObjectsDone, this.objectSelector);
         this.sliceHandler = new SliceHandlerImpl(
             (clientID) => this.setupInnerFlags(clientID, 'sliceHidden', true),
             (clientID) => this.setupInnerFlags(clientID, 'sliceHidden', false),
@@ -2128,14 +2251,19 @@ export class CanvasViewImpl implements CanvasView, Listener {
 
         this.canvas.addEventListener('mousedown', (event): void => {
             if ([0, 1].includes(event.button)) {
+                // the multi-selection modifier + left button is reserved for the rubber-band
+                // selection, so it must not start panning the image
+                const reservedForSelection = event.button === 0 && this.isMultiSelectModifierPressed(event);
                 if (
-                    [Mode.IDLE, Mode.DRAG_CANVAS, Mode.MERGE, Mode.SPLIT]
-                        .includes(this.mode) || event.button === 1 || event.altKey
+                    ([Mode.IDLE, Mode.DRAG_CANVAS, Mode.MERGE, Mode.SPLIT].includes(this.mode) &&
+                        !reservedForSelection) ||
+                    event.button === 1 || (event.altKey && !reservedForSelection)
                 ) {
                     this.controller.enableDrag(event.clientX, event.clientY);
                 }
             }
         });
+        this.canvas.addEventListener('mousedown', this.onContentMouseDown);
 
         window.document.addEventListener('mouseup', this.onMouseUp);
         window.document.addEventListener('keydown', this.onKeyDown);
@@ -2392,6 +2520,8 @@ export class CanvasViewImpl implements CanvasView, Listener {
         } else if (reason === UpdateReasons.OBJECTS_UPDATED) {
             this.objectSelector.resetSelected();
             this.setupObjects(this.controller.objects);
+            // re-apply the multi-selection visual, lost when shapes are redrawn
+            this.setupSelectedObjects();
             if (this.mode === Mode.MERGE) {
                 this.mergeHandler.repeatSelection();
             }
@@ -2575,12 +2705,27 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 this.mode = Mode.SLICE;
                 this.sliceHandler.slice(data);
             }
+        } else if (reason === UpdateReasons.SELECT_OBJECTS) {
+            const data: SelectData = this.controller.selectData;
+            if (data.enabled) {
+                this.mode = Mode.SELECT;
+                this.selectHandler.select(
+                    data, { objectType: ['shape'], intersect: true }, this.pendingSelectionEvent,
+                );
+            } else {
+                this.selectHandler.select(data, {});
+            }
+        } else if (reason === UpdateReasons.SELECTED_OBJECTS_UPDATED) {
+            this.selectedObjects = this.controller.selectedObjects;
+            this.setupSelectedObjects();
         } else if (reason === UpdateReasons.SELECT) {
             this.objectSelector.push(this.controller.selected);
             if (this.mode === Mode.MERGE) {
                 this.mergeHandler.select(this.controller.selected);
             } else if (this.mode === Mode.SPLIT) {
                 this.splitHandler.select(this.controller.selected);
+            } else if (this.mode === Mode.SELECT) {
+                this.selectHandler.push(this.controller.selected);
             }
         } else if (reason === UpdateReasons.CANCEL) {
             if (this.mode === Mode.DRAW) {
@@ -2597,6 +2742,8 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 this.splitHandler.cancel();
             } else if (this.mode === Mode.GROUP || this.mode === Mode.JOIN) {
                 this.groupHandler.cancel();
+            } else if (this.mode === Mode.SELECT) {
+                this.selectHandler.cancel();
             } else if (this.mode === Mode.SLICE) {
                 this.sliceHandler.cancel();
             } else if (this.mode === Mode.SELECT_REGION) {
@@ -2638,6 +2785,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
             window.document.removeEventListener('keydown', this.onKeyDown);
             window.document.removeEventListener('keyup', this.onKeyUp);
             window.document.removeEventListener('mouseup', this.onMouseUp);
+            this.canvas.removeEventListener('mousedown', this.onContentMouseDown);
             this.interactionHandler.destroy();
         }
 
@@ -3334,7 +3482,11 @@ export class CanvasViewImpl implements CanvasView, Listener {
             });
         }
 
-        if (!state.pinned) {
+        // membership in a multi-selection overrides pinned, so the whole
+        // selection can be dragged as a group grabbing any of its shapes
+        const draggableBySelection = this.selectedObjects.length > 1 &&
+            this.selectedObjects.includes(state.clientID);
+        if (!state.pinned || draggableBySelection) {
             this.draggable(state, shape, () => {
                 this.mode = Mode.DRAG;
                 hideText();
@@ -3411,6 +3563,41 @@ export class CanvasViewImpl implements CanvasView, Listener {
             this.deactivate();
             const clientID = this.highlightedElements.elementsIDs[0];
             this.activate({ clientID, attributeID: null });
+        }
+    }
+
+    private translateStatePoints(state: any, dx: number, dy: number): number[] {
+        const points = [...state.points];
+        if (state.shapeType === 'mask') {
+            // mask points are [...rle, left, top, right, bottom]; shift the bounding box
+            const n = points.length;
+            points[n - 4] += dx;
+            points[n - 3] += dy;
+            points[n - 2] += dx;
+            points[n - 1] += dy;
+            return points;
+        }
+
+        for (let i = 0; i < points.length; i += 2) {
+            points[i] += dx;
+            points[i + 1] += dy;
+        }
+        return points;
+    }
+
+    private setupSelectedObjects(): void {
+        // reflect the persistent multi-selection on the shapes with a dedicated class
+        for (const shape of Array.from(
+            this.content.getElementsByClassName('cvat_canvas_shape_selected_object'),
+        )) {
+            shape.classList.remove('cvat_canvas_shape_selected_object');
+        }
+
+        for (const clientID of this.selectedObjects) {
+            const shape = this.svgShapes[clientID];
+            if (shape) {
+                shape.addClass('cvat_canvas_shape_selected_object');
+            }
         }
     }
 

--- a/cvat-canvas/src/typescript/objectSelector.ts
+++ b/cvat-canvas/src/typescript/objectSelector.ts
@@ -12,12 +12,16 @@ export interface SelectionFilter {
     shapeType?: string[];
     maxCount?: number;
     restrictToFirstSelectedType?: boolean;
+    // when true, a shape is selected if its bounding box intersects the selection box
+    // (default behaviour requires the selection box to fully contain the shape)
+    intersect?: boolean;
 }
 
 export interface ObjectSelector {
     enable(
         callback: (selected: ObjectState[]) => void,
         filter?: SelectionFilter,
+        initialEvent?: MouseEvent,
     ): void;
     transform(geometry: Geometry): void;
     push(state: ObjectState): void;
@@ -123,15 +127,21 @@ export class ObjectSelectorImpl implements ObjectSelector {
                 (shape: SVG.Shape): boolean => !shape.hasClass('cvat_canvas_hidden'),
             );
 
+            const intersect = !!this.selectionFilter?.intersect;
             let newStates = [];
             for (const shape of shapes) {
                 const bbox = shape.bbox();
                 const clientID = shape.attr('clientID');
-                if (
-                    bbox.x > box.xtl &&
+                const contained = bbox.x > box.xtl &&
                     bbox.y > box.ytl &&
                     bbox.x + bbox.width < box.xbr &&
-                    bbox.y + bbox.height < box.ybr &&
+                    bbox.y + bbox.height < box.ybr;
+                const intersected = bbox.x < box.xbr &&
+                    bbox.x + bbox.width > box.xtl &&
+                    bbox.y < box.ybr &&
+                    bbox.y + bbox.height > box.ytl;
+                if (
+                    (intersect ? intersected : contained) &&
                     !(clientID in this.selectedObjects)
                 ) {
                     const objectState = states.find((state: ObjectState): boolean => state.clientID === clientID);
@@ -170,7 +180,11 @@ export class ObjectSelectorImpl implements ObjectSelector {
         this.resetAppearance = {};
     }
 
-    public enable(callback: (selected: ObjectState[]) => void, filter?: SelectionFilter): void {
+    public enable(
+        callback: (selected: ObjectState[]) => void,
+        filter?: SelectionFilter,
+        initialEvent?: MouseEvent,
+    ): void {
         if (!this.isEnabled) {
             window.document.addEventListener('mouseup', this.onMouseUp);
             this.canvas.node.addEventListener('mousedown', this.onMouseDown);
@@ -251,6 +265,13 @@ export class ObjectSelectorImpl implements ObjectSelector {
 
             this.selectionFilter = filter;
             this.isEnabled = true;
+
+            if (initialEvent) {
+                // start the selection box immediately from the triggering mousedown
+                // (used by shift + left-mousedown selection, where the listeners below
+                // are attached only after the initial press has already happened)
+                this.onMouseDown(initialEvent);
+            }
         }
     }
 

--- a/cvat-canvas/src/typescript/selectHandler.ts
+++ b/cvat-canvas/src/typescript/selectHandler.ts
@@ -1,0 +1,67 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import { SelectData } from './canvasModel';
+import { ObjectSelector, SelectionFilter } from './objectSelector';
+
+export interface SelectHandler {
+    select(selectData: SelectData, selectionFilter: SelectionFilter, initialEvent?: MouseEvent): void;
+    push(state: any): void;
+    cancel(): void;
+}
+
+export class SelectHandlerImpl implements SelectHandler {
+    private onSelectDone: (objects?: any[]) => void;
+    private selector: ObjectSelector;
+    private initialized: boolean;
+    private selectedStates: any[];
+
+    private release(): void {
+        this.selector.disable();
+        this.initialized = false;
+    }
+
+    private initSelection(selectionFilter: SelectionFilter, initialEvent?: MouseEvent): void {
+        this.selectedStates = [];
+        this.selector.enable((selected) => {
+            this.selectedStates = selected;
+        }, selectionFilter, initialEvent);
+        this.initialized = true;
+    }
+
+    private closeSelection(): void {
+        if (this.initialized) {
+            const { selectedStates } = this;
+            this.release();
+            this.onSelectDone(selectedStates);
+        }
+    }
+
+    public constructor(
+        onSelectDone: SelectHandlerImpl['onSelectDone'],
+        selector: ObjectSelector,
+    ) {
+        this.onSelectDone = onSelectDone;
+        this.selector = selector;
+        this.selectedStates = [];
+        this.initialized = false;
+    }
+
+    public select(selectData: SelectData, selectionFilter: SelectionFilter, initialEvent?: MouseEvent): void {
+        if (selectData.enabled) {
+            this.initSelection(selectionFilter, initialEvent);
+        } else {
+            this.closeSelection();
+        }
+    }
+
+    public push(objectState: any): void {
+        this.selector.push(objectState);
+    }
+
+    public cancel(): void {
+        this.release();
+        this.onSelectDone();
+    }
+}

--- a/cvat-core/src/annotations-collection.ts
+++ b/cvat-core/src/annotations-collection.ts
@@ -249,6 +249,138 @@ export default class Collection {
         return updatedStates;
     }
 
+    // Saves several object states at once and records the whole change as a single
+    // undo/redo item (e.g. moving a multi-selection together). Mirrors _applyZOrderUpdates.
+    public updateBatch(objectStates: ObjectState[]): ObjectState[] {
+        checkObjectType('objectStates', objectStates, null, { cls: Array, name: 'Array' });
+
+        const updatedStates: ObjectState[] = [];
+        const snapshots: {
+            clientID: number;
+            frame: number;
+            undo: () => void;
+            redo: () => void;
+        }[] = [];
+
+        // save() only applies fields raised in updateFlags, so a restore must go
+        // through the points setter of a fresh state
+        const restorePoints = (object: Shape | Track, frame: number, points: number[] | null): void => {
+            if (!Array.isArray(points)) {
+                return;
+            }
+            const target = new ObjectState(object.get(frame));
+            target.points = [...points];
+            object.save(frame, target);
+        };
+
+        // Prevent each individual object.save() from creating its own history item.
+        this.history.freeze(true);
+
+        try {
+            for (const state of objectStates) {
+                const object = this.objects[state.clientID];
+                if (!(object instanceof Shape || object instanceof Track) || object.removed || object.lock) {
+                    continue;
+                }
+
+                const { frame } = state;
+                const beforePoints = new ObjectState(object.get(frame)).points;
+                const updatedState = object.save(frame, state);
+                const afterPoints = updatedState.points;
+
+                snapshots.push({
+                    clientID: state.clientID,
+                    frame,
+                    undo: () => restorePoints(object, frame, beforePoints),
+                    redo: () => restorePoints(object, frame, afterPoints),
+                });
+                updatedStates.push(updatedState);
+            }
+        } catch (error: unknown) {
+            snapshots.forEach(({ undo }) => undo());
+            throw error;
+        } finally {
+            this.history.freeze(false);
+        }
+
+        if (snapshots.length) {
+            const { frame } = snapshots[snapshots.length - 1];
+            this.history.do(
+                HistoryActions.CHANGED_POINTS,
+                () => {
+                    this.history.freeze(true);
+                    try {
+                        snapshots.forEach(({ undo }) => undo());
+                    } finally {
+                        this.history.freeze(false);
+                    }
+                },
+                () => {
+                    this.history.freeze(true);
+                    try {
+                        snapshots.forEach(({ redo }) => redo());
+                    } finally {
+                        this.history.freeze(false);
+                    }
+                },
+                snapshots.map(({ clientID }) => clientID),
+                frame,
+            );
+        }
+
+        return updatedStates;
+    }
+
+    // Removes several objects at once and records the whole change as a single
+    // undo/redo item (e.g. deleting a multi-selection together)
+    public removeBatch(objectStates: ObjectState[], force: boolean): number[] {
+        checkObjectType('objectStates', objectStates, null, { cls: Array, name: 'Array' });
+
+        const removedObjects: (Shape | Track | Tag)[] = [];
+        let frame = null;
+
+        // Prevent each individual object.delete() from creating its own history item.
+        this.history.freeze(true);
+        try {
+            for (const state of objectStates) {
+                const object = this.objects[state.clientID];
+                if (!(object instanceof Shape || object instanceof Track || object instanceof Tag) ||
+                    object.removed) {
+                    continue;
+                }
+
+                if (object.delete(state.frame, force)) {
+                    removedObjects.push(object);
+                    frame = state.frame;
+                }
+            }
+        } finally {
+            this.history.freeze(false);
+        }
+
+        if (removedObjects.length) {
+            this.history.do(
+                HistoryActions.REMOVED_OBJECT,
+                () => {
+                    removedObjects.forEach((object) => {
+                        object.removed = false;
+                        object.updated = Date.now();
+                    });
+                },
+                () => {
+                    removedObjects.forEach((object) => {
+                        object.removed = true;
+                        object.updated = Date.now();
+                    });
+                },
+                removedObjects.map((object) => object.clientID),
+                frame,
+            );
+        }
+
+        return removedObjects.map((object) => object.clientID);
+    }
+
     public import(data: Partial<SerializedCollection>): {
         tags: Tag[];
         shapes: Shape[];

--- a/cvat-core/src/session-implementation.ts
+++ b/cvat-core/src/session-implementation.ts
@@ -542,6 +542,25 @@ export function implementJob(Job: typeof JobClass): typeof JobClass {
         },
     });
 
+    Object.defineProperty(Job.prototype.annotations.updateBatch, 'implementation', {
+        value: function updateBatchAnnotationsImplementation(
+            this: JobClass,
+            objectStates: Parameters<typeof JobClass.prototype.annotations.updateBatch>[0],
+        ): ReturnType<typeof JobClass.prototype.annotations.updateBatch> {
+            return Promise.resolve(getCollection(this).updateBatch(objectStates));
+        },
+    });
+
+    Object.defineProperty(Job.prototype.annotations.removeBatch, 'implementation', {
+        value: function removeBatchAnnotationsImplementation(
+            this: JobClass,
+            objectStates: Parameters<typeof JobClass.prototype.annotations.removeBatch>[0],
+            force: Parameters<typeof JobClass.prototype.annotations.removeBatch>[1],
+        ): ReturnType<typeof JobClass.prototype.annotations.removeBatch> {
+            return Promise.resolve(getCollection(this).removeBatch(objectStates, force ?? false));
+        },
+    });
+
     Object.defineProperty(Job.prototype.annotations.import, 'implementation', {
         value: function importAnnotationsImplementation(
             this: JobClass,
@@ -1338,6 +1357,25 @@ export function implementTask(Task: typeof TaskClass): typeof TaskClass {
             objectStates: Parameters<typeof TaskClass.prototype.annotations.put>[0],
         ): ReturnType<typeof TaskClass.prototype.annotations.put> {
             return Promise.resolve(getCollection(this).put(objectStates));
+        },
+    });
+
+    Object.defineProperty(Task.prototype.annotations.updateBatch, 'implementation', {
+        value: function updateBatchAnnotationsImplementation(
+            this: TaskClass,
+            objectStates: Parameters<typeof TaskClass.prototype.annotations.updateBatch>[0],
+        ): ReturnType<typeof TaskClass.prototype.annotations.updateBatch> {
+            return Promise.resolve(getCollection(this).updateBatch(objectStates));
+        },
+    });
+
+    Object.defineProperty(Task.prototype.annotations.removeBatch, 'implementation', {
+        value: function removeBatchAnnotationsImplementation(
+            this: TaskClass,
+            objectStates: Parameters<typeof TaskClass.prototype.annotations.removeBatch>[0],
+            force: Parameters<typeof TaskClass.prototype.annotations.removeBatch>[1],
+        ): ReturnType<typeof TaskClass.prototype.annotations.removeBatch> {
+            return Promise.resolve(getCollection(this).removeBatch(objectStates, force ?? false));
         },
     });
 

--- a/cvat-core/src/session.ts
+++ b/cvat-core/src/session.ts
@@ -200,6 +200,25 @@ function buildDuplicatedAPI(prototype): void {
                     return result;
                 },
 
+                async updateBatch(objectStates) {
+                    const result = await PluginRegistry.apiWrapper.call(
+                        this,
+                        prototype.annotations.updateBatch,
+                        objectStates,
+                    );
+                    return result;
+                },
+
+                async removeBatch(objectStates, force = false) {
+                    const result = await PluginRegistry.apiWrapper.call(
+                        this,
+                        prototype.annotations.removeBatch,
+                        objectStates,
+                        force,
+                    );
+                    return result;
+                },
+
                 async import(data) {
                     const result = await PluginRegistry.apiWrapper.call(this, prototype.annotations.import, data);
                     return result;
@@ -406,6 +425,8 @@ export class Session {
             objectStates: ObjectState[],
         ) => Promise<ObjectState[]>;
         compactLayers: (frame: number) => Promise<ObjectState[]>;
+        updateBatch: (objectStates: ObjectState[]) => Promise<ObjectState[]>;
+        removeBatch: (objectStates: ObjectState[], force?: boolean) => Promise<number[]>;
         clear: (options?: {
             reload?: boolean;
             from?: number;
@@ -524,6 +545,8 @@ export class Session {
             slice: Object.getPrototypeOf(this).annotations.slice.bind(this),
             updateLayer: Object.getPrototypeOf(this).annotations.updateLayer.bind(this),
             compactLayers: Object.getPrototypeOf(this).annotations.compactLayers.bind(this),
+            updateBatch: Object.getPrototypeOf(this).annotations.updateBatch.bind(this),
+            removeBatch: Object.getPrototypeOf(this).annotations.removeBatch.bind(this),
             clear: Object.getPrototypeOf(this).annotations.clear.bind(this),
             search: Object.getPrototypeOf(this).annotations.search.bind(this),
             upload: Object.getPrototypeOf(this).annotations.upload.bind(this),

--- a/cvat-ui/src/actions/annotation-actions.ts
+++ b/cvat-ui/src/actions/annotation-actions.ts
@@ -119,6 +119,8 @@ export enum AnnotationActionTypes {
     COLLAPSE_APPEARANCE = 'COLLAPSE_APPEARANCE',
     COLLAPSE_OBJECT_ITEMS = 'COLLAPSE_OBJECT_ITEMS',
     ACTIVATE_OBJECT = 'ACTIVATE_OBJECT',
+    SELECT_OBJECTS = 'SELECT_OBJECTS',
+    COPY_SELECTION = 'COPY_SELECTION',
     UPDATE_EDITED_STATE = 'UPDATE_EDITED_STATE',
     HIDE_ACTIVE_OBJECT = 'HIDE_ACTIVE_OBJECT',
     REMOVE_OBJECT = 'REMOVE_OBJECT',
@@ -603,6 +605,137 @@ export function copyShape(objectState: any): AnyAction {
         payload: {
             objectState,
         },
+    };
+}
+
+export function selectObjects(selectedStatesID: number[]): AnyAction {
+    return {
+        type: AnnotationActionTypes.SELECT_OBJECTS,
+        payload: {
+            selectedStatesID,
+        },
+    };
+}
+
+export function copySelection(objectStates: any[]): AnyAction {
+    const job = getStore().getState().annotation.job.instance;
+    job?.logger.log(EventScope.copyObject, { count: objectStates.length });
+
+    return {
+        type: AnnotationActionTypes.COPY_SELECTION,
+        payload: {
+            // keep the source states as the clipboard; new objects are built lazily on paste,
+            // so copy on one frame + paste on a later frame works
+            copiedStates: objectStates,
+        },
+    };
+}
+
+// removes the whole multi-selection as a single undoable change
+export function removeSelectionAsync(force: boolean): ThunkAction {
+    return async (dispatch: ThunkDispatch): Promise<void> => {
+        const {
+            job: { instance: jobInstance },
+            annotations: { states, selectedStatesID },
+        } = getStore().getState().annotation;
+
+        const selectedStates = states
+            .filter((state: any) => selectedStatesID.includes(state.clientID));
+        if (!jobInstance || !selectedStates.length) {
+            return;
+        }
+
+        try {
+            const removedIDs: number[] = await jobInstance.annotations.removeBatch(selectedStates, force);
+            if (removedIDs.length) {
+                await jobInstance.logger.log(EventScope.deleteObject, { count: removedIDs.length });
+                dispatch(selectObjects([]));
+                dispatch(fetchAnnotationsAsync());
+            }
+        } catch (error) {
+            dispatch({
+                type: AnnotationActionTypes.REMOVE_OBJECT_FAILED,
+                payload: { error },
+            });
+        }
+    };
+}
+
+// build a serialized copy of a state translated by (dx, dy), preserving relative geometry;
+// mirrors the serialization used by cvat.utils.propagateShapes, but allows same-frame paste
+function serializeStateWithOffset(state: any, frame: number, dx: number, dy: number): any {
+    const offsetPoints = (points: number[] | null, shapeType: string): number[] | null => {
+        if (!points) {
+            return points;
+        }
+        if (shapeType === 'mask') {
+            // [...rle, left, top, right, bottom]
+            const shifted = [...points];
+            const n = shifted.length;
+            shifted[n - 4] += dx;
+            shifted[n - 3] += dy;
+            shifted[n - 2] += dx;
+            shifted[n - 1] += dy;
+            return shifted;
+        }
+        return points.map((value, index) => value + (index % 2 === 0 ? dx : dy));
+    };
+
+    return {
+        attributes: { ...state.attributes },
+        points: state.shapeType === 'skeleton' ? null : offsetPoints(state.points, state.shapeType),
+        occluded: state.occluded,
+        outside: state.outside,
+        objectType: state.objectType !== ObjectType.TRACK ? state.objectType : ObjectType.SHAPE,
+        shapeType: state.shapeType,
+        label: state.label,
+        zOrder: state.zOrder,
+        rotation: state.rotation,
+        frame,
+        elements: state.shapeType === 'skeleton' ?
+            state.elements.map((element: any) => serializeStateWithOffset(element, frame, dx, dy)) : [],
+        source: state.source,
+    };
+}
+
+export function pasteSelectionAsync(): ThunkAction {
+    return async (dispatch: ThunkDispatch): Promise<void> => {
+        const {
+            job: { instance: jobInstance },
+            player: { frame: { number: frameNumber } },
+            drawing: { copiedStates },
+        } = getStore().getState().annotation;
+
+        if (!jobInstance || !copiedStates || !copiedStates.length) {
+            return;
+        }
+
+        // small constant offset so pasted objects do not perfectly overlap the originals
+        const offset = 20;
+        const statesToCreate = copiedStates.map((state: any): ObjectState => {
+            if (state.objectType === ObjectType.TAG) {
+                return new cvat.classes.ObjectState({
+                    objectType: ObjectType.TAG,
+                    label: state.label,
+                    attributes: { ...state.attributes },
+                    frame: frameNumber,
+                });
+            }
+            return new cvat.classes.ObjectState(serializeStateWithOffset(state, frameNumber, offset, offset));
+        });
+
+        try {
+            // a single put() records one CREATED_OBJECTS history action -> one undo step
+            const clientIDs: number[] = await jobInstance.annotations.put(statesToCreate);
+            await dispatch(fetchAnnotationsAsync());
+            // select the freshly pasted objects so the whole group can be moved into place
+            dispatch(selectObjects(clientIDs));
+        } catch (error) {
+            dispatch({
+                type: AnnotationActionTypes.CREATE_ANNOTATIONS_FAILED,
+                payload: { error },
+            });
+        }
     };
 }
 
@@ -1252,6 +1385,37 @@ export function updateAnnotationsAsync(statesToUpdate: ObjectState[]): ThunkActi
             if (workspace === Workspace.REVIEW) {
                 states = lockStatesForReviewWorkspace(states);
             }
+
+            const needToUpdateAll = states
+                .some((state) => state.shapeType === ShapeType.MASK || state.parentID !== null);
+            if (needToUpdateAll) {
+                dispatch(fetchAnnotationsAsync());
+                return;
+            }
+
+            dispatchAnnotationsUpdate(dispatch, states, await jobInstance.actions.get());
+        } catch (error) {
+            dispatch({
+                type: AnnotationActionTypes.UPDATE_ANNOTATIONS_FAILED,
+                payload: { error },
+            });
+            dispatch(fetchAnnotationsAsync());
+        }
+    };
+}
+
+// Updates several objects at once and records the change as a single undo step
+// (used when a multi-selection is moved together).
+export function updateAnnotationsBatchAsync(statesToUpdate: ObjectState[]): ThunkAction {
+    return async (dispatch: ThunkDispatch): Promise<void> => {
+        const { jobInstance } = receiveAnnotationsParameters();
+        try {
+            const statesToSave = statesToUpdate.filter((objectState) => !objectState.isGroundTruth);
+            if (!statesToSave.length) {
+                return;
+            }
+
+            const states = await jobInstance.annotations.updateBatch(statesToSave);
 
             const needToUpdateAll = states
                 .some((state) => state.shapeType === ShapeType.MASK || state.parentID !== null);

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
@@ -35,9 +35,11 @@ import {
     resetCanvas,
     updateActiveControl as updateActiveControlAction,
     updateAnnotationsAsync,
+    updateAnnotationsBatchAsync,
     createAnnotationsAsync,
     mergeAnnotationsAsync,
     groupAnnotationsAsync,
+    selectObjects,
     joinAnnotationsAsync,
     sliceAnnotationsAsync,
     splitAnnotationsAsync,
@@ -80,6 +82,7 @@ interface StateToProps {
     activatedStateID: number | null;
     activatedElementID: number | null;
     activatedAttributeID: number | null;
+    selectedStatesID: number[];
     annotations: ObjectState[];
     renderData: RenderData;
     frameData: any;
@@ -134,10 +137,12 @@ interface DispatchToProps {
     onResetCanvas: () => void;
     updateActiveControl: (activeControl: ActiveControl) => void;
     onUpdateAnnotations(states: ObjectState[]): void;
+    onUpdateAnnotationsBatch(states: ObjectState[]): void;
     onCreateAnnotations(states: ObjectState[], source?: AnnotationSource): void;
     onMergeAnnotations(states: ObjectState[]): void;
     onSplitAnnotations(state: ObjectState): void;
     onGroupAnnotations(states: ObjectState[]): void;
+    onSelectObjects(selectedStatesID: number[]): void;
     onJoinAnnotations(states: ObjectState[], points: number[][]): void;
     onSliceAnnotations(state: ObjectState, results: number[][]): void;
     onActivateObject: (activatedStateID: number | null, activatedElementID: number | null) => void;
@@ -175,6 +180,7 @@ function mapStateToProps(state: CombinedState): StateToProps {
                 activatedStateID,
                 activatedElementID,
                 activatedAttributeID,
+                selectedStatesID,
                 zLayer: { cur: curZLayer },
                 highlightedConflict,
                 renderData,
@@ -227,6 +233,7 @@ function mapStateToProps(state: CombinedState): StateToProps {
         activatedStateID,
         activatedElementID,
         activatedAttributeID,
+        selectedStatesID,
         annotations,
         renderData,
         opacity: opacity / 100,
@@ -306,6 +313,28 @@ const componentShortcuts = {
 
 registerComponentShortcuts(componentShortcuts);
 
+// registered so users can rebind the modifier in the regular shortcuts settings,
+// but deliberately not passed to GlobalHotKeys: it is a mouse modifier read by the
+// canvas, not a keyboard-triggered action
+const multiSelectShortcut = {
+    CANVAS_MULTI_SELECT_MODIFIER: {
+        name: 'Multi-selection modifier',
+        description: 'Hold this key and drag with the left mouse button in cursor mode to select ' +
+            'several objects with a selection box (supported: shift, ctrl, alt, meta - other keys are ignored)',
+        sequences: ['shift'],
+        scope: ShortcutScope.STANDARD_WORKSPACE,
+    },
+};
+registerComponentShortcuts(multiSelectShortcut);
+
+function multiSelectModifierFromKeyMap(keyMap: KeyMap): 'shift' | 'ctrl' | 'alt' | 'meta' {
+    const [sequence] = keyMap.CANVAS_MULTI_SELECT_MODIFIER?.sequences ?? [];
+    if (sequence === 'ctrl' || sequence === 'control') return 'ctrl';
+    if (sequence === 'alt' || sequence === 'option') return 'alt';
+    if (sequence === 'meta' || sequence === 'command' || sequence === 'cmd') return 'meta';
+    return 'shift';
+}
+
 function mapDispatchToProps(dispatch: any): DispatchToProps {
     return {
         onSetupCanvas(): void {
@@ -320,6 +349,9 @@ function mapDispatchToProps(dispatch: any): DispatchToProps {
         onUpdateAnnotations(states: ObjectState[]): void {
             dispatch(updateAnnotationsAsync(states));
         },
+        onUpdateAnnotationsBatch(states: ObjectState[]): void {
+            dispatch(updateAnnotationsBatchAsync(states));
+        },
         onCreateAnnotations(
             states: ObjectState[],
             source: AnnotationSource = AnnotationSource.OTHER,
@@ -331,6 +363,9 @@ function mapDispatchToProps(dispatch: any): DispatchToProps {
         },
         onGroupAnnotations(states: ObjectState[]): void {
             dispatch(groupAnnotationsAsync(states));
+        },
+        onSelectObjects(selectedStatesID: number[]): void {
+            dispatch(selectObjects(selectedStatesID));
         },
         onJoinAnnotations(states: ObjectState[], points: number[][]): void {
             dispatch(joinAnnotationsAsync(states, points));
@@ -455,6 +490,7 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
             textContent,
             resetZoom,
             focusedObjectPadding,
+            multiSelectModifier: multiSelectModifierFromKeyMap(this.props.keyMap),
         });
 
         this.initialSetup();
@@ -472,6 +508,7 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
             frameAngle,
             annotations,
             activatedStateID,
+            selectedStatesID,
             curZLayer,
             resetZoom,
             smoothImage,
@@ -522,7 +559,8 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
             prevProps.outlined !== outlined ||
             prevProps.showGroundTruth !== showGroundTruth ||
             prevProps.resetZoom !== resetZoom ||
-            prevProps.focusedObjectPadding !== focusedObjectPadding
+            prevProps.focusedObjectPadding !== focusedObjectPadding ||
+            multiSelectModifierFromKeyMap(prevProps.keyMap) !== multiSelectModifierFromKeyMap(this.props.keyMap)
         ) {
             canvasInstance.configure({
                 undefinedAttrValue: config.UNDEFINED_ATTRIBUTE_VALUE,
@@ -544,6 +582,7 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
                 showConflicts: showGroundTruth,
                 resetZoom,
                 focusedObjectPadding,
+                multiSelectModifier: multiSelectModifierFromKeyMap(this.props.keyMap),
             });
         }
 
@@ -553,6 +592,12 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
 
         if (prevProps.activatedStateID !== null && prevProps.activatedStateID !== activatedStateID) {
             canvasInstance.activate(null);
+        }
+
+        if (prevProps.selectedStatesID !== selectedStatesID) {
+            // reflect the multi-selection (shift + left-mousedown) on the canvas:
+            // drives the persistent selection visual and enables live group drag
+            canvasInstance.setSelectedObjects(selectedStatesID);
         }
 
         if (prevProps.highlightedConflict !== highlightedConflict) {
@@ -654,11 +699,13 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
         canvasInstance.html().removeEventListener('canvas.zoom', this.onCanvasZoomChanged);
         canvasInstance.html().removeEventListener('canvas.fit', this.onCanvasImageFitted);
         canvasInstance.html().removeEventListener('canvas.dragshape', this.onCanvasShapeDragged as EventListener);
+        canvasInstance.html().removeEventListener('canvas.groupmoved', this.onCanvasObjectsGroupMoved as EventListener);
         canvasInstance.html().removeEventListener('canvas.resizeshape', this.onCanvasShapeResized as EventListener);
         canvasInstance.html().removeEventListener('canvas.clicked', this.onCanvasShapeClicked);
         canvasInstance.html().removeEventListener('canvas.drawn', this.onCanvasShapeDrawn);
         canvasInstance.html().removeEventListener('canvas.merged', this.onCanvasObjectsMerged);
         canvasInstance.html().removeEventListener('canvas.grouped', this.onCanvasObjectsGrouped);
+        canvasInstance.html().removeEventListener('canvas.selected', this.onCanvasSelected);
         canvasInstance.html().removeEventListener('canvas.joined', this.onCanvasObjectsJoined);
         canvasInstance.html().removeEventListener('canvas.regionselected', this.onCanvasPositionSelected);
         canvasInstance.html().removeEventListener('canvas.splitted', this.onCanvasTrackSplitted);
@@ -770,6 +817,13 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
         onGroupAnnotations(states);
     };
 
+    private onCanvasSelected = (event: any): void => {
+        const { onSelectObjects, updateActiveControl } = this.props;
+        const { states } = event.detail;
+        updateActiveControl(ActiveControl.CURSOR);
+        onSelectObjects(states.map((state: ObjectState): number => state.clientID));
+    };
+
     private onCanvasObjectsJoined = (event: any): void => {
         const {
             jobInstance, onJoinAnnotations, updateActiveControl,
@@ -807,7 +861,19 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
     };
 
     private onCanvasMouseDown = (e: MouseEvent): void => {
-        const { workspace, activatedStateID, onActivateObject } = this.props;
+        const {
+            workspace, activatedStateID, selectedStatesID, onActivateObject, onSelectObjects,
+        } = this.props;
+
+        // a click outside of the selected objects resets the multi-selection
+        // (shift is reserved for making a new selection, a click on a selected shape starts a group drag)
+        if (e.button === 0 && !e.shiftKey && selectedStatesID.length) {
+            const shapeElement = (e.target as Element)?.closest?.('.cvat_canvas_shape');
+            const clickedClientID = shapeElement ? +(shapeElement.getAttribute('clientID') as string) : null;
+            if (clickedClientID === null || !selectedStatesID.includes(clickedClientID)) {
+                onSelectObjects([]);
+            }
+        }
 
         if ((e.target as HTMLElement).tagName === 'svg' && e.button !== 2) {
             // Native double-click selection can escape from the SVG canvas to nearby UI text.
@@ -836,6 +902,21 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
             EventScope.dragObject,
             { duration, ...(serverID ? { obj_id: serverID } : {}) },
         );
+    };
+
+    private onCanvasObjectsGroupMoved = (
+        e: CustomEvent<{ duration: number; states: { state: ObjectState; points: number[] }[] }>,
+    ): void => {
+        const { onUpdateAnnotationsBatch } = this.props;
+        const { detail: { states } } = e;
+
+        // apply the new geometry and persist the whole selection as one undoable change
+        const updatedStates = states.map((moved): ObjectState => {
+            const { state: objectState } = moved;
+            objectState.points = moved.points;
+            return objectState;
+        });
+        onUpdateAnnotationsBatch(updatedStates);
     };
 
     private onCanvasShapeResized = (e: CustomEvent<{ duration: number; state: ObjectState }>): void => {
@@ -877,14 +958,28 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
 
     private onCanvasCursorMoved = async (event: any): Promise<void> => {
         const {
-            jobInstance, activatedStateID, activatedElementID, workspace, onActivateObject,
+            jobInstance, activatedStateID, activatedElementID, workspace, onActivateObject, selectedStatesID,
         } = this.props;
 
         if (![Workspace.STANDARD, Workspace.REVIEW, Workspace.SINGLE_SHAPE].includes(workspace)) {
             return;
         }
 
-        const result = await jobInstance.annotations.select(event.detail.states, event.detail.x, event.detail.y);
+        // when shapes overlap, prefer members of the multi-selection under the cursor
+        // so the selection can be grabbed and dragged as a group (e.g. right after paste)
+        let result = null;
+        if (selectedStatesID.length > 1) {
+            const selectedCandidates = event.detail.states
+                .filter((state: ObjectState) => selectedStatesID.includes(state.clientID as number));
+            if (selectedCandidates.length) {
+                result = await jobInstance.annotations.select(selectedCandidates, event.detail.x, event.detail.y);
+            }
+        }
+
+        if (!result || !result.state) {
+            result = await jobInstance.annotations.select(event.detail.states, event.detail.x, event.detail.y);
+        }
+
         if (result && result.state) {
             if ([ShapeType.POLYLINE, ShapeType.POINTS].includes(result.state.shapeType)) {
                 if (result.distance > MAX_DISTANCE_TO_OPEN_SHAPE) {
@@ -969,10 +1064,23 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
     };
 
     private onCanvasFindObject = async (e: any): Promise<void> => {
-        const { jobInstance } = this.props;
+        const { jobInstance, selectedStatesID } = this.props;
         const { canvasInstance } = this.props as { canvasInstance: Canvas };
 
-        const result = await jobInstance.annotations.select(e.detail.states, e.detail.x, e.detail.y);
+        // when shapes overlap, prefer members of the multi-selection under the cursor
+        // so the selection can be grabbed and dragged as a group (e.g. right after paste)
+        let result = null;
+        if (selectedStatesID.length > 1) {
+            const selectedCandidates = e.detail.states
+                .filter((state: ObjectState) => selectedStatesID.includes(state.clientID as number));
+            if (selectedCandidates.length) {
+                result = await jobInstance.annotations.select(selectedCandidates, e.detail.x, e.detail.y);
+            }
+        }
+
+        if (!result || !result.state) {
+            result = await jobInstance.annotations.select(e.detail.states, e.detail.x, e.detail.y);
+        }
 
         if (result && result.state) {
             if (['polyline', 'points'].includes(result.state.shapeType)) {
@@ -1133,11 +1241,13 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
         canvasInstance.html().addEventListener('canvas.zoom', this.onCanvasZoomChanged);
         canvasInstance.html().addEventListener('canvas.fit', this.onCanvasImageFitted);
         canvasInstance.html().addEventListener('canvas.dragshape', this.onCanvasShapeDragged as EventListener);
+        canvasInstance.html().addEventListener('canvas.groupmoved', this.onCanvasObjectsGroupMoved as EventListener);
         canvasInstance.html().addEventListener('canvas.resizeshape', this.onCanvasShapeResized as EventListener);
         canvasInstance.html().addEventListener('canvas.clicked', this.onCanvasShapeClicked);
         canvasInstance.html().addEventListener('canvas.drawn', this.onCanvasShapeDrawn);
         canvasInstance.html().addEventListener('canvas.merged', this.onCanvasObjectsMerged);
         canvasInstance.html().addEventListener('canvas.grouped', this.onCanvasObjectsGrouped);
+        canvasInstance.html().addEventListener('canvas.selected', this.onCanvasSelected);
         canvasInstance.html().addEventListener('canvas.joined', this.onCanvasObjectsJoined);
         canvasInstance.html().addEventListener('canvas.regionselected', this.onCanvasPositionSelected);
         canvasInstance.html().addEventListener('canvas.splitted', this.onCanvasTrackSplitted);

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/controls-side-bar.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/controls-side-bar.tsx
@@ -51,11 +51,13 @@ interface Props {
     normalizedKeyMap: Record<string, string>;
     labels: Label[];
     frameData: any;
+    hasCopiedSelection: boolean;
 
     updateActiveControl(activeControl: ActiveControl): void;
     rotateFrame(rotation: Rotation): void;
     repeatDrawShape(): void;
     pasteShape(): void;
+    pasteSelection(): void;
     resetGroup(): void;
     redrawShape(): void;
 }
@@ -156,9 +158,11 @@ export default function ControlsSideBarComponent(props: Props): JSX.Element {
         rotateFrame,
         repeatDrawShape,
         pasteShape,
+        pasteSelection,
         resetGroup,
         redrawShape,
         frameData,
+        hasCopiedSelection,
     } = props;
 
     const controlsDisabled = !labels.length || frameData.deleted;
@@ -344,7 +348,12 @@ export default function ControlsSideBarComponent(props: Props): JSX.Element {
             PASTE_SHAPE: (event: KeyboardEvent | undefined) => {
                 event?.preventDefault();
                 canvasInstance.cancel();
-                pasteShape();
+                // paste the whole multi-selection when it is on the clipboard, else a single shape
+                if (hasCopiedSelection) {
+                    pasteSelection();
+                } else {
+                    pasteShape();
+                }
             },
             SWITCH_DRAW_MODE_STANDARD_CONTROLS: (event: KeyboardEvent | undefined) => {
                 handleDrawMode(event, 'draw');

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
@@ -17,6 +17,7 @@ import ItemBasics from './object-item-basics';
 interface Props {
     normalizedKeyMap: Record<string, string>;
     activated: boolean;
+    multiSelected: boolean;
     objectType: ObjectType;
     shapeType: ShapeType;
     clientID: number;
@@ -57,6 +58,7 @@ interface Props {
 function ObjectItemComponent(props: Props): JSX.Element {
     const {
         activated,
+        multiSelected,
         objectType,
         shapeType,
         clientID,
@@ -99,11 +101,14 @@ function ObjectItemComponent(props: Props): JSX.Element {
             ObjectType.TAG.toUpperCase() :
             `${shapeType.toUpperCase()} ${objectType.toUpperCase()}`;
 
-    const className = !activated ?
+    let className = !activated ?
         `cvat-objects-sidebar-state-item${zLayerDragging ? ' cvat-objects-sidebar-state-item-dragging' : ''}` :
         `cvat-objects-sidebar-state-item cvat-objects-sidebar-state-active-item${
             zLayerDragging ? ' cvat-objects-sidebar-state-item-dragging' : ''
         }`;
+    if (multiSelected) {
+        className += ' cvat-objects-sidebar-state-item-multi-selected';
+    }
 
     const activateState = useCallback(() => {
         activate();

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/styles.scss
@@ -518,6 +518,12 @@
     border: 2px solid rgba(0, 0, 0, 66%);
 }
 
+// objects that are part of the canvas multi-selection
+.cvat-objects-sidebar-state-item.cvat-objects-sidebar-state-item-multi-selected {
+    border: 2px dashed #1890ff;
+    box-shadow: 0 0 6px rgba(24, 144, 255, 60%);
+}
+
 .cvat-objects-sidebar-state-item {
     width: 100%;
     background-color: rgba(var(--state-item-background), 1);

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/controls-side-bar.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/controls-side-bar.tsx
@@ -12,6 +12,7 @@ import {
     rotateCurrentFrame,
     repeatDrawShapeAsync,
     pasteShapeAsync,
+    pasteSelectionAsync,
     resetAnnotationsGroup,
 } from 'actions/annotation-actions';
 import ControlsSideBarComponent from 'components/annotation-page/standard-workspace/controls-side-bar/controls-side-bar';
@@ -26,6 +27,7 @@ interface StateToProps {
     normalizedKeyMap: Record<string, string>;
     labels: CombinedState['annotation']['job']['labels'];
     frameData: any;
+    hasCopiedSelection: boolean;
 }
 
 interface DispatchToProps {
@@ -34,6 +36,7 @@ interface DispatchToProps {
     resetGroup(): void;
     repeatDrawShape(): void;
     pasteShape(): void;
+    pasteSelection(): void;
     redrawShape(): void;
 }
 
@@ -45,6 +48,7 @@ function mapStateToProps(state: CombinedState): StateToProps {
             player: {
                 frame: { data: frameData },
             },
+            drawing: { copiedStates },
         },
         settings: {
             player: { rotateAll },
@@ -60,6 +64,7 @@ function mapStateToProps(state: CombinedState): StateToProps {
         normalizedKeyMap,
         keyMap,
         frameData,
+        hasCopiedSelection: !!copiedStates && copiedStates.length > 0,
     };
 }
 
@@ -76,6 +81,9 @@ function dispatchToProps(dispatch: any): DispatchToProps {
         },
         pasteShape(): void {
             dispatch(pasteShapeAsync());
+        },
+        pasteSelection(): void {
+            dispatch(pasteSelectionAsync());
         },
         resetGroup(): void {
             dispatch(resetAnnotationsGroup());

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
@@ -52,6 +52,7 @@ interface StateToProps {
     jobInstance: Job;
     frameNumber: number;
     activated: boolean;
+    multiSelected: boolean;
     colorBy: ColorBy;
     ready: boolean;
     activeControl: ActiveControl;
@@ -86,6 +87,7 @@ function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
         annotation: {
             annotations: {
                 activatedStateID,
+                selectedStatesID,
                 zLayer: { min: minZLayer, max: maxZLayer },
             },
             job: { attributes: jobAttributes, instance: jobInstance, labels },
@@ -116,6 +118,7 @@ function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
         jobInstance,
         frameNumber,
         activated: activatedStateID === clientID,
+        multiSelected: selectedStatesID.includes(clientID),
         minZLayer,
         maxZLayer,
         normalizedKeyMap,
@@ -573,6 +576,7 @@ class ObjectItemContainer extends React.PureComponent<Props, State> {
             objectState,
             attributes,
             activated,
+            multiSelected,
             colorBy,
             normalizedKeyMap,
             keyMap,
@@ -591,6 +595,7 @@ class ObjectItemContainer extends React.PureComponent<Props, State> {
                     zLayerDragProps={zLayerDragProps}
                     zLayerDragging={zLayerDragging}
                     activated={activated}
+                    multiSelected={multiSelected}
                     objectType={objectState.objectType}
                     shapeType={objectState.shapeType}
                     clientID={objectState.clientID as number}

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/objects-list.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/objects-list.tsx
@@ -15,9 +15,11 @@ import {
     collapseObjectItems,
     changeGroupColorAsync,
     copyShape as copyShapeAction,
+    copySelection as copySelectionAction,
     switchPropagateVisibility as switchPropagateVisibilityAction,
     switchSimplifyVisibility as switchSimplifyVisibilityAction,
     removeObject as removeObjectAction,
+    removeSelectionAsync,
     fetchAnnotationsAsync,
     changeHideActiveObjectAsync,
     updateLayerAsync,
@@ -60,6 +62,7 @@ interface StateToProps {
     colorBy: ColorBy;
     activatedStateID: number | null;
     activatedElementID: number | null;
+    selectedStatesID: number[];
     minZLayer: number;
     maxZLayer: number;
     curZLayer: number;
@@ -76,7 +79,9 @@ interface DispatchToProps {
     updateAnnotations(...args: Parameters<typeof updateAnnotationsAsync>): void;
     collapseStates(...args: Parameters<typeof collapseObjectItems>): void;
     removeObject(...args: Parameters<typeof removeObjectAction>): void;
+    removeSelection(...args: Parameters<typeof removeSelectionAsync>): void;
     copyShape(...args: Parameters<typeof copyShapeAction>): void;
+    copySelection(...args: Parameters<typeof copySelectionAction>): void;
     switchPropagateVisibility(...args: Parameters<typeof switchPropagateVisibilityAction>): void;
     switchSimplifyVisibility(...args: Parameters<typeof switchSimplifyVisibilityAction>): void;
     changeFrame(...args: Parameters<typeof changeFrameAsync>): void;
@@ -224,6 +229,7 @@ function mapStateToProps(state: CombinedState): StateToProps {
                 collapsedAll,
                 activatedStateID,
                 activatedElementID,
+                selectedStatesID,
                 zLayer: { cur: curZLayer, min: minZLayer, max: maxZLayer },
             },
             job: { instance: jobInstance },
@@ -276,6 +282,7 @@ function mapStateToProps(state: CombinedState): StateToProps {
         colorBy,
         activatedStateID,
         activatedElementID,
+        selectedStatesID,
         minZLayer,
         maxZLayer,
         curZLayer,
@@ -299,6 +306,12 @@ function mapDispatchToProps(dispatch: any): DispatchToProps {
         },
         removeObject(...args: Parameters<typeof removeObjectAction>): void {
             dispatch(removeObjectAction(...args));
+        },
+        removeSelection(...args: Parameters<typeof removeSelectionAsync>): void {
+            dispatch(removeSelectionAsync(...args));
+        },
+        copySelection(...args: Parameters<typeof copySelectionAction>): void {
+            dispatch(copySelectionAction(...args));
         },
         copyShape(...args: Parameters<typeof copyShapeAction>): void {
             dispatch(copyShapeAction(...args));
@@ -559,7 +572,10 @@ class ObjectsListContainer extends React.PureComponent<Props, State> {
             updateAnnotations,
             changeGroupColor,
             removeObject,
+            removeSelection,
             copyShape,
+            copySelection,
+            selectedStatesID,
             switchPropagateVisibility,
             switchSimplifyVisibility,
             changeFrame,
@@ -662,6 +678,12 @@ class ObjectsListContainer extends React.PureComponent<Props, State> {
             },
             DELETE_OBJECT_STANDARD_WORKSPACE: (event?: KeyboardEvent) => {
                 preventDefault(event);
+                // with an active multi-selection the whole selection is removed
+                if (selectedStatesID.length > 1) {
+                    removeSelection(event ? event.shiftKey : false);
+                    return;
+                }
+
                 const state = activatedState(true);
                 if (state) {
                     removeObject(state, event ? event.shiftKey : false);
@@ -717,6 +739,16 @@ class ObjectsListContainer extends React.PureComponent<Props, State> {
                 }
             },
             COPY_SHAPE: () => {
+                // with an active multi-selection the whole selection is copied
+                if (selectedStatesID.length > 1) {
+                    const selectedStates = objectStates
+                        .filter((objectState: ObjectState) => selectedStatesID.includes(objectState.clientID));
+                    if (selectedStates.length) {
+                        copySelection(selectedStates);
+                        return;
+                    }
+                }
+
                 const state = activatedState(true);
                 if (state) {
                     copyShape(state);

--- a/cvat-ui/src/reducers/annotation-reducer.ts
+++ b/cvat-ui/src/reducers/annotation-reducer.ts
@@ -143,6 +143,7 @@ const defaultState: AnnotationState = {
         activatedStateID: null,
         activatedElementID: null,
         activatedAttributeID: null,
+        selectedStatesID: [],
         highlightedConflict: null,
         saving: {
             forceExit: false,
@@ -413,6 +414,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                 annotations: {
                     ...state.annotations,
                     activatedStateID: updateActivatedStateID(states, activatedStateID),
+                    selectedStatesID: [],
                     highlightedConflict: null,
                     states,
                     renderData: getAnnotationsRenderData(states, state.annotations.filters),
@@ -706,6 +708,16 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                 },
             };
         }
+        case AnnotationActionTypes.SELECT_OBJECTS: {
+            const { selectedStatesID } = action.payload;
+            return {
+                ...state,
+                annotations: {
+                    ...state.annotations,
+                    selectedStatesID,
+                },
+            };
+        }
         case AnnotationActionTypes.REMOVE_OBJECT: {
             const { objectState, force } = action.payload;
             return {
@@ -803,6 +815,19 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                 drawing: {
                     ...state.drawing,
                     activeInitialState: objectState,
+                    // single-shape copy clears any multi-selection clipboard
+                    copiedStates: undefined,
+                },
+            };
+        }
+        case AnnotationActionTypes.COPY_SELECTION: {
+            const { copiedStates } = action.payload;
+
+            return {
+                ...state,
+                drawing: {
+                    ...state.drawing,
+                    copiedStates,
                 },
             };
         }

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -923,6 +923,7 @@ export interface AnnotationState {
         activeLabelID: number | null;
         activeObjectType: ObjectType;
         activeInitialState?: any;
+        copiedStates?: any[];
         activeSimplifyPoly?: boolean;
     };
     editing: EditingState;
@@ -930,6 +931,7 @@ export interface AnnotationState {
         activatedStateID: number | null;
         activatedElementID: number | null;
         activatedAttributeID: number | null;
+        selectedStatesID: number[];
         highlightedConflict: QualityConflict | null;
         collapsed: Record<number, boolean>;
         collapsedAll: boolean;

--- a/site/content/en/docs/annotation/manual-annotation/shapes/multi-selection.md
+++ b/site/content/en/docs/annotation/manual-annotation/shapes/multi-selection.md
@@ -1,0 +1,38 @@
+---
+title: 'Multi-selection of shapes'
+linkTitle: 'Multi-selection'
+weight: 12
+description: 'Selecting several shapes at once to move, copy, paste, or delete them together.'
+---
+
+In the standard workspace you can select several shapes at once and
+manipulate them as a group.
+
+## Selecting shapes
+
+Hold `Shift` and drag with the left mouse button over the canvas in cursor
+mode. Every shape whose bounding box intersects the selection box becomes
+selected. Selected shapes are highlighted on the canvas and in the objects
+sidebar.
+
+The modifier key is rebindable: search for `Multi-selection modifier` in the
+shortcut settings (supported values are `shift`, `ctrl`, `alt` and `meta`).
+
+To reset the selection, click anywhere outside of the selected shapes.
+The selection is also reset when you switch to another frame.
+
+## Manipulating the selection
+
+- **Move**: drag any of the selected shapes — the whole selection moves
+  with it. Shapes that are pinned can also be dragged this way while they
+  are part of the selection.
+- **Copy and paste**: press `Ctrl+C` to copy the selection and `Ctrl+V` to
+  paste it. The relative positions of the copied shapes are preserved, and
+  the pasted shapes become the new selection, so they can be dragged into
+  place right away. The clipboard survives frame changes — you can copy
+  shapes on one frame and paste them on another.
+- **Delete**: press `Del` to remove all selected shapes
+  (`Shift+Del` to remove them even if they are locked).
+
+Moving, pasting, or deleting a selection is registered as a single action
+in the annotation history, so one `Ctrl+Z` reverts the whole operation.

--- a/tests/cypress/e2e/features/multiselect_cursor.js
+++ b/tests/cypress/e2e/features/multiselect_cursor.js
@@ -1,0 +1,166 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+context('Rubber-band multi-selection in cursor mode', { scrollBehavior: false }, () => {
+    const taskName = 'Cursor multi-selection';
+    const labelName = 'rectangle label';
+    const serverFiles = ['images/image_1.jpg', 'images/image_2.jpg'];
+
+    const rectangles = [
+        {
+            labelName, points: 'By 2 Points', type: 'Shape', firstX: 150, firstY: 150, secondX: 250, secondY: 250,
+        },
+        {
+            labelName, points: 'By 2 Points', type: 'Shape', firstX: 350, firstY: 150, secondX: 450, secondY: 250,
+        },
+        {
+            labelName, points: 'By 2 Points', type: 'Shape', firstX: 550, firstY: 350, secondX: 650, secondY: 450,
+        },
+    ];
+
+    let taskId = null;
+    let jobId = null;
+
+    function selectionBox(firstX, firstY, lastX, lastY) {
+        // hold the multi-selection modifier (default shift) and drag with the left mouse button
+        cy.get('.cvat-canvas-container')
+            .trigger('mousedown', firstX, firstY, { button: 0, shiftKey: true });
+        cy.get('.cvat-canvas-container')
+            .trigger('mousemove', lastX, lastY, { shiftKey: true });
+        cy.get('.cvat-canvas-container')
+            .trigger('mouseup', lastX, lastY, { button: 0, shiftKey: true });
+    }
+
+    function selectFirstTwoRectangles() {
+        // box covers the first two rectangles, but not the third
+        selectionBox(120, 120, 480, 300);
+        cy.get('.cvat_canvas_shape_selected_object').should('have.length', 2);
+    }
+
+    before(() => {
+        cy.visit('/auth/login');
+        cy.login();
+        cy.headlessCreateTask({
+            labels: [{ name: labelName, attributes: [], type: 'rectangle' }],
+            name: taskName,
+            project_id: null,
+            source_storage: { location: 'local' },
+            target_storage: { location: 'local' },
+        }, {
+            server_files: serverFiles,
+            image_quality: 70,
+            use_zip_chunks: true,
+            use_cache: true,
+            sorting_method: 'lexicographical',
+        }).then((response) => {
+            taskId = response.taskId;
+            [jobId] = response.jobIds;
+        }).then(() => {
+            cy.visit(`/tasks/${taskId}/jobs/${jobId}`);
+            cy.get('.cvat-canvas-container').should('exist').and('be.visible');
+        });
+    });
+
+    after(() => {
+        cy.logout();
+        cy.task('getAuthHeaders').then((authHeaders) => {
+            cy.request({
+                method: 'DELETE',
+                url: `/api/tasks/${taskId}`,
+                headers: authHeaders,
+            });
+        });
+    });
+
+    beforeEach(() => {
+        cy.removeAnnotations();
+        cy.goCheckFrameNumber(0);
+        rectangles.forEach((rectangle) => cy.createRectangle(rectangle));
+    });
+
+    describe('Making a selection', () => {
+        it('Modifier + drag selects intersecting shapes, indicated on canvas and in the sidebar', () => {
+            selectFirstTwoRectangles();
+            cy.get('.cvat-objects-sidebar-state-item-multi-selected').should('have.length', 2);
+        });
+
+        it('A click outside of the selected shapes resets the selection', () => {
+            selectFirstTwoRectangles();
+            cy.get('.cvat-canvas-container').click(800, 600);
+            cy.get('.cvat_canvas_shape_selected_object').should('have.length', 0);
+            cy.get('.cvat-objects-sidebar-state-item-multi-selected').should('have.length', 0);
+        });
+    });
+
+    describe('Manipulating the selection', () => {
+        it('Dragging one selected shape moves the whole selection, single undo restores it', () => {
+            selectFirstTwoRectangles();
+
+            const before = {};
+            cy.get('.cvat_canvas_shape_selected_object').each(($shape) => {
+                before[$shape.attr('id')] = +$shape.attr('x');
+            });
+
+            // hover a selected shape and drag whichever selected shape gets activated
+            cy.get('.cvat_canvas_shape_selected_object').first().trigger('mousemove');
+            cy.get('.cvat_canvas_shape_selected_object').first().trigger('mouseover');
+            cy.get('.cvat_canvas_shape_activated').should('exist');
+            cy.get('.cvat_canvas_shape_activated').trigger('mousedown', { which: 1 });
+            cy.get('.cvat-canvas-container').trigger('mousemove', 300, 350);
+            cy.get('.cvat-canvas-container').trigger('mouseup', 300, 350);
+
+            cy.get('.cvat_canvas_shape_selected_object').each(($shape) => {
+                expect(+$shape.attr('x')).to.not.equal(before[$shape.attr('id')]);
+            });
+
+            cy.get('body').type('{ctrl}z');
+            cy.get('.cvat_canvas_shape_selected_object').each(($shape) => {
+                expect(+$shape.attr('x')).to.equal(before[$shape.attr('id')]);
+            });
+        });
+
+        it('Copy and paste duplicates the whole selection, single undo removes it', () => {
+            cy.get('.cvat_canvas_shape').should('have.length', 3);
+            selectFirstTwoRectangles();
+
+            cy.get('body').type('{ctrl}c');
+            cy.get('body').type('{ctrl}v');
+
+            // two extra shapes are created preserving relative geometry, and become the new selection
+            cy.get('.cvat_canvas_shape').should('have.length', 5);
+            cy.get('.cvat_canvas_shape_selected_object').should('have.length', 2);
+
+            cy.get('body').type('{ctrl}z');
+            cy.get('.cvat_canvas_shape').should('have.length', 3);
+        });
+
+        it('The clipboard survives frame changes', () => {
+            selectFirstTwoRectangles();
+            cy.get('body').type('{ctrl}c');
+
+            cy.goCheckFrameNumber(1);
+            // the frame selector keeps the focus, but shortcuts are ignored inside inputs
+            cy.get('.cvat-player-frame-selector input[role="spinbutton"]').blur();
+            cy.get('.cvat_canvas_shape').should('have.length', 0);
+            cy.get('body').type('{ctrl}v');
+            cy.get('.cvat_canvas_shape').should('have.length', 2);
+
+            cy.goCheckFrameNumber(0);
+            cy.get('.cvat_canvas_shape').should('have.length', 3);
+        });
+
+        it('Pressing delete removes the whole selection, single undo restores it', () => {
+            selectFirstTwoRectangles();
+
+            cy.get('body').type('{del}');
+            cy.get('.cvat_canvas_shape').should('have.length', 1);
+            cy.get('.cvat_canvas_shape_selected_object').should('have.length', 0);
+
+            cy.get('body').type('{ctrl}z');
+            cy.get('.cvat_canvas_shape').should('have.length', 3);
+        });
+    });
+});


### PR DESCRIPTION


### Demo


https://github.com/user-attachments/assets/d6eee20e-c49b-4be2-b7dd-acc30b9ab9b9



The video shows: multi-select via Shift+drag, copy/paste of the selection,
selecting a subset of the pasted shapes, deleting it, moving the whole
selection with a single drag, and copying on frame 0 / pasting on frame 1.

### Motivation and context

Resolves #2340 (multi-selection with moving, copying and pasting; bulk label
assignment mentioned in that issue is not part of this PR and could be a
follow-up).

This PR adds a general-purpose multi-selection to the standard workspace:

- **Selecting**: hold a modifier key (Shift by default) and drag with the left
  mouse button in cursor mode - every shape whose bounding box intersects the
  rubber-band box becomes selected. The modifier is registered in the regular
  shortcut settings (`Multi-selection modifier`) and can be rebound to
  Ctrl/Alt/Meta. Selected shapes are highlighted on the canvas (dashed glow)
  and in the objects sidebar; a click outside the selection clears it.
- **Moving**: dragging any selected shape moves the whole selection live.
- **Copy/paste**: Ctrl+C copies the selection to the internal clipboard,
  Ctrl+V recreates it preserving the relative geometry between the objects.
  The clipboard survives frame changes, so a constellation can be copied on
  one frame and pasted on another. Pasted objects become the new selection so
  they can immediately be dragged into place.
- **Delete**: Del removes the whole selection (Shift+Del to force-delete
  locked objects, consistent with single-object behaviour).
- **Undo/redo**: group move, paste and delete are each recorded as a *single*
  history item.

Implementation notes, by package:

- `cvat-canvas`: the rubber-band mechanics reuse the existing `ObjectSelector`
  (used by group/merge/join) through a thin new `selectHandler`; a new
  `intersect` option implements intersection-based selection while the
  existing consumers keep their contain-only behaviour. The canvas keeps a
  persistent set of selected clientIDs (`setSelectedObjects()`) which drives
  the selection visuals and the live group drag. A group drag emits a single
  `canvas.groupmoved` event with all moved states. Membership in the
  selection temporarily overrides `pinned` so pinned-by-default shapes
  (polygons/polylines/points) can be grabbed to drag the group.
- `cvat-core`: new `Collection.updateBatch()` and `Collection.removeBatch()`
  save/remove several object states while recording one combined undo/redo
  item, mirroring the existing `history.freeze()` pattern used by
  `updateLayer`. Exposed as `annotations.updateBatch` / `annotations.removeBatch`.
- `cvat-ui`: `selectedStatesID` in the annotation state, wiring of the new
  canvas events, selection-aware branches in the existing copy/delete/paste
  shortcut handlers (deliberately extending the existing handlers instead of
  registering competing bindings for the same keys), sidebar highlighting,
  and activation preference for selected shapes when shapes overlap (so a
  freshly pasted group can be grabbed although it overlaps its source).

### How has this been tested?

- New Cypress E2E spec `tests/cypress/e2e/features/multiselect_cursor.js`
  with one test case per behaviour (6 passing):
  1. modifier+drag selects intersecting shapes, indicated on canvas and sidebar
  2. a click outside of the selected shapes resets the selection
  3. dragging one selected shape moves the whole selection, single undo restores it
  4. copy and paste duplicates the whole selection, single undo removes it
  5. the clipboard survives frame changes
  6. delete removes the whole selection, single undo restores it
- Manual + scripted browser testing of the full matrix across all 2D shape
  types (rectangle, polygon, polyline, points, ellipse, cuboid, mask):
  select / live group move / single-undo / copy / paste / move pasted group -
  all working. Known limitation: undoing a group move of a *skeleton* restores
  nothing for the skeleton itself (its points live in its elements); this is
  called out in `Collection.updateBatch` and can be addressed in a follow-up.
- Environment: local `docker compose` deployment (server from `cvat/server:dev`)
  with the UI dev server; `yarn type-check` and ESLint pass on all touched files.
- Existing behaviours were regression-checked manually: single-object
  copy/paste/delete, canvas panning (left-drag without the modifier), shape
  resizing with Shift snap-to-angle, and the group/merge/join modes that share
  the `ObjectSelector`.

### Checklist
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
  (new page: `site/content/en/docs/annotation/manual-annotation/shapes/multi-selection.md`)
- [x] I have added tests to cover my changes
- [x] I have linked related issues (resolves #2340)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
