### PR TITLE
Stop logging to `cvat_server.log`

### DIFF
--- a/changelog.d/20260723_165321_roman_rm_file_log.md
+++ b/changelog.d/20260723_165321_roman_rm_file_log.md
@@ -1,0 +1,4 @@
+### Removed
+
+- Backend processes no longer write their logs to `logs/cvat_server.log`
+  (<https://github.com/cvat-ai/cvat/pull/10939>)

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -561,14 +561,6 @@ LOGGING = {
             "filters": [],
             "formatter": "standard",
         },
-        "server_file": {
-            "class": "logging.handlers.RotatingFileHandler",
-            "level": "DEBUG",
-            "filename": LOGS_ROOT / "cvat_server.log",
-            "formatter": "standard",
-            "maxBytes": 1024 * 1024 * 50,  # 50 MB
-            "backupCount": 5,
-        },
         "dataset_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "level": "DEBUG",
@@ -592,7 +584,7 @@ LOGGING = {
         },
     },
     "root": {
-        "handlers": ["console", "server_file"],
+        "handlers": ["console"],
     },
     "loggers": {
         "cvat": {

--- a/cvat/settings/testing.py
+++ b/cvat/settings/testing.py
@@ -64,8 +64,6 @@ for logger in LOGGING["loggers"].values():
     if isinstance(logger, dict) and "level" in logger:
         logger["level"] = "ERROR"
 
-LOGGING["handlers"]["server_file"] = LOGGING["handlers"]["console"]
-
 PASSWORD_HASHERS = ("django.contrib.auth.hashers.MD5PasswordHasher",)
 
 # When you run ./manage.py test, Django looks at the TEST_RUNNER setting to


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
File logging just doesn't work in the presence of multiple server processes. In particular, rotation is broken, since every process tries to do it independently, so the log gets rotated multiple times at once, which can even cause it do be deleted immediately (if it gets rotated more times than there are backups).

In Kubernetes, it's even worse, because the logs directory is typically mounted over NFS. To quote the `open(2)` man page:

> O_APPEND may lead to corrupted files on NFS filesystems if more than one process appends data to a file at once.

The log rotation process also tends to produce NFS "stale file handle" errors (I haven't quite understood how this happens, but I assume it has to do with a process trying to write to a log file that's been deleted after being rotated). Once this happens in a process, every subsequent log attempt results in another error, which gets logged to stderr. So this messes up both the file _and_ console outputs.

Finally, even if this worked without any bugs, I think a log file with interleaved output from all backend processes with no way of figuring out who logged what is of questionable utility anyway.

I left the other file-based handler (`dataset_handler`) alone for now, since `dataset_logger` has no other handlers. But IMO, in the future we should get rid of it as well.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
