### PR TITLE
fix: Add success/error notifications for label update (#10642)

### DIFF
--- a/cvat-ui/src/components/task-page/details.tsx
+++ b/cvat-ui/src/components/task-page/details.tsx
@@ -10,6 +10,7 @@ import dayjs from 'dayjs';
 import { Row, Col } from 'antd/lib/grid';
 import Text from 'antd/lib/typography/Text';
 import Title from 'antd/lib/typography/Title';
+import notification from 'antd/lib/notification';
 
 import {
     User, getCore, Project, Task, FramesMetaData, CloudStorage,
@@ -184,6 +185,16 @@ class DetailsComponent extends React.PureComponent<Props, State> {
                         onSubmit={(labels: any[]): void => {
                             onUpdateTask(taskInstance, {
                                 labels: labels.map((labelData): any => new core.classes.Label(labelData)),
+                            }).then(() => {
+                                notification.success({
+                                    message: 'Labels updated',
+                                    description: 'Labels have been successfully saved',
+                                });
+                            }).catch((error: Error) => {
+                                notification.error({
+                                    message: 'Failed to update labels',
+                                    description: error.message || 'An unknown error occurred while saving labels',
+                                });
                             });
                         }}
                     />

--- a/cvat-ui/src/components/task-page/details.tsx
+++ b/cvat-ui/src/components/task-page/details.tsx
@@ -67,6 +67,7 @@ interface State {
     name: string;
     subset: string;
     consensusEnabled: boolean;
+    labelsEditorKey: number; // used to force remount on error
 }
 
 type Props = DispatchToProps & StateToProps & OwnProps;
@@ -79,6 +80,7 @@ class DetailsComponent extends React.PureComponent<Props, State> {
             name: taskInstance.name,
             subset: taskInstance.subset,
             consensusEnabled: taskInstance.consensusEnabled,
+            labelsEditorKey: Date.now(),
         };
     }
 
@@ -175,11 +177,13 @@ class DetailsComponent extends React.PureComponent<Props, State> {
 
     private renderLabelsEditor(): JSX.Element {
         const { task: taskInstance, onUpdateTask, labelsEditorProps } = this.props;
+        const { labelsEditorKey } = this.state;
 
         return (
             <Row>
                 <Col span={24}>
                     <LabelsEditorComponent
+                        key={labelsEditorKey} // forces remount on error
                         {...labelsEditorProps}
                         labels={taskInstance.labels.map((label) => label.toJSON())}
                         onSubmit={(labels: any[]): void => {
@@ -195,6 +199,8 @@ class DetailsComponent extends React.PureComponent<Props, State> {
                                     message: 'Failed to update labels',
                                     description: error.message || 'An unknown error occurred while saving labels',
                                 });
+                                // Force editor to reset to saved state by remounting with fresh props
+                                this.setState({ labelsEditorKey: Date.now() });
                             });
                         }}
                     />


### PR DESCRIPTION
### Motivation and context
This change adds user feedback when saving task labels on the task details page. Previously, after editing labels and clicking "Save", there was no visual confirmation of success or failure.

- On successful save, a success notification appears: "Labels updated – Labels have been successfully saved".
- On error, an error notification appears with the specific error message (or a generic fallback).

Closes #10642

### How has this been tested?
Manually tested in a local development environment:
- Edited labels on a task's detail page and saved – observed the success notification.
- Simulated a server error (by temporarily breaking the API endpoint) – observed the error notification with the correct message.
- Verified that existing functionality (labels editor, task update) remains unchanged.

### Checklist
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues

### License
- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.