### PR TITLE
Audio: improve adaptive timeline

### DIFF
--- a/changelog.d/20260727_131439_aleksey.zinovyev_adaptive_timeline.md
+++ b/changelog.d/20260727_131439_aleksey.zinovyev_adaptive_timeline.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed audio canvas adaptive timeline granularity
+  (<https://github.com/cvat-ai/cvat/pull/10947>)

--- a/changelog.d/20260727_131439_aleksey.zinovyev_adaptive_timeline.md
+++ b/changelog.d/20260727_131439_aleksey.zinovyev_adaptive_timeline.md
@@ -1,4 +1,4 @@
 ### Fixed
 
-- Fixed audio canvas adaptive timeline granularity
+- Improved audio waveform timeline detail at larger zoom levels
   (<https://github.com/cvat-ai/cvat/pull/10947>)

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-adaptive-timeline.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-adaptive-timeline.ts
@@ -1,0 +1,136 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import { useLayoutEffect, useRef } from 'react';
+import TimelinePlugin, { type TimelinePluginOptions } from 'wavesurfer.js/dist/plugins/timeline';
+
+import { formatSecondsWithPrecision } from 'audio/utils/format-audio-time';
+
+import type { WaveSurferRuntime } from './use-audio-waveform';
+
+interface TimelineDensityBand {
+    minPixelsPerSecond: number;
+    options: TimelinePluginOptions;
+}
+
+// Must be ordered by minPixelsPerSecond DESC
+// Using spacing over interval settings as the latter may introduce uneven labels
+// Need to explicitly clear interval options as there are defaults that are
+// getting merged with custom spacing settings otherwise
+const DENSITY_BANDS: TimelineDensityBand[] = [
+    {
+        minPixelsPerSecond: 1500,
+        options: {
+            timeInterval: 0.03125,
+            primaryLabelInterval: 0,
+            secondaryLabelInterval: 0,
+            primaryLabelSpacing: 8,
+            secondaryLabelSpacing: 4,
+            formatTimeCallback: (seconds: number): string => formatSecondsWithPrecision(seconds, 3),
+        },
+    },
+    {
+        minPixelsPerSecond: 350,
+        options: {
+            timeInterval: 0.125,
+            primaryLabelInterval: 0,
+            secondaryLabelInterval: 0,
+            primaryLabelSpacing: 8,
+            secondaryLabelSpacing: 4,
+            formatTimeCallback: (seconds: number): string => formatSecondsWithPrecision(seconds, 2),
+        },
+    },
+    {
+        minPixelsPerSecond: 70,
+        options: {
+            timeInterval: 0.5,
+            primaryLabelInterval: 0,
+            secondaryLabelInterval: 0,
+            primaryLabelSpacing: 10,
+            secondaryLabelSpacing: 5,
+            formatTimeCallback: (seconds: number): string => formatSecondsWithPrecision(seconds, 1),
+        },
+    },
+    {
+        minPixelsPerSecond: 35,
+        options: {
+            timeInterval: 1,
+            primaryLabelInterval: 0,
+            secondaryLabelInterval: 0,
+            primaryLabelSpacing: 10,
+            secondaryLabelSpacing: 5,
+        },
+    },
+    {
+        minPixelsPerSecond: 7,
+        options: {
+            timeInterval: 5,
+            primaryLabelInterval: 0,
+            secondaryLabelInterval: 0,
+            primaryLabelSpacing: 6,
+            secondaryLabelSpacing: 3,
+        },
+    },
+    {
+        minPixelsPerSecond: 3.5,
+        options: {
+            timeInterval: 10,
+            primaryLabelInterval: 0,
+            secondaryLabelInterval: 0,
+            primaryLabelSpacing: 6,
+            secondaryLabelSpacing: 3,
+        },
+    },
+    {
+        minPixelsPerSecond: 1.2,
+        options: {
+            timeInterval: 30,
+            primaryLabelInterval: 0,
+            secondaryLabelInterval: 0,
+            primaryLabelSpacing: 10,
+            secondaryLabelSpacing: 5,
+        },
+    },
+    {
+        minPixelsPerSecond: 0,
+        options: {
+            timeInterval: 60,
+            primaryLabelInterval: 0,
+            secondaryLabelInterval: 0,
+            primaryLabelSpacing: 10,
+            secondaryLabelSpacing: 5,
+        },
+    },
+];
+
+function getTimelineDensityBand(pixelsPerSecond: number): TimelineDensityBand {
+    const band = DENSITY_BANDS.find(({ minPixelsPerSecond }) => pixelsPerSecond >= minPixelsPerSecond);
+    return band || DENSITY_BANDS[DENSITY_BANDS.length - 1];
+}
+
+/**
+ * TimelinePlugin has no public API for updating interval options. Replace it
+ * only when zoom moves to a different prepared density band.
+ */
+export function useAdaptiveTimeline(runtime: WaveSurferRuntime, pixelsPerSecond: number): void {
+    const previousBandRef = useRef<TimelineDensityBand | null>(null);
+
+    useLayoutEffect(() => {
+        const { instanceRef, timelineRef } = runtime;
+        const instance = instanceRef.current;
+        const timeline = timelineRef.current;
+        if (!runtime.ready || !instance || !timeline) {
+            return;
+        }
+
+        const band = getTimelineDensityBand(pixelsPerSecond);
+        if (previousBandRef.current === band) return;
+
+        timeline.destroy();
+        const nextTimeline = TimelinePlugin.create(band.options);
+        timelineRef.current = nextTimeline;
+        previousBandRef.current = band;
+        instance.registerPlugin(nextTimeline);
+    }, [pixelsPerSecond, runtime.instanceRef, runtime.ready, runtime.timelineRef]);
+}

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-adaptive-timeline.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-adaptive-timeline.ts
@@ -20,14 +20,36 @@ interface TimelineDensityBand {
 // getting merged with custom spacing settings otherwise
 const DENSITY_BANDS: TimelineDensityBand[] = [
     {
+        minPixelsPerSecond: 25000,
+        options: {
+            timeInterval: 0.001953125,
+            primaryLabelInterval: 0,
+            secondaryLabelInterval: 0,
+            primaryLabelSpacing: 8,
+            secondaryLabelSpacing: 2,
+            formatTimeCallback: formatSecondsWithPrecision(3),
+        },
+    },
+    {
+        minPixelsPerSecond: 7000,
+        options: {
+            timeInterval: 0.0078125,
+            primaryLabelInterval: 0,
+            secondaryLabelInterval: 0,
+            primaryLabelSpacing: 8,
+            secondaryLabelSpacing: 2,
+            formatTimeCallback: formatSecondsWithPrecision(3),
+        },
+    },
+    {
         minPixelsPerSecond: 1500,
         options: {
             timeInterval: 0.03125,
             primaryLabelInterval: 0,
             secondaryLabelInterval: 0,
             primaryLabelSpacing: 8,
-            secondaryLabelSpacing: 4,
-            formatTimeCallback: (seconds: number): string => formatSecondsWithPrecision(seconds, 3),
+            secondaryLabelSpacing: 2,
+            formatTimeCallback: formatSecondsWithPrecision(3),
         },
     },
     {
@@ -37,19 +59,19 @@ const DENSITY_BANDS: TimelineDensityBand[] = [
             primaryLabelInterval: 0,
             secondaryLabelInterval: 0,
             primaryLabelSpacing: 8,
-            secondaryLabelSpacing: 4,
-            formatTimeCallback: (seconds: number): string => formatSecondsWithPrecision(seconds, 2),
+            secondaryLabelSpacing: 2,
+            formatTimeCallback: formatSecondsWithPrecision(2),
         },
     },
     {
-        minPixelsPerSecond: 70,
+        minPixelsPerSecond: 75,
         options: {
             timeInterval: 0.5,
             primaryLabelInterval: 0,
             secondaryLabelInterval: 0,
             primaryLabelSpacing: 10,
-            secondaryLabelSpacing: 5,
-            formatTimeCallback: (seconds: number): string => formatSecondsWithPrecision(seconds, 1),
+            secondaryLabelSpacing: 2,
+            formatTimeCallback: formatSecondsWithPrecision(1),
         },
     },
     {
@@ -59,7 +81,7 @@ const DENSITY_BANDS: TimelineDensityBand[] = [
             primaryLabelInterval: 0,
             secondaryLabelInterval: 0,
             primaryLabelSpacing: 10,
-            secondaryLabelSpacing: 5,
+            secondaryLabelSpacing: 2,
         },
     },
     {
@@ -69,7 +91,7 @@ const DENSITY_BANDS: TimelineDensityBand[] = [
             primaryLabelInterval: 0,
             secondaryLabelInterval: 0,
             primaryLabelSpacing: 6,
-            secondaryLabelSpacing: 3,
+            secondaryLabelSpacing: 2,
         },
     },
     {
@@ -79,7 +101,7 @@ const DENSITY_BANDS: TimelineDensityBand[] = [
             primaryLabelInterval: 0,
             secondaryLabelInterval: 0,
             primaryLabelSpacing: 6,
-            secondaryLabelSpacing: 3,
+            secondaryLabelSpacing: 2,
         },
     },
     {
@@ -89,7 +111,7 @@ const DENSITY_BANDS: TimelineDensityBand[] = [
             primaryLabelInterval: 0,
             secondaryLabelInterval: 0,
             primaryLabelSpacing: 10,
-            secondaryLabelSpacing: 5,
+            secondaryLabelSpacing: 2,
         },
     },
     {
@@ -99,14 +121,24 @@ const DENSITY_BANDS: TimelineDensityBand[] = [
             primaryLabelInterval: 0,
             secondaryLabelInterval: 0,
             primaryLabelSpacing: 10,
-            secondaryLabelSpacing: 5,
+            secondaryLabelSpacing: 2,
         },
     },
 ];
 
+// Enforce sorted nature of the array
+let prevMPPS = Number.MAX_SAFE_INTEGER;
+for (const band of DENSITY_BANDS) {
+    const currMpps = band.minPixelsPerSecond;
+    if (currMpps > prevMPPS) {
+        throw new Error(`DENSITY_BANDS must be sorted by MPPS descending. Conflicting band: ${JSON.stringify(band)}`);
+    }
+    prevMPPS = currMpps;
+}
+
 function getTimelineDensityBand(pixelsPerSecond: number): TimelineDensityBand {
     const band = DENSITY_BANDS.find(({ minPixelsPerSecond }) => pixelsPerSecond >= minPixelsPerSecond);
-    return band || DENSITY_BANDS[DENSITY_BANDS.length - 1];
+    return band ?? DENSITY_BANDS[DENSITY_BANDS.length - 1];
 }
 
 /**

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-audio-waveform.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-audio-waveform.ts
@@ -21,6 +21,7 @@ import { ThunkDispatch } from 'utils/redux';
 import { injectScrollbarStyle } from '../utils/inject-scrollbar-style';
 import { useWaveformViewport, WaveformViewport } from './use-waveform-viewport';
 import { useWaveformPlayback, WaveformPlayback } from './use-waveform-playback';
+import { useAdaptiveTimeline } from './use-adaptive-timeline';
 
 export interface WaveformPlayerBindings {
     plugins: GenericPlugin[];
@@ -50,6 +51,8 @@ export interface WaveSurferRuntime {
     durationRef: React.MutableRefObject<number>;
     /** Stable ref */
     minimap: MinimapPlugin;
+    /** Stable ref */
+    timelineRef: React.MutableRefObject<TimelinePlugin | null>;
     /** Stable ref */
     playerBindings: WaveformPlayerBindings;
     regionRuntime: WaveformRegionRuntime;
@@ -87,6 +90,7 @@ function useWaveSurferRuntime({
     instanceRef.current = instance;
     const durationRef = useRef(0);
     const readyRef = useRef(false);
+    const timelineRef = useRef<TimelinePlugin | null>(null);
 
     const createSourceScope = (): WaveSurferSourceScope => {
         const minimap = MinimapPlugin.create({
@@ -98,9 +102,11 @@ function useWaveSurferRuntime({
             height: 50,
             overlayColor: 'rgba(0, 85, 255, 0.3)',
         });
+        const timeline = TimelinePlugin.create();
+        timelineRef.current = timeline;
         const regions = RegionsPlugin.create();
         const plugins: GenericPlugin[] = [
-            TimelinePlugin.create(),
+            timeline,
             minimap,
             HoverPlugin.create({
                 lineColor: '#C084FC',
@@ -149,6 +155,7 @@ function useWaveSurferRuntime({
         instanceRef,
         durationRef,
         minimap: sourceScope.minimap,
+        timelineRef,
         playerBindings: sourceScope.playerBindings,
         regionRuntime,
         ready: instance !== null,
@@ -162,6 +169,7 @@ function useWaveSurferRuntime({
 export function useAudioWaveform(params: Params): AudioWaveform {
     const runtime = useWaveSurferRuntime(params);
     const viewport = useWaveformViewport(runtime);
+    useAdaptiveTimeline(runtime, viewport.pixelsPerSecond);
     const playback = useWaveformPlayback(runtime);
 
     return {

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-viewport.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-viewport.ts
@@ -24,6 +24,9 @@ const ZOOM_DELTA_LIMIT = 8;
 export interface WaveformViewport {
     /** Bound in AudioCanvas view rendering */
     containerRef: React.RefObject<HTMLDivElement>;
+
+    /** Current reactive zoom expressed in pixels per second. */
+    pixelsPerSecond: number;
     /**
      * Converts clientX coordinate from viewport to semantic timestamp on the current track.
      * Returns the track boundary (start/end correspondingly) if clientX is outside of the container's BB.
@@ -187,6 +190,7 @@ export function useWaveformViewport(runtime: WaveSurferRuntime): WaveformViewpor
 
     return {
         containerRef,
+        pixelsPerSecond,
         clientXToTime,
         centerTimeRange,
         ensureTimeVisible,

--- a/cvat-ui/src/audio/utils/format-audio-time.ts
+++ b/cvat-ui/src/audio/utils/format-audio-time.ts
@@ -19,6 +19,18 @@ export function formatMilliseconds(value: number): string {
     return `${minutes}:${seconds.toString().padStart(2, '0')}.${milliseconds.toString().padStart(3, '0')}`;
 }
 
+export function formatSecondsWithPrecision(value: number, precision: number): string {
+    const safePrecision = Math.max(0, Math.floor(precision));
+    const multiplier = 10 ** safePrecision;
+    const safe = Number.isFinite(value) ? Math.max(0, Math.round(value * multiplier)) : 0;
+    const minutes = Math.floor(safe / (60 * multiplier));
+    const seconds = Math.floor(safe / multiplier) % 60;
+    const fractional = safe % multiplier;
+    const suffix = safePrecision ? `.${fractional.toString().padStart(safePrecision, '0')}` : '';
+
+    return `${minutes}:${seconds.toString().padStart(2, '0')}${suffix}`;
+}
+
 export function formatSeconds(value: number): string {
-    return formatMilliseconds(value * 1000);
+    return formatSecondsWithPrecision(value, 3);
 }

--- a/cvat-ui/src/audio/utils/format-audio-time.ts
+++ b/cvat-ui/src/audio/utils/format-audio-time.ts
@@ -19,18 +19,21 @@ export function formatMilliseconds(value: number): string {
     return `${minutes}:${seconds.toString().padStart(2, '0')}.${milliseconds.toString().padStart(3, '0')}`;
 }
 
-export function formatSecondsWithPrecision(value: number, precision: number): string {
-    const safePrecision = Math.max(0, Math.floor(precision));
-    const multiplier = 10 ** safePrecision;
-    const safe = Number.isFinite(value) ? Math.max(0, Math.round(value * multiplier)) : 0;
-    const minutes = Math.floor(safe / (60 * multiplier));
-    const seconds = Math.floor(safe / multiplier) % 60;
-    const fractional = safe % multiplier;
-    const suffix = safePrecision ? `.${fractional.toString().padStart(safePrecision, '0')}` : '';
+export function formatSecondsWithPrecision(precision: number): (value: number) => string {
+    if (!Number.isInteger(precision) || precision < 0) {
+        throw new RangeError('Precision must be a non-negative integer');
+    }
 
-    return `${minutes}:${seconds.toString().padStart(2, '0')}${suffix}`;
+    return (value: number): string => {
+        const multiplier = 10 ** precision;
+        const safe = Number.isFinite(value) ? Math.max(0, Math.round(value * multiplier)) : 0;
+        const minutes = Math.floor(safe / (60 * multiplier));
+        const seconds = Math.floor(safe / multiplier) % 60;
+        const fractional = safe % multiplier;
+        const suffix = precision ? `.${fractional.toString().padStart(precision, '0')}` : '';
+
+        return `${minutes}:${seconds.toString().padStart(2, '0')}${suffix}`;
+    };
 }
 
-export function formatSeconds(value: number): string {
-    return formatSecondsWithPrecision(value, 3);
-}
+export const formatSeconds = formatSecondsWithPrecision(3);


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

The default timeline of Wavesurfer is not fine-grained enough so on large scale it can effectively disappear from the viewport making it hard to navigate.

The changes introduce custom adaptive fine-grained timeline handling.

Before:
<img width="1334" height="348" alt="TimelineBefore" src="https://github.com/user-attachments/assets/3af87034-e187-4d70-9a5f-1861391ec397" />

After:
<img width="1335" height="320" alt="AdaptiveTimeline0" src="https://github.com/user-attachments/assets/3ad293b5-9928-4fa4-a926-087c7a6af1b1" />

<img width="1336" height="285" alt="AdaptiveTimeline" src="https://github.com/user-attachments/assets/80f577b5-6f26-413e-b6b6-fff20ad5e05b" />


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Tested manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
