### PR TITLE
Audio workspace: fix interval resize handles

### DIFF
--- a/changelog.d/20260727_154122_aleksey.zinovyev_fix_interval_resize_handles.md
+++ b/changelog.d/20260727_154122_aleksey.zinovyev_fix_interval_resize_handles.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed misaligned resize handles for selected audio intervals.
+  (<https://github.com/cvat-ai/cvat/pull/10951>)

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-region-projection.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-region-projection.ts
@@ -63,7 +63,11 @@ export function useRegionProjection({ regionRuntime, ready }: Params): void {
                 element.style.pointerEvents = selectionDisabled ? 'none' : 'all';
                 const highlighted = isActive || interval.clientID === hoveredIntervalID;
                 const borderColor = getRegionItemColor(interval, labels, colorBy);
-                element.style.border = highlighted ? `2px solid ${borderColor}` : '';
+                // A border changes the region's padding box. WaveSurfer anchors resize handles
+                // to that box, which shifts their hit areas inward from the displayed boundaries.
+                // An inset shadow provides the same visual selection outline without changing
+                // the coordinate system used by the handles.
+                element.style.boxShadow = highlighted ? `inset 0 0 0 2px ${borderColor}` : '';
             }
         };
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Hand tool for moving interval appears outside the interval.

This change fixes a 1px mismatch between selected audio interval boundaries and WaveSurfer resize handles. The selected-state border changed the region’s internal geometry, shifting the resize hit areas inward and causing move/resize cursor flicker near interval edges. Replaced the border with an inset shadow so the visual outline does not affect handle positioning.

Before:
<img width="468" height="243" alt="ResizeHandleBefore" src="https://github.com/user-attachments/assets/d794c530-d8f8-4309-8e7f-59589f7a2644" />

After:
<img width="267" height="246" alt="ResizeHandleAfter" src="https://github.com/user-attachments/assets/02a362e2-60b5-478a-966a-63dd1f661f2a" />

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Manually tested

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
