### PR TITLE
Stabilize masks and review e2e tests

### DIFF
--- a/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
+++ b/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
@@ -7,19 +7,20 @@
 
 context('Review pipeline feature', () => {
     const serverFiles = ['archive.zip'];
+    const randomSuffix = Math.floor(100000 + Math.random() * 900000);
     const additionalUsers = {
         annotator: {
-            username: 'annotator',
+            username: `annotator${randomSuffix}`,
             firstName: 'Firstname',
             lastName: 'Lastname',
-            email: 'annotator@local.local',
+            email: `annotator${randomSuffix}@local.local`,
             password: 'UfdU21!dds',
         },
         reviewer: {
-            username: 'reviewer',
+            username: `reviewer${randomSuffix}`,
             firstName: 'Firstname',
             lastName: 'Lastname',
-            email: 'reviewer@local.local',
+            email: `reviewer${randomSuffix}@local.local`,
             password: 'Fv5Df3#f55g',
         },
     };
@@ -186,6 +187,11 @@ context('Review pipeline feature', () => {
             // https://github.com/cypress-io/cypress/issues/27415
 
             const countIssuesByFrame = [[0, 1, 'Wrong position'], [1, 1, customIssueDescription], [2, 1, customIssueDescription]];
+            const clickIssueSidebarControl = (selector) => {
+                cy.get(selector).should('be.visible').click();
+                cy.hideTooltips();
+            };
+
             for (const [frame, issues, text] of countIssuesByFrame) {
                 cy.goCheckFrameNumber(frame);
                 cy.get('.cvat_canvas_issue_region').should('have.length', issues);
@@ -277,13 +283,13 @@ context('Review pipeline feature', () => {
             cy.get('.cvat-issues-sidebar-previous-frame')
                 .should('have.attr', 'style')
                 .and('contain', 'opacity: 0.5;'); // the element is not active
-            cy.get('.cvat-issues-sidebar-next-frame').should('be.visible').click();
+            clickIssueSidebarControl('.cvat-issues-sidebar-next-frame');
             cy.checkFrameNum(1);
-            cy.get('.cvat-issues-sidebar-next-frame').should('be.visible').click();
+            clickIssueSidebarControl('.cvat-issues-sidebar-next-frame');
             cy.checkFrameNum(2);
             cy.get('.cvat-issues-sidebar-next-frame').should('have.attr', 'style')
                 .and('contain', 'opacity: 0.5;'); // the element is not active
-            cy.get('.cvat-issues-sidebar-previous-frame').should('be.visible').click();
+            clickIssueSidebarControl('.cvat-issues-sidebar-previous-frame');
             cy.checkFrameNum(1);
 
             cy.goCheckFrameNumber(1);
@@ -293,13 +299,13 @@ context('Review pipeline feature', () => {
                 }
             });
             cy.goCheckFrameNumber(0);
-            cy.get('.cvat-issues-sidebar-hidden-resolved-status').click();
-            cy.get('.cvat-issues-sidebar-next-frame').should('be.visible').click();
+            clickIssueSidebarControl('.cvat-issues-sidebar-hidden-resolved-status');
+            clickIssueSidebarControl('.cvat-issues-sidebar-next-frame');
             cy.checkFrameNum(2);
-            cy.get('.cvat-issues-sidebar-hidden-resolved-status').click();
+            clickIssueSidebarControl('.cvat-issues-sidebar-hidden-resolved-status');
 
             // Hide all issues. All issues are hidden on all frames
-            cy.get('.cvat-issues-sidebar-shown-issues').click();
+            clickIssueSidebarControl('.cvat-issues-sidebar-shown-issues');
             for (const [frame, issues] of countIssuesByFrame) {
                 cy.goCheckFrameNumber(frame);
                 cy.get('.cvat-objects-sidebar-issue-item').should('have.length', issues);
@@ -308,7 +314,7 @@ context('Review pipeline feature', () => {
             }
 
             // Show them back
-            cy.get('.cvat-issues-sidebar-hidden-issues').click();
+            clickIssueSidebarControl('.cvat-issues-sidebar-hidden-issues');
             for (const [frame, issues] of countIssuesByFrame) {
                 cy.goCheckFrameNumber(frame);
                 cy.get('.cvat-objects-sidebar-issue-item').should('have.length', issues);

--- a/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
+++ b/tests/cypress/e2e/actions_users/registration_involved/case_28_review_pipeline_feature.js
@@ -7,20 +7,19 @@
 
 context('Review pipeline feature', () => {
     const serverFiles = ['archive.zip'];
-    const randomSuffix = Math.floor(100000 + Math.random() * 900000);
     const additionalUsers = {
         annotator: {
-            username: `annotator${randomSuffix}`,
+            username: 'annotator',
             firstName: 'Firstname',
             lastName: 'Lastname',
-            email: `annotator${randomSuffix}@local.local`,
+            email: 'annotator@local.local',
             password: 'UfdU21!dds',
         },
         reviewer: {
-            username: `reviewer${randomSuffix}`,
+            username: 'reviewer',
             firstName: 'Firstname',
             lastName: 'Lastname',
-            email: `reviewer${randomSuffix}@local.local`,
+            email: 'reviewer@local.local',
             password: 'Fv5Df3#f55g',
         },
     };

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -485,8 +485,14 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
                 cy.get(`#cvat_canvas_shape_${index + 1}`).should('exist').and('be.visible');
             }
 
-            // Fist mask is updated, second mask is removed after third mask is drawn
-            cy.contains('Some objects were deleted').should('exist').and('be.visible');
+            // First mask is updated, second mask is removed after third mask is drawn
+            cy.get('.cvat-empty-masks-notification').should('be.visible').within(() => {
+                cy.contains('Some objects were deleted').should('be.visible');
+                cy.contains(
+                    'As a result of removing the underlying pixels, some masks became empty and were subsequently deleted.',
+                ).should('be.visible');
+            });
+            cy.closeNotification('.cvat-empty-masks-notification');
             for (const id of [1, 3]) {
                 cy.get(`#cvat_canvas_shape_${id}`).should('exist').and('be.visible');
             }


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Stabilized a couple of tests:
- Mask test should close the notification
- Review test should hide the tooltips

Those tests failied a couple of times [here](https://github.com/cvat-ai/cvat/actions/runs/30254951528/job/89959343894?pr=10704)

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
