### PR TITLE
ci: pass the PR branch name through env and quote the push refspec

### DIFF
--- a/.github/workflows/update-python-requirements.yml
+++ b/.github/workflows/update-python-requirements.yml
@@ -82,10 +82,11 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: "${{ steps.gen-token.outputs.token }}"
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           git config user.name "cvat-bot[bot]"
           git config user.email "147643061+cvat-bot[bot]@users.noreply.github.com"
           git add cvat/requirements/*.txt utils/dataset_manifest/requirements.txt
           git commit -m "Regenerate Python requirements"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push origin "HEAD:$HEAD_REF"


### PR DESCRIPTION
Hi, and thanks for CVAT.

In `.github/workflows/update-python-requirements.yml`, the final push interpolates the PR's source branch name straight into the command:

```yaml
git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
git push origin HEAD:${{ github.event.pull_request.head.ref }}
```

Actions substitutes `${{ ... }}` into the script text before bash runs, so the branch name lands as script rather than as an argument, and it is unquoted. Git permits `$`, `(`, `)`, backticks and spaces in branch names, so a branch named something like `x$(id)` would execute on the runner — in a step that has just put an app token into the origin remote URL.

The step is already doing the right thing for its other sensitive value: `GH_TOKEN` comes in through `env:` and is used as `${GH_TOKEN}`. This change applies the same treatment to the branch name:

```yaml
env:
  GH_TOKEN: "${{ steps.gen-token.outputs.token }}"
  HEAD_REF: ${{ github.event.pull_request.head.ref }}
run: |
  ...
  git push origin "HEAD:$HEAD_REF"
```

I also quoted the refspec, so branch names with spaces push correctly instead of being split into two arguments.

One thing I could not check from outside, and would rather flag than assume: how this workflow is invoked for fork PRs. On a plain `pull_request` event a fork gets a read-only token, which would limit this considerably; if it is reachable another way, the token in that remote URL makes it more serious. You will know that better than I do.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow myself.
