### PR TITLE
Fix backup temp storage path and tmp mount point in Helm

### DIFF
--- a/changelog.d/20260729_083618_andrey_helm_fix_tmp_mount.md
+++ b/changelog.d/20260729_083618_andrey_helm_fix_tmp_mount.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- \[Helm\] Fixed backup/export workers using ephemeral storage for backup
+  temporary files.
+  (<https://github.com/cvat-ai/cvat/pull/10958>)

--- a/cvat/apps/engine/backup.py
+++ b/cvat/apps/engine/backup.py
@@ -8,7 +8,6 @@ import mimetypes
 import os
 import re
 import shutil
-import tempfile
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict, deque
 from collections.abc import Collection, Iterable
@@ -500,7 +499,7 @@ class TaskExporter(_ExporterBase, _TaskBackupBase):
                 if imm_original.exists:
                     present_frame_nums = {im.frame for im in self._db_data.images.all()}
 
-                    with tempfile.TemporaryDirectory() as tmp_dir:
+                    with TmpDirManager.get_tmp_directory() as tmp_dir:
                         filtered_manifest_path = Path(tmp_dir, self.MEDIA_MANIFEST_FILENAME)
                         imm_filtered = ImageManifestManager(
                             filtered_manifest_path, create_index=False
@@ -556,7 +555,7 @@ class TaskExporter(_ExporterBase, _TaskBackupBase):
 
         if media_files_to_download:
             storage_client = self._db_data.get_cloud_storage_instance()
-            with tempfile.TemporaryDirectory() as tmp_dir:
+            with TmpDirManager.get_tmp_directory() as tmp_dir:
                 storage_client.bulk_download_to_dir(
                     files=media_files_to_download, upload_dir=Path(tmp_dir)
                 )

--- a/helm-chart/templates/cvat_backend/worker_annotation/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_annotation/deployment.yml
@@ -80,9 +80,6 @@ spec:
           - mountPath: /home/django/logs
             name: cvat-backend-data
             subPath: logs
-          - mountPath: /home/django/tmp_storage
-            name: cvat-backend-data
-            subPath: tmp_storage
           {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/helm-chart/templates/cvat_backend/worker_export/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_export/deployment.yml
@@ -80,9 +80,6 @@ spec:
           - mountPath: /home/django/logs
             name: cvat-backend-data
             subPath: logs
-          - mountPath: /home/django/tmp_storage
-            name: cvat-backend-data
-            subPath: tmp_storage
           {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/helm-chart/templates/cvat_backend/worker_import/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_import/deployment.yml
@@ -80,9 +80,6 @@ spec:
           - mountPath: /home/django/logs
             name: cvat-backend-data
             subPath: logs
-          - mountPath: /home/django/tmp_storage
-            name: cvat-backend-data
-            subPath: tmp_storage
           {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}


### PR DESCRIPTION
### Changes

- Updated backup code to use CVAT’s configured temporary directory via `TmpDirManager`.
- Removed the obsolete `/home/django/tmp_storage` mount from annotation, import, and export workers.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
