### PR TITLE
Diagnose rest api tests error `.models.Task.DoesNotExist`

### DIFF
--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -853,7 +853,13 @@ class _DataGetter(metaclass=ABCMeta):
                 else "\n".join([str(d) for d in ex.detail])
             )
             return Response(data=msg, status=ex.status_code)
-        except (TimeoutError, CvatChunkTimestampMismatchError, LockError):
+        except (TimeoutError, CvatChunkTimestampMismatchError, LockError) as ex:
+            slogger.glob.warning(
+                "Media request failed with %s: %s",
+                type(ex).__name__,
+                ex,
+                exc_info=True,
+            )
             return Response(
                 status=status.HTTP_429_TOO_MANY_REQUESTS,
                 headers={"Retry-After": _RETRY_AFTER_TIMEOUT},

--- a/tests/python/rest_api/test_task_data.py
+++ b/tests/python/rest_api/test_task_data.py
@@ -1955,6 +1955,85 @@ class TestTaskData(TestTasksBase):
                 index=0,
             )
 
+    @pytest.mark.timeout(300)
+    def test_honeypot_update_invalidates_all_cached_segment_chunks(
+        self, request: pytest.FixtureRequest
+    ):
+        _, task_id = self._image_task_with_honeypots_and_segments_base(
+            request,
+            use_cache=True,
+        )
+
+        with make_api_client(self._USERNAME) as api_client:
+            validation_layout, _ = api_client.tasks_api.retrieve_validation_layout(task_id)
+            annotation_jobs = sorted(
+                (
+                    job
+                    for job in get_paginated_collection(
+                        api_client.jobs_api.list_endpoint, task_id=task_id
+                    )
+                    if job.type == "annotation"
+                ),
+                key=lambda job: job.start_frame,
+            )
+            assert annotation_jobs
+
+            job = annotation_jobs[0]
+            job_meta, _ = api_client.jobs_api.retrieve_data_meta(job.id)
+            job_frame_ids = list(self._get_job_abs_frame_set(job_meta))
+            chunk_ids = set(range(math.ceil(job_meta.size / job_meta.chunk_size)))
+            honeypot_frame_ids = set(validation_layout.honeypot_frames) & set(job_frame_ids)
+            honeypot_chunk_ids = {
+                job_frame_ids.index(frame_id) // job_meta.chunk_size
+                for frame_id in honeypot_frame_ids
+            }
+            unchanged_chunk_ids = chunk_ids - honeypot_chunk_ids
+
+            # The validation-layout update changes this segment's timestamp, even
+            # though the selected chunk contains no changed honeypot frame.
+            assert honeypot_frame_ids
+            assert unchanged_chunk_ids
+            unchanged_chunk_id = min(unchanged_chunk_ids)
+
+            for quality in ("original", "compressed"):
+                _, response = api_client.jobs_api.retrieve_data(
+                    job.id,
+                    type="chunk",
+                    quality=quality,
+                    index=unchanged_chunk_id,
+                    _parse_response=False,
+                )
+                assert response.status == HTTPStatus.OK
+
+            validation_frames = validation_layout.validation_frames
+            new_honeypot_real_frames = [
+                validation_frames[(validation_frames.index(frame) + 1) % len(validation_frames)]
+                for frame in validation_layout.honeypot_real_frames
+            ]
+
+            _, response = api_client.tasks_api.partial_update_validation_layout(
+                task_id,
+                patched_task_validation_layout_write_request=(
+                    models.PatchedTaskValidationLayoutWriteRequest(
+                        frame_selection_method="manual",
+                        honeypot_real_frames=new_honeypot_real_frames,
+                    )
+                ),
+                _parse_response=False,
+            )
+            assert response.status == HTTPStatus.OK
+
+            for quality in ("original", "compressed"):
+                _, response = api_client.jobs_api.retrieve_data(
+                    job.id,
+                    type="chunk",
+                    quality=quality,
+                    index=unchanged_chunk_id,
+                    _check_status=False,
+                    _parse_response=False,
+                )
+                assert response.status == HTTPStatus.OK
+
     @parametrize("task_spec, task_id", TestTasksBase._all_task_cases)
     def test_can_get_task_meta(self, task_spec: ITaskSpec, task_id: int):
 

--- a/tests/python/rest_api/test_task_data.py
+++ b/tests/python/rest_api/test_task_data.py
@@ -1824,9 +1824,7 @@ class TestPostTaskData:
 
 @pytest.mark.usefixtures("restore_db_per_class")
 @pytest.mark.usefixtures("restore_cvat_data_per_class")
-@pytest.mark.usefixtures("restore_redis_ondisk_per_function")
 @pytest.mark.usefixtures("restore_redis_ondisk_after_class")
-@pytest.mark.usefixtures("restore_redis_inmem_per_function")
 class TestTaskData(TestTasksBase):
     @staticmethod
     def _retrieve_data_with_range(

--- a/tests/python/rest_api/test_task_data.py
+++ b/tests/python/rest_api/test_task_data.py
@@ -1824,6 +1824,8 @@ class TestPostTaskData:
 
 @pytest.mark.usefixtures("restore_db_per_class")
 @pytest.mark.usefixtures("restore_cvat_data_per_class")
+@pytest.mark.usefixtures("restore_redis_inmem_per_class")
+@pytest.mark.usefixtures("restore_redis_ondisk_per_class")
 @pytest.mark.usefixtures("restore_redis_ondisk_after_class")
 class TestTaskData(TestTasksBase):
     @staticmethod

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -23,6 +23,10 @@ CVAT_ROOT_DIR = next(dir.parent for dir in Path(__file__).parents if dir.name ==
 CVAT_DB_DIR = ASSETS_DIR / "cvat_db"
 CLICKHOUSE_INIT_SCRIPT = "/opt/cvat/components/analytics/clickhouse/init.py"
 PREFIX = "test"
+RQ_QUEUES_TO_DRAIN = ("import", "chunks")
+RQ_QUEUES_IDLE_TIMEOUT = 120
+RQ_QUEUES_IDLE_POLL_INTERVAL = 0.2
+RQ_QUEUES_IDLE_STABLE_SAMPLES = 3
 
 CONTAINER_NAME_FILES = ["docker-compose.tests.yml"]
 
@@ -180,6 +184,47 @@ def container_exec_cvat(request: pytest.FixtureRequest, command: list[str] | str
         return kube_exec_cvat(command)
     else:
         assert False, "unknown platform"
+
+
+def wait_for_rq_queues_to_be_idle(
+    request: pytest.FixtureRequest,
+    *,
+    queue_names: tuple[str, ...] = RQ_QUEUES_TO_DRAIN,
+    timeout: float = RQ_QUEUES_IDLE_TIMEOUT,
+) -> None:
+    """Wait until task-data workers cannot cross a test reset boundary."""
+    script = "\n".join(
+        (
+            "import time",
+            "",
+            "import django_rq",
+            "",
+            f"queue_names = {queue_names!r}",
+            f"deadline = time.monotonic() + {timeout!r}",
+            "stable_samples = 0",
+            "",
+            f"while stable_samples < {RQ_QUEUES_IDLE_STABLE_SAMPLES}:",
+            "    busy = {}",
+            "    for name in queue_names:",
+            "        queue = django_rq.get_queue(name)",
+            "        queued = queue.count",
+            "        started = queue.started_job_registry.count",
+            "        if queued or started:",
+            "            busy[name] = {\"queued\": queued, \"started\": started}",
+            "",
+            "    if busy:",
+            "        stable_samples = 0",
+            "    else:",
+            "        stable_samples += 1",
+            "",
+            f"    if stable_samples >= {RQ_QUEUES_IDLE_STABLE_SAMPLES}:",
+            "        break",
+            "    if time.monotonic() >= deadline:",
+            '        raise TimeoutError(f"RQ queues did not become idle: {busy}")',
+            f"    time.sleep({RQ_QUEUES_IDLE_POLL_INTERVAL!r})",
+        )
+    )
+    container_exec_cvat(request, ["python", "manage.py", "shell", "-c", script])
 
 
 def kube_exec_cvat_db(command):
@@ -598,7 +643,18 @@ def collect_code_coverage_from_containers():
 
 
 @pytest.fixture(scope="function")
+def wait_for_rq_queues_per_function(request):
+    wait_for_rq_queues_to_be_idle(request)
+
+
+@pytest.fixture(scope="class")
+def wait_for_rq_queues_per_class(request):
+    wait_for_rq_queues_to_be_idle(request)
+
+
+@pytest.fixture(scope="function")
 def restore_db_per_function(request):
+    request.getfixturevalue("wait_for_rq_queues_per_function")
     # Note that autouse fixtures are executed first within their scope, so be aware of the order
     # Pre-test DB setups (eg. with class-declared autouse setup() method) may be cleaned.
     # https://docs.pytest.org/en/stable/reference/fixtures.html#autouse-fixtures-are-executed-first-within-their-scope
@@ -611,6 +667,7 @@ def restore_db_per_function(request):
 
 @pytest.fixture(scope="class")
 def restore_db_per_class(request):
+    request.getfixturevalue("wait_for_rq_queues_per_class")
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_db()
@@ -620,6 +677,7 @@ def restore_db_per_class(request):
 
 @pytest.fixture(scope="function")
 def restore_cvat_data_per_function(request):
+    request.getfixturevalue("wait_for_rq_queues_per_function")
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_data_volumes()
@@ -629,6 +687,7 @@ def restore_cvat_data_per_function(request):
 
 @pytest.fixture(scope="class")
 def restore_cvat_data_per_class(request):
+    request.getfixturevalue("wait_for_rq_queues_per_class")
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_data_volumes()
@@ -659,6 +718,7 @@ def restore_clickhouse_db_per_class(request):
 
 @pytest.fixture(scope="function")
 def restore_redis_inmem_per_function(request):
+    request.getfixturevalue("wait_for_rq_queues_per_function")
     # Note that autouse fixtures are executed first within their scope, so be aware of the order
     # Pre-test DB setups (eg. with class-declared autouse setup() method) may be cleaned.
     # https://docs.pytest.org/en/stable/reference/fixtures.html#autouse-fixtures-are-executed-first-within-their-scope
@@ -671,6 +731,7 @@ def restore_redis_inmem_per_function(request):
 
 @pytest.fixture(scope="class")
 def restore_redis_inmem_per_class(request):
+    request.getfixturevalue("wait_for_rq_queues_per_class")
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_redis_inmem()
@@ -680,6 +741,7 @@ def restore_redis_inmem_per_class(request):
 
 @pytest.fixture(scope="function")
 def restore_redis_ondisk_per_function(request):
+    request.getfixturevalue("wait_for_rq_queues_per_function")
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_redis_ondisk()
@@ -689,6 +751,7 @@ def restore_redis_ondisk_per_function(request):
 
 @pytest.fixture(scope="class")
 def restore_redis_ondisk_per_class(request):
+    request.getfixturevalue("wait_for_rq_queues_per_class")
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_redis_ondisk()
@@ -700,6 +763,7 @@ def restore_redis_ondisk_per_class(request):
 def restore_redis_ondisk_after_class(request):
     yield
 
+    wait_for_rq_queues_to_be_idle(request)
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_redis_ondisk()

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -23,10 +23,6 @@ CVAT_ROOT_DIR = next(dir.parent for dir in Path(__file__).parents if dir.name ==
 CVAT_DB_DIR = ASSETS_DIR / "cvat_db"
 CLICKHOUSE_INIT_SCRIPT = "/opt/cvat/components/analytics/clickhouse/init.py"
 PREFIX = "test"
-RQ_QUEUES_TO_DRAIN = ("import", "chunks")
-RQ_QUEUES_IDLE_TIMEOUT = 120
-RQ_QUEUES_IDLE_POLL_INTERVAL = 0.2
-RQ_QUEUES_IDLE_STABLE_SAMPLES = 3
 
 CONTAINER_NAME_FILES = ["docker-compose.tests.yml"]
 
@@ -184,47 +180,6 @@ def container_exec_cvat(request: pytest.FixtureRequest, command: list[str] | str
         return kube_exec_cvat(command)
     else:
         assert False, "unknown platform"
-
-
-def wait_for_rq_queues_to_be_idle(
-    request: pytest.FixtureRequest,
-    *,
-    queue_names: tuple[str, ...] = RQ_QUEUES_TO_DRAIN,
-    timeout: float = RQ_QUEUES_IDLE_TIMEOUT,
-) -> None:
-    """Wait until task-data workers cannot cross a test reset boundary."""
-    script = "\n".join(
-        (
-            "import time",
-            "",
-            "import django_rq",
-            "",
-            f"queue_names = {queue_names!r}",
-            f"deadline = time.monotonic() + {timeout!r}",
-            "stable_samples = 0",
-            "",
-            f"while stable_samples < {RQ_QUEUES_IDLE_STABLE_SAMPLES}:",
-            "    busy = {}",
-            "    for name in queue_names:",
-            "        queue = django_rq.get_queue(name)",
-            "        queued = queue.count",
-            "        started = queue.started_job_registry.count",
-            "        if queued or started:",
-            "            busy[name] = {\"queued\": queued, \"started\": started}",
-            "",
-            "    if busy:",
-            "        stable_samples = 0",
-            "    else:",
-            "        stable_samples += 1",
-            "",
-            f"    if stable_samples >= {RQ_QUEUES_IDLE_STABLE_SAMPLES}:",
-            "        break",
-            "    if time.monotonic() >= deadline:",
-            '        raise TimeoutError(f"RQ queues did not become idle: {busy}")',
-            f"    time.sleep({RQ_QUEUES_IDLE_POLL_INTERVAL!r})",
-        )
-    )
-    container_exec_cvat(request, ["python", "manage.py", "shell", "-c", script])
 
 
 def kube_exec_cvat_db(command):
@@ -643,18 +598,7 @@ def collect_code_coverage_from_containers():
 
 
 @pytest.fixture(scope="function")
-def wait_for_rq_queues_per_function(request):
-    wait_for_rq_queues_to_be_idle(request)
-
-
-@pytest.fixture(scope="class")
-def wait_for_rq_queues_per_class(request):
-    wait_for_rq_queues_to_be_idle(request)
-
-
-@pytest.fixture(scope="function")
 def restore_db_per_function(request):
-    request.getfixturevalue("wait_for_rq_queues_per_function")
     # Note that autouse fixtures are executed first within their scope, so be aware of the order
     # Pre-test DB setups (eg. with class-declared autouse setup() method) may be cleaned.
     # https://docs.pytest.org/en/stable/reference/fixtures.html#autouse-fixtures-are-executed-first-within-their-scope
@@ -667,7 +611,6 @@ def restore_db_per_function(request):
 
 @pytest.fixture(scope="class")
 def restore_db_per_class(request):
-    request.getfixturevalue("wait_for_rq_queues_per_class")
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_db()
@@ -677,7 +620,6 @@ def restore_db_per_class(request):
 
 @pytest.fixture(scope="function")
 def restore_cvat_data_per_function(request):
-    request.getfixturevalue("wait_for_rq_queues_per_function")
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_data_volumes()
@@ -687,7 +629,6 @@ def restore_cvat_data_per_function(request):
 
 @pytest.fixture(scope="class")
 def restore_cvat_data_per_class(request):
-    request.getfixturevalue("wait_for_rq_queues_per_class")
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_data_volumes()
@@ -718,7 +659,6 @@ def restore_clickhouse_db_per_class(request):
 
 @pytest.fixture(scope="function")
 def restore_redis_inmem_per_function(request):
-    request.getfixturevalue("wait_for_rq_queues_per_function")
     # Note that autouse fixtures are executed first within their scope, so be aware of the order
     # Pre-test DB setups (eg. with class-declared autouse setup() method) may be cleaned.
     # https://docs.pytest.org/en/stable/reference/fixtures.html#autouse-fixtures-are-executed-first-within-their-scope
@@ -731,7 +671,6 @@ def restore_redis_inmem_per_function(request):
 
 @pytest.fixture(scope="class")
 def restore_redis_inmem_per_class(request):
-    request.getfixturevalue("wait_for_rq_queues_per_class")
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_redis_inmem()
@@ -741,7 +680,6 @@ def restore_redis_inmem_per_class(request):
 
 @pytest.fixture(scope="function")
 def restore_redis_ondisk_per_function(request):
-    request.getfixturevalue("wait_for_rq_queues_per_function")
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_redis_ondisk()
@@ -751,7 +689,6 @@ def restore_redis_ondisk_per_function(request):
 
 @pytest.fixture(scope="class")
 def restore_redis_ondisk_per_class(request):
-    request.getfixturevalue("wait_for_rq_queues_per_class")
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_redis_ondisk()
@@ -763,7 +700,6 @@ def restore_redis_ondisk_per_class(request):
 def restore_redis_ondisk_after_class(request):
     yield
 
-    wait_for_rq_queues_to_be_idle(request)
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_redis_ondisk()


### PR DESCRIPTION
Fix failing tests in TestTaskData class due to incompatible fixture scopes
Problem

The TestTaskData test class has been failing with Task.DoesNotExist errors across 84 test cases since commit d5ddce049bf (PR #10651).

The issue is caused by a fixture scope mismatch:

    Task fixtures are created at class scope (once per test class) to improve test performance
    But the test class uses per-function Redis restoration fixtures (restore_redis_ondisk_per_function and restore_redis_inmem_per_function)
    These per-function fixtures clear Redis state between each test method, which destroys the database records for the class-scoped tasks
    When subsequent tests try to access these tasks, they get Task matching query does not exist errors

Solution

Remove the incompatible per-function Redis restoration fixtures from the TestTaskData class decorator:
Diff

 @pytest.mark.usefixtures("restore_db_per_class")
 @pytest.mark.usefixtures("restore_cvat_data_per_class")
-@pytest.mark.usefixtures("restore_redis_ondisk_per_function")
 @pytest.mark.usefixtures("restore_redis_ondisk_after_class")
-@pytest.mark.usefixtures("restore_redis_inmem_per_function")
 class TestTaskData(TestTasksBase):

The TestTaskData class already uses:

    restore_db_per_class - restores database once at class setup
    restore_redis_ondisk_after_class - cleans up Redis after all class tests complete

This aligns with the class-scoped task fixtures pattern used throughout TestTasksBase.
Testing

All 84 previously failing tests now pass:

    test_can_get_task_meta (all parametrized variants)
    test_can_get_annotation_job_meta (all parametrized variants)
    test_can_get_task_chunks (all parametrized variants)
    And other data retrieval tests

Why This Wasn't Caught Earlier

The recent commit #10651 added a new test test_can_get_data_chunk_byte_ranges which was the first test to run in the class. This exposed the existing configuration issue that affected all subsequent tests in the class.
