### PR TITLE
Added outlines to interactor mask previews to make mask boundaries easier to distinguish

### DIFF
--- a/changelog.d/20260731_154355_glebpotapov_interactor_mask_outlines.md
+++ b/changelog.d/20260731_154355_glebpotapov_interactor_mask_outlines.md
@@ -1,0 +1,4 @@
+### Added
+
+- Added outlines to interactor mask previews to make mask boundaries easier to distinguish.
+  (<https://github.com/cvat-ai/cvat/pull/10966>)

--- a/cvat-canvas/src/scss/canvas.scss
+++ b/cvat-canvas/src/scss/canvas.scss
@@ -250,18 +250,8 @@ g.cvat_canvas_shape_occluded {
     @extend .cvat_canvas_shape;
 }
 
-@keyframes cvat-canvas-interact-mask-outline-animation {
-    to {
-        stroke-dashoffset: -12px;
-    }
-}
-
 .cvat_canvas_interact_mask_outline {
     pointer-events: none;
-}
-
-.cvat_canvas_interact_mask_outline_animated {
-    animation: cvat-canvas-interact-mask-outline-animation 0.6s linear infinite;
 }
 
 .cvat_interaction_delete_button {

--- a/cvat-canvas/src/scss/canvas.scss
+++ b/cvat-canvas/src/scss/canvas.scss
@@ -250,7 +250,7 @@ g.cvat_canvas_shape_occluded {
     @extend .cvat_canvas_shape;
 }
 
-@keyframes cvat_canvas_interact_mask_outline_animation {
+@keyframes cvat-canvas-interact-mask-outline-animation {
     to {
         stroke-dashoffset: -12px;
     }
@@ -261,7 +261,7 @@ g.cvat_canvas_shape_occluded {
 }
 
 .cvat_canvas_interact_mask_outline_animated {
-    animation: cvat_canvas_interact_mask_outline_animation 0.6s linear infinite;
+    animation: cvat-canvas-interact-mask-outline-animation 0.6s linear infinite;
 }
 
 .cvat_interaction_delete_button {

--- a/cvat-canvas/src/scss/canvas.scss
+++ b/cvat-canvas/src/scss/canvas.scss
@@ -250,6 +250,20 @@ g.cvat_canvas_shape_occluded {
     @extend .cvat_canvas_shape;
 }
 
+@keyframes cvat_canvas_interact_mask_outline_animation {
+    to {
+        stroke-dashoffset: -12px;
+    }
+}
+
+.cvat_canvas_interact_mask_outline {
+    pointer-events: none;
+}
+
+.cvat_canvas_interact_mask_outline_animated {
+    animation: cvat_canvas_interact_mask_outline_animation 0.6s linear infinite;
+}
+
 .cvat_interaction_delete_button {
     opacity: 0.25;
 

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -138,7 +138,6 @@ export interface InteractionData {
         shapes: {
             shapeType: string;
             points: ArrayLike<number>;
-            color?: string;
             outlines?: ArrayLike<number>[];
         }[];
     };

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -139,6 +139,7 @@ export interface InteractionData {
             shapeType: string;
             points: ArrayLike<number>;
             color?: string;
+            outlines?: ArrayLike<number>[];
         }[];
     };
     settings?: {

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -138,6 +138,7 @@ export interface InteractionData {
         shapes: {
             shapeType: string;
             points: ArrayLike<number>;
+            color?: string;
         }[];
     };
     settings?: {

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -138,7 +138,7 @@ export interface InteractionData {
         shapes: {
             shapeType: string;
             points: ArrayLike<number>;
-            outlines?: ArrayLike<number>[];
+            maskOutlines?: ArrayLike<number>[];
         }[];
     };
     settings?: {

--- a/cvat-canvas/src/typescript/interactionHandler.ts
+++ b/cvat-canvas/src/typescript/interactionHandler.ts
@@ -283,7 +283,7 @@ export class InteractionHandlerImpl implements InteractionHandler {
 
         for (const shape of shapes) {
             const {
-                points, shapeType, outlines,
+                points, shapeType, maskOutlines,
             } = shape;
             if (shapeType === 'polygon') {
                 const isInvalidShape = points.length < 3 * 2;
@@ -316,7 +316,7 @@ export class InteractionHandlerImpl implements InteractionHandler {
                 this.intermediateShapes.push(image);
 
                 let insertionPoint = image.node;
-                for (const outline of outlines ?? []) {
+                for (const outline of maskOutlines ?? []) {
                     if (outline.length >= 3 * 2) {
                         const outlinePoints = stringifyPoints(translateToCanvas(this.geometry.offset, outline));
                         const strokeWidth = consts.BASE_STROKE_WIDTH / this.geometry.scale;

--- a/cvat-canvas/src/typescript/interactionHandler.ts
+++ b/cvat-canvas/src/typescript/interactionHandler.ts
@@ -29,13 +29,6 @@ type SupportedShapes = SVG.Rect | SVG.Circle;
 
 const DELETE_BUTTON_OFFSET = 8;
 
-function hexToRGB(color: string): [number, number, number] {
-    const result = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(color);
-    return result ?
-        [Number.parseInt(result[1], 16), Number.parseInt(result[2], 16), Number.parseInt(result[3], 16)] :
-        [255, 255, 255];
-}
-
 function getTopRightPosition(shape: SVG.Rect | SVG.Circle): { x: number; y: number } {
     if (shape instanceof SVG.Rect) {
         return {
@@ -286,7 +279,7 @@ export class InteractionHandlerImpl implements InteractionHandler {
 
         for (const shape of shapes) {
             const {
-                points, shapeType, color = '#ffffff', outlines,
+                points, shapeType, outlines,
             } = shape;
             if (shapeType === 'polygon') {
                 const isInvalidShape = points.length < 3 * 2;
@@ -298,7 +291,7 @@ export class InteractionHandlerImpl implements InteractionHandler {
                         'stroke-width': consts.BASE_STROKE_WIDTH / this.geometry.scale,
                         stroke: isInvalidShape ? 'red' : 'black',
                     })
-                    .fill({ opacity: this.effectiveShapeOpacity, color })
+                    .fill({ opacity: this.effectiveShapeOpacity, color: 'white' })
                     .addClass('cvat_canvas_interact_intermediate_shape');
                 this.container.node.prepend(polygon.node);
                 this.intermediateShapes.push(polygon);
@@ -307,8 +300,7 @@ export class InteractionHandlerImpl implements InteractionHandler {
                 const top = points[points.length - 3];
                 const right = points[points.length - 2];
                 const bottom = points[points.length - 1];
-                const [red, green, blue] = hexToRGB(color);
-                const imageBitmap = RLEToImageData(red, green, blue, points);
+                const imageBitmap = RLEToImageData(255, 255, 255, points);
                 const image = this.container.image().attr({
                     'color-rendering': 'optimizeQuality',
                     'shape-rendering': 'geometricprecision',
@@ -324,24 +316,15 @@ export class InteractionHandlerImpl implements InteractionHandler {
                     if (outline.length >= 3 * 2) {
                         const outlinePoints = stringifyPoints(translateToCanvas(this.geometry.offset, outline));
                         const strokeWidth = consts.BASE_STROKE_WIDTH / this.geometry.scale;
-                        const dashSize = 6 / this.geometry.scale;
-                        const outlineBackground = this.container
+                        const maskOutline = this.container
                             .polygon(outlinePoints)
                             .fill('none')
                             .stroke({ color: '#000000', width: strokeWidth })
                             .addClass('cvat_canvas_interact_mask_outline');
-                        const outlineForeground = this.container
-                            .polygon(outlinePoints)
-                            .fill('none')
-                            .stroke({ color: '#ffffff', width: strokeWidth })
-                            .attr({ 'stroke-dasharray': `${dashSize} ${dashSize}` })
-                            .addClass('cvat_canvas_interact_mask_outline')
-                            .addClass('cvat_canvas_interact_mask_outline_animated');
 
-                        insertionPoint.after(outlineBackground.node);
-                        outlineBackground.node.after(outlineForeground.node);
-                        insertionPoint = outlineForeground.node;
-                        this.intermediateShapes.push(outlineBackground, outlineForeground);
+                        insertionPoint.after(maskOutline.node);
+                        insertionPoint = maskOutline.node;
+                        this.intermediateShapes.push(maskOutline);
                     }
                 }
 
@@ -590,10 +573,6 @@ export class InteractionHandlerImpl implements InteractionHandler {
         this.intermediateShapes.forEach((shape) => {
             if (shape.hasClass('cvat_canvas_interact_mask_outline')) {
                 shape.stroke({ width: this.effectiveStrokeWidth });
-                if (shape.hasClass('cvat_canvas_interact_mask_outline_animated')) {
-                    const dashSize = 6 / this.geometry.scale;
-                    shape.attr({ 'stroke-dasharray': `${dashSize} ${dashSize}` });
-                }
             } else {
                 shape.fill({ opacity: this.effectiveShapeOpacity });
             }

--- a/cvat-canvas/src/typescript/interactionHandler.ts
+++ b/cvat-canvas/src/typescript/interactionHandler.ts
@@ -285,7 +285,9 @@ export class InteractionHandlerImpl implements InteractionHandler {
         this.clearIntermediateShapes();
 
         for (const shape of shapes) {
-            const { points, shapeType, color = '#ffffff' } = shape;
+            const {
+                points, shapeType, color = '#ffffff', outlines,
+            } = shape;
             if (shapeType === 'polygon') {
                 const isInvalidShape = points.length < 3 * 2;
                 const polygon = this.container
@@ -316,6 +318,32 @@ export class InteractionHandlerImpl implements InteractionHandler {
                 image.move(this.geometry.offset + left, this.geometry.offset + top);
                 this.container.node.prepend(image.node);
                 this.intermediateShapes.push(image);
+
+                let insertionPoint = image.node;
+                for (const outline of outlines || []) {
+                    if (outline.length >= 3 * 2) {
+                        const outlinePoints = stringifyPoints(translateToCanvas(this.geometry.offset, outline));
+                        const strokeWidth = consts.BASE_STROKE_WIDTH / this.geometry.scale;
+                        const dashSize = 6 / this.geometry.scale;
+                        const outlineBackground = this.container
+                            .polygon(outlinePoints)
+                            .fill('none')
+                            .stroke({ color: '#000000', width: strokeWidth })
+                            .addClass('cvat_canvas_interact_mask_outline');
+                        const outlineForeground = this.container
+                            .polygon(outlinePoints)
+                            .fill('none')
+                            .stroke({ color: '#ffffff', width: strokeWidth })
+                            .attr({ 'stroke-dasharray': `${dashSize} ${dashSize}` })
+                            .addClass('cvat_canvas_interact_mask_outline')
+                            .addClass('cvat_canvas_interact_mask_outline_animated');
+
+                        insertionPoint.after(outlineBackground.node);
+                        outlineBackground.node.after(outlineForeground.node);
+                        insertionPoint = outlineForeground.node;
+                        this.intermediateShapes.push(outlineBackground, outlineForeground);
+                    }
+                }
 
                 imageDataToDataURL(
                     imageBitmap,
@@ -560,7 +588,15 @@ export class InteractionHandlerImpl implements InteractionHandler {
         });
 
         this.intermediateShapes.forEach((shape) => {
-            shape.fill({ opacity: this.effectiveShapeOpacity });
+            if (shape.hasClass('cvat_canvas_interact_mask_outline')) {
+                shape.stroke({ width: this.effectiveStrokeWidth });
+                if (shape.hasClass('cvat_canvas_interact_mask_outline_animated')) {
+                    const dashSize = 6 / this.geometry.scale;
+                    shape.attr({ 'stroke-dasharray': `${dashSize} ${dashSize}` });
+                }
+            } else {
+                shape.fill({ opacity: this.effectiveShapeOpacity });
+            }
         });
     }
 

--- a/cvat-canvas/src/typescript/interactionHandler.ts
+++ b/cvat-canvas/src/typescript/interactionHandler.ts
@@ -29,6 +29,13 @@ type SupportedShapes = SVG.Rect | SVG.Circle;
 
 const DELETE_BUTTON_OFFSET = 8;
 
+function hexToRGB(color: string): [number, number, number] {
+    const result = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(color);
+    return result ?
+        [Number.parseInt(result[1], 16), Number.parseInt(result[2], 16), Number.parseInt(result[3], 16)] :
+        [255, 255, 255];
+}
+
 function getTopRightPosition(shape: SVG.Rect | SVG.Circle): { x: number; y: number } {
     if (shape instanceof SVG.Rect) {
         return {
@@ -278,7 +285,7 @@ export class InteractionHandlerImpl implements InteractionHandler {
         this.clearIntermediateShapes();
 
         for (const shape of shapes) {
-            const { points, shapeType } = shape;
+            const { points, shapeType, color = '#ffffff' } = shape;
             if (shapeType === 'polygon') {
                 const isInvalidShape = points.length < 3 * 2;
                 const polygon = this.container
@@ -289,7 +296,7 @@ export class InteractionHandlerImpl implements InteractionHandler {
                         'stroke-width': consts.BASE_STROKE_WIDTH / this.geometry.scale,
                         stroke: isInvalidShape ? 'red' : 'black',
                     })
-                    .fill({ opacity: this.effectiveShapeOpacity, color: 'white' })
+                    .fill({ opacity: this.effectiveShapeOpacity, color })
                     .addClass('cvat_canvas_interact_intermediate_shape');
                 this.container.node.prepend(polygon.node);
                 this.intermediateShapes.push(polygon);
@@ -298,7 +305,8 @@ export class InteractionHandlerImpl implements InteractionHandler {
                 const top = points[points.length - 3];
                 const right = points[points.length - 2];
                 const bottom = points[points.length - 1];
-                const imageBitmap = RLEToImageData(255, 255, 255, points);
+                const [red, green, blue] = hexToRGB(color);
+                const imageBitmap = RLEToImageData(red, green, blue, points);
                 const image = this.container.image().attr({
                     'color-rendering': 'optimizeQuality',
                     'shape-rendering': 'geometricprecision',

--- a/cvat-canvas/src/typescript/interactionHandler.ts
+++ b/cvat-canvas/src/typescript/interactionHandler.ts
@@ -62,6 +62,7 @@ export class InteractionHandlerImpl implements InteractionHandler {
     private allPrompts: SupportedShapes[];
     private deletionButtons: Map<SupportedShapes, SVG.G>;
     private intermediateShapes: (SVG.Image | SVG.Polygon)[];
+    private intermediateMaskOutlines: SVG.Polygon[];
     private onInteraction: (interactionResult: InteractionResult[], finished?: boolean) => void;
     private onMessage: (messages: CanvasHint[] | null, topic: string) => void;
     private geometry: Geometry;
@@ -101,6 +102,7 @@ export class InteractionHandlerImpl implements InteractionHandler {
         this.pointPrompts = [];
         this.allPrompts = [];
         this.intermediateShapes = [];
+        this.intermediateMaskOutlines = [];
         this.deletionButtons = new Map();
         this.effectiveStrokeWidth = consts.BASE_STROKE_WIDTH / this.geometry.scale;
         this.effectivePointSize = (configuration.controlPointsSize ?? consts.BASE_POINT_SIZE) / this.geometry.scale;
@@ -150,7 +152,9 @@ export class InteractionHandlerImpl implements InteractionHandler {
             }
             shape.remove();
         });
+        this.intermediateMaskOutlines.forEach((outline) => outline.remove());
         this.intermediateShapes = [];
+        this.intermediateMaskOutlines = [];
     }
 
     private release(): void {
@@ -312,7 +316,7 @@ export class InteractionHandlerImpl implements InteractionHandler {
                 this.intermediateShapes.push(image);
 
                 let insertionPoint = image.node;
-                for (const outline of outlines || []) {
+                for (const outline of outlines ?? []) {
                     if (outline.length >= 3 * 2) {
                         const outlinePoints = stringifyPoints(translateToCanvas(this.geometry.offset, outline));
                         const strokeWidth = consts.BASE_STROKE_WIDTH / this.geometry.scale;
@@ -324,7 +328,7 @@ export class InteractionHandlerImpl implements InteractionHandler {
 
                         insertionPoint.after(maskOutline.node);
                         insertionPoint = maskOutline.node;
-                        this.intermediateShapes.push(maskOutline);
+                        this.intermediateMaskOutlines.push(maskOutline);
                     }
                 }
 
@@ -571,11 +575,11 @@ export class InteractionHandlerImpl implements InteractionHandler {
         });
 
         this.intermediateShapes.forEach((shape) => {
-            if (shape.hasClass('cvat_canvas_interact_mask_outline')) {
-                shape.stroke({ width: this.effectiveStrokeWidth });
-            } else {
-                shape.fill({ opacity: this.effectiveShapeOpacity });
-            }
+            shape.fill({ opacity: this.effectiveShapeOpacity });
+        });
+
+        this.intermediateMaskOutlines.forEach((outline) => {
+            outline.stroke({ width: this.effectiveStrokeWidth });
         });
     }
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
@@ -46,6 +46,7 @@ import DetectorRunner, {
     type RegionOfInterest,
 } from 'components/model-runner-modal/detector-runner';
 import RegionOfInterestInputComponent from 'components/model-runner-modal/region-of-interest-input';
+import ColorPicker from 'components/annotation-page/standard-workspace/objects-side-bar/color-picker';
 import LabelSelector from 'components/label-selector/label-selector';
 import CVATTooltip from 'components/common/cvat-tooltip';
 import CVATMarkdown from 'components/common/cvat-markdown';
@@ -174,6 +175,7 @@ interface State {
     interactorRegionOfInterest: RegionOfInterest;
     detectorRegionOfInterest: RegionOfInterest;
     toolsPopoverVisible: boolean;
+    interactorMaskColor: string;
 }
 
 type DetectorResults = Extract<
@@ -284,6 +286,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
             interactorRegionOfInterest: null,
             detectorRegionOfInterest: null,
             toolsPopoverVisible: false,
+            interactorMaskColor: '#ff00ff',
         };
 
         this.interaction = {
@@ -779,13 +782,14 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
 
     private drawIntermediateShapesOnCanvas(): void {
         const { canvasInstance } = this.props;
-        const { convertMasksToPolygons, thresholdValue } = this.state;
+        const { convertMasksToPolygons, thresholdValue, interactorMaskColor } = this.state;
         const shapesToBeDrawn = this.interaction.latestResponse
             .filter(({ confidence }) => typeof confidence !== 'number' || confidence >= thresholdValue)
             .filter(({ approximatedPoints }) => !convertMasksToPolygons || approximatedPoints.length >= 3)
             .map(({ rle, approximatedPoints }) => ({
                 shapeType: convertMasksToPolygons ? ShapeType.POLYGON : ShapeType.MASK,
                 points: convertMasksToPolygons ? approximatedPoints.flat() : rle,
+                color: interactorMaskColor,
             }));
 
         canvasInstance.interact({
@@ -1275,7 +1279,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
         } = this.props;
         const {
             activeInteractor, activeLabelID, fetching, allowROI,
-            startInteractingWithBox, convertMasksToPolygons,
+            startInteractingWithBox, convertMasksToPolygons, interactorMaskColor,
         } = this.state;
 
         if (!interactors.length) {
@@ -1352,6 +1356,29 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                             }}
                         />
                         <Text>Convert masks to polygons</Text>
+                    </div>
+                    <div>
+                        <Text>Mask color</Text>
+                        <ColorPicker
+                            value={interactorMaskColor}
+                            resetVisible={false}
+                            placement='right'
+                            onChange={(color: string) => {
+                                this.setState({ interactorMaskColor: color });
+                            }}
+                        >
+                            <Button
+                                shape='circle'
+                                aria-label='Interactor mask color'
+                                style={{
+                                    width: 24,
+                                    height: 24,
+                                    minWidth: 24,
+                                    marginLeft: 8,
+                                    backgroundColor: interactorMaskColor,
+                                }}
+                            />
+                        </ColorPicker>
                     </div>
 
                     {renderStartWithBox && (

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
@@ -176,6 +176,7 @@ interface State {
     detectorRegionOfInterest: RegionOfInterest;
     toolsPopoverVisible: boolean;
     interactorMaskColor: string;
+    showInteractorMaskContours: boolean;
 }
 
 type DetectorResults = Extract<
@@ -246,6 +247,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
         latestResponse: {
             rle: Int32Array;
             points: [number, number][];
+            contours: [number, number][][];
             approximatedPoints: [number, number][];
             confidence: number;
         }[];
@@ -287,6 +289,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
             detectorRegionOfInterest: null,
             toolsPopoverVisible: false,
             interactorMaskColor: '#ff00ff',
+            showInteractorMaskContours: true,
         };
 
         this.interaction = {
@@ -319,7 +322,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
             isActivated, defaultApproxPolyAccuracy, states, toolsBlockerState, jobInstance,
         } = this.props;
         const {
-            approxPolyAccuracy, mode, activeTracker, thresholdValue,
+            approxPolyAccuracy, mode, activeTracker, thresholdValue, showInteractorMaskContours,
         } = this.state;
 
         if (prevProps.states !== states || prevState.activeTracker !== activeTracker) {
@@ -376,6 +379,12 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
 
         if (prevState.thresholdValue !== thresholdValue) {
             if (isActivated && mode === 'interaction') {
+                this.drawIntermediateShapesOnCanvas();
+            }
+        }
+
+        if (prevState.showInteractorMaskContours !== showInteractorMaskContours) {
+            if (isActivated && mode === 'interaction' && this.interaction.latestResponse.length) {
                 this.drawIntermediateShapesOnCanvas();
             }
         }
@@ -547,7 +556,8 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                     if (item.type !== ShapeType.MASK) continue;
 
                     const points = Int32Array.from(item.points);
-                    const polygonPoints = this.receivePointsFromMask(points);
+                    const contours = this.receiveContoursFromMask(points);
+                    const polygonPoints = contours[0] || [];
                     if (polygonPoints.length < 3) {
                         continue;
                     }
@@ -559,6 +569,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                     latestResponse.push({
                         rle: points,
                         points: polygonPoints,
+                        contours,
                         approximatedPoints: approximated,
                         confidence,
                     });
@@ -782,14 +793,19 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
 
     private drawIntermediateShapesOnCanvas(): void {
         const { canvasInstance } = this.props;
-        const { convertMasksToPolygons, thresholdValue, interactorMaskColor } = this.state;
+        const {
+            convertMasksToPolygons, thresholdValue, interactorMaskColor, showInteractorMaskContours,
+        } = this.state;
         const shapesToBeDrawn = this.interaction.latestResponse
             .filter(({ confidence }) => typeof confidence !== 'number' || confidence >= thresholdValue)
             .filter(({ approximatedPoints }) => !convertMasksToPolygons || approximatedPoints.length >= 3)
-            .map(({ rle, approximatedPoints }) => ({
+            .map(({ rle, contours, approximatedPoints }) => ({
                 shapeType: convertMasksToPolygons ? ShapeType.POLYGON : ShapeType.MASK,
                 points: convertMasksToPolygons ? approximatedPoints.flat() : rle,
                 color: interactorMaskColor,
+                outlines: showInteractorMaskContours && !convertMasksToPolygons ?
+                    contours.map((contour) => contour.flat()) :
+                    undefined,
             }));
 
         canvasInstance.interact({
@@ -1146,7 +1162,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
         }
     }
 
-    private receivePointsFromMask(mask: Int32Array): [number, number][] {
+    private receiveContoursFromMask(mask: Int32Array): [number, number][][] {
         if (!openCVWrapper.isInitialized) {
             throw new Error('OpenCV was not initialized');
         }
@@ -1156,12 +1172,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
             return [];
         }
 
-        const polygons = openCVWrapper.getContoursFromStateSync({ points: mask, shapeType: ShapeType.MASK });
-        if (polygons.length) {
-            return polygons[0].map<[number, number]>((val) => [val[0], val[1]]);
-        }
-
-        return [];
+        return openCVWrapper.getContoursFromStateSync({ points: mask, shapeType: ShapeType.MASK });
     }
 
     private approximateResponsePoints(points: [number, number][]): [number, number][] {
@@ -1279,7 +1290,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
         } = this.props;
         const {
             activeInteractor, activeLabelID, fetching, allowROI,
-            startInteractingWithBox, convertMasksToPolygons, interactorMaskColor,
+            startInteractingWithBox, convertMasksToPolygons, interactorMaskColor, showInteractorMaskContours,
         } = this.state;
 
         if (!interactors.length) {
@@ -1379,6 +1390,16 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                                 }}
                             />
                         </ColorPicker>
+                    </div>
+                    <div>
+                        <Switch
+                            checked={showInteractorMaskContours}
+                            disabled={convertMasksToPolygons}
+                            onChange={(checked: boolean) => {
+                                this.setState({ showInteractorMaskContours: checked });
+                            }}
+                        />
+                        <Text>Show mask outline</Text>
                     </div>
 
                     {renderStartWithBox && (

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
@@ -174,7 +174,6 @@ interface State {
     interactorRegionOfInterest: RegionOfInterest;
     detectorRegionOfInterest: RegionOfInterest;
     toolsPopoverVisible: boolean;
-    showInteractorMaskContours: boolean;
 }
 
 type DetectorResults = Extract<
@@ -286,7 +285,6 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
             interactorRegionOfInterest: null,
             detectorRegionOfInterest: null,
             toolsPopoverVisible: false,
-            showInteractorMaskContours: true,
         };
 
         this.interaction = {
@@ -319,7 +317,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
             isActivated, defaultApproxPolyAccuracy, states, toolsBlockerState, jobInstance,
         } = this.props;
         const {
-            approxPolyAccuracy, mode, activeTracker, thresholdValue, showInteractorMaskContours,
+            approxPolyAccuracy, mode, activeTracker, thresholdValue,
         } = this.state;
 
         if (prevProps.states !== states || prevState.activeTracker !== activeTracker) {
@@ -376,12 +374,6 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
 
         if (prevState.thresholdValue !== thresholdValue) {
             if (isActivated && mode === 'interaction') {
-                this.drawIntermediateShapesOnCanvas();
-            }
-        }
-
-        if (prevState.showInteractorMaskContours !== showInteractorMaskContours) {
-            if (isActivated && mode === 'interaction' && this.interaction.latestResponse.length) {
                 this.drawIntermediateShapesOnCanvas();
             }
         }
@@ -553,13 +545,13 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                     if (item.type !== ShapeType.MASK) continue;
 
                     const points = Int32Array.from(item.points);
-                    const polygonPoints = this.receivePointsFromMask(points);
+                    const contours = this.receiveContoursFromMask(points);
+                    const polygonPoints = this.receivePointsFromMask(contours);
                     if (polygonPoints.length < 3) {
                         continue;
                     }
 
-                    const contours = this.receiveContoursFromMask(points);
-                    const approximated = this.approximateResponsePoints(polygonPoints!);
+                    const approximated = this.approximateResponsePoints(polygonPoints);
                     const confidenceAttr = item.attributes.find((attr) => attr.spec_id === 0);
                     const confidence = confidenceAttr ? +confidenceAttr.value : 1;
                     showConfidenceControl = showConfidenceControl || !!confidenceAttr;
@@ -790,18 +782,14 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
 
     private drawIntermediateShapesOnCanvas(): void {
         const { canvasInstance } = this.props;
-        const {
-            convertMasksToPolygons, thresholdValue, showInteractorMaskContours,
-        } = this.state;
+        const { convertMasksToPolygons, thresholdValue } = this.state;
         const shapesToBeDrawn = this.interaction.latestResponse
             .filter(({ confidence }) => typeof confidence !== 'number' || confidence >= thresholdValue)
             .filter(({ approximatedPoints }) => !convertMasksToPolygons || approximatedPoints.length >= 3)
             .map(({ rle, contours, approximatedPoints }) => ({
                 shapeType: convertMasksToPolygons ? ShapeType.POLYGON : ShapeType.MASK,
                 points: convertMasksToPolygons ? approximatedPoints.flat() : rle,
-                outlines: showInteractorMaskContours && !convertMasksToPolygons ?
-                    contours.map((contour) => contour.flat()) :
-                    undefined,
+                maskOutlines: contours.map((contour) => contour.flat()),
             }));
 
         canvasInstance.interact({
@@ -1158,19 +1146,9 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
         }
     }
 
-    private receivePointsFromMask(mask: Int32Array): [number, number][] {
-        if (!openCVWrapper.isInitialized) {
-            throw new Error('OpenCV was not initialized');
-        }
-
-        if (mask.length < 6) {
-            // minimal non-empty RLE is 6 points
-            return [];
-        }
-
-        const polygons = openCVWrapper.getContoursFromStateSync({ points: mask, shapeType: ShapeType.MASK });
-        if (polygons.length) {
-            return polygons[0].map<[number, number]>((val) => [val[0], val[1]]);
+    private receivePointsFromMask(contours: [number, number][][]): [number, number][] {
+        if (contours.length) {
+            return contours[0].map<[number, number]>((val) => [val[0], val[1]]);
         }
 
         return [];
@@ -1304,7 +1282,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
         } = this.props;
         const {
             activeInteractor, activeLabelID, fetching, allowROI,
-            startInteractingWithBox, convertMasksToPolygons, showInteractorMaskContours,
+            startInteractingWithBox, convertMasksToPolygons,
         } = this.state;
 
         if (!interactors.length) {
@@ -1382,17 +1360,6 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                         />
                         <Text>Convert masks to polygons</Text>
                     </div>
-                    <div>
-                        <Switch
-                            checked={showInteractorMaskContours}
-                            disabled={convertMasksToPolygons}
-                            onChange={(checked: boolean) => {
-                                this.setState({ showInteractorMaskContours: checked });
-                            }}
-                        />
-                        <Text>Show mask outline</Text>
-                    </div>
-
                     {renderStartWithBox && (
                         <div>
                             <Switch

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
@@ -46,7 +46,6 @@ import DetectorRunner, {
     type RegionOfInterest,
 } from 'components/model-runner-modal/detector-runner';
 import RegionOfInterestInputComponent from 'components/model-runner-modal/region-of-interest-input';
-import ColorPicker from 'components/annotation-page/standard-workspace/objects-side-bar/color-picker';
 import LabelSelector from 'components/label-selector/label-selector';
 import CVATTooltip from 'components/common/cvat-tooltip';
 import CVATMarkdown from 'components/common/cvat-markdown';
@@ -175,7 +174,6 @@ interface State {
     interactorRegionOfInterest: RegionOfInterest;
     detectorRegionOfInterest: RegionOfInterest;
     toolsPopoverVisible: boolean;
-    interactorMaskColor: string;
     showInteractorMaskContours: boolean;
 }
 
@@ -288,7 +286,6 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
             interactorRegionOfInterest: null,
             detectorRegionOfInterest: null,
             toolsPopoverVisible: false,
-            interactorMaskColor: '#ff00ff',
             showInteractorMaskContours: true,
         };
 
@@ -556,12 +553,12 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                     if (item.type !== ShapeType.MASK) continue;
 
                     const points = Int32Array.from(item.points);
-                    const contours = this.receiveContoursFromMask(points);
-                    const polygonPoints = contours[0] || [];
+                    const polygonPoints = this.receivePointsFromMask(points);
                     if (polygonPoints.length < 3) {
                         continue;
                     }
 
+                    const contours = this.receiveContoursFromMask(points);
                     const approximated = this.approximateResponsePoints(polygonPoints!);
                     const confidenceAttr = item.attributes.find((attr) => attr.spec_id === 0);
                     const confidence = confidenceAttr ? +confidenceAttr.value : 1;
@@ -794,7 +791,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
     private drawIntermediateShapesOnCanvas(): void {
         const { canvasInstance } = this.props;
         const {
-            convertMasksToPolygons, thresholdValue, interactorMaskColor, showInteractorMaskContours,
+            convertMasksToPolygons, thresholdValue, showInteractorMaskContours,
         } = this.state;
         const shapesToBeDrawn = this.interaction.latestResponse
             .filter(({ confidence }) => typeof confidence !== 'number' || confidence >= thresholdValue)
@@ -802,7 +799,6 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
             .map(({ rle, contours, approximatedPoints }) => ({
                 shapeType: convertMasksToPolygons ? ShapeType.POLYGON : ShapeType.MASK,
                 points: convertMasksToPolygons ? approximatedPoints.flat() : rle,
-                color: interactorMaskColor,
                 outlines: showInteractorMaskContours && !convertMasksToPolygons ?
                     contours.map((contour) => contour.flat()) :
                     undefined,
@@ -1162,6 +1158,24 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
         }
     }
 
+    private receivePointsFromMask(mask: Int32Array): [number, number][] {
+        if (!openCVWrapper.isInitialized) {
+            throw new Error('OpenCV was not initialized');
+        }
+
+        if (mask.length < 6) {
+            // minimal non-empty RLE is 6 points
+            return [];
+        }
+
+        const polygons = openCVWrapper.getContoursFromStateSync({ points: mask, shapeType: ShapeType.MASK });
+        if (polygons.length) {
+            return polygons[0].map<[number, number]>((val) => [val[0], val[1]]);
+        }
+
+        return [];
+    }
+
     private receiveContoursFromMask(mask: Int32Array): [number, number][][] {
         if (!openCVWrapper.isInitialized) {
             throw new Error('OpenCV was not initialized');
@@ -1290,7 +1304,7 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
         } = this.props;
         const {
             activeInteractor, activeLabelID, fetching, allowROI,
-            startInteractingWithBox, convertMasksToPolygons, interactorMaskColor, showInteractorMaskContours,
+            startInteractingWithBox, convertMasksToPolygons, showInteractorMaskContours,
         } = this.state;
 
         if (!interactors.length) {
@@ -1367,29 +1381,6 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                             }}
                         />
                         <Text>Convert masks to polygons</Text>
-                    </div>
-                    <div>
-                        <Text>Mask color</Text>
-                        <ColorPicker
-                            value={interactorMaskColor}
-                            resetVisible={false}
-                            placement='right'
-                            onChange={(color: string) => {
-                                this.setState({ interactorMaskColor: color });
-                            }}
-                        >
-                            <Button
-                                shape='circle'
-                                aria-label='Interactor mask color'
-                                style={{
-                                    width: 24,
-                                    height: 24,
-                                    minWidth: 24,
-                                    marginLeft: 8,
-                                    backgroundColor: interactorMaskColor,
-                                }}
-                            />
-                        </ColorPicker>
                     </div>
                     <div>
                         <Switch


### PR DESCRIPTION
### Motivation and context

Interactor preview masks are rendered in white by default, making them difficult to distinguish on bright or grayscale images.

This change adds a color picker to the interactor menu and passes the selected color through the canvas interaction payload. The selected color is applied to temporary mask and polygon previews without affecting the color of the final annotation.

Existing callers that do not provide a color continue to use white as a fallback.

Closes #6111.

### How has this been tested?

The following checks were run:

- ESLint for the modified `cvat-ui` and `cvat-canvas` files.
- Full TypeScript type checking with `yarn type-check`.

Both checks passed.

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- [ ] ~~I have updated the documentation accordingly~~
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit *my code changes* under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.