### PR TITLE
Cover ground truth validation percentage and fix quantity input helper

### DIFF
--- a/tests/cypress/e2e/features2/ground_truth_jobs.js
+++ b/tests/cypress/e2e/features2/ground_truth_jobs.js
@@ -241,7 +241,10 @@ context('Ground truth jobs', () => {
     });
 
     describe('Testing creating task with quality params', () => {
-        const imagesCount = 3;
+        const imagesCount = 7;
+        const gtQuantityPercent = 70;
+        const expectedGtFrameCount = Math.floor((imagesCount * gtQuantityPercent) / 100);
+        const expectedGtFramePercent = Math.round((expectedGtFrameCount / imagesCount) * 100);
         const imageFileName = `image_${taskName.replace(' ', '_').toLowerCase()}`;
         const width = 800;
         const height = 800;
@@ -265,7 +268,12 @@ context('Ground truth jobs', () => {
         it('Create task with ground truth job', () => {
             createTaskWithQualityParams({
                 validationMode: 'Ground Truth',
+                validationFramesPercent: gtQuantityPercent,
             }, archiveName);
+
+            cy.get('.cvat-job-item').first()
+                .find('.cvat-job-item-frames')
+                .should('have.text', `${expectedGtFrameCount} (${expectedGtFramePercent}%)`);
         });
 
         it('Create task with honeypots', () => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1058,12 +1058,11 @@ Cypress.Commands.add('configureTaskQualityMode', (qualityConfigurationParams) =>
         });
     }
     if (qualityConfigurationParams.validationFramesPercent) {
-        cy.get('#validationFramesPercent').clear();
-        cy.get('#validationFramesPercent').type(qualityConfigurationParams.validationFramesPercent);
+        cy.get('#validationFramesPercent').type(`{selectall}${qualityConfigurationParams.validationFramesPercent}`);
     }
     if (qualityConfigurationParams.validationFramesPerJobPercent) {
-        cy.get('#validationFramesPerJobPercent').clear();
-        cy.get('#validationFramesPerJobPercent').type(qualityConfigurationParams.validationFramesPerJobPercent);
+        cy.get('#validationFramesPerJobPercent')
+            .type(`{selectall}${qualityConfigurationParams.validationFramesPerJobPercent}`);
     }
 });
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
There is a scenario for creating a ground truth job, but the quality percentage field is left at their default value, leaving that field uncovered. This update to the existing test interacts with the 'Quantity' field, then verifies frame count for the created job.
Additionally had to fix used procedure configureTaskQualityMode, which was typing 700 when 70 was passed.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
