### PR TITLE
Fix tooltips obscuring view in e2e test image rotates

### DIFF
--- a/tests/cypress/e2e/actions_tasks3/case_19_all_image_rotate_features.js
+++ b/tests/cypress/e2e/actions_tasks3/case_19_all_image_rotate_features.js
@@ -11,12 +11,6 @@ import { imageRotate, checkDegRotate } from '../../support/utils.cy';
 context('Rotate all images feature.', () => {
     const caseId = '19';
 
-    function checkFrameNum(frameNum) {
-        cy.get('.cvat-player-frame-selector').within(() => {
-            cy.get('input[role="spinbutton"]').should('have.value', frameNum);
-        });
-    }
-
     before(() => {
         cy.prepareUserSession();
         cy.openTaskJob(taskName);
@@ -31,7 +25,7 @@ context('Rotate all images feature.', () => {
 
         it("Go to the next frame. It wasn't rotated.", () => {
             cy.get('.cvat-player-next-button').click();
-            checkFrameNum(1);
+            cy.checkFrameNum(1);
             checkDegRotate(0);
         });
 
@@ -48,10 +42,10 @@ context('Rotate all images feature.', () => {
 
         it('Go to the previous and to the next frame. They are also rotated 180 deg.', () => {
             cy.get('.cvat-player-previous-button').click();
-            checkFrameNum(0);
+            cy.checkFrameNum(0);
             checkDegRotate(180);
             cy.get('.cvat-player-next-button').click();
-            checkFrameNum(1);
+            cy.checkFrameNum(1);
             checkDegRotate(180);
         });
     });

--- a/tests/cypress/e2e/actions_tasks3/case_19_all_image_rotate_features.js
+++ b/tests/cypress/e2e/actions_tasks3/case_19_all_image_rotate_features.js
@@ -6,25 +6,10 @@
 /// <reference types="cypress" />
 
 import { taskName } from '../../support/const';
+import { imageRotate, checkDegRotate } from '../../support/utils.cy';
 
 context('Rotate all images feature.', () => {
     const caseId = '19';
-
-    function checkDegRotate(deg) {
-        cy.get('#cvat_canvas_background').should('have.attr', 'style').and('contain', `rotate(${deg}deg);`);
-    }
-
-    function imageRotate(direction = 'anticlockwise', deg) {
-        cy.get('.cvat-rotate-canvas-control').click();
-        cy.get('.cvat-rotate-canvas-popover').should('be.visible');
-        if (direction === 'clockwise') {
-            cy.get('.cvat-rotate-canvas-controls-right').should('be.visible').click();
-        } else {
-            cy.get('.cvat-rotate-canvas-controls-left').should('be.visible').click();
-        }
-        checkDegRotate(deg);
-        cy.get('body').click();
-    }
 
     function checkFrameNum(frameNum) {
         cy.get('.cvat-player-frame-selector').within(() => {

--- a/tests/cypress/e2e/actions_tasks3/case_5_image_rotate.js
+++ b/tests/cypress/e2e/actions_tasks3/case_5_image_rotate.js
@@ -5,20 +5,10 @@
 /// <reference types="cypress" />
 
 import { taskName } from '../../support/const';
+import { imageRotate } from '../../support/utils.cy';
 
 context('Check if the image is rotated', () => {
     const caseId = '5';
-
-    function imageRotate(direction = 'anticlockwise') {
-        cy.interactControlButton('rotate-canvas');
-        if (direction === 'clockwise') {
-            cy.get('.cvat-rotate-canvas-controls-right').click();
-        } else {
-            cy.get('.cvat-rotate-canvas-controls-left').click();
-        }
-        cy.get('.cvat-canvas-container').click(); // Hide popover
-        cy.get('.cvat-rotate-canvas-popover').should('be.hidden');
-    }
 
     function scaleFitImage() {
         let scaleBefore;

--- a/tests/cypress/e2e/features/single_object_annotation.js
+++ b/tests/cypress/e2e/features/single_object_annotation.js
@@ -61,12 +61,6 @@ context('Single object annotation mode', { scrollBehavior: false }, () => {
         });
     }
 
-    function checkFrameNum(frameNum) {
-        cy.get('.cvat-player-frame-selector').within(() => {
-            cy.get('input[role="spinbutton"]').should('have.value', frameNum);
-        });
-    }
-
     function checkSingleShapeModeOpened() {
         cy.get('.cvat-workspace-selector').should('have.text', 'Single shape');
         cy.get('.cvat-canvas-controls-sidebar').should('not.exist');
@@ -93,7 +87,7 @@ context('Single object annotation mode', { scrollBehavior: false }, () => {
 
         cy.intercept('PATCH', `/api/jobs/${jobId}/**`).as('submitJob');
         for (let frame = 0; frame < frameCount; frame++) {
-            checkFrameNum(frame);
+            cy.checkFrameNum(frame);
             creatorFunction();
         }
 
@@ -208,14 +202,14 @@ context('Single object annotation mode', { scrollBehavior: false }, () => {
             cy.get('.cvat-single-shape-annotation-sidebar-finish-frame-wrapper').within(() => {
                 cy.contains('Skip').click();
             });
-            checkFrameNum(1);
+            cy.checkFrameNum(1);
 
             // Auto next frame - disabled
             cy.get('.cvat-single-shape-annotation-sidebar-auto-next-frame-checkbox').within(() => {
                 cy.get('[type="checkbox"]').uncheck();
             });
             clickPoints(polygonShape);
-            checkFrameNum(1);
+            cy.checkFrameNum(1);
 
             // Auto save when finish - disabled
             cy.get('.cvat-player-next-button-empty').click();
@@ -227,16 +221,16 @@ context('Single object annotation mode', { scrollBehavior: false }, () => {
 
             // Navigate only on empty frames
             cy.get('.cvat-player-previous-button-empty').click();
-            checkFrameNum(0);
+            cy.checkFrameNum(0);
             cy.get('.cvat-player-next-button-empty').click();
-            checkFrameNum(0);
+            cy.checkFrameNum(0);
             cy.get('.cvat-single-shape-annotation-sidebar-navigate-empty-checkbox').within(() => {
                 cy.get('[type="checkbox"]').uncheck();
             });
             cy.get('.cvat-player-next-button').click();
-            checkFrameNum(1);
+            cy.checkFrameNum(1);
             cy.get('.cvat-player-next-button').click();
-            checkFrameNum(2);
+            cy.checkFrameNum(2);
 
             cy.saveJob();
         });

--- a/tests/cypress/e2e/issues_prs/issue_2174_reset_zoom_in_tag_annotation_mode.js
+++ b/tests/cypress/e2e/issues_prs/issue_2174_reset_zoom_in_tag_annotation_mode.js
@@ -31,12 +31,6 @@ context('Reset zoom in tag annotation', () => {
         cy.closeSettings();
     }
 
-    function checkFrameNum(frameNum) {
-        cy.get('.cvat-player-frame-selector').within(() => {
-            cy.get('input[role="spinbutton"]').should('have.value', frameNum);
-        });
-    }
-
     before(() => {
         cy.prepareUserSession();
         cy.openTaskJob(taskName);
@@ -63,7 +57,7 @@ context('Reset zoom in tag annotation', () => {
 
         it('Go to next frame and check reset scale on second frame', () => {
             cy.get('.cvat-player-next-button').click();
-            checkFrameNum(1);
+            cy.checkFrameNum(1);
             cy.getScaleValue().then((value) => {
                 scaleSecondFrame = value;
                 expect(scaleFirstFrame).to.not.equal(scaleSecondFrame);
@@ -84,7 +78,7 @@ context('Reset zoom in tag annotation', () => {
 
         it('Go to previous frame and check save scale on first frame', () => {
             cy.get('.cvat-player-previous-button').click();
-            checkFrameNum(0);
+            cy.checkFrameNum(0);
             cy.getScaleValue().then((value) => {
                 scaleFirstFrame = value;
                 expect(scaleSecondFrame).to.equal(scaleFirstFrame);

--- a/tests/cypress/e2e/issues_prs2/pr_9924_video_chapters.js
+++ b/tests/cypress/e2e/issues_prs2/pr_9924_video_chapters.js
@@ -2,12 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-function checkFrameNum(frameNum) {
-    cy.get('.cvat-player-frame-selector').within(() => {
-        cy.get('input[role="spinbutton"]').should('have.value', frameNum);
-    });
-}
-
 function switchChapter(chapterNumber) {
     cy.contains('.cvat-player-chapter-menu-list-item', `Kapitel ${chapterNumber}`)
         .should('exist')
@@ -25,7 +19,7 @@ function checkChapterNavigationButtons(direction, expectedSliderPos) {
         .should('exist')
         .and('be.visible')
         .click();
-    checkFrameNum(expectedSliderPos);
+    cy.checkFrameNum(expectedSliderPos);
     cy.get(`.cvat-player-buttons > .cvat-player-${direction}-button-chapter`).rightclick();
     cy.get(`.cvat-player-${direction}-inlined-button`)
         .should('exist')
@@ -84,11 +78,11 @@ context('Video chapters', () => {
     describe('Test chapter navigation via shortcuts', () => {
         it('Chapter forward (b)', () => {
             cy.realPress('b');
-            checkFrameNum('20');
+            cy.checkFrameNum('20');
         });
         it('Chapter backwards (x)', () => {
             cy.realPress('x');
-            checkFrameNum('0');
+            cy.checkFrameNum('0');
         });
     });
 
@@ -97,9 +91,9 @@ context('Video chapters', () => {
             cy.get('.cvat-player-chapters-menu-button').click();
             cy.get('.cvat-player-chapter-menu-wrapper').should('exist').and('be.visible');
             switchChapter(2);
-            checkFrameNum('20');
+            cy.checkFrameNum('20');
             switchChapter(1);
-            checkFrameNum('0');
+            cy.checkFrameNum('0');
         });
     });
 });

--- a/tests/cypress/support/utils.cy.js
+++ b/tests/cypress/support/utils.cy.js
@@ -169,8 +169,8 @@ export function getShapeCoord(type, objectSelector) {
 }
 
 export function checkDegRotate(deg) {
-        cy.get('#cvat_canvas_background').should('have.attr', 'style').and('contain', `rotate(${deg}deg);`);
-    }
+    cy.get('#cvat_canvas_background').should('have.attr', 'style').and('contain', `rotate(${deg}deg);`);
+}
 
 export function imageRotate(direction = 'anticlockwise', deg) {
     cy.get('.cvat-rotate-canvas-control').click();
@@ -181,7 +181,7 @@ export function imageRotate(direction = 'anticlockwise', deg) {
     } else {
         cy.get('.cvat-rotate-canvas-controls-left').should('be.visible').click();
     }
-    if (Number.isInteger(deg)){
+    if (Number.isInteger(deg)) {
         checkDegRotate(deg);
     }
     cy.get('body').click();

--- a/tests/cypress/support/utils.cy.js
+++ b/tests/cypress/support/utils.cy.js
@@ -167,3 +167,22 @@ export function getShapeCoord(type, objectSelector) {
     }
     return cy.wrap(arrToPush);
 }
+
+export function checkDegRotate(deg) {
+        cy.get('#cvat_canvas_background').should('have.attr', 'style').and('contain', `rotate(${deg}deg);`);
+    }
+
+export function imageRotate(direction = 'anticlockwise', deg) {
+    cy.get('.cvat-rotate-canvas-control').click();
+    cy.hideTooltips();
+    cy.get('.cvat-rotate-canvas-popover').should('be.visible');
+    if (direction === 'clockwise') {
+        cy.get('.cvat-rotate-canvas-controls-right').should('be.visible').click();
+    } else {
+        cy.get('.cvat-rotate-canvas-controls-left').should('be.visible').click();
+    }
+    if (Number.isInteger(deg)){
+        checkDegRotate(deg);
+    }
+    cy.get('body').click();
+}


### PR DESCRIPTION
Here we have failures of image rotation tests, [link](https://github.com/cvat-ai/app.cvat.ai/actions/runs/30495940487/job/90726775766). The flake was always there it's just that the base_e2e jobs trip over it more easily.


<img width="1280" height="577" alt="Check if the image is rotated -- Testing case 5 -- Rotate image anticlockwise 360deg (failed)" src="https://github.com/user-attachments/assets/e787eaa1-1584-4a0a-b962-1436db6f91aa" />
<img width="1280" height="577" alt="Check if the image is rotated -- Testing case 5 -- Rotate image anticlockwise 270deg (failed)" src="https://github.com/user-attachments/assets/cb03ff7d-9447-4295-b96a-acd9d3d604ea" />
...
etc. with every test case

Also, it refactors image rotation to share across two spec files that need this logic.
Also, refactor `checkFrameNum` calls to use `cy.checkFrameNum` instead, to reduce duplication