### PR TITLE
ci: add name to pipx setup step for readability

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -88,7 +88,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - id: setup-pipx
+      - name: Configure pipx cache paths
+        id: setup-pipx
         shell: bash
         run: |
           # custom cached dir


### PR DESCRIPTION
## Problem

In `.github/workflows/linters.yml`, the `setup-pipx` step is a long unnamed `run` block, so the Actions UI shows a generic label while configuring pipx cache paths.

## Changes

Semantics are unchanged: same `id: setup-pipx`, same `GITHUB_OUTPUT` keys, and the same step output wiring used by the cache/install steps.

- Add `name: Configure pipx cache paths` to the existing `setup-pipx` step

## Test plan
- [ ] Confirm later steps still read `steps.setup-pipx.outputs.*`
- [ ] Confirm the setup script is unchanged
