### PR TITLE
fix flake in e2e test `new_organization_pipeline`

### DIFF
--- a/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
+++ b/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
@@ -354,7 +354,7 @@ context('New organization pipeline.', () => {
         });
 
         it('Deleted organization disappears from the switcher without page reload.', () => {
-            allure.issue('https://github.com/cvat-ai/cvat/issues/10678', 'Deleted org still visible in switcher')
+            allure.issue('https://github.com/cvat-ai/cvat/issues/10678', 'Deleted org still visible in switcher');
             cy.get('.cvat-header-menu-user-dropdown').click();
             cy.get('.cvat-header-menu')
                 .should('be.visible')

--- a/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
+++ b/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
@@ -5,8 +5,8 @@
 
 /// <reference types="cypress" />
 
-import { defaultTaskSpec } from '../../support/default-specs';
 import * as allure from 'allure-js-commons';
+import { defaultTaskSpec } from '../../support/default-specs';
 
 context('New organization pipeline.', () => {
     const caseId = '113';

--- a/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
+++ b/tests/cypress/e2e/features/case_113_new_organization_pipeline.js
@@ -6,6 +6,7 @@
 /// <reference types="cypress" />
 
 import { defaultTaskSpec } from '../../support/default-specs';
+import * as allure from 'allure-js-commons';
 
 context('New organization pipeline.', () => {
     const caseId = '113';
@@ -338,8 +339,8 @@ context('New organization pipeline.', () => {
         });
     });
 
-    describe('Organization switcher cleanup.', () => {
-        beforeEach(() => {
+    describe('Regression tests.', () => {
+        before(() => {
             cy.headlessLogout().then(() => {
                 cy.task('getAuthHeaders').then((authHeaders) => {
                     cy.deleteOrganizations(authHeaders, [switcherOrganizationParams.shortName]);
@@ -348,11 +349,12 @@ context('New organization pipeline.', () => {
                 });
             });
             cy.headlessCreateUser(switcherUser);
+            cy.headlessLogin(makeLoginUser(switcherUser));
+            cy.createOrganization(switcherOrganizationParams);
         });
 
         it('Deleted organization disappears from the switcher without page reload.', () => {
-            cy.headlessLogin(makeLoginUser(switcherUser));
-            cy.createOrganization(switcherOrganizationParams);
+            allure.issue('https://github.com/cvat-ai/cvat/issues/10678', 'Deleted org still visible in switcher')
             cy.get('.cvat-header-menu-user-dropdown').click();
             cy.get('.cvat-header-menu')
                 .should('be.visible')

--- a/tests/cypress/support/commands_organizations.js
+++ b/tests/cypress/support/commands_organizations.js
@@ -43,6 +43,7 @@ Cypress.Commands.add('createOrganization', (organizationParams) => {
             });
     });
     cy.get('.cvat-organization-page').should('exist').and('be.visible');
+    cy.get('.cvat-spinner').should('not.exist');
     return cy.wrap(idWrapper);
 });
 


### PR DESCRIPTION
Race between dropdown and page load

fix:
- wait for cvat spinner after organization creation
- move headless calls from test to before hook