### PR TITLE
Fix canvas tooltip ignoring label attribute order

### DIFF
--- a/changelog.d/20260803_112428_ansh120022_canvas_tooltip_attribute_order.md
+++ b/changelog.d/20260803_112428_ansh120022_canvas_tooltip_attribute_order.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Canvas tooltip now shows label attributes in the label's defined order rather
+  than sorted by attribute ID, matching the object details panel
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/changelog.d/20260803_112428_ansh120022_canvas_tooltip_attribute_order.md
+++ b/changelog.d/20260803_112428_ansh120022_canvas_tooltip_attribute_order.md
@@ -2,4 +2,4 @@
 
 - Canvas tooltip now shows label attributes in the label's defined order rather
   than sorted by attribute ID, matching the object details panel
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/10986>)

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -3658,7 +3658,10 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         .addClass('cvat_canvas_text_score');
                 }
                 if (withAttr) {
-                    Object.keys(attributes).forEach((attrID: string, idx: number) => {
+                    const orderedAttrIDs = state.label.attributes
+                        .map((attr) => `${attr.id}`)
+                        .filter((attrID: string): boolean => attrID in attributes);
+                    orderedAttrIDs.forEach((attrID: string, idx: number) => {
                         const values = `${attributes[attrID] === undefinedAttrValue ?
                             '' : attributes[attrID]}`.split('\n');
                         const parent = block.tspan(`${attrNames[attrID]}: `)

--- a/tests/cypress/e2e/issues_prs2/issue_9866_attribute_order_preserved_on_canvas.js
+++ b/tests/cypress/e2e/issues_prs2/issue_9866_attribute_order_preserved_on_canvas.js
@@ -1,0 +1,159 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+context('Reordered label attributes should be reflected in the constructor, canvas tooltip, and object details', () => {
+    const issueId = '9866';
+    const labelName = `Issue ${issueId}`;
+
+    const attributeNames = ['z_first', 'm_second', 'a_third'];
+    const reorderedAttributeNames = [...attributeNames].reverse();
+
+    function makeAttribute(name) {
+        return {
+            name,
+            mutable: false,
+            input_type: 'text',
+            default_value: '',
+            values: [''],
+        };
+    }
+
+    const taskSpec = {
+        name: `Task for ${labelName}`,
+        labels: [{ name: labelName, attributes: attributeNames.map(makeAttribute) }],
+    };
+    const dataSpec = {
+        server_files: ['images/image_1.jpg'],
+        image_quality: 70,
+    };
+
+    const rectangleShape = {
+        points: 'By 2 Points',
+        type: 'Shape',
+        labelName,
+        firstX: 250,
+        firstY: 350,
+        secondX: 350,
+        secondY: 450,
+    };
+    const secondRectangleShape = {
+        ...rectangleShape,
+        firstX: 400,
+        firstY: 350,
+        secondX: 500,
+        secondY: 450,
+    };
+
+    let taskId;
+
+    function readLabel() {
+        return cy.get('.cvat-raw-labels-viewer').then(($rawLabelsTextarea) => {
+            const labels = JSON.parse($rawLabelsTextarea.text());
+            return labels.find((_label) => _label.name === labelName);
+        });
+    }
+
+    function writeLabels(labels) {
+        cy.get('.cvat-raw-labels-viewer').clear();
+        cy.get('.cvat-raw-labels-viewer').type(JSON.stringify(labels), { parseSpecialCharSequences: false });
+        cy.contains('[type="submit"]', 'Save').click();
+    }
+
+    function reorderAttributes(names) {
+        cy.contains('[role="tab"]', 'Raw').click();
+        readLabel().then((label) => {
+            const existingByName = new Map(label.attributes.map((attr) => [attr.name, attr]));
+            const attributes = names.map((name) => existingByName.get(name));
+            writeLabels([{ ...label, attributes }]);
+        });
+    }
+
+    function checkTooltipAttributeOrder(shapeSelector, expectedOrder) {
+        cy.get(shapeSelector).trigger('mousemove');
+        cy.get('#cvat_canvas_text_content').should(($el) => {
+            const text = $el.text();
+            expectedOrder.forEach((name) => {
+                expect(text, `"${name}" should be present in the tooltip`).to.include(name);
+            });
+        });
+        cy.get('#cvat_canvas_text_content')
+            .invoke('text')
+            .then((text) => {
+                const positions = expectedOrder.map((name) => text.indexOf(name));
+                for (let i = 1; i < positions.length; i += 1) {
+                    expect(positions[i]).to.be.greaterThan(positions[i - 1]);
+                }
+            });
+    }
+
+    function checkDetailsPanelAttributeOrder(clientId, expectedOrder) {
+        const itemSelector = `#cvat-objects-sidebar-state-item-${clientId}`;
+        cy.get(itemSelector).contains('.ant-collapse-header', 'DETAILS').click();
+        cy.get(itemSelector).find('.cvat-object-item-attribute-wrapper').should('have.length', expectedOrder.length);
+        cy.get(itemSelector)
+            .find('.cvat-object-item-attribute-wrapper')
+            .then(($wrappers) => {
+                const names = [...$wrappers].map((el) => el.querySelector('.cvat-text').textContent.trim());
+                expect(names).to.deep.equal(expectedOrder);
+            });
+    }
+
+    function checkConstructorAttributeOrder(expectedOrder) {
+        cy.reload();
+        cy.contains('[role="tab"]', 'Constructor').click();
+        cy.get('.cvat-constructor-viewer-item').find('[aria-label="edit"]').click();
+        cy.get('.cvat-attribute-name-input input').should('have.length', expectedOrder.length);
+        cy.get('.cvat-attribute-name-input input').then(($inputs) => {
+            const names = [...$inputs].map((el) => el.value);
+            expect(names).to.deep.equal(expectedOrder);
+        });
+        cy.get('.cvat-cancel-new-label-button').click();
+    }
+
+    before(() => {
+        cy.prepareUserSession();
+        cy.headlessCreateTask(taskSpec, dataSpec).then((response) => {
+            taskId = response.taskId;
+        });
+    });
+
+    after(() => {
+        cy.headlessDeleteTask(taskId);
+    });
+
+    describe(`Testing issue "${issueId}"`, () => {
+        it("Canvas tooltip shows attributes in the label's current order", () => {
+            cy.openTaskById(taskId);
+            cy.openJob();
+            cy.createRectangle(rectangleShape);
+            cy.saveJob();
+            checkTooltipAttributeOrder('#cvat_canvas_shape_1', attributeNames);
+        });
+
+        it('Reorder the label attributes via the raw editor', () => {
+            cy.interactMenu('Open the task');
+            reorderAttributes(reorderedAttributeNames);
+        });
+
+        it('Constructor reflects the reordered attributes', () => {
+            checkConstructorAttributeOrder(reorderedAttributeNames);
+        });
+
+        it('Canvas tooltip reflects the reordered attributes for the existing shape', () => {
+            cy.openJob(0, false);
+            checkTooltipAttributeOrder('#cvat_canvas_shape_1', reorderedAttributeNames);
+        });
+
+        it('Object details panel reflects the reordered attributes', () => {
+            checkDetailsPanelAttributeOrder(1, reorderedAttributeNames);
+        });
+
+        it('Canvas tooltip reflects the reordered attributes for a new shape', () => {
+            cy.createRectangle(secondRectangleShape);
+            checkTooltipAttributeOrder('#cvat_canvas_shape_2', reorderedAttributeNames);
+        });
+    });
+});


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Resolves #9866

The canvas tooltip built its attribute list by iterating `Object.keys(attributes)` - numeric attribute IDs, which JS returns in ascending numeric order, so the tooltip sorted by ID instead of the label's defined order. The details panel was unaffected
(it iterates `state.label.attributes`). Fixed by deriving order from `state.label.attributes` and looking up each value by ID, matching the details panel.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Added a Cypress regression test (`issue_9866_...`) that reorders a label's attributes and asserts the order is reflected consistently in the canvas tooltip (existing and newly-drawn shapes), the object details panel, and the constructor.
Verified the tooltip checks fail without the fix and pass with it; the details panel and constructor checks pass in both cases (they were never affected).

Test output before the fix:
<img width="520" height="845" alt="Screenshot 2026-08-03 at 11 13 28" src="https://github.com/user-attachments/assets/889fc75c-ad8a-486e-91e1-072f6bbbdc2e" />

Test output with fix applied:
<img width="520" height="845" alt="Screenshot 2026-08-03 at 11 15 20" src="https://github.com/user-attachments/assets/a3eb7d97-acfd-46e3-9255-6c1e55103f6b" />


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
