### PR TITLE
Audio workspace: exclusive interval end model

### DIFF
--- a/changelog.d/20260804_130555_aleksey.zinovyev_exclusive_interval_end.md
+++ b/changelog.d/20260804_130555_aleksey.zinovyev_exclusive_interval_end.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed saving annotations after expanding/moving an interval to the end of the track
+  (<https://github.com/cvat-ai/cvat/pull/10948>)

--- a/cvat-core/src/annotations-collection.ts
+++ b/cvat-core/src/annotations-collection.ts
@@ -1284,7 +1284,7 @@ export default class Collection {
                 constructed.intervals.push({
                     attributes,
                     start: state.start,
-                    stop: Math.min(state.stop ?? this.stopFrame, this.stopFrame),
+                    stop: Math.min(state.stop ?? this.stopFrame + 1, this.stopFrame + 1),
                     label_id: state.label.id,
                     group: 0,
                     source: state.source,

--- a/cvat/apps/dataset_manager/annotation.py
+++ b/cvat/apps/dataset_manager/annotation.py
@@ -175,10 +175,12 @@ class AnnotationIR:
 
     @staticmethod
     def is_interval_inside(interval: dict[str, Any], start: int, stop: int) -> bool:
+        # Task ranges are inclusive, while an interval stop is exclusive.
+        # So an interval may stop immediately after the last frame in the range.
         return (
             interval["start"] >= start
             and interval["start"] <= stop
-            and (interval["stop"] is None or interval["stop"] <= stop)
+            and (interval["stop"] is None or interval["stop"] <= stop + 1)
         )
 
     def slice(self, start, stop):

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -383,17 +383,31 @@ class CommonData(InstanceLabelData):
     def _get_db_images(self) -> Iterator[models.Image]:
         raise NotImplementedError()
 
-    def abs_frame_id(self, relative_id):
+    def _abs_frame_id(self, relative_id, *, allow_after_range: bool = False):
         # relative_id is frame index in segment for job, so it can start with more than just zero
-        if relative_id not in self.rel_range:
+        if relative_id not in self.rel_range and not (
+            allow_after_range and relative_id == self.rel_range.stop
+        ):
             raise ValueError("Unknown internal frame id %s" % relative_id)
         return relative_id * self._frame_step + self._db_data.start_frame
 
-    def rel_frame_id(self, absolute_id):
+    def abs_frame_id(self, relative_id):
+        return self._abs_frame_id(relative_id)
+
+    def abs_interval_stop(self, relative_id):
+        return self._abs_frame_id(relative_id, allow_after_range=True)
+
+    def _rel_frame_id(self, absolute_id, *, allow_after_range: bool = False):
         d, m = divmod(absolute_id - self._db_data.start_frame, self._frame_step)
-        if m or d not in self.rel_range:
+        if m or (d not in self.rel_range and not (allow_after_range and d == self.rel_range.stop)):
             raise ValueError("Unknown frame %s" % absolute_id)
         return d
+
+    def rel_frame_id(self, absolute_id):
+        return self._rel_frame_id(absolute_id)
+
+    def rel_interval_stop(self, absolute_id):
+        return self._rel_frame_id(absolute_id, allow_after_range=True)
 
     def _init_frame_info(self):
         self._deleted_frames = {k: True for k in self._db_data.deleted_frames}
@@ -557,7 +571,7 @@ class CommonData(InstanceLabelData):
             id=interval["id"],
             start=frame_to_timestamp(self.abs_frame_id(interval["start"])),
             stop=(
-                frame_to_timestamp(self.abs_frame_id(interval["stop"]))
+                frame_to_timestamp(self.abs_interval_stop(interval["stop"]))
                 if interval["stop"] is not None
                 else None
             ),
@@ -763,7 +777,7 @@ class CommonData(InstanceLabelData):
         label_id = self._get_label_id(_interval.pop("label"))
         _interval["start"] = self.rel_frame_id(timestamp_to_frame(_interval["start"]))
         _interval["stop"] = (
-            self.rel_frame_id(timestamp_to_frame(_interval["stop"]))
+            self.rel_interval_stop(timestamp_to_frame(_interval["stop"]))
             if _interval["stop"] is not None
             else None
         )

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -152,8 +152,8 @@ def _validate_input_annotations(
                     f"Interval {interval['id']}" if interval.get("id") is not None else "Interval"
                 )
                 raise ValidationError(
-                    f"{interval_ref} cannot be outside the task boundaries"
-                    f"[{task_start}, {task_stop}], got "
+                    f"{interval_ref} start must be within [{task_start}, {task_stop}] "
+                    f"and stop must be within [{task_start}, {task_stop + 1}], got "
                     f"[{interval['start']}, {interval['stop']}]"
                 )
 

--- a/cvat/apps/dataset_manager/tests/test_annotation.py
+++ b/cvat/apps/dataset_manager/tests/test_annotation.py
@@ -418,6 +418,14 @@ class TrackManagerTest(TestCase):
 
 
 class AnnotationIRTest(TestCase):
+    def test_interval_stop_can_be_immediately_after_range(self):
+        interval = {"id": 1, "start": 0, "stop": 11}
+
+        self.assertTrue(AnnotationIR.is_interval_inside(interval, 0, 10))
+
+        self.assertFalse(AnnotationIR.is_interval_inside({**interval, "stop": 12}, 0, 10))
+        self.assertFalse(AnnotationIR.is_interval_inside({**interval, "start": 11}, 0, 10))
+
     def test_slice_track_does_not_duplicate_outside_frame_on_the_end(self):
         for dimension in [DimensionType.DIM_2D, DimensionType.DIM_3D]:
             with self.subTest(dimension=dimension):

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -1667,7 +1667,9 @@ class TrackedShapeAttributeVal(AttributeVal):
 
 class LabeledInterval(Annotation, ScoredAnnotationMixin):
     start = models.PositiveIntegerField()
+    "Must be within the task frame bounds."
     stop = models.PositiveIntegerField(null=True)
+    "Exclusive interval end. May be one greater than the task stop frame."
 
 
 class LabeledIntervalAttributeVal(AttributeVal):

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -4191,13 +4191,11 @@ class LabeledIntervalSerializer(
         min_value=0,
         help_text="Must be within the task frame bounds.",
     )
-    "Must be within the task frame bounds."
     stop = serializers.IntegerField(
         min_value=0,
         allow_null=True,
         help_text="Exclusive interval end. May be one greater than the task stop frame.",
     )
-    "Exclusive interval end. May be one greater than the task stop frame."
 
 
 class LabeledDataSerializer(serializers.Serializer):

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -4187,8 +4187,15 @@ class LabeledIntervalSerializer(
     AttributedAnnotationSerializer,
     ScoredAnnotationSerializer,
 ):
-    start = serializers.IntegerField(min_value=0)
-    stop = serializers.IntegerField(min_value=0, allow_null=True)
+    start = serializers.IntegerField(
+        min_value=0,
+        help_text="Must be within the task frame bounds.",
+    )
+    stop = serializers.IntegerField(
+        min_value=0,
+        allow_null=True,
+        help_text="Exclusive interval end. May be one greater than the task stop frame.",
+    )
 
 
 class LabeledDataSerializer(serializers.Serializer):

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -4191,11 +4191,13 @@ class LabeledIntervalSerializer(
         min_value=0,
         help_text="Must be within the task frame bounds.",
     )
+    "Must be within the task frame bounds."
     stop = serializers.IntegerField(
         min_value=0,
         allow_null=True,
         help_text="Exclusive interval end. May be one greater than the task stop frame.",
     )
+    "Exclusive interval end. May be one greater than the task stop frame."
 
 
 class LabeledDataSerializer(serializers.Serializer):

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -8865,10 +8865,13 @@ components:
         start:
           type: integer
           minimum: 0
+          description: Must be within the task frame bounds.
         stop:
           type: integer
           minimum: 0
           nullable: true
+          description: Exclusive interval end. May be one greater than the task stop
+            frame.
       required:
       - label_id
       - start
@@ -8905,10 +8908,13 @@ components:
         start:
           type: integer
           minimum: 0
+          description: Must be within the task frame bounds.
         stop:
           type: integer
           minimum: 0
           nullable: true
+          description: Exclusive interval end. May be one greater than the task stop
+            frame.
       required:
       - label_id
       - start

--- a/tests/python/rest_api/test_audio_support.py
+++ b/tests/python/rest_api/test_audio_support.py
@@ -298,7 +298,7 @@ class TestAudioAnnotations:
             yield
 
     @parametrize("instance_type", ["task", "job"])
-    def test_can_save_intervals(self, tasks, instance_type: str):
+    def test_can_save_interval_ending_at_task_boundary(self, tasks, instance_type: str):
         task_id = next(t for t in tasks if t["media_type"] == "audio")["id"]
 
         task = self.client.tasks.retrieve(task_id)
@@ -310,7 +310,7 @@ class TestAudioAnnotations:
                 models.LabeledIntervalRequest(
                     label_id=label.id,
                     start=0,
-                    stop=task.size - 1,
+                    stop=task.size,
                 ),
             ]
         )
@@ -377,7 +377,7 @@ class TestAudioAnnotations:
                 models.LabeledIntervalRequest(
                     label_id=labels[0].id,
                     start=0,
-                    stop=task.size,
+                    stop=task.size + 1,
                 ),
             ]
         )
@@ -392,4 +392,4 @@ class TestAudioAnnotations:
         with pytest.raises(exceptions.ApiException) as capture:
             instance.set_annotations(payload)
 
-        assert "cannot be outside" in str(capture.value)
+        assert "stop must be within" in str(capture.value)

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -33,6 +33,7 @@ from cvat_sdk.api_client.api_client import ApiClient, Endpoint
 from cvat_sdk.api_client.exceptions import ForbiddenException
 from cvat_sdk.core.exceptions import BackgroundRequestException
 from cvat_sdk.core.helpers import get_paginated_collection
+from cvat_sdk.core.proxies.annotations import AnnotationUpdateAction
 from cvat_sdk.core.progress import NullProgressReporter
 from cvat_sdk.core.proxies.tasks import ResourceType, Task
 from cvat_sdk.core.uploading import Uploader
@@ -3742,6 +3743,21 @@ class TestImportTaskAnnotations:
             for t in tasks
             if t.get("size")
             if t["media_type"] == "audio" and t.get("validation_mode") != "gt_pool"
+        )
+        task_obj = self.client.tasks.retrieve(task["id"])
+        # add an annotation covering the whole interval with exclusive stop after the last frame
+        label = next(label for label in task_obj.get_labels() if label.type == "interval")
+        task_obj.update_annotations(
+            models.PatchedLabeledDataRequest(
+                intervals=[
+                    models.LabeledIntervalRequest(
+                        label_id=label.id,
+                        start=0,
+                        stop=task["size"],
+                    )
+                ]
+            ),
+            action=AnnotationUpdateAction.CREATE,
         )
 
         format_name = "Generic TSV 1.0"

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -33,8 +33,8 @@ from cvat_sdk.api_client.api_client import ApiClient, Endpoint
 from cvat_sdk.api_client.exceptions import ForbiddenException
 from cvat_sdk.core.exceptions import BackgroundRequestException
 from cvat_sdk.core.helpers import get_paginated_collection
-from cvat_sdk.core.proxies.annotations import AnnotationUpdateAction
 from cvat_sdk.core.progress import NullProgressReporter
+from cvat_sdk.core.proxies.annotations import AnnotationUpdateAction
 from cvat_sdk.core.proxies.tasks import ResourceType, Task
 from cvat_sdk.core.uploading import Uploader
 from deepdiff import DeepDiff


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Extending or moving an interval to the end of the track results in error when saving the annotations.

This change resolves the problem of handling an interval stop differently on the frontend and backend. Backend will now treat intervals with exclusive `end` frame allowing `job.stopFrame + 1` as the last valid end position.

Migration is intentionally omitted as the change does not make any data invalid and 1ms end semantic shift is not critical at this point.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Tested manually, unit and rest API tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
