### PR TITLE
Remove audio workspace from non-audio jobs

### DIFF
--- a/changelog.d/20260804_174111_aleksey.zinovyev_fix_2d_workspaces.md
+++ b/changelog.d/20260804_174111_aleksey.zinovyev_fix_2d_workspaces.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Removed audio annotation option from workspace selector for non-audio jobs
+  (<https://github.com/cvat-ai/cvat/pull/10965>)

--- a/cvat-ui/src/components/annotation-page/top-bar/right-group.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/right-group.tsx
@@ -159,6 +159,9 @@ function RightGroup(props: Props): JSX.Element {
                     value={workspace}
                 >
                     {Object.values(Workspace).map((ws) => {
+                        if (jobInstance.mediaType !== 'audio' && ws === Workspace.AUDIO) {
+                            return null;
+                        }
                         if (jobInstance.dimension === DimensionType.DIMENSION_3D) {
                             if (ws === Workspace.STANDARD) {
                                 return null;

--- a/tests/cypress/e2e/actions_tasks/workspace_selector.js
+++ b/tests/cypress/e2e/actions_tasks/workspace_selector.js
@@ -1,0 +1,56 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { defaultTaskSpec } from '../../support/default-specs';
+
+context('Workspace selector for a regular task', () => {
+    const taskName = 'Workspace selector';
+    const { taskSpec, dataSpec, extras } = defaultTaskSpec({
+        taskName,
+        labelName: 'label',
+        serverFiles: ['images/image_1.jpg'],
+    });
+    let taskId = null;
+    let jobId = null;
+
+    before(() => {
+        cy.visit('/auth/login');
+        cy.login();
+        cy.url().should('contain', '/tasks');
+
+        cy.headlessCreateTask(taskSpec, dataSpec, extras).then(({ taskId: tid, jobIds: [jid] }) => {
+            [taskId, jobId] = [tid, jid];
+            cy.intercept('GET', `/tasks/${taskId}/jobs/${jobId}`).as('visitAnnotationView');
+            cy.visit(`/tasks/${taskId}/jobs/${jobId}`);
+            cy.wait('@visitAnnotationView');
+            cy.get('.cvat-canvas-container').should('exist').and('be.visible');
+        });
+    });
+
+    after(() => {
+        cy.headlessDeleteTask(taskId);
+    });
+
+    it('shows the workspaces available for a regular 2D task', () => {
+        const expectedWorkspaces = [
+            'Standard',
+            'Attribute annotation',
+            'Single shape',
+            'Tag annotation',
+            'Review',
+        ];
+
+        cy.get('.cvat-workspace-selector').should('be.visible').click();
+        cy.get('.cvat-workspace-selector-dropdown')
+            .not('.ant-select-dropdown-hidden')
+            .find('.ant-select-item-option')
+            .should('have.length', expectedWorkspaces.length)
+            .then(($options) => {
+                const workspaces = Array.from($options, (option) => option.getAttribute('title'));
+                expect(workspaces).to.deep.equal(expectedWorkspaces);
+            });
+    });
+});


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

In a regular/cv non-audio job there's an Audio Workspace option available which leads the UI into a stuck state.

This change removes the option for non-audio jobs.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Tested manually, added e2e test verifying the list of available workspaces for a regular non-audio task.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
