### PR TITLE
Audio: prevent scroll jump when resizing window

### DIFF
--- a/changelog.d/20260804_200507_aleksey.zinovyev_consistent_zoom.md
+++ b/changelog.d/20260804_200507_aleksey.zinovyev_consistent_zoom.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed scroll jumping to waveform playback cursor when resizing the window
+  (<https://github.com/cvat-ai/cvat/pull/10995>)

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-viewport.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-viewport.ts
@@ -162,26 +162,40 @@ export function useWaveformViewport(
     }, []);
 
     const previousZoomRef = useRef(pixelsPerSecond);
+    const previousContainerWidthRef = useRef(containerWidth);
+    // A resize changes pixels-per-second because it is derived from the container width.
+    // During resize, preserve the leftmost visible timestamp.
+    // Slider and programmatic zoom retain the playback cursor's screen position
+    // when it is visible; otherwise retain the current viewport's left edge.
+    // Wheel zoom retain the timestamp under the pointer.
     useLayoutEffect(() => {
         const instance = runtime.instanceRef.current;
         const scrollContainer = getScrollContainer();
         if (!instance || !scrollContainer) return;
 
         const previousZoom = previousZoomRef.current;
+        const previousContainerWidth = previousContainerWidthRef.current;
         previousZoomRef.current = pixelsPerSecond;
+        previousContainerWidthRef.current = containerWidth;
         const maximumScroll = Math.max(0, runtime.durationRef.current * pixelsPerSecond - scrollContainer.clientWidth);
         const anchor = zoomAnchorRef.current;
         zoomAnchorRef.current = null;
+        const containerResized = previousContainerWidth > 0 && containerWidth !== previousContainerWidth;
+        const visibleStartTime = previousZoom > 0 ? scrollContainer.scrollLeft / previousZoom : 0;
+        const currentTime = instance.getCurrentTime();
+        const cursorOffset = currentTime * previousZoom - scrollContainer.scrollLeft;
+        const cursorIsVisible = cursorOffset >= 0 && cursorOffset <= scrollContainer.clientWidth;
         instance.zoom(pixelsPerSecond);
         if (anchor) {
             instance.setScroll(clamp(anchor.time * pixelsPerSecond - anchor.x, 0, maximumScroll));
-        } else if (pixelsPerSecond < previousZoom) {
-            instance.setScroll(centeredScrollOffsetForTime(
-                instance.getCurrentTime(),
-                pixelsPerSecond,
-                scrollContainer.clientWidth,
-                maximumScroll,
-            ));
+        } else if (containerResized) {
+            instance.setScroll(clamp(visibleStartTime * pixelsPerSecond, 0, maximumScroll));
+        } else if (pixelsPerSecond !== previousZoom) {
+            let scrollOffset = visibleStartTime * pixelsPerSecond;
+            if (cursorIsVisible) {
+                scrollOffset = currentTime * pixelsPerSecond - cursorOffset;
+            }
+            instance.setScroll(clamp(scrollOffset, 0, maximumScroll));
         }
     }, [pixelsPerSecond, ready]);
 

--- a/tests/cypress/e2e/audio_workspace/case_audio_35_viewport_positioning.js
+++ b/tests/cypress/e2e/audio_workspace/case_audio_35_viewport_positioning.js
@@ -1,0 +1,152 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName } from '../../support/const_audio';
+
+context('Audio annotation. Waveform viewport positioning.', { testIsolation: false }, () => {
+    const caseId = 'audio_35';
+    const WHEEL_DELTA_Y_PX = -8;
+    const WHEEL_ZOOM_EVENT_COUNT = 5;
+    const ZOOM_BASELINE_STEPS = 20;
+    const ZOOM_ADJUSTMENT_STEPS = 20;
+    const TIMESTAMP_TOLERANCE_FRACTION = 0.01;
+    const CURSOR_POSITION_TOLERANCE_PX = 2;
+
+    const getWaveformHost = () => cy.get('.cvat-audio-waveform-wrapper > div:first-child > div');
+    const getScrollContainer = () => getWaveformHost().shadow().find('.scroll');
+    const getCursor = () => getWaveformHost().shadow().find('.cursor');
+
+    const scrollToOneThird = () => getScrollContainer().then(($scroll) => {
+        const { clientWidth, scrollWidth } = $scroll[0];
+        cy.wrap($scroll).scrollTo((scrollWidth - clientWidth) / 3, 0);
+    });
+
+    const seekAtViewportOffset = (offset) => getScrollContainer().then(($scroll) => {
+        const { scrollLeft, clientWidth, clientHeight } = $scroll[0];
+        getWaveformHost().shadow().find('.wrapper').click(
+            scrollLeft + clientWidth * offset,
+            clientHeight / 2,
+            { force: true },
+        );
+    });
+
+    const getViewportPosition = () => getScrollContainer().then(($scroll) => {
+        const { scrollLeft, scrollWidth } = $scroll[0];
+        return scrollLeft / scrollWidth;
+    });
+
+    const getCursorPosition = () => getScrollContainer().then(($scroll) => {
+        const { scrollLeft } = $scroll[0];
+        return getCursor().then(($cursor) => $cursor[0].offsetLeft - scrollLeft);
+    });
+
+    before(() => {
+        cy.prepareUserSession();
+        cy.openAudioJob(taskName);
+    });
+
+    beforeEach(() => {
+        cy.viewport(1400, 900);
+        cy.audioSliderSetValue('cvat-audio-zoom-control', '{home}', 1);
+        cy.get('.cvat-audio-zoom-control .cvat-audio-slider-value-badge')
+            .should('have.text', 'x1');
+    });
+
+    describe(`Testing case "${caseId}"`, () => {
+        it('Wheel zoom keeps the timestamp under the pointer fixed', () => {
+            // x1 -> x3
+            cy.audioSliderSetValue('cvat-audio-zoom-control', '{downarrow}', ZOOM_BASELINE_STEPS);
+            scrollToOneThird();
+
+            getWaveformHost().then(($host) => {
+                const rect = $host[0].getBoundingClientRect();
+                const pointerOffset = rect.width * 0.25;
+                getScrollContainer().then(($scroll) => {
+                    const before = ($scroll[0].scrollLeft + pointerOffset) / $scroll[0].scrollWidth;
+                    const beforeWidth = $scroll[0].scrollWidth;
+
+                    for (let eventIndex = 0; eventIndex < WHEEL_ZOOM_EVENT_COUNT; eventIndex += 1) {
+                        $host[0].dispatchEvent(new WheelEvent('wheel', {
+                            bubbles: true,
+                            cancelable: true,
+                            clientX: rect.left + pointerOffset,
+                            clientY: rect.top + rect.height / 2,
+                            deltaY: WHEEL_DELTA_Y_PX,
+                        }));
+                    }
+
+                    getScrollContainer().should(($updatedScroll) => {
+                        expect($updatedScroll[0].scrollWidth).to.be.greaterThan(beforeWidth);
+                        const after = ($updatedScroll[0].scrollLeft + pointerOffset) / $updatedScroll[0].scrollWidth;
+                        expect(after).to.be.closeTo(before, TIMESTAMP_TOLERANCE_FRACTION);
+                    });
+                });
+            });
+        });
+
+        it('Window resizing preserves the leftmost visible timestamp', () => {
+            const RESIZED_SCROLL_WIDTH_UPPER_BOUND_PX = 700;
+            // x1 -> x3
+            cy.audioSliderSetValue('cvat-audio-zoom-control', '{downarrow}', ZOOM_BASELINE_STEPS);
+            scrollToOneThird();
+
+            getViewportPosition().then((before) => {
+                cy.viewport(1000, 700);
+                getScrollContainer().should(($updatedScroll) => {
+                    expect($updatedScroll[0].clientWidth).to.be.at.most(RESIZED_SCROLL_WIDTH_UPPER_BOUND_PX);
+                    const after = $updatedScroll[0].scrollLeft / $updatedScroll[0].scrollWidth;
+                    expect(after).to.be.closeTo(before, TIMESTAMP_TOLERANCE_FRACTION);
+                });
+            });
+        });
+
+        it('Slider zoom preserves a visible playback cursor position', () => {
+            // x1 -> x3
+            cy.audioSliderSetValue('cvat-audio-zoom-control', '{downarrow}', ZOOM_BASELINE_STEPS);
+            scrollToOneThird();
+            seekAtViewportOffset(0.6);
+
+            getCursorPosition().then((before) => {
+                getScrollContainer().then(($scroll) => {
+                    const beforeWidth = $scroll[0].scrollWidth;
+                    // x3 -> x5
+                    cy.audioSliderSetValue('cvat-audio-zoom-control', '{downarrow}', ZOOM_ADJUSTMENT_STEPS);
+                    getScrollContainer().should(($updatedScroll) => {
+                        expect($updatedScroll[0].scrollWidth).to.be.greaterThan(beforeWidth);
+                    });
+                });
+                getCursorPosition().should('be.closeTo', before, CURSOR_POSITION_TOLERANCE_PX);
+
+                // x5 -> x3
+                cy.audioSliderSetValue('cvat-audio-zoom-control', '{uparrow}', ZOOM_ADJUSTMENT_STEPS);
+                getCursorPosition().should('be.closeTo', before, CURSOR_POSITION_TOLERANCE_PX);
+            });
+        });
+
+        it('Slider zoom preserves the leftmost timestamp when the playback cursor is hidden', () => {
+            seekAtViewportOffset(0);
+            // x1 -> x3
+            cy.audioSliderSetValue('cvat-audio-zoom-control', '{downarrow}', ZOOM_BASELINE_STEPS);
+            scrollToOneThird();
+
+            getViewportPosition().then((before) => {
+                getScrollContainer().then(($scroll) => {
+                    const beforeWidth = $scroll[0].scrollWidth;
+                    // x3 -> x5
+                    cy.audioSliderSetValue('cvat-audio-zoom-control', '{downarrow}', ZOOM_ADJUSTMENT_STEPS);
+                    getScrollContainer().should(($updatedScroll) => {
+                        expect($updatedScroll[0].scrollWidth).to.be.greaterThan(beforeWidth);
+                    });
+                });
+                getViewportPosition().should('be.closeTo', before, TIMESTAMP_TOLERANCE_FRACTION);
+
+                // x5 -> x3
+                cy.audioSliderSetValue('cvat-audio-zoom-control', '{uparrow}', ZOOM_ADJUSTMENT_STEPS);
+                getViewportPosition().should('be.closeTo', before, TIMESTAMP_TOLERANCE_FRACTION);
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

When downsizing the window it jumps to the playback cursor position.

The changes introduce stable handling for all sources of zoom (pixelsPerSecond change) preventing such behavior.
The implemented rules are:
1. Wheel zoom continues to anchor the timestamp under the pointer.
2. Resize preserves the leftmost visible timestamp.
3. Slider/programmatic zoom:
3.1. keeps the playback cursor at its current screen position if it is visible;
3.2. otherwise preserves the leftmost visible timestamp.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Tested manually, added e2e tests covering the scenarios described above.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
