### PR TITLE
Normalize email addresses in organization invitations

### DIFF
--- a/changelog.d/20260805_145304_andrey_fix_invitations.md
+++ b/changelog.d/20260805_145304_andrey_fix_invitations.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed duplicate accounts from mixed-case invitation emails.
+  (<https://github.com/cvat-ai/cvat/pull/10997>)

--- a/cvat/apps/iam/tests/test_rest_api.py
+++ b/cvat/apps/iam/tests/test_rest_api.py
@@ -167,6 +167,7 @@ class UserRegisterAPITestCase(ApiTestBase):
             query_params={"org": org_slug},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(User.objects.filter(email=self.user_data["email"]).exists())
 
         response = self._run_api_v2_user_register(self.user_data)
         self._check_response(
@@ -181,6 +182,8 @@ class UserRegisterAPITestCase(ApiTestBase):
             },
         )
         invited_db_user = User.objects.get(email=self.user_data["email"])
+        self.assertEqual(User.objects.filter(email__iexact=self.user_data["email"]).count(), 1)
+        self.assertTrue(invited_db_user.memberships.filter(organization__slug=org_slug).exists())
         self.assertTrue(invited_db_user.emailaddress_set.update(verified=True))
         response = self.client.post(
             "/api/auth/login",

--- a/cvat/apps/organizations/serializers.py
+++ b/cvat/apps/organizations/serializers.py
@@ -119,11 +119,11 @@ class InvitationWriteSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         membership_data = validated_data.pop("membership")
         organization = validated_data.pop("organization")
+        user_email = membership_data["user"]["email"].lower()
         try:
-            user = get_user_model().objects.get(email__iexact=membership_data["user"]["email"])
+            user = get_user_model().objects.get(email__iexact=user_email)
             del membership_data["user"]
         except ObjectDoesNotExist:
-            user_email = membership_data["user"]["email"]
             user = User.objects.create_user(username=user_email, email=user_email)
             user.set_unusable_password()
             user.save()


### PR DESCRIPTION
### Motivation and context
Fixes organization invitations creating dummy users with mixed-case email addresses.
Invitation emails are now normalized to lowercase before creating the dummy user. This ensures a later standard registration with the same email reuses that dummy user instead of creating a duplicate account.

### How has this been tested?
Extended the existing mixed-case invitation/registration test to verify:
the dummy user is created with a lowercase email;
exactly one user exists for the email, case-insensitively;
the organization membership belongs to that user.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
