### PR TITLE
Audio: fix wrong interval end created with extend after playback

### DIFF
--- a/cvat-ui/src/actions/audio-actions.ts
+++ b/cvat-ui/src/actions/audio-actions.ts
@@ -229,10 +229,6 @@ export function createAudioIntervalAsync(start: number, stop: number, labelID: n
             stop: Math.round(stop * 1000),
             source: Source.MANUAL,
         });
-        state.attributes = Object.fromEntries(label.attributes.map((attribute) => [
-            attribute.id as number,
-            attribute.defaultValue,
-        ]));
 
         const { createAnnotationsAsync } = await import('./annotation-actions');
         await dispatch(createAnnotationsAsync([state]));

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-audio-waveform.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-audio-waveform.ts
@@ -70,7 +70,7 @@ interface WaveSurferWebAudioPlayer {
     // It is intentionally typed locally because this is private-API binding,
     // not a public WaveSurfer API contract.
     buffer: AudioBuffer | null;
-    emit(eventName: 'durationchange'): void;
+    emit(eventName: 'loadedmetadata' | 'canplay'): void;
 }
 
 /**
@@ -152,16 +152,19 @@ function useWaveSurferRuntime({
             plugins: pluginsScope.plugins,
         });
 
-        const unsubscribeReady = wsInstance.on('ready', () => {
-            // There seem to be no way to re-use the audio buffer using
-            // existing public APIs of WaveSurfer
-            // NOTE: This place relies on the internal implementation.
+        // WaveSurfer has no public API for passing an already-decoded AudioBuffer.
+        // Initialize its WebAudioPlayer before WaveSurfer starts loading the supplied
+        // peaks and duration. This mirrors the player.src initialization path: it
+        // installs the buffer and emits the metadata/readiness events that update
+        // WaveSurfer's internal player state.
+        const unsubscribeInit = wsInstance.on('init', () => {
             const player = wsInstance.getMediaElement() as unknown as WaveSurferWebAudioPlayer;
             player.buffer = audioBuffer;
-            // The precomputed-peaks path sets the WebAudio player's duration directly.
-            // Notify WaveSurfer's reactive state so plugins, including Hover, see it.
-            player.emit('durationchange');
+            player.emit('loadedmetadata');
+            player.emit('canplay');
+        });
 
+        const unsubscribeReady = wsInstance.on('ready', () => {
             setInstance(wsInstance);
             injectScrollbarStyle(wsInstance.getWrapper());
             durationRef.current = wsInstance.getDuration();
@@ -171,6 +174,7 @@ function useWaveSurferRuntime({
         });
 
         return () => {
+            unsubscribeInit();
             unsubscribeReady();
             setInstance(null);
             readyRef.current = false;

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-playback.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-playback.ts
@@ -68,9 +68,13 @@ export function useWaveformPlayback(runtime: WaveSurferRuntime): WaveformPlaybac
         const instance = runtime.instanceRef.current;
         if (!instance) return undefined;
 
-        const onTimeUpdate = (time: number): void => {
-            dispatch(audioActions.reportAudioCurrentTime(time));
-            listenersRef.current.forEach((listener) => listener(time));
+        const onTimeUpdate = (): void => {
+            // With the WebAudio backend, a timeupdate emitted after pausing can
+            // carry WaveSurfer's stale reactive time (the previous seek position).
+            // Its player clock remains correct, so use it as the source of truth.
+            const currentTime = instance.getCurrentTime();
+            dispatch(audioActions.reportAudioCurrentTime(currentTime));
+            listenersRef.current.forEach((listener) => listener(currentTime));
         };
         const onFinish = (): void => {
             dispatch(audioActions.switchAudioPlay(false));

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-playback.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-playback.ts
@@ -71,6 +71,7 @@ export function useWaveformPlayback(runtime: WaveSurferRuntime): WaveformPlaybac
         const onTimeUpdate = (): void => {
             // With the WebAudio backend, a timeupdate emitted after pausing can
             // carry WaveSurfer's stale reactive time (the previous seek position).
+            // See: https://github.com/katspaugh/wavesurfer.js/issues/4347
             // Its player clock remains correct, so use it as the source of truth.
             const currentTime = instance.getCurrentTime();
             dispatch(audioActions.reportAudioCurrentTime(currentTime));

--- a/tests/cypress/e2e/audio_workspace/case_audio_25_extend_via_button.js
+++ b/tests/cypress/e2e/audio_workspace/case_audio_25_extend_via_button.js
@@ -8,31 +8,79 @@ import { taskName, firstLabelName } from '../../support/const_audio';
 
 context('Audio annotation. Extend region via toolbar button.', () => {
     const caseId = 'audio_25';
+    const REGION_POSITION_TOLERANCE_PX = 4;
 
-    before(() => {
+    const getWaveformHost = () => cy.get('.cvat-audio-waveform-wrapper > div:first-child > div');
+    const getWaveformWrapper = () => getWaveformHost().shadow().find('.wrapper');
+    const getPlaybackCursor = () => getWaveformHost().shadow().find('.cursor');
+    const getRegionRects = () => getWaveformHost().shadow().find('[part~="region"]').then(($regions) => (
+        Array.from($regions)
+            .map((region) => region.getBoundingClientRect())
+            .sort((left, right) => left.left - right.left)
+    ));
+
+    beforeEach(() => {
         cy.prepareUserSession();
         cy.openAudioJob(taskName);
     });
 
+    afterEach(() => {
+        cy.audioClearAnnotations();
+    });
+
     describe(`Testing case "${caseId}"`, () => {
-        it('Extend button creates a new region from the end of the last region to the playhead', () => {
-            cy.get('body').then(($body) => {
-                const initial = $body.find('.cvat-audio-region-item').length;
-                cy.audioCreateRegionViaButton(firstLabelName, 100, 250);
-                cy.get('.cvat-audio-region-item').should('have.length', initial + 1);
-                cy.get('body').type('{esc}');
-                cy.get('.cvat-cursor-control').should('have.class', 'cvat-active-canvas-control');
-                cy.get('.cvat-audio-waveform-wrapper').first().then(($el) => {
-                    const rect = $el[0].getBoundingClientRect();
-                    cy.get('.cvat-audio-waveform-wrapper').realClick({
-                        position: { x: rect.width * 0.9, y: rect.height / 2 },
-                        button: 'left',
+        it('Extend button uses the closest region to the left, regardless of creation order', () => {
+            cy.audioCreateRegionViaButton(firstLabelName, 500, 650);
+            cy.audioCreateRegionViaButton(firstLabelName, 100, 250);
+            cy.get('.cvat-audio-region-item').should('have.length', 2);
+
+            cy.get('.cvat-audio-waveform-wrapper').first().then(($el) => {
+                const rect = $el[0].getBoundingClientRect();
+                cy.get('.cvat-audio-waveform-wrapper').realClick({
+                    position: { x: 400, y: rect.height / 2 },
+                    button: 'left',
+                });
+            });
+            cy.audioExtendViaButton(firstLabelName);
+
+            cy.get('.cvat-audio-region-item', { timeout: 5000 }).should('have.length', 3);
+            getRegionRects().then(([left, extended, right]) => {
+                expect(extended.left).to.be.closeTo(left.right, REGION_POSITION_TOLERANCE_PX);
+                expect(extended.right).to.be.lessThan(right.left);
+                expect(extended.width).to.be.greaterThan(0);
+            });
+        });
+
+        it('Extend button creates a region from audio start to the paused playback position', () => {
+            cy.get('.cvat-audio-region-item').should('have.length', 0);
+
+            cy.get('.cvat-player-play-button').click();
+            cy.get('.cvat-player-pause-button').should('exist');
+            // Keep playing for ~0.5sec
+            cy.wait(500);
+            cy.get('.cvat-player-pause-button').click();
+            cy.get('.cvat-player-play-button').should('exist');
+
+            getWaveformWrapper().then(($wrapper) => {
+                const wrapperLeft = $wrapper[0].getBoundingClientRect().left;
+                getPlaybackCursor().then(($cursor) => {
+                    const pausedCursorPosition = $cursor[0].getBoundingClientRect().left - wrapperLeft;
+                    cy.wrap(pausedCursorPosition).as('pausedCursorPosition');
+                });
+            });
+
+            cy.audioExtendViaButton(firstLabelName);
+            cy.get('.cvat-audio-region-item', { timeout: 5000 }).should('have.length', 1);
+            cy.get('.cvat-audio-region-item').first().should('contain.text', firstLabelName);
+            cy.get('@pausedCursorPosition').then((pausedCursorPosition) => {
+                getWaveformWrapper().then(($wrapper) => {
+                    const wrapperLeft = $wrapper[0].getBoundingClientRect().left;
+                    getRegionRects().then(([region]) => {
+                        expect(region.left - wrapperLeft).to.be.closeTo(0, REGION_POSITION_TOLERANCE_PX);
+                        expect(region.right - wrapperLeft)
+                            .to.be.closeTo(pausedCursorPosition, REGION_POSITION_TOLERANCE_PX);
                     });
                 });
-                cy.audioExtendViaButton(firstLabelName);
-                cy.get('.cvat-audio-region-item', { timeout: 5000 })
-                    .should('have.length', initial + 2);
-                cy.get('.cvat-audio-region-item').last().should('contain.text', firstLabelName);
             });
         });
     });


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Creating a new interval after playback resulted in wrong end position of the new interval.
It's a regression introduced while switching to WebAudio backend: https://github.com/cvat-ai/cvat/pull/10980.

The root cause is that with the `WebAudio` backend WaveSurfer emits `timeupdate` with stale (last sought) timestamp which causes wrong `currentTime` in Redux store used by the extend function.
See https://github.com/katspaugh/wavesurfer.js/issues/4347

**NOTE: no changelog fragment for this change because it's the regression of the unreleased changes.**

P.S. also contains small unrelated cleanup of code that was explicitly providing default attributes for new intervals. Core logic already takes care of this so no need to duplicate.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Tested manually, added e2e test.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
