### PR TITLE
Invalidate all chunks of the updated segment on honeypot updates

### DIFF
--- a/changelog.d/20260806_182110_mzhiltsov_fix_chunk_refresh_date_desync.md
+++ b/changelog.d/20260806_182110_mzhiltsov_fix_chunk_refresh_date_desync.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Persistent `429 Too Many Requests` API errors on chunk retrieval for jobs
+  with honeypots after partial honeypot updates
+  (<https://github.com/cvat-ai/cvat/pull/11007>)

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1691,8 +1691,14 @@ class JobValidationLayoutWriteSerializer(serializers.Serializer):
             # Update chunks
             job_frame_provider = JobFrameProvider(db_job)
             updated_segment_chunk_ids = set(
-                job_frame_provider.get_chunk_number(updated_segment_frame_id)
-                for updated_segment_frame_id in updated_honeypots
+                # We store chunk update dates only per segment,
+                # so we invalidate all the chunks in the segment.
+                # This allows the cache to check the chunk timestamps before returning them.
+                # Change the granularity to per chunk, if the performance is bad.
+                range(
+                    job_frame_provider.get_chunk_number(db_segment.start_frame),
+                    job_frame_provider.get_chunk_number(db_segment.stop_frame),
+                )
             )
             segment_frames = sorted(segment_frame_set)
             segment_frame_map = dict(zip(segment_honeypots, requested_frames))
@@ -1705,7 +1711,9 @@ class JobValidationLayoutWriteSerializer(serializers.Serializer):
                 ]
 
                 for quality in models.FrameQuality:
-                    if db_data.storage_method == models.StorageMethodChoice.FILE_SYSTEM:
+                    if db_data.storage_method == models.StorageMethodChoice.FILE_SYSTEM and not (
+                        updated_honeypots.keys().isdisjoint(chunk_frames)
+                    ):
                         rq_id = f"segment_{db_segment.id}_write_chunk_{chunk_id}_{quality}"
                         rq_job = enqueue_create_chunk_job(
                             queue=queue,

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1690,15 +1690,13 @@ class JobValidationLayoutWriteSerializer(serializers.Serializer):
 
             # Update chunks
             job_frame_provider = JobFrameProvider(db_job)
-            updated_segment_chunk_ids = set(
+            updated_segment_chunk_ids = range(
                 # We store chunk update dates only per segment,
                 # so we invalidate all the chunks in the segment.
                 # This allows the cache to check the chunk timestamps before returning them.
                 # Change the granularity to per chunk, if the performance is bad.
-                range(
-                    job_frame_provider.get_chunk_number(db_segment.start_frame),
-                    job_frame_provider.get_chunk_number(db_segment.stop_frame),
-                )
+                job_frame_provider.get_chunk_number(db_segment.start_frame),
+                job_frame_provider.get_chunk_number(db_segment.stop_frame),
             )
             segment_frames = sorted(segment_frame_set)
             segment_frame_map = dict(zip(segment_honeypots, requested_frames))

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1694,8 +1694,8 @@ class JobValidationLayoutWriteSerializer(serializers.Serializer):
                 # so we invalidate all the chunks in the segment.
                 # This allows the cache to check the chunk timestamps before returning them.
                 # Change the granularity to per chunk, if the performance is bad.
-                job_frame_provider.get_chunk_number(db_segment.start_frame),
-                job_frame_provider.get_chunk_number(db_segment.stop_frame),
+                job_frame_provider.get_chunk_number(min(segment_frame_set)),
+                job_frame_provider.get_chunk_number(max(segment_frame_set)) + 1,
             )
             segment_frames = sorted(segment_frame_set)
             segment_frame_map = dict(zip(segment_honeypots, requested_frames))

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -2,8 +2,89 @@
 #
 # SPDX-License-Identifier: MIT
 
+import pytest
+from pytest_cases import NOT_USED
+
 # Force execution of fixture definitions
 from shared.fixtures.data import *  # pylint: disable=wildcard-import
 from shared.fixtures.init import *  # pylint: disable=wildcard-import
 from shared.fixtures.s3 import *  # pylint: disable=wildcard-import
 from shared.fixtures.util import *  # pylint: disable=wildcard-import
+
+# Any value that cannot collide with a real parameter index, which pytest numbers from 0.
+_NOT_USED_PARAM_INDEX = -1
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items):
+    """
+    Workaround the conflict between pytest_cases.fixture(), pytest_cases.parametrize(),
+    and fixture scope > "function": using them together results in the fixture scope being
+    ignored, so that, e.g., a class-scoped fixture is launched repeatedly for each depending
+    test case.
+
+    The workaround gives deactivated fixture union alternatives a parameter index of their own,
+    so that pytest can group test nodes by the fixtures they actually use, as intended.
+
+    `@parametrize("...", [fixture_ref(...), ...])` builds a fixture union, which puts
+    every alternative into the fixture closure of every test of the class.
+    https://smarie.github.io/python-pytest-cases/unions_theory
+    https://smarie.github.io/python-pytest-cases/pytest_goodies/#parametrize
+
+    For the test nodes where an alternative is not the selected one, pytest-cases
+    deactivates it by parametrizing it with a single dummy `NOT_USED` value:
+    https://github.com/smarie/python-pytest-cases/blob/3.10.1/src/pytest_cases/plugin.py#L1149-L1153
+
+    That dummy is injected as a new single-value parametrization, and `Metafunc.parametrize()`
+    numbers the values it is given from 0, so `callspec.indices` ends up holding 0 both for
+    the real parameter and for the deactivated one. pytest groups test nodes by that index,
+    so it cannot distinguish between these two, and leaves the alternatives interleaved:
+    https://github.com/pytest-dev/pytest/blob/9.0.3/src/_pytest/fixtures.py#L187
+
+    Interleaving is not just a missed optimization. A *parametrized* fixture is cached by
+    pytest under its parameter value, so alternating between the real value and `NOT_USED`
+    invalidates the cache and tears the fixture down between two consecutive uses. A
+    class-scoped parametrized fixture is then re-created for every test in the class - in
+    this suite, one full task creation per test.
+    https://github.com/pytest-dev/pytest/blob/9.0.3/src/_pytest/fixtures.py#L1119-L1120
+
+    Correcting the index is enough: pytest's own `reorder_items()` then groups the nodes and
+    each fixture is set up once per parameter combination. `callspec` is a frozen dataclass,
+    but `indices` is a plain dict, and pytest-cases already writes to it the same way for the
+    function-scoped fixtures it deactivates:
+    https://github.com/smarie/python-pytest-cases/blob/3.10.1/src/pytest_cases/plugin.py#L1167
+    https://github.com/pytest-dev/pytest/blob/9.0.3/src/_pytest/fixtures.py#L217
+
+    The index is also reported as `request.param_index` to the fixture, which is harmless
+    here. A deactivated fixture returns (or yields) `NOT_USED` before its body runs, and the
+    check it does that on reads `request.param`, never the index; pytest likewise keys the
+    fixture cache on `request.param`:
+    https://github.com/smarie/python-pytest-cases/blob/3.10.1/src/pytest_cases/fixture_core2.py#L567-L569
+    https://github.com/smarie/python-pytest-cases/blob/3.10.1/src/pytest_cases/fixture_core1_unions.py#L203-L213
+
+    Unparametrized fixtures are unaffected by the issue. They have no parameter, so their cache key
+    is constant and their scope is already honoured.
+
+    The same defect was reported and fixed for *unparametrized* session- and module-scoped
+    fixtures in pytest-cases 2.1.0, by restricting the dummy-parameter hack to function-scoped
+    fixtures. The neighbouring branch that handles parametrized fixtures never got that scope
+    guard, and cannot trivially get it: a parametrized fixture must carry some parameter
+    value, and any value other than the real one busts the cache key.
+    https://github.com/smarie/python-pytest-cases/issues/120
+    https://github.com/smarie/python-pytest-cases/blob/3.10.1/src/pytest_cases/plugin.py#L1128
+
+    Regrouping these nodes is also what pytest-cases has open as a TODO of its own:
+    https://github.com/smarie/python-pytest-cases/blob/3.10.1/src/pytest_cases/plugin.py#L1523
+
+    `pytest_collection_modifyitems` receives every collected item once the
+    conftest is loaded. It must run before pytest reorders, hence `tryfirst`.
+    https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_collection_modifyitems
+    """
+    for item in items:
+        callspec = getattr(item, "callspec", None)
+        if callspec is None:
+            continue
+
+        for argname, value in callspec.params.items():
+            if value is NOT_USED:
+                callspec.indices[argname] = _NOT_USED_PARAM_INDEX

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -2,89 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
-import pytest
-from pytest_cases import NOT_USED
-
 # Force execution of fixture definitions
 from shared.fixtures.data import *  # pylint: disable=wildcard-import
 from shared.fixtures.init import *  # pylint: disable=wildcard-import
 from shared.fixtures.s3 import *  # pylint: disable=wildcard-import
 from shared.fixtures.util import *  # pylint: disable=wildcard-import
-
-# Any value that cannot collide with a real parameter index, which pytest numbers from 0.
-_NOT_USED_PARAM_INDEX = -1
-
-
-@pytest.hookimpl(tryfirst=True)
-def pytest_collection_modifyitems(items):
-    """
-    Workaround the conflict between pytest_cases.fixture(), pytest_cases.parametrize(),
-    and fixture scope > "function": using them together results in the fixture scope being
-    ignored, so that, e.g., a class-scoped fixture is launched repeatedly for each depending
-    test case.
-
-    The workaround gives deactivated fixture union alternatives a parameter index of their own,
-    so that pytest can group test nodes by the fixtures they actually use, as intended.
-
-    `@parametrize("...", [fixture_ref(...), ...])` builds a fixture union, which puts
-    every alternative into the fixture closure of every test of the class.
-    https://smarie.github.io/python-pytest-cases/unions_theory
-    https://smarie.github.io/python-pytest-cases/pytest_goodies/#parametrize
-
-    For the test nodes where an alternative is not the selected one, pytest-cases
-    deactivates it by parametrizing it with a single dummy `NOT_USED` value:
-    https://github.com/smarie/python-pytest-cases/blob/3.10.1/src/pytest_cases/plugin.py#L1149-L1153
-
-    That dummy is injected as a new single-value parametrization, and `Metafunc.parametrize()`
-    numbers the values it is given from 0, so `callspec.indices` ends up holding 0 both for
-    the real parameter and for the deactivated one. pytest groups test nodes by that index,
-    so it cannot distinguish between these two, and leaves the alternatives interleaved:
-    https://github.com/pytest-dev/pytest/blob/9.0.3/src/_pytest/fixtures.py#L187
-
-    Interleaving is not just a missed optimization. A *parametrized* fixture is cached by
-    pytest under its parameter value, so alternating between the real value and `NOT_USED`
-    invalidates the cache and tears the fixture down between two consecutive uses. A
-    class-scoped parametrized fixture is then re-created for every test in the class - in
-    this suite, one full task creation per test.
-    https://github.com/pytest-dev/pytest/blob/9.0.3/src/_pytest/fixtures.py#L1119-L1120
-
-    Correcting the index is enough: pytest's own `reorder_items()` then groups the nodes and
-    each fixture is set up once per parameter combination. `callspec` is a frozen dataclass,
-    but `indices` is a plain dict, and pytest-cases already writes to it the same way for the
-    function-scoped fixtures it deactivates:
-    https://github.com/smarie/python-pytest-cases/blob/3.10.1/src/pytest_cases/plugin.py#L1167
-    https://github.com/pytest-dev/pytest/blob/9.0.3/src/_pytest/fixtures.py#L217
-
-    The index is also reported as `request.param_index` to the fixture, which is harmless
-    here. A deactivated fixture returns (or yields) `NOT_USED` before its body runs, and the
-    check it does that on reads `request.param`, never the index; pytest likewise keys the
-    fixture cache on `request.param`:
-    https://github.com/smarie/python-pytest-cases/blob/3.10.1/src/pytest_cases/fixture_core2.py#L567-L569
-    https://github.com/smarie/python-pytest-cases/blob/3.10.1/src/pytest_cases/fixture_core1_unions.py#L203-L213
-
-    Unparametrized fixtures are unaffected by the issue. They have no parameter, so their cache key
-    is constant and their scope is already honoured.
-
-    The same defect was reported and fixed for *unparametrized* session- and module-scoped
-    fixtures in pytest-cases 2.1.0, by restricting the dummy-parameter hack to function-scoped
-    fixtures. The neighbouring branch that handles parametrized fixtures never got that scope
-    guard, and cannot trivially get it: a parametrized fixture must carry some parameter
-    value, and any value other than the real one busts the cache key.
-    https://github.com/smarie/python-pytest-cases/issues/120
-    https://github.com/smarie/python-pytest-cases/blob/3.10.1/src/pytest_cases/plugin.py#L1128
-
-    Regrouping these nodes is also what pytest-cases has open as a TODO of its own:
-    https://github.com/smarie/python-pytest-cases/blob/3.10.1/src/pytest_cases/plugin.py#L1523
-
-    `pytest_collection_modifyitems` receives every collected item once the
-    conftest is loaded. It must run before pytest reorders, hence `tryfirst`.
-    https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_collection_modifyitems
-    """
-    for item in items:
-        callspec = getattr(item, "callspec", None)
-        if callspec is None:
-            continue
-
-        for argname, value in callspec.params.items():
-            if value is NOT_USED:
-                callspec.indices[argname] = _NOT_USED_PARAM_INDEX

--- a/tests/python/rest_api/_test_base.py
+++ b/tests/python/rest_api/_test_base.py
@@ -246,12 +246,8 @@ class TestTasksBase:
             request, start_frame=start_frame, step=step
         )
 
-    def _images_task_with_honeypots_and_changed_real_frames_base(
-        self, request: pytest.FixtureRequest, **kwargs
-    ):
-        task_spec, task_id = self._image_task_with_honeypots_and_segments_base(
-            request, start_frame=2, step=3, **kwargs
-        )
+    def _rotate_all_task_honeypots(self, task_spec: ITaskSpec, task_id: int) -> None:
+        "Updates the passed task and task spec inplace"
 
         with make_api_client(self._USERNAME) as api_client:
             validation_layout, _ = api_client.tasks_api.retrieve_validation_layout(task_id)
@@ -277,7 +273,16 @@ class TestTasksBase:
             _get_frame = task_spec._get_frame
             task_spec._get_frame = lambda i: _get_frame(frame_map.get(i, i))
 
-            return task_spec, task_id
+    def _images_task_with_honeypots_and_changed_real_frames_base(
+        self, request: pytest.FixtureRequest, **kwargs
+    ):
+        task_spec, task_id = self._image_task_with_honeypots_and_segments_base(
+            request, start_frame=2, step=3, **kwargs
+        )
+
+        self._rotate_all_task_honeypots(task_spec=task_spec, task_id=task_id)
+
+        return task_spec, task_id
 
     @fixture(scope="class")
     @parametrize("random_seed", [1, 2, 5])

--- a/tests/python/rest_api/test_task_data.py
+++ b/tests/python/rest_api/test_task_data.py
@@ -27,7 +27,7 @@ from cvat_sdk.api_client import models
 from cvat_sdk.core.helpers import get_paginated_collection
 from deepdiff import DeepDiff
 from PIL import Image
-from pytest_cases import fixture_ref, parametrize
+from pytest_cases import fixture, fixture_ref, parametrize
 
 import shared.utils.s3 as s3
 from rest_api._test_base import TestTasksBase
@@ -1954,23 +1954,86 @@ class TestTaskData(TestTasksBase):
                 index=0,
             )
 
+    def _ensure_task_has_mixed_job_chunk_counts(self, task_id: int) -> None:
+        "Check the task has both jobs with both 1 and multiple chunks"
+
+        with make_api_client(self._USERNAME) as api_client:
+            annotation_jobs = [
+                job
+                for job in get_paginated_collection(
+                    api_client.jobs_api.list_endpoint, task_id=task_id
+                )
+                if job.type == "annotation"
+            ]
+            assert annotation_jobs
+
+            chunk_counts = set()
+            for job in annotation_jobs:
+                job_meta, _ = api_client.jobs_api.retrieve_data_meta(job.id)
+                chunk_counts.add(math.ceil(job_meta.size / job_meta.chunk_size))
+
+            assert min(chunk_counts) == 1 and max(chunk_counts) > 1, (
+                "The task must have both single-chunk and multi-chunk jobs, "
+                f"got job chunk counts {sorted(chunk_counts)}"
+            )
+
+    def _image_task_with_honeypots_and_mixed_job_chunk_counts_base(
+        self, request: pytest.FixtureRequest, **kwargs
+    ) -> tuple[ITaskSpec, int]:
+        "The task to check for regressions on https://github.com/cvat-ai/cvat/issues/11006"
+
+        # The chunk size is picked so that the task has both single-chunk and multi-chunk jobs:
+        # the regular jobs have 4 + 2 honeypot frames, and the last one has 2 + 2.
+        # Honeypots are placed randomly inside a job, so both the first and the last chunk
+        # of a job can contain them.
+        task_spec, task_id = self._image_task_with_honeypots_and_segments_base(
+            request, chunk_size=4, **kwargs
+        )
+        self._ensure_task_has_mixed_job_chunk_counts(task_id)
+        return task_spec, task_id
+
+    @fixture(scope="class")
+    @parametrize(
+        "static_cache_enabled",
+        [
+            pytest.param(
+                to_bool(os.getenv("CVAT_ALLOW_STATIC_CACHE", False)),
+                marks=[
+                    pytest.mark.skipif(
+                        not to_bool(os.getenv("CVAT_ALLOW_STATIC_CACHE", False)),
+                        reason="This test covers only the static cache."
+                        "Check test_all_job_chunks_available_after_honeypot_frame_change()"
+                        "for the dynamic cache case.",
+                    )
+                ],
+            ),
+        ],
+    )
+    def fxt_uploaded_images_task_with_honeypots_mixed_job_chunk_counts_and_changed_honeypots(
+        self, request: pytest.FixtureRequest, *, static_cache_enabled: bool
+    ) -> tuple[ITaskSpec, int]:
+        "The task to check for regressions on https://github.com/cvat-ai/cvat/issues/11006"
+
+        assert static_cache_enabled
+        task_spec, task_id = self._image_task_with_honeypots_and_mixed_job_chunk_counts_base(
+            request
+        )
+        self._rotate_all_task_honeypots(task_spec, task_id)
+        return task_spec, task_id
+
     @pytest.mark.timeout(300)
+    @pytest.mark.skipif(
+        to_bool(os.getenv("CVAT_ALLOW_STATIC_CACHE", False)),
+        reason="This test covers only the dynamic cache.",
+    )
     def test_all_job_chunks_available_after_honeypot_frame_change(
         self, request: pytest.FixtureRequest
     ):
-        # Check for regressions on https://github.com/cvat-ai/cvat/issues/11006
-
-        # Create a new task to be modified in the test
-        task_spec, task_id = self._image_task_with_honeypots_and_segments_base(request)
+        task_spec, task_id = self._image_task_with_honeypots_and_mixed_job_chunk_counts_base(
+            request
+        )
 
         with make_api_client(self._USERNAME) as api_client:
-            task_meta, _ = api_client.tasks_api.retrieve_data_meta(task_id)
-            validation_layout, _ = api_client.tasks_api.retrieve_validation_layout(task_id)
-            honeypot_abs_frames = {
-                rel_frame: rel_frame * task_spec.frame_step + task_meta.start_frame
-                for rel_frame in validation_layout.honeypot_frames
-            }  # { rel_frame -> abs_frame }
-
             annotation_jobs = sorted(
                 (
                     job
@@ -1981,68 +2044,35 @@ class TestTaskData(TestTasksBase):
                 ),
                 key=lambda job: job.start_frame,
             )
-            assert annotation_jobs
 
+            job_chunk_ids: dict[int, Sequence[int]] = {}
             for job in annotation_jobs:
                 job_meta, _ = api_client.jobs_api.retrieve_data_meta(job.id)
-                job_chunk_ids = set(range(math.ceil(job_meta.size / job_meta.chunk_size)))
-                job_honeypot_chunk_ids = {
-                    (abs_frame - job_meta.start_frame)
-                    // task_spec.frame_step
-                    // job_meta.chunk_size
-                    for abs_frame in honeypot_abs_frames
-                }
-                job_non_honeypot_chunk_ids = job_chunk_ids - job_honeypot_chunk_ids
-                if not job_honeypot_chunk_ids or not job_non_honeypot_chunk_ids:
-                    continue
+                job_chunk_ids[job.id] = range(math.ceil(job_meta.size / job_meta.chunk_size))
 
-            assert (
-                job_non_honeypot_chunk_ids and job_honeypot_chunk_ids
-            ), "Can't find a suitable job for the test"
+            def _read_all_chunks():
+                for job_id, chunk_ids in job_chunk_ids.items():
+                    for chunk_id, quality in product(chunk_ids, ("original", "compressed")):
+                        _, response = api_client.jobs_api.retrieve_data(
+                            job_id,
+                            type="chunk",
+                            quality=quality,
+                            index=chunk_id,
+                            _check_status=False,
+                            _parse_response=False,
+                        )
+                        assert (
+                            response.status == HTTPStatus.OK
+                        ), f"{job_id=}, {chunk_id=} of {sorted(chunk_ids)}, {quality=}"
 
-            unchanged_chunk_id = min(job_non_honeypot_chunk_ids)
-
-            # Initialize the chunk in the cache
-            for quality in ("original", "compressed"):
-                _, response = api_client.jobs_api.retrieve_data(
-                    job.id,
-                    type="chunk",
-                    quality=quality,
-                    index=unchanged_chunk_id,
-                    _parse_response=False,
-                )
-                assert response.status == HTTPStatus.OK
+            # Initialize chunks in the cache
+            _read_all_chunks()
 
             # Update honeypots
-            validation_frames = validation_layout.validation_frames
-            new_honeypot_real_frames = [
-                validation_frames[(validation_frames.index(frame) + 1) % len(validation_frames)]
-                for frame in validation_layout.honeypot_real_frames
-            ]
-
-            _, response = api_client.tasks_api.partial_update_validation_layout(
-                task_id,
-                patched_task_validation_layout_write_request=(
-                    models.PatchedTaskValidationLayoutWriteRequest(
-                        frame_selection_method="manual",
-                        honeypot_real_frames=new_honeypot_real_frames,
-                    )
-                ),
-                _parse_response=False,
-            )
-            assert response.status == HTTPStatus.OK
+            self._rotate_all_task_honeypots(task_spec, task_id)
 
             # Check all the chunks are still available
-            for quality in ("original", "compressed"):
-                _, response = api_client.jobs_api.retrieve_data(
-                    job.id,
-                    type="chunk",
-                    quality=quality,
-                    index=unchanged_chunk_id,
-                    _check_status=False,
-                    _parse_response=False,
-                )
-                assert response.status == HTTPStatus.OK
+            _read_all_chunks()
 
     @parametrize("task_spec, task_id", TestTasksBase._all_task_cases)
     def test_can_get_task_meta(self, task_spec: ITaskSpec, task_id: int):
@@ -2436,7 +2466,15 @@ class TestTaskData(TestTasksBase):
         # This test has to check all the job frames availability, it can make many requests
         timeout=300
     )
-    @parametrize("task_spec, task_id", TestTasksBase._2d_task_cases)
+    @parametrize(
+        "task_spec, task_id",
+        TestTasksBase._2d_task_cases
+        + [
+            fixture_ref(
+                fxt_uploaded_images_task_with_honeypots_mixed_job_chunk_counts_and_changed_honeypots
+            )
+        ],
+    )
     def test_can_get_job_frames(self, task_spec: ITaskSpec, task_id: int):
         with make_api_client(self._USERNAME) as api_client:
             jobs = sorted(

--- a/tests/python/rest_api/test_task_data.py
+++ b/tests/python/rest_api/test_task_data.py
@@ -1916,9 +1916,8 @@ class TestTaskData(TestTasksBase):
             f"bytes 0-{len(full_chunk) - 1}/{len(full_chunk)}"
         )
 
-    def test_can_get_data_chunk_byte_ranges(self, fxt_uploaded_images_task: tuple[ITaskSpec, int]):
-        _, task_id = fxt_uploaded_images_task
-
+    @parametrize("task_spec, task_id", [fixture_ref("fxt_uploaded_images_task")])
+    def test_can_get_data_chunk_byte_ranges(self, task_spec: ITaskSpec, task_id: int):
         with make_api_client(self._USERNAME) as api_client:
             _, task_chunk_response = api_client.tasks_api.retrieve_data(
                 task_id, type="chunk", quality="compressed", number=0, _parse_response=False
@@ -1956,13 +1955,13 @@ class TestTaskData(TestTasksBase):
             )
 
     @pytest.mark.timeout(300)
-    @parametrize(
-        "task_spec, task_id", [fixture_ref("fxt_uploaded_images_task_with_honeypots_and_segments")]
-    )
     def test_all_job_chunks_available_after_honeypot_frame_change(
-        self, task_spec: ITaskSpec, task_id: int
+        self, request: pytest.FixtureRequest
     ):
         # Check for regressions on https://github.com/cvat-ai/cvat/issues/11006
+
+        # Create a new task to be modified in the test
+        task_spec, task_id = self._image_task_with_honeypots_and_segments_base(request)
 
         with make_api_client(self._USERNAME) as api_client:
             task_meta, _ = api_client.tasks_api.retrieve_data_meta(task_id)

--- a/tests/python/rest_api/test_task_data.py
+++ b/tests/python/rest_api/test_task_data.py
@@ -27,7 +27,7 @@ from cvat_sdk.api_client import models
 from cvat_sdk.core.helpers import get_paginated_collection
 from deepdiff import DeepDiff
 from PIL import Image
-from pytest_cases import parametrize
+from pytest_cases import fixture_ref, parametrize
 
 import shared.utils.s3 as s3
 from rest_api._test_base import TestTasksBase
@@ -1824,9 +1824,9 @@ class TestPostTaskData:
 
 @pytest.mark.usefixtures("restore_db_per_class")
 @pytest.mark.usefixtures("restore_cvat_data_per_class")
-@pytest.mark.usefixtures("restore_redis_ondisk_per_function")
+@pytest.mark.usefixtures("restore_redis_ondisk_per_class")
 @pytest.mark.usefixtures("restore_redis_ondisk_after_class")
-@pytest.mark.usefixtures("restore_redis_inmem_per_function")
+@pytest.mark.usefixtures("restore_redis_inmem_per_class")
 class TestTaskData(TestTasksBase):
     @staticmethod
     def _retrieve_data_with_range(
@@ -1954,6 +1954,96 @@ class TestTaskData(TestTasksBase):
                 quality="compressed",
                 index=0,
             )
+
+    @pytest.mark.timeout(300)
+    @parametrize(
+        "task_spec, task_id", [fixture_ref("fxt_uploaded_images_task_with_honeypots_and_segments")]
+    )
+    def test_all_job_chunks_available_after_honeypot_frame_change(
+        self, task_spec: ITaskSpec, task_id: int
+    ):
+        # Check for regressions on https://github.com/cvat-ai/cvat/issues/11006
+
+        with make_api_client(self._USERNAME) as api_client:
+            task_meta, _ = api_client.tasks_api.retrieve_data_meta(task_id)
+            validation_layout, _ = api_client.tasks_api.retrieve_validation_layout(task_id)
+            honeypot_abs_frames = {
+                rel_frame: rel_frame * task_spec.frame_step + task_meta.start_frame
+                for rel_frame in validation_layout.honeypot_frames
+            }  # { rel_frame -> abs_frame }
+
+            annotation_jobs = sorted(
+                (
+                    job
+                    for job in get_paginated_collection(
+                        api_client.jobs_api.list_endpoint, task_id=task_id
+                    )
+                    if job.type == "annotation"
+                ),
+                key=lambda job: job.start_frame,
+            )
+            assert annotation_jobs
+
+            for job in annotation_jobs:
+                job_meta, _ = api_client.jobs_api.retrieve_data_meta(job.id)
+                job_chunk_ids = set(range(math.ceil(job_meta.size / job_meta.chunk_size)))
+                job_honeypot_chunk_ids = {
+                    (abs_frame - job_meta.start_frame)
+                    // task_spec.frame_step
+                    // job_meta.chunk_size
+                    for abs_frame in honeypot_abs_frames
+                }
+                job_non_honeypot_chunk_ids = job_chunk_ids - job_honeypot_chunk_ids
+                if not job_honeypot_chunk_ids or not job_non_honeypot_chunk_ids:
+                    continue
+
+            assert (
+                job_non_honeypot_chunk_ids and job_honeypot_chunk_ids
+            ), "Can't find a suitable job for the test"
+
+            unchanged_chunk_id = min(job_non_honeypot_chunk_ids)
+
+            # Initialize the chunk in the cache
+            for quality in ("original", "compressed"):
+                _, response = api_client.jobs_api.retrieve_data(
+                    job.id,
+                    type="chunk",
+                    quality=quality,
+                    index=unchanged_chunk_id,
+                    _parse_response=False,
+                )
+                assert response.status == HTTPStatus.OK
+
+            # Update honeypots
+            validation_frames = validation_layout.validation_frames
+            new_honeypot_real_frames = [
+                validation_frames[(validation_frames.index(frame) + 1) % len(validation_frames)]
+                for frame in validation_layout.honeypot_real_frames
+            ]
+
+            _, response = api_client.tasks_api.partial_update_validation_layout(
+                task_id,
+                patched_task_validation_layout_write_request=(
+                    models.PatchedTaskValidationLayoutWriteRequest(
+                        frame_selection_method="manual",
+                        honeypot_real_frames=new_honeypot_real_frames,
+                    )
+                ),
+                _parse_response=False,
+            )
+            assert response.status == HTTPStatus.OK
+
+            # Check all the chunks are still available
+            for quality in ("original", "compressed"):
+                _, response = api_client.jobs_api.retrieve_data(
+                    job.id,
+                    type="chunk",
+                    quality=quality,
+                    index=unchanged_chunk_id,
+                    _check_status=False,
+                    _parse_response=False,
+                )
+                assert response.status == HTTPStatus.OK
 
     @parametrize("task_spec, task_id", TestTasksBase._all_task_cases)
     def test_can_get_task_meta(self, task_spec: ITaskSpec, task_id: int):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Fixes #11006 

There are 2 possible solutions: update all the segment chunks or store per chunk update dates in the DB. This PR implements the first option to minimize the impact. The honeypot update operation is quite rare, so it's not expected to affect the performance significantly.

The problem wasn't observed earlier because the test suite had per function kvrocks cleanup, which cleaned the cache, hiding the error.

- Honeypot updates now invalidate all the segment chunks instead of only the chunks with honeypot changes

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Unit tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
