### PR TITLE
add chunks logs to rest api tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -231,6 +231,7 @@ jobs:
             docker logs test_cvat_worker_consensus_1 > $LOGS_DIR/cvat_worker_consensus.log
             docker logs test_cvat_worker_webhooks_1 > $LOGS_DIR/cvat_worker_webhooks.log
             docker logs test_cvat_worker_export_1 > $LOGS_DIR/cvat_worker_export.log
+            docker logs test_cvat_worker_chunks_1 > $LOGS_DIR/cvat_worker_chunks.log
             docker logs test_cvat_redis_inmem_1 > $LOGS_DIR/cvat_redis_inmem.log
             docker logs test_cvat_redis_ondisk_1 > $LOGS_DIR/cvat_redis_ondisk.log
 


### PR DESCRIPTION
#10839 didn't keep chunks worker logs after rest api testing. This fixes that

needed to investigate failures like
- https://github.com/cvat-ai/cvat/actions/runs/30669830821/job/91285310979
- https://github.com/cvat-ai/cvat/actions/runs/31089064559