### PR TITLE
e2e test ground_truth_jobs.js: fix racing in annotation mode dropdown

### DIFF
--- a/tests/cypress/e2e/features2/ground_truth_jobs.js
+++ b/tests/cypress/e2e/features2/ground_truth_jobs.js
@@ -484,7 +484,7 @@ context('Ground truth jobs', () => {
                 });
             });
 
-            it('Check GT annotation source in GT job and regular job review overlay', { scrollBehavior: false }, () => {
+            it.only('Check GT annotation source in GT job and regular job review overlay', { scrollBehavior: false }, () => {
                 const [frame] = groundTruthFrames;
                 const [rectangle] = groundTruthRectangles;
 
@@ -519,16 +519,21 @@ context('Ground truth jobs', () => {
                     cy.get('body').trigger('mouseup');
                     checkCanvasObjectSource(rectangle, 'semi-auto', 'Ground truth');
 
-                    cy.visit(`/tasks/${taskId}/jobs/${jobId}`);
-                    cy.get('.cvat-spinner').should('not.exist');
+                    cy.visit(
+                        `/tasks/${taskId}/jobs/${jobId}?defaultWorkspace=REVIEW&frame=${frame}`,
+                    );
                     cy.get('.cvat-canvas-container').should('exist').and('be.visible');
-                    cy.get('.cvat-workspace-selector').should('exist').and('be.visible');
-                    cy.changeWorkspace('Review');
-                    cy.get('.cvat-objects-sidebar-show-ground-truth').click();
+                    cy.get('#cvat_canvas_background').should('exist').and('be.visible');
+                    cy.get('.cvat-workspace-selector')
+                        .should('be.visible')
+                        .and('contain.text', 'Review');
+                    cy.checkFrameNum(frame);
+                    cy.get('.cvat-objects-sidebar-show-ground-truth')
+                        .should('be.visible')
+                        .click();
                     cy.get('.cvat-objects-sidebar-show-ground-truth').should(
                         'have.class', 'cvat-objects-sidebar-show-ground-truth-active',
                     );
-                    cy.goCheckFrameNumber(frame);
                     checkRectangleAndObjectMenu(rectangle);
                     checkCanvasObjectSource(rectangle, 'Ground truth', 'auto');
                     cy.get(`#cvat-objects-sidebar-state-item-${rectangle.id}`)

--- a/tests/cypress/e2e/features2/ground_truth_jobs.js
+++ b/tests/cypress/e2e/features2/ground_truth_jobs.js
@@ -484,7 +484,7 @@ context('Ground truth jobs', () => {
                 });
             });
 
-            it.only('Check GT annotation source in GT job and regular job review overlay', { scrollBehavior: false }, () => {
+            it('Check GT annotation source in GT job and regular job review overlay', { scrollBehavior: false }, () => {
                 const [frame] = groundTruthFrames;
                 const [rectangle] = groundTruthRectangles;
 


### PR DESCRIPTION
`ground_truth_jobs.js` always fails with same problem: annotation mode dropdown gets clicked too early until the page is ready. Diagnostics was hampered by uninformative screenshots and choppy videos where no error is shown, and the logs saying the element disappared from page whilst the server logs showed successful requests all round

<img width="1280" height="577" alt="Ground truth jobs -- Regression tests -- GT jobs from images -- Check GT annotation source in GT job and regular job review overlay (failed)" src="https://github.com/user-attachments/assets/ee87d265-5fc2-4301-a9bc-5963498d4092" />

 No retry-based fixes worked for this case, so I use `defaultWorkspace` UI param to circumvent the dropdown. The dropdown is proven to work correctly in the dedicated tests, so we don't need to commit to clicking on it every time.

If the fix proves to last, will refactor similar places to use the parameter in the next pr and where the annotation mode dropdown is not the main element under test