### PR TITLE
Add task and project detail extension points for UI plugins

### DIFF
--- a/cvat-ui/src/actions/plugins-actions.ts
+++ b/cvat-ui/src/actions/plugins-actions.ts
@@ -34,13 +34,13 @@ export const pluginActions = {
     ),
     addUIComponent: (
         path: string,
-        component: React.Component,
+        component: React.ComponentType<any>,
         data: {
             weight?: number;
             shouldBeRendered?: (props?: object, state?: object) => boolean;
         } = {},
     ) => createAction(PluginsActionTypes.ADD_UI_COMPONENT, { path, component, data }),
-    removeUIComponent: (path: string, component: React.Component) => createAction(
+    removeUIComponent: (path: string, component: React.ComponentType<any>) => createAction(
         PluginsActionTypes.REMOVE_UI_COMPONENT, { path, component },
     ),
     addUICallback: (

--- a/cvat-ui/src/components/project-page/details.tsx
+++ b/cvat-ui/src/components/project-page/details.tsx
@@ -14,6 +14,8 @@ import LabelsEditor from 'components/labels-editor/labels-editor';
 import BugTrackerEditor from 'components/task-page/bug-tracker-editor';
 import UserSelector from 'components/task-page/user-selector';
 import MdGuideControl from 'components/md-guide/md-guide-control';
+import { CombinedState } from 'reducers';
+import { usePlugins } from 'utils/hooks';
 
 const core = getCore();
 
@@ -25,10 +27,14 @@ interface DetailsComponentProps {
 export default function DetailsComponent(props: DetailsComponentProps): JSX.Element {
     const { project, onUpdateProject } = props;
     const [projectName, setProjectName] = useState(project.name);
+    const extras = usePlugins(
+        (state: CombinedState) => state.plugins.components.projectPage.details.topBar.extras,
+        props,
+    );
 
     return (
         <div data-cvat-project-id={project.id} className='cvat-project-details'>
-            <Row>
+            <Row justify='space-between' align='middle'>
                 <Col>
                     <Title
                         level={4}
@@ -43,6 +49,13 @@ export default function DetailsComponent(props: DetailsComponentProps): JSX.Elem
                     >
                         {projectName}
                     </Title>
+                </Col>
+                <Col>
+                    {extras.sort((left, right) => left.weight - right.weight).map(({
+                        component: Component,
+                    }, index) => (
+                        <Component key={index} targetProps={props} />
+                    ))}
                 </Col>
             </Row>
             <Row justify='space-between' className='cvat-project-description'>

--- a/cvat-ui/src/components/project-page/styles.scss
+++ b/cvat-ui/src/components/project-page/styles.scss
@@ -49,6 +49,12 @@
     margin: $grid-unit-size * 2 0;
     background: $background-color-1;
 
+    > div:first-child {
+        // title and extras
+        display: flex;
+        align-items: start;
+    }
+
     .cvat-project-name {
         margin: 0;
         margin-bottom: $grid-unit-size * 2;

--- a/cvat-ui/src/components/task-page/details.tsx
+++ b/cvat-ui/src/components/task-page/details.tsx
@@ -20,6 +20,7 @@ import Preview from 'components/common/preview';
 import { cancelInferenceAsync } from 'actions/models-actions';
 import { CombinedState, ActiveInference } from 'reducers';
 import CVATTag, { TagType } from 'components/common/cvat-tag';
+import { usePlugins } from 'utils/hooks';
 import UserSelector from './user-selector';
 import BugTrackerEditor from './bug-tracker-editor';
 import CloudStorageEditor from './cloud-storage-editor';
@@ -69,6 +70,29 @@ interface State {
 }
 
 type Props = DispatchToProps & StateToProps & OwnProps;
+
+function DetailsTopBarExtras({ targetProps, targetState }: {
+    targetProps: Props;
+    targetState: State;
+}): JSX.Element {
+    // the component is used as a plugin entrypoint
+    // only implemented as a separated functional component in order to use usePlugins inside
+    const extras = usePlugins(
+        (state: CombinedState) => state.plugins.components.taskPage.details.topBar.extras,
+        targetProps,
+        targetState,
+    );
+
+    return (
+        <>
+            {extras.sort((left, right) => left.weight - right.weight).map(({
+                component: Component,
+            }, index) => (
+                <Component key={index} targetProps={targetProps} targetState={targetState} />
+            ))}
+        </>
+    );
+}
 
 class DetailsComponent extends React.PureComponent<Props, State> {
     constructor(props: Props) {
@@ -128,6 +152,7 @@ class DetailsComponent extends React.PureComponent<Props, State> {
             cloudStorageInstance,
             onUpdateTaskMeta,
         } = this.props;
+
         const { consensusEnabled } = this.state;
         const owner = taskInstance.owner ? taskInstance.owner.username : null;
         const assignee = taskInstance.assignee ? taskInstance.assignee : null;
@@ -230,8 +255,11 @@ class DetailsComponent extends React.PureComponent<Props, State> {
 
         return (
             <div className='cvat-task-details'>
-                <Row justify='start' align='middle'>
+                <Row justify='space-between' align='middle'>
                     <Col className='cvat-task-details-task-name'>{this.renderTaskName()}</Col>
+                    <Col>
+                        <DetailsTopBarExtras targetProps={this.props} targetState={this.state} />
+                    </Col>
                 </Row>
                 <Row justify='space-between' align='top'>
                     <Col md={8} lg={7} xl={7} xxl={6}>

--- a/cvat-ui/src/components/task-page/styles.scss
+++ b/cvat-ui/src/components/task-page/styles.scss
@@ -30,6 +30,12 @@
             }
         }
 
+        > div:first-child {
+            // title and extras
+            display: flex;
+            align-items: start;
+        }
+
         > div:nth-child(2) {
             > div:nth-child(2) {
                 padding-left: 20px;

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -432,6 +432,20 @@ export interface PluginsState {
                 items: PluginComponent[];
             };
         }
+        taskPage: {
+            details: {
+                topBar: {
+                    extras: PluginComponent[];
+                };
+            };
+        };
+        projectPage: {
+            details: {
+                topBar: {
+                    extras: PluginComponent[];
+                };
+            };
+        };
         modelsPage: {
             topBar: {
                 items: PluginComponent[];

--- a/cvat-ui/src/reducers/plugins-reducer.ts
+++ b/cvat-ui/src/reducers/plugins-reducer.ts
@@ -62,6 +62,20 @@ const defaultState: PluginsState = {
                 items: [],
             },
         },
+        taskPage: {
+            details: {
+                topBar: {
+                    extras: [],
+                },
+            },
+        },
+        projectPage: {
+            details: {
+                topBar: {
+                    extras: [],
+                },
+            },
+        },
         modelsPage: {
             topBar: {
                 items: [],

--- a/cvat-ui/src/utils/event-recorder.ts
+++ b/cvat-ui/src/utils/event-recorder.ts
@@ -15,12 +15,6 @@ interface Logger {
     log(...parameters: Parameters<typeof core.logger.log>): ReturnType<typeof core.logger['log']>;
 }
 
-export interface ImmediateMouseEventContext {
-    task_id?: number;
-    project_id?: number;
-    organization?: number;
-}
-
 const defaultLogger: Logger = core.logger;
 
 // the class is responsible for logging general mouse events
@@ -62,34 +56,6 @@ class EventRecorder {
                 obj_name: this.filterClassName(elementToRecord.className),
                 location: window.location.pathname,
             }, false);
-        }
-    }
-
-    public async recordMouseEventImmediately(
-        event: MouseEvent,
-        cssClass: string,
-        context: ImmediateMouseEventContext,
-    ): Promise<void> {
-        const elementToRecord = this.isEventToBeRecorded(event.target as HTMLElement | null, [cssClass]);
-        if (!elementToRecord) {
-            throw new Error(`Could not find the clicked element with class "${cssClass}"`);
-        }
-
-        const recordedEvent = await core.logger.log(EventScope.clickElement, {
-            obj_val: elementToRecord.innerText,
-            obj_name: this.filterClassName(elementToRecord.className),
-            location: window.location.pathname,
-            ...context,
-        }, false);
-
-        try {
-            await core.logger.save();
-        } catch (error: unknown) {
-            const eventIndex = core.logger.collection.indexOf(recordedEvent);
-            if (eventIndex !== -1) {
-                core.logger.collection.splice(eventIndex, 1);
-            }
-            throw error;
         }
     }
 

--- a/cvat-ui/src/utils/event-recorder.ts
+++ b/cvat-ui/src/utils/event-recorder.ts
@@ -15,6 +15,12 @@ interface Logger {
     log(...parameters: Parameters<typeof core.logger.log>): ReturnType<typeof core.logger['log']>;
 }
 
+export interface ImmediateMouseEventContext {
+    task_id?: number;
+    project_id?: number;
+    organization?: number;
+}
+
 const defaultLogger: Logger = core.logger;
 
 // the class is responsible for logging general mouse events
@@ -56,6 +62,34 @@ class EventRecorder {
                 obj_name: this.filterClassName(elementToRecord.className),
                 location: window.location.pathname,
             }, false);
+        }
+    }
+
+    public async recordMouseEventImmediately(
+        event: MouseEvent,
+        cssClass: string,
+        context: ImmediateMouseEventContext,
+    ): Promise<void> {
+        const elementToRecord = this.isEventToBeRecorded(event.target as HTMLElement | null, [cssClass]);
+        if (!elementToRecord) {
+            throw new Error(`Could not find the clicked element with class "${cssClass}"`);
+        }
+
+        const recordedEvent = await core.logger.log(EventScope.clickElement, {
+            obj_val: elementToRecord.innerText,
+            obj_name: this.filterClassName(elementToRecord.className),
+            location: window.location.pathname,
+            ...context,
+        }, false);
+
+        try {
+            await core.logger.save();
+        } catch (error: unknown) {
+            const eventIndex = core.logger.collection.indexOf(recordedEvent);
+            if (eventIndex !== -1) {
+                core.logger.collection.splice(eventIndex, 1);
+            }
+            throw error;
         }
     }
 

--- a/cvat-ui/src/utils/hooks.ts
+++ b/cvat-ui/src/utils/hooks.ts
@@ -56,8 +56,8 @@ export function usePlugins(
             component,
             weight: data.weight,
         }));
-    const ref = useRef<Plugin[]>(mappedComponents);
 
+    const ref = useRef<Plugin[]>(mappedComponents);
     if (!_.isEqual(ref.current, mappedComponents)) {
         ref.current = mappedComponents;
     }

--- a/cvat-ui/webpack.config.js
+++ b/cvat-ui/webpack.config.js
@@ -226,7 +226,7 @@ module.exports = (env, argv = {}) => {
                         to  : 'assets/[name][ext]',
                     },
                     {
-                        from: 'plugins/**/assets/*.(onnx|js)',
+                        from: 'plugins/**/assets/*.(onnx|js|png)',
                         to  : 'assets/[name][ext]',
                     },
                 ],


### PR DESCRIPTION
### Motivation and context

UI plugins need a generic way to contribute controls to task and project detail headers without modifying the corresponding page components.

This PR:

- Adds `taskPage.details.topBar.extras` and `projectPage.details.topBar.extras` extension points.
- Renders registered components beside task and project titles in weight order.
- Passes the relevant page props and state to plugin components.
- Uses `React.ComponentType` for registered UI component types.
- Supports copying PNG assets from UI plugins during webpack builds.
- Adjusts task and project header layouts to accommodate extension content.

### How has this been tested?

- Manually
### Checklist

- [x] I submit my changes into the `develop` branch
- [ ] ~~I have created a changelog fragment~~
- [ ] ~~I have updated the documentation accordingly~~
- [ ] ~~I have added tests to cover my changes~~
- [ ] ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that’s a concern.