### PR TITLE
harden org menu for new_organinzation_pipeline

### DIFF
--- a/tests/cypress/support/commands_organizations.js
+++ b/tests/cypress/support/commands_organizations.js
@@ -10,13 +10,13 @@ import { convertClasses } from './utils';
 function openOrganizationsMenu() {
     cy.get('.cvat-header-menu-user-dropdown')
         .should('exist').and('be.visible').click();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(500); // animation
+    cy.get('.cvat-header-menu').should('be.visible');
     cy.get('.cvat-header-menu')
-        .should('exist')
-        .and('be.visible')
         .find('[role="menuitem"]')
         .filter(':contains("Organization")')
+        .should('exist')
+        .and('be.visible')
         .click();
 }
 


### PR DESCRIPTION
#10985 didn't account for dropdown flake in organization menu, so the spinner assertions were not enough.
On close inspection, the `openOrganizationsMenu` does not assert on the filtered elements, added assertions after filtering. Also, added re-querying of the header menu to avoid DOM issues