### PR TITLE
Fixed height of list with labels mapping

### DIFF
--- a/changelog.d/20260814_082117_sekachev.bs_fixed_10228.md
+++ b/changelog.d/20260814_082117_sekachev.bs_fixed_10228.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed the label mapping list height in the model runner dialog, allowing long lists to be scrolled
+  (<https://github.com/cvat-ai/cvat/pull/11045>)

--- a/cvat-ui/src/components/model-runner-modal/styles.scss
+++ b/cvat-ui/src/components/model-runner-modal/styles.scss
@@ -41,7 +41,9 @@
 .cvat-runner-label-mapper {
     @extend .cvat-labels-attributes-mapper-tree;
 
-    width: 100%;
+    max-height: $grid-unit-size * 50;
+    overflow: auto;
+    width: calc(100% - $grid-unit-size);
 
     span {
         text-align: center;


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Solved #10228

Before:
<img width="566" height="943" alt="image" src="https://github.com/user-attachments/assets/df4b177d-fff9-4272-bc54-4748b3faaf77" />

After:
<img width="573" height="766" alt="image" src="https://github.com/user-attachments/assets/fae8b9aa-a542-4981-a778-88c91e8d0a77" />


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
