### PR TITLE
Deduplicate setup specs from second e2e cmdline in schedule.yml

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -300,7 +300,7 @@ jobs:
           echo "CYPRESS_ARGS=${CYPRESS_ARGS[*]}"
 
           yarn cypress run --headless "${CYPRESS_ARGS[@]}" --env coverage=false --spec "$CYPRESS_SETUP_SPECS" # if fail, further behavior is unpredictable
-          yarn cypress run --headed "${CYPRESS_ARGS[@]}" --spec "${CYPRESS_SETUP_SPECS},${CYPRESS_SPECS}"
+          yarn cypress run --headed "${CYPRESS_ARGS[@]}" --spec "${CYPRESS_SPECS}"
 
       - name: Creating a log file from "cvat" container logs
         if: failure()


### PR DESCRIPTION
#1000 left a double run, which consistently failed `actions_projects_models` suite 

#### Reason
Two identically named objects 'Delete this project' lead to `cy.click() returned multiple elements ...`, failing the test
<img width="1011" height="789" alt="image" src="https://github.com/user-attachments/assets/a52f7b10-8e7f-447b-9399-0c826ff535dd" />
On the picture we can see setup assets initialized twice, confirmed by the gh run logs as well
[857/job/94736396674](https://github.com/cvat-ai/cvat/actions/runs/31790497857/job/94736396674)

#### Fix
Remove CYPRESS_SETUP_SPECS from the second cmdline in schedule.yml

