### PR TITLE
Prevent deleted Lambda auto-annotation requests from overwriting a newer same-task request

### DIFF
--- a/changelog.d/20260809_031454_ksm46351_lambda_aba_fix.md
+++ b/changelog.d/20260809_031454_ksm46351_lambda_aba_fix.md
@@ -1,8 +1,10 @@
 ### Fixed
 
-- \[Server API\] Deleting a still-running Lambda auto-annotation request no
-  longer frees up its deterministic RQ job ID for immediate reuse, which
-  could let a later request for the same task overwrite or replay the
-  in-flight one. `DELETE` on a running request now returns `409 Conflict`
-  instead of `204`.
+- \[Server API\] Canceling a running Lambda auto-annotation request now stops the
+  work horse process instead of only deleting the RQ job hash. Previously the
+  deleted request kept running and submitting annotations while its
+  deterministic RQ job ID was already free for reuse, so a later request for the
+  same task could be overwritten or replayed by the old execution. If the work
+  horse cannot be stopped, the API returns `409 Conflict` and keeps the RQ job
+  hash to prevent the request ID from being reused
   (<https://github.com/cvat-ai/cvat/pull/11048>)

--- a/changelog.d/20260809_031454_ksm46351_lambda_aba_fix.md
+++ b/changelog.d/20260809_031454_ksm46351_lambda_aba_fix.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- \[Server API\] Deleting a still-running Lambda auto-annotation request no
+  longer frees up its deterministic RQ job ID for immediate reuse, which
+  could let a later request for the same task overwrite or replay the
+  in-flight one. `DELETE` on a running request now returns `409 Conflict`
+  instead of `204`.
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/changelog.d/20260809_031454_ksm46351_lambda_aba_fix.md
+++ b/changelog.d/20260809_031454_ksm46351_lambda_aba_fix.md
@@ -5,4 +5,4 @@
   could let a later request for the same task overwrite or replay the
   in-flight one. `DELETE` on a running request now returns `409 Conflict`
   instead of `204`.
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/11048>)

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -9,6 +9,7 @@ import json
 import os
 from collections import Counter
 from contextlib import contextmanager
+from datetime import timedelta
 from itertools import groupby
 from unittest import mock, skip
 
@@ -18,7 +19,9 @@ from django.http import HttpResponseNotFound, HttpResponseServerError
 from PIL import Image
 from rest_framework import status
 from rq.job import JobStatus
+from rq.worker import Worker as RQWorker
 
+from cvat.apps.engine.rq import RQJobMetaField
 from cvat.apps.engine.tests.utils import (
     ApiTestBase,
     ForceLogin,
@@ -29,6 +32,7 @@ from cvat.apps.engine.tests.utils import (
 )
 from cvat.apps.iam.models import User
 from cvat.apps.lambda_manager.views import LambdaQueue
+from cvat.apps.redis_handler.utils import CVAT_CAN_STOP_STARTED_JOBS_KEY
 
 LAMBDA_ROOT_PATH = "/api/lambda"
 LAMBDA_FUNCTIONS_PATH = f"{LAMBDA_ROOT_PATH}/functions"
@@ -259,17 +263,17 @@ class _LambdaTestCaseBase(ApiTestBase):
             return image.size
 
     @contextmanager
-    def _lambda_request_enqueued_as_started(self):
+    def _lambda_request_enqueued_as_started(self, *, worker_name: str = "test-worker"):
         # cvat.settings.testing forces every RQ queue to run inline (ASYNC=False),
-        # so a plain request would finish before a second request/DELETE could
+        # so a plain request would finish before a second request or a DELETE could
         # race it. This makes the enclosed request creation save its RQ job as
-        # STARTED and never actually run it, simulating a job whose Nuclio
-        # work-horse is still executing. See the "결정적 자동 회귀 테스트" section
-        # of docs/cvat/2026-08-08_auto-annotation-public-safe-implementation-handoff.md
+        # STARTED and never actually run it, simulating a job whose work horse
+        # is still executing on a worker.
         queue_class = type(LambdaQueue()._get_queue())
 
         def enqueue_as_started(queue, job, *args, **kwargs):
             job.origin = queue.name
+            job.worker_name = worker_name
             job.set_status(JobStatus.STARTED)
             job.save()
             return job
@@ -277,10 +281,33 @@ class _LambdaTestCaseBase(ApiTestBase):
         with mock.patch.object(queue_class, "enqueue_job", new=enqueue_as_started):
             yield
 
+    @contextmanager
+    def _stop_job_command_stopping_the_job(self):
+        """
+        Replaces send_stop_job_command with a worker that immediately reacts to it,
+        i.e. kills the work horse and moves the job to the stopped state.
+        """
+
+        def stop_job(connection, job_id, *args, **kwargs):
+            self._set_lambda_request_status(job_id, JobStatus.STOPPED)
+
+        with mock.patch(
+            "cvat.apps.lambda_manager.views.send_stop_job_command", side_effect=stop_job
+        ) as send_stop_command:
+            yield send_stop_command
+
     def _set_lambda_request_status(self, request_id: str, new_status: JobStatus) -> None:
         rq_job = LambdaQueue()._get_queue().fetch_job(request_id)
         rq_job.set_status(new_status)
         rq_job.save()
+
+    def _mark_worker_unable_to_stop_started_jobs(self, worker_name: str) -> None:
+        connection = LambdaQueue()._get_queue().connection
+        connection.hset(
+            f"{RQWorker.redis_worker_namespace_prefix}{worker_name}",
+            CVAT_CAN_STOP_STARTED_JOBS_KEY,
+            0,
+        )
 
 
 class LambdaTestCases(_LambdaTestCaseBase):
@@ -556,7 +583,44 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 response = self._delete_request(f"{LAMBDA_REQUESTS_PATH}/{id_request}", user)
                 self.assertEqual(response.status_code, expected_status)
 
-    def test_api_v2_lambda_requests_delete_not_finished_request(self):
+    def test_api_v2_lambda_requests_delete_checks_permissions_under_job_lock(self):
+        data = {
+            "function": id_function_detector,
+            "task": self.assigneed_to_user_task["id"],
+            "cleanup": True,
+            "mapping": {"car": {"name": "car"}},
+        }
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.user, data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        request_id = response.data["id"]
+
+        @contextmanager
+        def replace_request_owner_before_lock_body():
+            rq_job = LambdaQueue()._get_queue().fetch_job(request_id)
+            rq_job.meta[RQJobMetaField.USER] = {
+                RQJobMetaField.UserField.ID: self.owner.id,
+                RQJobMetaField.UserField.USERNAME: self.owner.username,
+                RQJobMetaField.UserField.EMAIL: self.owner.email,
+            }
+            rq_job.save_meta()
+            yield
+
+        # Simulate another request reusing the deterministic RQ ID between an
+        # out-of-lock permission check and the protected fetch.
+        with mock.patch(
+            "cvat.apps.lambda_manager.views.get_rq_lock_for_job",
+            return_value=replace_request_owner_before_lock_body(),
+        ):
+            response = self._delete_request(f"{LAMBDA_REQUESTS_PATH}/{request_id}", self.user)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # The replacement request belongs to another user and must survive.
+        response = self._get_request(f"{LAMBDA_REQUESTS_PATH}/{request_id}", self.admin)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self._delete_lambda_request(request_id)
+
+    def _create_started_lambda_request(self, **kwargs) -> str:
         data = {
             "function": id_function_detector,
             "task": self.main_task["id"],
@@ -566,41 +630,100 @@ class LambdaTestCases(_LambdaTestCaseBase):
             },
         }
 
-        with self._lambda_request_enqueued_as_started():
+        with self._lambda_request_enqueued_as_started(**kwargs):
             response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        request_id_a = response.data["id"]
         self.assertEqual(response.data["status"], "started")
 
-        # Minimal conservative policy: DELETE must not discard the Redis
-        # identity of a job whose work-horse might still be running.
-        response = self._delete_request(f"{LAMBDA_REQUESTS_PATH}/{request_id_a}", self.admin)
-        self.assertIn(
-            response.status_code,
-            (status.HTTP_400_BAD_REQUEST, status.HTTP_409_CONFLICT),
-        )
+        return response.data["id"]
 
-        # The job must still be there and still "started" - the hash was not deleted.
+    def test_api_v2_lambda_requests_delete_not_finished_request(self):
+        request_id_a = self._create_started_lambda_request()
+
+        # Deleting the job hash alone would leave the work horse running while
+        # freeing its RQ id, so the request must be stopped first.
+        with self._stop_job_command_stopping_the_job() as send_stop_command:
+            response = self._delete_request(f"{LAMBDA_REQUESTS_PATH}/{request_id_a}", self.admin)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        send_stop_command.assert_called_once()
+        self.assertEqual(send_stop_command.call_args.args[1], request_id_a)
+
         response = self._get_request(f"{LAMBDA_REQUESTS_PATH}/{request_id_a}", self.admin)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["status"], "started")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        # A second request for the same task must still be rejected while A is
-        # running: A's RQ id may not be handed over to a new run (B).
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
-        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
-
-        # Once A reaches a real terminal state, the task slot becomes
-        # available again and the new request executes exactly once.
-        self._set_lambda_request_status(request_id_a, JobStatus.FINISHED)
-
-        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
+        # The task slot is free again, and the new request gets the same RQ id
+        # without inheriting anything from the stopped one.
+        response = self._post_request(
+            LAMBDA_REQUESTS_PATH,
+            self.admin,
+            data={
+                "function": id_function_detector,
+                "task": self.main_task["id"],
+                "cleanup": True,
+                "mapping": {"car": {"name": "car"}},
+            },
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         request_id_b = response.data["id"]
         self.assertEqual(request_id_b, request_id_a)
         self.assertEqual(response.data["status"], "finished")
 
         self._delete_lambda_request(request_id_b)
+
+    def test_api_v2_lambda_requests_delete_not_finished_request_on_unstoppable_worker(self):
+        worker_name = "simple-worker"
+        request_id = self._create_started_lambda_request(worker_name=worker_name)
+        self._mark_worker_unable_to_stop_started_jobs(worker_name)
+
+        with self._stop_job_command_stopping_the_job() as send_stop_command:
+            response = self._delete_request(f"{LAMBDA_REQUESTS_PATH}/{request_id}", self.admin)
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        send_stop_command.assert_not_called()
+
+        # The job must still be there and still started - the hash was not deleted.
+        response = self._get_request(f"{LAMBDA_REQUESTS_PATH}/{request_id}", self.admin)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["status"], "started")
+
+        # A second request for the same task must still be rejected: the RQ id of a
+        # running job may not be handed over to a new run.
+        response = self._post_request(
+            LAMBDA_REQUESTS_PATH,
+            self.admin,
+            data={
+                "function": id_function_detector,
+                "task": self.main_task["id"],
+                "cleanup": True,
+                "mapping": {"car": {"name": "car"}},
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+        self._set_lambda_request_status(request_id, JobStatus.FINISHED)
+        self._delete_lambda_request(request_id)
+
+    def test_api_v2_lambda_requests_delete_not_finished_request_that_does_not_stop(self):
+        request_id = self._create_started_lambda_request()
+
+        # The worker never reacts to the stop command, so the work horse may still
+        # be alive and the hash must be kept.
+        with (
+            mock.patch.object(LambdaQueue, "STOP_TIMEOUT", timedelta(milliseconds=200)),
+            mock.patch("cvat.apps.lambda_manager.views.send_stop_job_command"),
+        ):
+            response = self._delete_request(f"{LAMBDA_REQUESTS_PATH}/{request_id}", self.admin)
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+        response = self._get_request(f"{LAMBDA_REQUESTS_PATH}/{request_id}", self.admin)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["status"], "started")
+
+        self._set_lambda_request_status(request_id, JobStatus.FINISHED)
+        self._delete_lambda_request(request_id)
 
     def test_api_v2_lambda_requests_create(self):
         ids_functions = [

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -8,6 +8,7 @@ import io
 import json
 import os
 from collections import Counter
+from contextlib import contextmanager
 from itertools import groupby
 from unittest import mock, skip
 
@@ -16,6 +17,7 @@ from django.core.signing import TimestampSigner
 from django.http import HttpResponseNotFound, HttpResponseServerError
 from PIL import Image
 from rest_framework import status
+from rq.job import JobStatus
 
 from cvat.apps.engine.tests.utils import (
     ApiTestBase,
@@ -26,6 +28,7 @@ from cvat.apps.engine.tests.utils import (
     get_paginated_collection,
 )
 from cvat.apps.iam.models import User
+from cvat.apps.lambda_manager.views import LambdaQueue
 
 LAMBDA_ROOT_PATH = "/api/lambda"
 LAMBDA_FUNCTIONS_PATH = f"{LAMBDA_ROOT_PATH}/functions"
@@ -254,6 +257,30 @@ class _LambdaTestCaseBase(ApiTestBase):
         image_data = base64.b64decode(payload["image"])
         with Image.open(io.BytesIO(image_data)) as image:
             return image.size
+
+    @contextmanager
+    def _lambda_request_enqueued_as_started(self):
+        # cvat.settings.testing forces every RQ queue to run inline (ASYNC=False),
+        # so a plain request would finish before a second request/DELETE could
+        # race it. This makes the enclosed request creation save its RQ job as
+        # STARTED and never actually run it, simulating a job whose Nuclio
+        # work-horse is still executing. See the "결정적 자동 회귀 테스트" section
+        # of docs/cvat/2026-08-08_auto-annotation-public-safe-implementation-handoff.md
+        queue_class = type(LambdaQueue()._get_queue())
+
+        def enqueue_as_started(queue, job, *args, **kwargs):
+            job.origin = queue.name
+            job.set_status(JobStatus.STARTED)
+            job.save()
+            return job
+
+        with mock.patch.object(queue_class, "enqueue_job", new=enqueue_as_started):
+            yield
+
+    def _set_lambda_request_status(self, request_id: str, new_status: JobStatus) -> None:
+        rq_job = LambdaQueue()._get_queue().fetch_job(request_id)
+        rq_job.set_status(new_status)
+        rq_job.save()
 
 
 class LambdaTestCases(_LambdaTestCaseBase):
@@ -529,9 +556,51 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 response = self._delete_request(f"{LAMBDA_REQUESTS_PATH}/{id_request}", user)
                 self.assertEqual(response.status_code, expected_status)
 
-    @skip("Fail: add mock")
     def test_api_v2_lambda_requests_delete_not_finished_request(self):
-        pass
+        data = {
+            "function": id_function_detector,
+            "task": self.main_task["id"],
+            "cleanup": True,
+            "mapping": {
+                "car": {"name": "car"},
+            },
+        }
+
+        with self._lambda_request_enqueued_as_started():
+            response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        request_id_a = response.data["id"]
+        self.assertEqual(response.data["status"], "started")
+
+        # Minimal conservative policy: DELETE must not discard the Redis
+        # identity of a job whose work-horse might still be running.
+        response = self._delete_request(f"{LAMBDA_REQUESTS_PATH}/{request_id_a}", self.admin)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_400_BAD_REQUEST, status.HTTP_409_CONFLICT),
+        )
+
+        # The job must still be there and still "started" - the hash was not deleted.
+        response = self._get_request(f"{LAMBDA_REQUESTS_PATH}/{request_id_a}", self.admin)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["status"], "started")
+
+        # A second request for the same task must still be rejected while A is
+        # running: A's RQ id may not be handed over to a new run (B).
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+        # Once A reaches a real terminal state, the task slot becomes
+        # available again and the new request executes exactly once.
+        self._set_lambda_request_status(request_id_a, JobStatus.FINISHED)
+
+        response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        request_id_b = response.data["id"]
+        self.assertEqual(request_id_b, request_id_a)
+        self.assertEqual(response.data["status"], "finished")
+
+        self._delete_lambda_request(request_id_b)
 
     def test_api_v2_lambda_requests_create(self):
         ids_functions = [
@@ -636,7 +705,6 @@ class LambdaTestCases(_LambdaTestCaseBase):
         response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    @skip("Fail: add mock")
     def test_api_v2_lambda_requests_create_two_requests(self):
         data = {
             "function": id_function_detector,
@@ -646,10 +714,12 @@ class LambdaTestCases(_LambdaTestCaseBase):
                 "car": {"name": "car"},
             },
         }
-        request_id = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data).data["id"]
+        with self._lambda_request_enqueued_as_started():
+            request_id = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data).data["id"]
         response = self._post_request(LAMBDA_REQUESTS_PATH, self.admin, data=data)
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
 
+        self._set_lambda_request_status(request_id, JobStatus.FINISHED)
         self._delete_lambda_request(request_id)
 
     def test_api_v2_lambda_requests_create_empty_mapping(self):

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -10,10 +10,11 @@ import io
 import json
 import os
 import textwrap
+import time
 from copy import deepcopy
 from datetime import timedelta
 from functools import wraps
-from typing import Any
+from typing import Any, Callable
 
 import datumaro.util.mask_tools as mask_tools
 import django_rq
@@ -23,6 +24,7 @@ import rq
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.signing import BadSignature, TimestampSigner
+from django_rq.queues import DjangoRQ
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -34,6 +36,8 @@ from drf_spectacular.utils import (
 from PIL import Image
 from rest_framework import serializers, status, viewsets
 from rest_framework.response import Response
+from rq.command import send_stop_job_command
+from rq.exceptions import InvalidJobOperation
 
 import cvat.apps.dataset_manager as dm
 from cvat.apps.dataset_manager.task import PatchAction
@@ -66,6 +70,7 @@ from cvat.apps.lambda_manager.serializers import (
 )
 from cvat.apps.lambda_manager.signals import interactive_function_call_signal
 from cvat.apps.lambda_manager.utils import ROIHelper
+from cvat.apps.redis_handler.utils import can_worker_stop_started_jobs
 from cvat.utils.http import make_requests_session
 
 slogger = ServerLogManager(__name__)
@@ -720,6 +725,11 @@ class LambdaFunction:
 class LambdaQueue:
     RESULT_TTL = timedelta(minutes=30)
     FAILED_TTL = timedelta(hours=3)
+    # How long a DELETE waits for the worker to react to the stop command.
+    # Stopping is normally almost instant: the worker SIGKILLs the work horse
+    # and updates the job status right after waitpid() returns.
+    STOP_TIMEOUT = timedelta(seconds=10)
+    STOP_POLL_INTERVAL = timedelta(milliseconds=100)
 
     def _get_queue(self):
         return django_rq.get_queue(settings.CVAT_QUEUES.AUTO_ANNOTATION.value)
@@ -820,7 +830,7 @@ class LambdaQueue:
 
         return LambdaJob(rq_job)
 
-    def delete_job(self, pk: str) -> None:
+    def delete_job(self, pk: str, *, check_permissions: Callable[[LambdaJob], None]) -> None:
         queue = self._get_queue()
 
         # Use the same (queue, rq_id) lock as enqueue() so a DELETE cannot
@@ -832,25 +842,66 @@ class LambdaQueue:
                     "{} lambda job is not found".format(pk), code=status.HTTP_404_NOT_FOUND
                 )
 
-            job_status = rq_job.get_status(refresh=False)
-            if job_status == rq.job.JobStatus.STARTED:
-                # The work-horse may still be running and writing annotations.
-                # Deleting the hash now would let this RQ id be reused by a
-                # new request while the old execution is still alive, so the
-                # old run's late progress/result could overwrite the new one.
-                raise ValidationError(
-                    "Request #{} is still running and cannot be canceled".format(pk),
-                    code=status.HTTP_409_CONFLICT,
-                )
+            # The job ID is deterministic and can be reused. Check permissions on
+            # the same job instance whose status is inspected and whose hash will
+            # be deleted, while reuse of the ID is prevented by the lock.
+            check_permissions(LambdaJob(rq_job))
 
-            if job_status in (
+            job_status = rq_job.get_status(refresh=False)
+
+            if job_status == rq.job.JobStatus.STARTED:
+                # Deleting the hash of a started job is not enough to stop it: the
+                # work horse keeps running and submitting annotations, while the RQ id
+                # becomes free for a new request for the same task. The old execution
+                # would then overwrite or replay the new one. Terminate the work horse
+                # first and only delete the hash once the job has really left the
+                # started state.
+                self._stop_started_job(queue, rq_job)
+            elif job_status in (
                 rq.job.JobStatus.QUEUED,
                 rq.job.JobStatus.DEFERRED,
                 rq.job.JobStatus.SCHEDULED,
             ):
-                rq_job.cancel()
+                rq_job.cancel(enqueue_dependents=settings.ONE_RUNNING_JOB_IN_QUEUE_PER_USER)
 
             rq_job.delete()
+
+    @classmethod
+    def _stop_started_job(cls, queue: DjangoRQ, rq_job: rq.job.Job) -> None:
+        if not can_worker_stop_started_jobs(rq_job):
+            raise ValidationError(
+                "Request #{} is executed by a worker that cannot stop started requests".format(
+                    rq_job.id
+                ),
+                code=status.HTTP_409_CONFLICT,
+            )
+
+        try:
+            # The worker kills the forked work horse and moves the job to the
+            # stopped state from its own monitoring loop.
+            send_stop_job_command(queue.connection, rq_job.id, serializer=queue.serializer)
+        except InvalidJobOperation as ex:
+            # The job is no longer being executed, e.g. it has just finished.
+            slogger.glob.warning("Failed to stop lambda RQ job %s: %s", rq_job.id, ex)
+
+        cls._wait_until_not_started(rq_job)
+
+    @classmethod
+    def _wait_until_not_started(cls, rq_job: rq.job.Job) -> None:
+        deadline = time.monotonic() + cls.STOP_TIMEOUT.total_seconds()
+
+        while True:
+            # A deleted job reports no status, which also means the work horse is gone.
+            if rq_job.get_status(refresh=True) != rq.job.JobStatus.STARTED:
+                return
+
+            if time.monotonic() >= deadline:
+                raise ValidationError(
+                    "Request #{} could not be stopped in time, please try again".format(rq_job.id),
+                    code=status.HTTP_409_CONFLICT,
+                )
+
+            time.sleep(cls.STOP_POLL_INTERVAL.total_seconds())
 
 
 class DetectionResultConverter:
@@ -1480,9 +1531,7 @@ class FunctionViewSet(viewsets.ViewSet):
         ],
         responses={
             "204": OpenApiResponse(description="The request has been canceled"),
-            "409": OpenApiResponse(
-                description="The request is still running and cannot be canceled"
-            ),
+            "409": OpenApiResponse(description="The request could not be stopped"),
         },
     ),
 )
@@ -1587,6 +1636,7 @@ class RequestViewSet(viewsets.ViewSet):
     @return_response(status.HTTP_204_NO_CONTENT)
     def destroy(self, request, pk):
         queue = LambdaQueue()
-        rq_job = queue.fetch_job(pk)
-        self.check_object_permissions(request, rq_job)
-        queue.delete_job(pk)
+        queue.delete_job(
+            pk,
+            check_permissions=lambda rq_job: self.check_object_permissions(request, rq_job),
+        )

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -1478,6 +1478,12 @@ class FunctionViewSet(viewsets.ViewSet):
                 description="Request id",
             ),
         ],
+        responses={
+            "204": OpenApiResponse(description="The request has been canceled"),
+            "409": OpenApiResponse(
+                description="The request is still running and cannot be canceled"
+            ),
+        },
     ),
 )
 class RequestViewSet(viewsets.ViewSet):

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -820,6 +820,38 @@ class LambdaQueue:
 
         return LambdaJob(rq_job)
 
+    def delete_job(self, pk: str) -> None:
+        queue = self._get_queue()
+
+        # Use the same (queue, rq_id) lock as enqueue() so a DELETE cannot
+        # race a concurrent POST for the same task over this job's identity.
+        with get_rq_lock_for_job(queue, pk):
+            rq_job = queue.fetch_job(pk)
+            if rq_job is None or not LambdaRQMeta.for_job(rq_job).lambda_:
+                raise ValidationError(
+                    "{} lambda job is not found".format(pk), code=status.HTTP_404_NOT_FOUND
+                )
+
+            job_status = rq_job.get_status(refresh=False)
+            if job_status == rq.job.JobStatus.STARTED:
+                # The work-horse may still be running and writing annotations.
+                # Deleting the hash now would let this RQ id be reused by a
+                # new request while the old execution is still alive, so the
+                # old run's late progress/result could overwrite the new one.
+                raise ValidationError(
+                    "Request #{} is still running and cannot be canceled".format(pk),
+                    code=status.HTTP_409_CONFLICT,
+                )
+
+            if job_status in (
+                rq.job.JobStatus.QUEUED,
+                rq.job.JobStatus.DEFERRED,
+                rq.job.JobStatus.SCHEDULED,
+            ):
+                rq_job.cancel()
+
+            rq_job.delete()
+
 
 class DetectionResultConverter:
     def __init__(self, db_task: Task) -> None:
@@ -1049,9 +1081,6 @@ class LambdaJob:
     @property
     def is_scheduled(self):
         return self.get_status() == rq.job.JobStatus.SCHEDULED
-
-    def delete(self):
-        self.job.delete()
 
     @classmethod
     def _call_detector(
@@ -1554,4 +1583,4 @@ class RequestViewSet(viewsets.ViewSet):
         queue = LambdaQueue()
         rq_job = queue.fetch_job(pk)
         self.check_object_permissions(request, rq_job)
-        rq_job.delete()
+        queue.delete_job(pk)

--- a/cvat/apps/redis_handler/utils.py
+++ b/cvat/apps/redis_handler/utils.py
@@ -10,8 +10,32 @@ from typing import Any, Self
 import rq
 from rq.job import Job as RQJob
 from rq.job import JobStatus
+from rq.worker import Worker as RQWorker
 
 from cvat.apps.redis_handler import signals
+
+CVAT_CAN_STOP_STARTED_JOBS_KEY = "cvat_can_stop_started_jobs"
+
+
+def can_worker_stop_started_jobs(rq_job: RQJob) -> bool:
+    """
+    Checks whether the worker running the job is able to stop its work horse.
+
+    Workers that execute jobs in-process (the debug SimpleWorker) have no forked
+    work horse to kill, so stopping a started job there would kill the worker itself.
+    """
+    worker_key = f"{RQWorker.redis_worker_namespace_prefix}{rq_job.worker_name}"
+    # The marker is CVAT-specific and can be absent on already running or older production
+    # workers. Only SimpleWorker writes "0", so default to "can stop" for backward
+    # compatibility.
+    can_stop_started_jobs = (
+        rq_job.connection.hget(worker_key, CVAT_CAN_STOP_STARTED_JOBS_KEY) or "1"
+    )
+
+    if isinstance(can_stop_started_jobs, bytes):
+        can_stop_started_jobs = can_stop_started_jobs.decode()
+
+    return can_stop_started_jobs != "0"
 
 
 class DetachedJob(RQJob):

--- a/cvat/apps/redis_handler/views.py
+++ b/cvat/apps/redis_handler/views.py
@@ -26,7 +26,6 @@ from rq.command import send_stop_job_command
 from rq.exceptions import InvalidJobOperation
 from rq.job import Job as RQJob
 from rq.job import JobStatus as RQJobStatus
-from rq.worker import Worker as RQWorker
 
 from cvat.apps.engine.filters import (
     NonModelJsonLogicFilter,
@@ -41,10 +40,9 @@ from cvat.apps.redis_handler.apps import SELECTOR_TO_QUEUE
 from cvat.apps.redis_handler.permissions import RequestPermission
 from cvat.apps.redis_handler.rq import CustomRQJob, RequestId
 from cvat.apps.redis_handler.serializers import RequestSerializer, RequestStatus
+from cvat.apps.redis_handler.utils import can_worker_stop_started_jobs
 
 slogger = ServerLogManager(__name__)
-
-CVAT_CAN_STOP_STARTED_JOBS_KEY = "cvat_can_stop_started_jobs"
 
 
 @extend_schema(tags=["requests"])
@@ -225,21 +223,7 @@ class RequestViewSet(viewsets.GenericViewSet):
 
     @classmethod
     def _is_started_process_cancellable(cls, rq_job: CustomRQJob) -> bool:
-        if not cls._is_export_request(rq_job):
-            return False
-
-        worker_key = f"{RQWorker.redis_worker_namespace_prefix}{rq_job.worker_name}"
-        # The marker is CVAT-specific and can be absent on already running or older production
-        # workers. Only SimpleWorker writes "0", so default to "can stop" for backward
-        # compatibility.
-        can_stop_started_jobs = (
-            rq_job.connection.hget(worker_key, CVAT_CAN_STOP_STARTED_JOBS_KEY) or "1"
-        )
-
-        if isinstance(can_stop_started_jobs, bytes):
-            can_stop_started_jobs = can_stop_started_jobs.decode()
-
-        return can_stop_started_jobs != "0"
+        return cls._is_export_request(rq_job) and can_worker_stop_started_jobs(rq_job)
 
     def _handle_redis_exceptions(func):
         @functools.wraps(func)

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -3502,7 +3502,7 @@ paths:
         '204':
           description: The request has been canceled
         '409':
-          description: The request is still running and cannot be canceled
+          description: The request could not be stopped
   /api/memberships:
     get:
       operationId: memberships_list

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -3500,7 +3500,9 @@ paths:
       - basicAuth: []
       responses:
         '204':
-          description: No response body
+          description: The request has been canceled
+        '409':
+          description: The request is still running and cannot be canceled
   /api/memberships:
     get:
       operationId: memberships_list


### PR DESCRIPTION
### Motivation and context

Fixes #11016.

`DELETE /api/lambda/requests/{id}` previously deleted the RQ job hash even
while the job was `STARTED`. Lambda auto-annotation uses a deterministic RQ job
ID derived from the target task. Deleting the hash therefore made the ID
available for a new request while the previous work horse could still be
running and submitting annotations.

This allowed the previous execution to overwrite the newer request's
progress/result or to submit annotations into the same task after the new run
had started.

This PR changes deletion of a running Lambda request to stop the work horse and
wait for the stop to be acknowledged before releasing the deterministic job ID.

### What has changed?

- `LambdaQueue.delete_job()` takes the same per-job RQ lock as `enqueue()`, so
  DELETE and POST cannot race over the same deterministic job ID.
- The object permission check is performed inside that lock on the exact RQ job
  instance that will be stopped and deleted. This prevents an ID-reuse race from
  applying permissions from an older job to its replacement.
- For a `STARTED` job, DELETE sends `send_stop_job_command` and waits until the
  job leaves the `STARTED` state before deleting its Redis hash and returning
  `204 No Content`.
- If the worker cannot stop started jobs, or the stop is not acknowledged within
  10 seconds, DELETE returns `409 Conflict` and keeps the job hash. The ID then
  remains unavailable to a new request while the previous execution may still
  be running.
- `QUEUED`, `DEFERRED`, and `SCHEDULED` jobs are canceled with
  `enqueue_dependents=settings.ONE_RUNNING_JOB_IN_QUEUE_PER_USER` before their
  hashes are deleted.
- The worker capability check used by export cancellation was extracted into a
  shared helper and reused by the Lambda cancellation path.
- The OpenAPI response descriptions and changelog fragment were updated for the
  new cancellation behavior.

### How has this been tested?

The tests cover:

- successful cancellation of a started request and safe reuse of its
  deterministic ID;
- a worker that cannot stop started jobs, including the `409` response and job
  hash retention;
- a stop command that is not acknowledged before the timeout, including the
  `409` response and job hash retention;
- permission checking under the per-job lock when the deterministic ID is
  replaced by a request owned by another user;
- the existing queued and terminal-state deletion behavior.

Because `cvat.settings.testing` runs RQ queues synchronously, the started-job
tests simulate the RQ lifecycle and stop acknowledgement without requiring a
live Nuclio function.

Tests run after rebasing onto `upstream/develop`:

```bash
python manage.py test --settings cvat.settings.testing \
  cvat.apps.lambda_manager.tests.test_lambda
python manage.py test --settings cvat.settings.testing \
  cvat.apps.redis_handler.tests.test_views
```

Results:

- Lambda manager: 71 tests run, 3 skipped, OK
- Redis handler cancellation tests: 3 tests run, OK
- Django system checks: no issues
- OpenAPI generation: 0 errors; the generated Lambda DELETE response block
  matches `cvat/schema.yml`
- `git diff --check upstream/develop...HEAD`: passed

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues

### License

- [x] I submit _my code changes_ under the same
  [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.