### PR TITLE
Audio workspace: integrate minimal media session handling

### DIFF
--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-audio-media-session.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-audio-media-session.ts
@@ -1,0 +1,110 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import { useEffect, useRef } from 'react';
+
+import type { WaveSurferRuntime } from './use-audio-waveform';
+
+// A 100 ms tone.
+// A completely silent, four-byte WAV is considered paused
+// even while the HTML media element is looping.
+const AUDIO_FOCUS_PROBE_SOURCE = [
+    'data:audio/wav;base64,',
+    'UklGRkQDAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YSADAACAq9Ht/f3v1K+EWTIVBAIPKU54o8vp+/7z2raM',
+    'YDkZBgELI0ZwnMTk+f/2372UaD8eCQEJHj9olL3f9v/55MSccEYjCwEGGTlgjLba8/776cujeE4pDwIEFTJZhK/U7/397dGrgFUv',
+    'EwMDESxRfKfO6/z+8deyiF01FwUCDSZKdKDH5/r/9d26kGQ8HAcBCiFDbJjB4vf/9+LBmGxDIQoBBxw8ZJC63fX/+ufHoHRKJg0C',
+    'BRc1XYiy1/H+/OvOp3xRLBEDAxMvVYCr0e39/e/Ur4RZMhUEAg8pTnijy+n7/vPatoxgORkGAQsjRnCcxOT5//bfvZRoPx4JAQke',
+    'P2iUvd/2//nkxJxwRiMLAQYZOWCMttrz/vvpy6N4TikPAgQVMlmEr9Tv/f3t0auAVS8TAwMRLFF8p87r/P7x17KIXTUXBQINJkp0',
+    'oMfn+v/13bqQZDwcBwEKIUNsmMHi9//34sGYbEMhCgEHHDxkkLrd9f/658egdEomDQIFFzVdiLLX8f78686nfFEsEQMDEy9VgKvR',
+    '7f3979SvhFkyFQQCDylOeKPL6fv+89q2jGA5GQYBCyNGcJzE5Pn/9t+9lGg/HgkBCR4/aJS93/b/+eTEnHBGIwsBBhk5YIy22vP++',
+    '+nLo3hOKQ8CBBUyWYSv1O/9/e3Rq4BVLxMDAxEsUXynzuv8/vHXsohdNRcFAg0mSnSgx+f6//XdupBkPBwHAQohQ2yYweL3//fiw',
+    'ZhsQyEKAQccPGSQut31//rnx6B0SiYNAgUXNV2Istfx/vzrzqd8USwRAwMTL1WAq9Ht/f3v1K+EWTIVBAIPKU54o8vp+/7z2raMYDk',
+    'ZBgELI0ZwnMTk+f/2372UaD8eCQEJHj9olL3f9v/55MSccEYjCwEGGTlgjLba8/776cujeE4pDwIEFTJZhK/U7/397dGrgFUvEwMD',
+    'ESxRfKfO6/z+8deyiF01FwUCDSZKdKDH5/r/9d26kGQ8HAcBCiFDbJjB4vf/9+LBmGxDIQoBBxw8ZJC63fX/+ufHoHRKJg0CBRc1',
+    'XYiy1/H+/OvOp3xRLBEDAxMvVQ==',
+].join('');
+
+/**
+ * Enables the Media Session API for the audio player.
+ * This allows the user to control playback using system-level media controls.
+ */
+export function useAudioMediaSession({ instanceRef, ready }: WaveSurferRuntime): void {
+    const audioFocusProbeRef = useRef<HTMLAudioElement | null>(null);
+
+    useEffect(() => {
+        // NOTE: audio focus is not requested by the browser when using WebAudio API
+        // so we need to play a silent audio element in order to request it.
+        // It's state and lifecycle is synced with the WaveSurfer instance.
+        // The focus is only requested on the first play.
+        const probe = new Audio(AUDIO_FOCUS_PROBE_SOURCE);
+        probe.loop = true;
+        probe.volume = 0;
+        audioFocusProbeRef.current = probe;
+
+        return () => {
+            probe.pause();
+            probe.removeAttribute('src');
+            probe.load();
+            audioFocusProbeRef.current = null;
+        };
+    }, []);
+
+    useEffect(() => {
+        const { mediaSession } = navigator;
+        if (!mediaSession) return undefined;
+
+        if ('MediaMetadata' in window) {
+            mediaSession.metadata = new MediaMetadata({
+                title: 'CVAT Audio Focus PoC',
+                artist: 'CVAT',
+            });
+        }
+        mediaSession.setActionHandler('play', () => {
+            instanceRef.current?.play().catch(() => {});
+        });
+        mediaSession.setActionHandler('pause', () => {
+            instanceRef.current?.pause();
+        });
+
+        return () => {
+            mediaSession.setActionHandler('play', null);
+            mediaSession.setActionHandler('pause', null);
+            mediaSession.metadata = null;
+        };
+    }, []);
+
+    useEffect(() => {
+        const instance = instanceRef.current;
+        if (!instance) return undefined;
+
+        const duration = instance.getDuration();
+        if (navigator.mediaSession && Number.isFinite(duration) && duration > 0) {
+            try {
+                navigator.mediaSession.setPositionState({ duration });
+            } catch {
+                // no op, some browsers don't support this API yet
+            }
+        }
+
+        const onPlay = (): void => {
+            audioFocusProbeRef.current?.play().catch(() => {});
+            if (navigator.mediaSession) {
+                navigator.mediaSession.playbackState = 'playing';
+            }
+        };
+        const onPause = (): void => {
+            audioFocusProbeRef.current?.pause();
+            if (navigator.mediaSession) {
+                navigator.mediaSession.playbackState = 'paused';
+            }
+        };
+
+        instance.on('play', onPlay);
+        instance.on('pause', onPause);
+        return () => {
+            instance.un('play', onPlay);
+            instance.un('pause', onPause);
+        };
+    }, [ready]);
+}

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-audio-media-session.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-audio-media-session.ts
@@ -30,6 +30,7 @@ const AUDIO_FOCUS_PROBE_SOURCE = [
  * This allows the user to control playback using system-level media controls.
  */
 export function useAudioMediaSession({ instanceRef, ready }: WaveSurferRuntime): void {
+    // NOTE: WaveSurfer had it as a plugin in v6 but it no longer available in v7.
     const audioFocusProbeRef = useRef<HTMLAudioElement | null>(null);
 
     useEffect(() => {

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-playback.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-playback.ts
@@ -12,6 +12,7 @@ import { CombinedState } from 'reducers';
 import { shallowEqual, ThunkDispatch } from 'utils/redux';
 import { clamp } from 'utils/math';
 
+import { useAudioMediaSession } from './use-audio-media-session';
 import type { WaveSurferRuntime } from './use-audio-waveform';
 
 export interface WaveformPlayback {
@@ -41,16 +42,15 @@ export function useWaveformPlayback(runtime: WaveSurferRuntime): WaveformPlaybac
     }), shallowEqual);
     const listenersRef = useRef(new Set<(time: number) => void>());
     const { ready } = runtime;
+    useAudioMediaSession(runtime);
 
     const play = useCallback((): void => {
         const instance = runtime.instanceRef.current;
         if (!instance) return;
         instance.play().catch(() => {});
-        dispatch(audioActions.switchAudioPlay(true));
     }, []);
     const pause = useCallback((): void => {
         runtime.instanceRef.current?.pause();
-        dispatch(audioActions.switchAudioPlay(false));
     }, []);
     const seek = useCallback((time: number): void => {
         const instance = runtime.instanceRef.current;
@@ -63,11 +63,17 @@ export function useWaveformPlayback(runtime: WaveSurferRuntime): WaveformPlaybac
         return () => listenersRef.current.delete(listener);
     }, []);
 
-    // Sync timeupdate and finish events from the WaveSurfer instance to redux
+    // Sync WaveSurfer transport events to Redux.
     useEffect(() => {
         const instance = runtime.instanceRef.current;
         if (!instance) return undefined;
 
+        const onPlay = (): void => {
+            dispatch(audioActions.switchAudioPlay(true));
+        };
+        const onPause = (): void => {
+            dispatch(audioActions.switchAudioPlay(false));
+        };
         const onTimeUpdate = (): void => {
             // With the WebAudio backend, a timeupdate emitted after pausing can
             // carry WaveSurfer's stale reactive time (the previous seek position).
@@ -80,9 +86,13 @@ export function useWaveformPlayback(runtime: WaveSurferRuntime): WaveformPlaybac
         const onFinish = (): void => {
             dispatch(audioActions.switchAudioPlay(false));
         };
+        instance.on('play', onPlay);
+        instance.on('pause', onPause);
         instance.on('timeupdate', onTimeUpdate);
         instance.on('finish', onFinish);
         return () => {
+            instance.un('play', onPlay);
+            instance.un('pause', onPause);
             instance.un('timeupdate', onTimeUpdate);
             instance.un('finish', onFinish);
         };


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Typing in a textarea disables app shortcuts to avoid breaking normal text editing. It makes it harder to control the audio (seek/playblack).

This PoC provides a **minimal** integration with [Media Session API](https://developer.mozilla.org/en-US/docs/Web/API/MediaSession) which allows the playback to be controlled with system on-screen and hardware controls when the audio workspace is the active media session.

E.g. on Mac it displays the active media session in system menu and allows controlling with with shortcuts like `F8` or `Fn+F8` based on configuration. The shortcuts work even when the focus is within a text area.
<img width="303" height="173" alt="MacAudioSession" src="https://github.com/user-attachments/assets/5c3a7cb7-b124-46bd-8b04-a6845077916c" />

Note: WaveSurfer used to have this integration as a plugin in v6 but it silently didn't make it into v7.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Tested manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
