### PR TITLE
Fix undo and redo for skeleton point outside state

### DIFF
--- a/changelog.d/20260820_200255_glebpotapov_skeleton_outside_undo_redo.md
+++ b/changelog.d/20260820_200255_glebpotapov_skeleton_outside_undo_redo.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Fixed undo and redo for outside state changes on skeleton points so they no
+  longer modify the occluded state
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/changelog.d/20260820_200255_glebpotapov_skeleton_outside_undo_redo.md
+++ b/changelog.d/20260820_200255_glebpotapov_skeleton_outside_undo_redo.md
@@ -2,4 +2,4 @@
 
 - Fixed undo and redo for outside state changes on skeleton points so they no
   longer modify the occluded state
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/11063>)

--- a/cvat-core/src/annotations-objects/shape.ts
+++ b/cvat-core/src/annotations-objects/shape.ts
@@ -202,14 +202,14 @@ export class Shape extends ScoredMixin(Drawn) {
         const redoSource = this.readOnlyFields.includes('source') ? this.source : computeNewSource(this.source);
 
         this.history.do(
-            HistoryActions.CHANGED_OCCLUDED,
+            HistoryActions.CHANGED_OUTSIDE,
             () => {
                 this.outside = undoOutside;
                 this.source = undoSource;
                 this.updated = Date.now();
             },
             () => {
-                this.occluded = redoOutside;
+                this.outside = redoOutside;
                 this.source = redoSource;
                 this.updated = Date.now();
             },

--- a/tests/cypress/e2e/features/skeletons_pipeline.js
+++ b/tests/cypress/e2e/features/skeletons_pipeline.js
@@ -174,6 +174,40 @@ context('Manipulations with skeletons', { scrollBehavior: false }, () => {
             cy.removeAnnotations();
         });
 
+        it('Undo and redo outside property for a skeleton point', () => {
+            createSkeletonObject('shape');
+
+            const skeletonPointSelector = '#cvat-objects-sidebar-state-item-element-2';
+            cy.get(skeletonPointSelector).within(() => {
+                cy.get('.cvat-object-item-button-outside').click();
+                cy.get('.cvat-object-item-button-outside-enabled').should('exist');
+                cy.get('.cvat-object-item-button-occluded-enabled').should('not.exist');
+            });
+
+            cy.get('.cvat-annotation-header-undo-button').trigger('mouseover');
+            cy.get('.ant-tooltip-inner').should('contain.text', 'Undo: Changed outside');
+            cy.get('.cvat-annotation-header-undo-button').click();
+            cy.get(skeletonPointSelector).within(() => {
+                cy.get('.cvat-object-item-button-outside-enabled').should('not.exist');
+                cy.get('.cvat-object-item-button-occluded-enabled').should('not.exist');
+            });
+
+            cy.get('.cvat-annotation-header-redo-button').click();
+            cy.get(skeletonPointSelector).within(() => {
+                cy.get('.cvat-object-item-button-outside-enabled').should('exist');
+                cy.get('.cvat-object-item-button-occluded-enabled').should('not.exist');
+            });
+
+            cy.get('.cvat-annotation-header-undo-button').click();
+            cy.get(skeletonPointSelector).within(() => {
+                cy.get('.cvat-object-item-button-outside-enabled').should('not.exist');
+                cy.get('.cvat-object-item-button-occluded-enabled').should('not.exist');
+            });
+
+            deleteSkeleton('#cvat_canvas_shape_1', 'shape', false);
+            cy.removeAnnotations();
+        });
+
         it('Creating, re-drawing, and removing a skeleton track', () => {
             createSkeletonObject('track');
 


### PR DESCRIPTION
### Motivation and context

Fixes #11059.

Undoing or redoing a change to the `outside` property of a skeleton point incorrectly affected its `occluded` property. The history entry was also registered as `Changed occluded` instead of `Changed outside`.

This PR:

- Registers outside-state changes using `HistoryActions.CHANGED_OUTSIDE`.
- Restores the `outside` property during redo instead of modifying `occluded`.
- Adds an end-to-end test for undoing and redoing a skeleton point’s outside state.
- Verifies that the point’s occluded state remains unchanged.

### How has this been tested?

The following checks passed:

```bash
./node_modules/.bin/eslint \
    cvat-core/src/annotations-objects/shape.ts \
    tests/cypress/e2e/features/skeletons_pipeline.js

./node_modules/.bin/tsc --noEmit -p cvat-core/tsconfig.json
```

A Cypress scenario was added to `skeletons_pipeline.js`, covering:

- Changing a skeleton point’s outside state.
- Displaying `Undo: Changed outside`.
- Undoing and redoing the outside state.
- Ensuring the occluded state is unaffected.

The Cypress scenario was not executed locally.

### Checklist

- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment
- [x] ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] I have linked related issues

### License

- [x] I submit *my code changes* under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.