### PR TITLE
Resolve ONNX Runtime Web imports in UI plugins

### DIFF
--- a/cvat-ui/plugins/tsconfig.plugin.base.json
+++ b/cvat-ui/plugins/tsconfig.plugin.base.json
@@ -3,6 +3,7 @@
     "target": "es2020",
     "baseUrl": "../src",
     "paths": {
+      "onnxruntime-web": ["../../node_modules/onnxruntime-web"],
       "@modules/react": ["../../node_modules/@types/react"],
       "@modules/react-dom": ["../../node_modules/@types/react-dom"],
       "@modules/react-dom/*": ["../../node_modules/@types/react-dom/*"],


### PR DESCRIPTION
### Motivation and context

Allow CVAT UI plugins to use the standard ONNX Runtime Web import:

```ts
import { env, InferenceSession, Tensor } from 'onnxruntime-web';
```

Internal plugin sources are located outside the CVAT package tree, while their dependencies are installed under `cvat/node_modules`. Consequently, TypeScript and webpack cannot resolve a bare `onnxruntime-web` import from these plugins without additional configuration.

### How has this been tested?

Manually

### Checklist

- [x] I submit my changes into the `develop` branch
- [ ] ~~I have created a changelog fragment~~
- [ ] ~~I have updated the documentation accordingly~~
- [ ] ~~I have added tests to cover my changes~~
- [ ] ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.