### PR TITLE
Fix raw validation for number attributes

### DIFF
--- a/cvat-ui/src/components/labels-editor/common.ts
+++ b/cvat-ui/src/components/labels-editor/common.ts
@@ -54,7 +54,10 @@ function validateParsedAttribute(attr: SerializedAttribute): void {
     }
 
     const attrValues = attr.values.map((value: string) => value.trim());
-    if (new Set(attrValues).size !== attrValues.length) {
+    if (
+        attr.input_type.toLowerCase() !== 'number' &&
+        new Set(attrValues).size !== attrValues.length
+    ) {
         throw new Error(`Attribute: "${attr.name}": attribute values must be unique`);
     }
 

--- a/tests/cypress/e2e/features/raw_number_attribute_validation.js
+++ b/tests/cypress/e2e/features/raw_number_attribute_validation.js
@@ -1,0 +1,78 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+context('Raw label editor number attribute validation', { browser: '!firefox' }, () => {
+    const projectName = 'Raw number attribute validation';
+
+    before(() => {
+        cy.visit('/');
+        cy.login();
+
+        cy.goToProjectsList();
+        cy.get('.cvat-create-project-button').click();
+        cy.get('#name').type(projectName);
+
+        cy.contains('[role="tab"]', 'Raw').click();
+
+        const labels = [
+            {
+                name: 'Test label',
+                color: '#ff0000',
+                type: 'any',
+                attributes: [
+                    {
+                        name: 'attr',
+                        mutable: false,
+                        input_type: 'number',
+                        default_value: '1',
+                        values: ['1', '4', '1'],
+                    },
+                ],
+            },
+        ];
+
+        cy.get('.cvat-raw-labels-viewer')
+            .clear()
+            .type(JSON.stringify(labels), {
+                parseSpecialCharSequences: false,
+            });
+
+        cy.contains('button', 'Done').click();
+        cy.contains('button', 'Submit').click();
+
+        cy.get('.cvat-notification-create-project-success').should('exist');
+    });
+
+    after(() => {
+        cy.getAuthKey().then((authKey) => {
+            cy.deleteProjects(authKey, [projectName]);
+        });
+    });
+
+    it('does not reject repeated values in number attribute configuration', () => {
+        cy.goToProjectsList();
+        cy.openProject(projectName);
+
+        cy.contains('[role="tab"]', 'Raw').click();
+
+        cy.get('.cvat-raw-labels-viewer')
+            .focus()
+            .realPress(['ControlLeft', 'a'])
+            .realPress(['ControlLeft', 'c']);
+
+        cy.get('.cvat-raw-labels-viewer')
+            .focus()
+            .clear()
+            .realPress(['ControlLeft', 'v']);
+
+        cy.contains(
+            'attribute values must be unique',
+        ).should('not.exist');
+
+        cy.get('.cvat-submit-raw-labels-conf-button')
+            .should('not.be.disabled');
+    });
+});


### PR DESCRIPTION
### Motivation and context

Fixes #11034.

The raw label editor validated all attribute values as unique.
For number attributes, `values` represents `[min, max, step]`, so values such as `["1", "4", "1"]` are valid even though `min` and `step` are equal.

This change skips the uniqueness check for number attributes while preserving it for other input types.

### How has this been tested?

- Verified a number attribute with min=1, max=4, step=1 can be pasted in the raw label editor without validation errors.
- Verified duplicate values for select/radio attributes are still rejected.
- Ran CVAT UI lint/build.