### PR TITLE
Audio workspace: Fix minimap playback cursor position after pause

### DIFF
--- a/changelog.d/20260825_181905_aleksey.zinovyev_fix_minimap_playback_pos.md
+++ b/changelog.d/20260825_181905_aleksey.zinovyev_fix_minimap_playback_pos.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed waveform minimap playback cursor position after playing and pausing audio track
+  (<https://github.com/cvat-ai/cvat/pull/11079>)

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-playback.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-playback.ts
@@ -74,6 +74,9 @@ export function useWaveformPlayback(runtime: WaveSurferRuntime): WaveformPlaybac
             // See: https://github.com/katspaugh/wavesurfer.js/issues/4347
             // Its player clock remains correct, so use it as the source of truth.
             const currentTime = instance.getCurrentTime();
+            // The minimap subscribes to the stale timeupdate payload directly, so
+            // restore its progress from the player clock as well.
+            runtime.minimap.instanceRef.current?.setTime(currentTime);
             dispatch(audioActions.reportAudioCurrentTime(currentTime));
             listenersRef.current.forEach((listener) => listener(currentTime));
         };


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
When playing and then stopping an audio the playback cursor position on the minimap jumps to the last sought position.

It's a regression after upgrading audio backend to WebAudio. See more details in https://github.com/katspaugh/wavesurfer.js/issues/4347.

The workaround is to restore the position manually until the upstream fix is released.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Tested manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
