### PR TITLE
Audio workspace: fix interval playback stop position

### DIFF
--- a/changelog.d/20260826_102912_aleksey.zinovyev_fix_interval_stop.md
+++ b/changelog.d/20260826_102912_aleksey.zinovyev_fix_interval_stop.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed audio interval playback automatic stop position
+  (<https://github.com/cvat-ai/cvat/pull/11080>)

--- a/cvat-ui/src/actions/audio-actions.ts
+++ b/cvat-ui/src/actions/audio-actions.ts
@@ -13,6 +13,7 @@ import { clamp } from 'utils/math';
 import {
     cacheAudioData, removeCachedAudioData,
 } from 'audio/utils/audio-data-cache';
+import type { AudioPlaybackRange } from 'audio/components/annotation-page/audio-workspace/utils/audio-interval';
 import { updateActiveControl } from './annotation-actions';
 
 export enum AudioActionTypes {
@@ -26,6 +27,11 @@ export enum AudioActionTypes {
     SET_AUDIO_ZOOM = 'SET_AUDIO_ZOOM',
     SET_AUDIO_VOLUME = 'SET_AUDIO_VOLUME',
     SET_AUDIO_LOOP = 'SET_AUDIO_LOOP',
+    SET_AUDIO_PLAYBACK_RANGE = 'SET_AUDIO_PLAYBACK_RANGE',
+    UPDATE_AUDIO_PLAYBACK_RANGE = 'UPDATE_AUDIO_PLAYBACK_RANGE',
+    CLEAR_AUDIO_PLAYBACK_RANGE = 'CLEAR_AUDIO_PLAYBACK_RANGE',
+    SET_AUDIO_INTERVAL_PLAYBACK_SOURCE = 'SET_AUDIO_INTERVAL_PLAYBACK_SOURCE',
+    CLEAR_AUDIO_INTERVAL_PLAYBACK_SOURCE = 'CLEAR_AUDIO_INTERVAL_PLAYBACK_SOURCE',
     FIT_AUDIO_INTERVAL = 'FIT_AUDIO_INTERVAL',
     COMPLETE_FIT_AUDIO_INTERVAL = 'COMPLETE_FIT_AUDIO_INTERVAL',
     SET_AUDIO_ACTIVE_INTERVAL = 'SET_AUDIO_ACTIVE_INTERVAL',
@@ -37,8 +43,6 @@ export enum AudioActionTypes {
     LOAD_AUDIO_DATA_FAILED = 'LOAD_AUDIO_DATA_FAILED',
     SET_WAVEFORM_READY = 'SET_WAVEFORM_READY',
     SET_AUDIO_ACTIVE_LABEL = 'SET_AUDIO_ACTIVE_LABEL',
-    PLAY_AUDIO_INTERVAL_ONCE = 'PLAY_AUDIO_INTERVAL_ONCE',
-    COMPLETE_PLAY_AUDIO_INTERVAL_ONCE = 'COMPLETE_PLAY_AUDIO_INTERVAL_ONCE',
     AUDIO_UNDO = 'AUDIO_UNDO',
     AUDIO_REDO = 'AUDIO_REDO',
 }
@@ -68,6 +72,21 @@ export const audioActions = {
     ),
     setAudioLoop: (loop: boolean) => (
         createAction(AudioActionTypes.SET_AUDIO_LOOP, { loop })
+    ),
+    setAudioPlaybackRange: (range: AudioPlaybackRange) => (
+        createAction(AudioActionTypes.SET_AUDIO_PLAYBACK_RANGE, { range })
+    ),
+    updateAudioPlaybackRange: (range: AudioPlaybackRange) => (
+        createAction(AudioActionTypes.UPDATE_AUDIO_PLAYBACK_RANGE, { range })
+    ),
+    clearAudioPlaybackRange: (id: object | null = null) => (
+        createAction(AudioActionTypes.CLEAR_AUDIO_PLAYBACK_RANGE, { id })
+    ),
+    setAudioIntervalPlaybackSource: (rangeID: object, intervalID: number) => (
+        createAction(AudioActionTypes.SET_AUDIO_INTERVAL_PLAYBACK_SOURCE, { rangeID, intervalID })
+    ),
+    clearAudioIntervalPlaybackSource: (rangeID: object) => (
+        createAction(AudioActionTypes.CLEAR_AUDIO_INTERVAL_PLAYBACK_SOURCE, { rangeID })
     ),
     fitAudioInterval: (clientID: number) => (
         createAction(AudioActionTypes.FIT_AUDIO_INTERVAL, { request: { clientID } })
@@ -107,12 +126,6 @@ export const audioActions = {
     setAudioActiveLabel: (labelId: number | null) => (
         createAction(AudioActionTypes.SET_AUDIO_ACTIVE_LABEL, { labelId })
     ),
-    playAudioIntervalOnce: (request: { intervalID: number }) => (
-        createAction(AudioActionTypes.PLAY_AUDIO_INTERVAL_ONCE, { request })
-    ),
-    completePlayAudioIntervalOnce: (request: { intervalID: number }) => (
-        createAction(AudioActionTypes.COMPLETE_PLAY_AUDIO_INTERVAL_ONCE, { request })
-    ),
     audioUndo: () => createAction(AudioActionTypes.AUDIO_UNDO),
     audioRedo: () => createAction(AudioActionTypes.AUDIO_REDO),
 };
@@ -121,10 +134,12 @@ export type AudioActions = ActionUnion<typeof audioActions>;
 
 export function toggleAudioPlayback(): ThunkAction {
     return async (dispatch: ThunkDispatch, getState): Promise<void> => {
-        const { playing, playIntervalOnceRequest } = getState().audio.player;
+        const {
+            playing, playbackRange,
+        } = getState().audio.player;
         if (playing) {
             dispatch(audioActions.switchAudioPlay(false));
-        } else if (playIntervalOnceRequest) {
+        } else if (playbackRange) {
             dispatch(audioActions.switchAudioPlay(true));
         } else {
             dispatch(audioActions.playFullAudio());
@@ -230,10 +245,22 @@ export function requestAudioSeekByIntent(intent: AudioSeekIntent): ThunkAction {
 
 export function requestPlayAudioIntervalOnce(clientID: number): ThunkAction {
     return async (dispatch: ThunkDispatch, getState): Promise<void> => {
-        const interval = getState().audio.player.intervals.find((_interval) => _interval.clientID === clientID);
+        const interval = getState().audio.player.intervals.find((item) => item.clientID === clientID);
         if (!interval) return;
 
-        dispatch(audioActions.playAudioIntervalOnce({ intervalID: clientID }));
+        const { duration } = getState().audio.player;
+
+        const range = {
+            id: {},
+            start: interval.start / 1000,
+            end: interval.stop ? interval.stop / 1000 : duration,
+        };
+        if (range.end <= range.start) return;
+
+        dispatch(audioActions.setAudioActiveInterval(clientID));
+        dispatch(audioActions.setAudioPlaybackRange(range));
+        dispatch(audioActions.setAudioIntervalPlaybackSource(range.id, clientID));
+        dispatch(audioActions.switchAudioPlay(true));
     };
 }
 

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-audio-interval-annotations.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-audio-interval-annotations.ts
@@ -28,9 +28,8 @@ export function useAudioIntervalAnnotations({ waveform }: Params): AudioInterval
         durationRef: waveform.durationRef,
     });
     useIntervalPlayback({
-        regionRuntime: waveform.regionRuntime,
-        playback: waveform.playback,
-        ready: waveform.ready,
+        getCurrentTime: waveform.playback.getCurrentTime,
+        durationRef: waveform.durationRef,
     });
     useAudioRecording({ playback: waveform.playback, regions, ready: waveform.ready });
     const navigation = useIntervalNavigation({ viewport: waveform.viewport });

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-interval-playback.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-interval-playback.ts
@@ -9,82 +9,111 @@ import { audioActions } from 'actions/audio-actions';
 import { CombinedState } from 'reducers';
 import { shallowEqual, ThunkDispatch } from 'utils/redux';
 
-import {
-    clientIDFromWaveRegionId, intervalEndSeconds, intervalStartSeconds,
-} from '../utils/audio-interval';
-import type { WaveformPlayback } from './use-waveform-playback';
-import type { WaveformRegionRuntime } from './use-audio-waveform';
-
 interface Params {
-    regionRuntime: WaveformRegionRuntime;
-    playback: WaveformPlayback;
-    ready: boolean;
+    getCurrentTime(): number;
+    durationRef: React.MutableRefObject<number>;
+}
+
+interface ObservedIntervalRange {
+    sourceIntervalID: number;
+    start: number;
+    end: number;
 }
 
 /**
- * Applies play-once and looping interval policies through the generic playback controller.
+ * Keeps interval-sourced playback ranges in sync with their source interval.
  */
-export function useIntervalPlayback({ regionRuntime, playback, ready }: Params): void {
+export function useIntervalPlayback({ getCurrentTime, durationRef }: Params): void {
     const dispatch = useDispatch<ThunkDispatch>();
     const {
-        play, pause, seek, subscribeTimeUpdates,
-    } = playback;
-    const {
-        request, loop, playing, activeIntervalID, intervals,
-    } = useSelector((state: CombinedState) => ({
-        request: state.audio.player.playIntervalOnceRequest,
-        loop: state.audio.player.loop,
-        playing: state.audio.player.playing,
-        activeIntervalID: state.audio.player.activeIntervalID,
-        intervals: state.audio.player.intervals,
-    }), shallowEqual);
-    const latestRef = useRef({
-        request, loop, playing, activeIntervalID, intervals,
-    });
-    latestRef.current = {
-        request, loop, playing, activeIntervalID, intervals,
-    };
+        currentPlaybackRange,
+        currentPlaybackRangeSource,
+        currentSourceInterval,
+    } = useSelector((state: CombinedState) => {
+        const { intervals } = state.audio.player;
+        const { playbackRange: playerPlaybackRange } = state.audio.player;
+        const { playbackRangeSource: playerPlaybackRangeSource } = state.audio.player;
 
-    // Start play-once through the generic transport.
+        return {
+            currentPlaybackRange: playerPlaybackRange,
+            currentPlaybackRangeSource: playerPlaybackRangeSource,
+            currentSourceInterval: playerPlaybackRangeSource === null ?
+                null : intervals.find(
+                    (interval) => interval.clientID === playerPlaybackRangeSource.intervalID,
+                ) ?? null,
+        };
+    }, shallowEqual);
+    const previousPlaybackRangeRef = useRef<ObservedIntervalRange | null>(null);
+
     useEffect(() => {
-        if (!ready || !request) return;
-        const latest = latestRef.current;
-        if (!latest.intervals.some((interval) => interval.clientID === request.intervalID)) {
-            dispatch(audioActions.completePlayAudioIntervalOnce(request));
+        if (!currentPlaybackRange) {
+            if (currentPlaybackRangeSource) {
+                dispatch(audioActions.clearAudioIntervalPlaybackSource(currentPlaybackRangeSource.rangeID));
+            }
+            previousPlaybackRangeRef.current = null;
             return;
         }
 
-        const region = regionRuntime.regionsPlugin.getRegions().find(
-            (item) => clientIDFromWaveRegionId(item.id) === request.intervalID,
-        );
-        if (!region) return;
+        if (!currentPlaybackRangeSource) {
+            // Some other source of playback range, not interval
+            previousPlaybackRangeRef.current = null;
+            return;
+        }
 
-        seek(region.start);
-        play();
-    }, [ready, request]);
+        const { id: currentPlaybackRangeID } = currentPlaybackRange;
+        if (currentPlaybackRangeSource.rangeID !== currentPlaybackRangeID) {
+            dispatch(audioActions.clearAudioIntervalPlaybackSource(currentPlaybackRangeSource.rangeID));
+            previousPlaybackRangeRef.current = null;
+            return;
+        }
 
-    useEffect(() => {
-        if (!ready) return undefined;
+        // at this point the source exists and its range ID matches the playback range ID
+        if (!currentSourceInterval) {
+            // e.g. interval was deleted
+            dispatch(audioActions.clearAudioPlaybackRange(currentPlaybackRangeID));
+            dispatch(audioActions.clearAudioIntervalPlaybackSource(currentPlaybackRangeID));
+            previousPlaybackRangeRef.current = null;
+            return;
+        }
 
-        return subscribeTimeUpdates((time: number): void => {
-            const latest = latestRef.current;
-            const intervalID = latest.request?.intervalID ?? (
-                latest.playing && latest.loop ? latest.activeIntervalID : null
-            );
-            if (intervalID === null) return;
+        const currentSourcePlaybackRange = {
+            start: currentSourceInterval.start / 1000,
+            end: currentSourceInterval.stop === null ? durationRef.current : currentSourceInterval.stop / 1000,
+        };
+        const previousPlaybackRange = previousPlaybackRangeRef.current;
+        previousPlaybackRangeRef.current = {
+            sourceIntervalID: currentPlaybackRangeSource.intervalID,
+            ...currentSourcePlaybackRange,
+        };
 
-            const interval = latest.intervals.find((item) => item.clientID === intervalID);
-            if (!interval || time < intervalEndSeconds(interval)) return;
+        if (
+            !previousPlaybackRange ||
+            previousPlaybackRange?.sourceIntervalID !== currentPlaybackRangeSource.intervalID ||
+            (
+                previousPlaybackRange.start === currentSourcePlaybackRange.start &&
+                previousPlaybackRange.end === currentSourcePlaybackRange.end
+            )
+        ) {
+            return;
+        }
 
-            if (latest.request?.intervalID === intervalID) {
-                pause();
-                dispatch(audioActions.completePlayAudioIntervalOnce(latest.request));
-                return;
-            }
+        const currentTime = getCurrentTime();
+        if (
+            currentTime < currentSourcePlaybackRange.start ||
+            currentSourcePlaybackRange.end <= currentTime
+        ) {
+            dispatch(audioActions.clearAudioPlaybackRange(currentPlaybackRangeID));
+            dispatch(audioActions.clearAudioIntervalPlaybackSource(currentPlaybackRangeID));
+            return;
+        }
 
-            if (latest.playing && latest.loop && latest.activeIntervalID === intervalID) {
-                seek(intervalStartSeconds(interval));
-            }
-        });
-    }, [ready]);
+        dispatch(audioActions.updateAudioPlaybackRange({
+            ...currentSourcePlaybackRange,
+            id: currentPlaybackRangeID,
+        }));
+    }, [
+        currentPlaybackRange,
+        currentPlaybackRangeSource,
+        currentSourceInterval,
+    ]);
 }

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-playback.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/hooks/use-waveform-playback.ts
@@ -13,9 +13,10 @@ import { shallowEqual, ThunkDispatch } from 'utils/redux';
 import { clamp } from 'utils/math';
 
 import type { WaveSurferRuntime } from './use-audio-waveform';
+import type { AudioTimeRange } from '../utils/audio-interval';
 
 export interface WaveformPlayback {
-    /** Play audio from the current position */
+    /** Play audio from the current position. */
     play(): void;
     /** Pause audio playback */
     pause(): void;
@@ -31,23 +32,60 @@ export interface WaveformPlayback {
 export function useWaveformPlayback(runtime: WaveSurferRuntime): WaveformPlayback {
     const dispatch = useDispatch<ThunkDispatch>();
     const {
-        playing, duration, volume, playbackRate, seekRequest,
+        playing, duration, volume, playbackRate, seekRequest, playbackRange, loop,
     } = useSelector((state: CombinedState) => ({
         playing: state.audio.player.playing,
         duration: state.audio.player.duration,
         volume: state.audio.player.volume,
         playbackRate: state.audio.player.playbackRate,
         seekRequest: state.audio.player.seekRequest,
+        playbackRange: state.audio.player.playbackRange,
+        loop: state.audio.player.loop,
     }), shallowEqual);
     const listenersRef = useRef(new Set<(time: number) => void>());
+    const lastTimeUpdateRef = useRef<number | null>(null);
+    const playbackRangeRef = useRef(playbackRange);
+    const previousPlaybackRangeRef = useRef<typeof playbackRange>(null);
+    const loopRef = useRef(loop);
+    const playingRef = useRef(playing);
+    playbackRangeRef.current = playbackRange;
+    loopRef.current = loop;
+    playingRef.current = playing;
     const { ready } = runtime;
 
     const play = useCallback((): void => {
         const instance = runtime.instanceRef.current;
         if (!instance) return;
+
         instance.play().catch(() => {});
         dispatch(audioActions.switchAudioPlay(true));
     }, []);
+    const playRange = useCallback((range: AudioTimeRange): void => {
+        const instance = runtime.instanceRef.current;
+        if (!instance) return;
+
+        instance.setTime(range.start);
+        instance.play(undefined, range.end).catch(() => {});
+        dispatch(audioActions.switchAudioPlay(true));
+    }, []);
+    const updateRunningPlaybackRange = useCallback((range: AudioTimeRange): void => {
+        const instance = runtime.instanceRef.current;
+        if (!instance || !instance.isPlaying()) return;
+
+        instance.play(undefined, range.end).catch(() => {});
+    }, []);
+    const syncPlaybackRangeAfterSeek = useCallback((time: number): void => {
+        const range = playbackRangeRef.current;
+        if (!range) return;
+
+        if (time < range.start || time >= range.end) {
+            dispatch(audioActions.clearAudioPlaybackRange());
+            return;
+        }
+
+        updateRunningPlaybackRange(range);
+    }, []);
+
     const pause = useCallback((): void => {
         runtime.instanceRef.current?.pause();
         dispatch(audioActions.switchAudioPlay(false));
@@ -55,7 +93,10 @@ export function useWaveformPlayback(runtime: WaveSurferRuntime): WaveformPlaybac
     const seek = useCallback((time: number): void => {
         const instance = runtime.instanceRef.current;
         if (!instance) return;
-        instance.setTime(clamp(time, 0, instance.getDuration()));
+
+        const target = clamp(time, 0, instance.getDuration());
+        instance.setTime(target);
+        syncPlaybackRangeAfterSeek(target);
     }, []);
     const getCurrentTime = useCallback((): number => runtime.instanceRef.current?.getCurrentTime() ?? 0, []);
     const subscribeTimeUpdates = useCallback((listener: (time: number) => void): (() => void) => {
@@ -68,6 +109,9 @@ export function useWaveformPlayback(runtime: WaveSurferRuntime): WaveformPlaybac
         const instance = runtime.instanceRef.current;
         if (!instance) return undefined;
 
+        let disposed = false;
+        lastTimeUpdateRef.current = null;
+
         const onTimeUpdate = (): void => {
             // With the WebAudio backend, a timeupdate emitted after pausing can
             // carry WaveSurfer's stale reactive time (the previous seek position).
@@ -77,17 +121,78 @@ export function useWaveformPlayback(runtime: WaveSurferRuntime): WaveformPlaybac
             // The minimap subscribes to the stale timeupdate payload directly, so
             // restore its progress from the player clock as well.
             runtime.minimap.instanceRef.current?.setTime(currentTime);
+
+            if (lastTimeUpdateRef.current === currentTime) return;
+            lastTimeUpdateRef.current = currentTime;
+
             dispatch(audioActions.reportAudioCurrentTime(currentTime));
             listenersRef.current.forEach((listener) => listener(currentTime));
         };
+        const handleRangeEnd = (): void => {
+            const range = playbackRangeRef.current;
+            if (!range || instance.getCurrentTime() < range.end) return;
+
+            if (playingRef.current && loopRef.current) {
+                Promise.resolve().then(() => {
+                    const activeRange = playbackRangeRef.current;
+                    if (
+                        disposed ||
+                        !playingRef.current ||
+                        !loopRef.current ||
+                        !activeRange ||
+                        activeRange.start !== range.start ||
+                        activeRange.end !== range.end
+                    ) {
+                        return;
+                    }
+
+                    playRange(activeRange);
+                });
+            } else {
+                // Without it the stop position is not accurate even when it's playing
+                // a range with WebAudio backend. Audio stop must be accurate with it though
+                // so we just fix the displayed position here to look precise as well.
+                instance.setTime(range.end);
+                dispatch(audioActions.clearAudioPlaybackRange());
+                dispatch(audioActions.switchAudioPlay(false));
+            }
+        };
         const onFinish = (): void => {
-            dispatch(audioActions.switchAudioPlay(false));
+            if (!playbackRangeRef.current) {
+                dispatch(audioActions.switchAudioPlay(false));
+                return;
+            }
+
+            handleRangeEnd();
+        };
+        const onPause = (): void => {
+            handleRangeEnd();
         };
         instance.on('timeupdate', onTimeUpdate);
         instance.on('finish', onFinish);
+        instance.on('pause', onPause);
         return () => {
+            disposed = true;
             instance.un('timeupdate', onTimeUpdate);
             instance.un('finish', onFinish);
+            instance.un('pause', onPause);
+        };
+    }, [ready]);
+
+    // WaveSurfer seeks directly on waveform clicks, bypassing Redux.
+    useEffect(() => {
+        const instance = runtime.instanceRef.current;
+        if (!instance) return undefined;
+
+        const handleWaveformSeek = (): void => {
+            syncPlaybackRangeAfterSeek(instance.getCurrentTime());
+        };
+        const unsubscribeMainClick = instance.on('click', handleWaveformSeek);
+        const unsubscribeMinimapClick = runtime.minimap.plugin.on('click', handleWaveformSeek);
+
+        return () => {
+            unsubscribeMainClick();
+            unsubscribeMinimapClick();
         };
     }, [ready]);
 
@@ -97,18 +202,49 @@ export function useWaveformPlayback(runtime: WaveSurferRuntime): WaveformPlaybac
         if (!instance) return;
 
         if (playing) {
-            instance.play().catch(() => {});
+            if (instance.isPlaying()) return;
+
+            instance.play(undefined, playbackRangeRef.current?.end).catch(() => {});
         } else {
             instance.pause();
         }
     }, [playing, ready]);
+
+    // Synchronize playback-range changes with WaveSurfer.
+    useEffect(() => {
+        const instance = runtime.instanceRef.current;
+        if (!instance) return;
+
+        const previousPlaybackRange = previousPlaybackRangeRef.current;
+        previousPlaybackRangeRef.current = playbackRange;
+
+        if (!playbackRange) {
+            if (previousPlaybackRange && instance.isPlaying()) {
+                instance.pause();
+                dispatch(audioActions.switchAudioPlay(false));
+            }
+            return;
+        }
+
+        if (!playingRef.current) return;
+
+        if (!previousPlaybackRange || previousPlaybackRange.id !== playbackRange.id) {
+            playRange(playbackRange);
+            return;
+        }
+
+        updateRunningPlaybackRange(playbackRange);
+    }, [playbackRange, ready]);
 
     // Handle seek requests from redux
     useEffect(() => {
         const instance = runtime.instanceRef.current;
         if (!instance || !seekRequest || duration <= 0) return;
 
-        instance.setTime(clamp(seekRequest.time, 0, duration));
+        const target = clamp(seekRequest.time, 0, duration);
+        instance.setTime(target);
+        syncPlaybackRangeAfterSeek(target);
+
         dispatch(audioActions.completeAudioSeek(seekRequest));
     }, [duration, ready, seekRequest]);
 

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/styles/_interval-header.scss
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/styles/_interval-header.scss
@@ -45,7 +45,7 @@
         align-items: center;
         gap: $grid-unit-size * 0.75;
         min-width: 0;
-        padding: $grid-unit-size * 0.5 $grid-unit-size * 0.75;
+        padding: $grid-unit-size * 0.5 $grid-unit-size * 0.25;
         border-radius: $grid-unit-size * 0.5;
         cursor: pointer;
 

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/styles/_region-details.scss
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/styles/_region-details.scss
@@ -19,7 +19,7 @@
         border-bottom: 1px solid #e5e7eb;
 
         .cvat-audio-interval-header-time {
-            padding-left: $grid-unit-size * 3.75;
+            padding-left: $grid-unit-size * 3.25;
         }
     }
 

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/styles/_regions-list.scss
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/styles/_regions-list.scss
@@ -90,5 +90,5 @@
         box-shadow: 0 3px 10px rgba(0, 0, 0, 14%);
     }
 
-    .cvat-audio-interval-header-time { padding-left: $grid-unit-size * 3.75; }
+    .cvat-audio-interval-header-time { padding-left: $grid-unit-size * 3.25; }
 }

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/utils/audio-interval.ts
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/utils/audio-interval.ts
@@ -11,6 +11,10 @@ export interface AudioTimeRange {
     end: number;
 }
 
+export interface AudioPlaybackRange extends AudioTimeRange {
+    id: object;
+}
+
 export function intervalID(interval: AudioIntervalState): number {
     return interval.clientID as number;
 }

--- a/cvat-ui/src/reducers/audio-reducer.ts
+++ b/cvat-ui/src/reducers/audio-reducer.ts
@@ -347,6 +347,8 @@ export default function audioReducer(state: AudioState = defaultState, action: A
                     activeIntervalID: null,
                     hoveredIntervalID: null,
                     interactingIntervalID: null,
+                    playbackRange: null,
+                    playbackRangeSource: null,
                     contextMenu: defaultState.player.contextMenu,
                 },
             };

--- a/cvat-ui/src/reducers/audio-reducer.ts
+++ b/cvat-ui/src/reducers/audio-reducer.ts
@@ -18,6 +18,8 @@ const defaultState: AudioState = {
         zoom: 1,
         volume: 1,
         loop: false,
+        playbackRange: null,
+        playbackRangeSource: null,
         fitIntervalRequest: null,
         intervals: [],
         activeIntervalID: null,
@@ -34,7 +36,6 @@ const defaultState: AudioState = {
         waveformReady: false,
         audioLoadRequest: null,
         seekRequest: null,
-        playIntervalOnceRequest: null,
         activeLabelId: null,
     },
 };
@@ -67,7 +68,6 @@ export default function audioReducer(state: AudioState = defaultState, action: A
                 player: {
                     ...state.player,
                     playing: true,
-                    playIntervalOnceRequest: null,
                 },
             };
         }
@@ -144,6 +144,62 @@ export default function audioReducer(state: AudioState = defaultState, action: A
                 },
             };
         }
+        case AudioActionTypes.SET_AUDIO_PLAYBACK_RANGE: {
+            return {
+                ...state,
+                player: {
+                    ...state.player,
+                    playbackRange: action.payload.range,
+                },
+            };
+        }
+        case AudioActionTypes.UPDATE_AUDIO_PLAYBACK_RANGE: {
+            if (state.player.playbackRange?.id !== action.payload.range.id) return state;
+
+            return {
+                ...state,
+                player: {
+                    ...state.player,
+                    playbackRange: action.payload.range,
+                },
+            };
+        }
+        case AudioActionTypes.CLEAR_AUDIO_PLAYBACK_RANGE: {
+            if (action.payload.id && state.player.playbackRange?.id !== action.payload.id) return state;
+
+            return {
+                ...state,
+                player: {
+                    ...state.player,
+                    playbackRange: null,
+                },
+            };
+        }
+        case AudioActionTypes.SET_AUDIO_INTERVAL_PLAYBACK_SOURCE: {
+            if (state.player.playbackRange?.id !== action.payload.rangeID) return state;
+
+            return {
+                ...state,
+                player: {
+                    ...state.player,
+                    playbackRangeSource: {
+                        rangeID: action.payload.rangeID,
+                        intervalID: action.payload.intervalID,
+                    },
+                },
+            };
+        }
+        case AudioActionTypes.CLEAR_AUDIO_INTERVAL_PLAYBACK_SOURCE: {
+            if (state.player.playbackRangeSource?.rangeID !== action.payload.rangeID) return state;
+
+            return {
+                ...state,
+                player: {
+                    ...state.player,
+                    playbackRangeSource: null,
+                },
+            };
+        }
         case AudioActionTypes.FIT_AUDIO_INTERVAL: {
             return {
                 ...state,
@@ -165,15 +221,11 @@ export default function audioReducer(state: AudioState = defaultState, action: A
             };
         }
         case AudioActionTypes.SET_AUDIO_ACTIVE_INTERVAL: {
-            const playIntervalOnceRequest =
-                state.player.playIntervalOnceRequest?.intervalID === action.payload.clientID ?
-                    state.player.playIntervalOnceRequest : null;
             return {
                 ...state,
                 player: {
                     ...state.player,
                     activeIntervalID: action.payload.clientID,
-                    playIntervalOnceRequest,
                 },
             };
         }
@@ -223,7 +275,8 @@ export default function audioReducer(state: AudioState = defaultState, action: A
                     audioDataToken: null,
                     audioLoadRequest: action.payload.request,
                     seekRequest: null,
-                    playIntervalOnceRequest: null,
+                    playbackRange: null,
+                    playbackRangeSource: null,
                     contextMenu: defaultState.player.contextMenu,
                 },
             };
@@ -269,27 +322,6 @@ export default function audioReducer(state: AudioState = defaultState, action: A
                 },
             };
         }
-        case AudioActionTypes.PLAY_AUDIO_INTERVAL_ONCE: {
-            return {
-                ...state,
-                player: {
-                    ...state.player,
-                    activeIntervalID: action.payload.request.intervalID,
-                    playIntervalOnceRequest: action.payload.request,
-                },
-            };
-        }
-        case AudioActionTypes.COMPLETE_PLAY_AUDIO_INTERVAL_ONCE: {
-            // request object used as an identity for the play-once operation, so we can ignore stale requests
-            if (state.player.playIntervalOnceRequest !== action.payload.request) return state;
-            return {
-                ...state,
-                player: {
-                    ...state.player,
-                    playIntervalOnceRequest: null,
-                },
-            };
-        }
         case AudioActionTypes.SET_AUDIO_ACTIVE_LABEL: {
             return {
                 ...state,
@@ -315,7 +347,6 @@ export default function audioReducer(state: AudioState = defaultState, action: A
                     activeIntervalID: null,
                     hoveredIntervalID: null,
                     interactingIntervalID: null,
-                    playIntervalOnceRequest: null,
                     contextMenu: defaultState.player.contextMenu,
                 },
             };
@@ -336,10 +367,6 @@ export default function audioReducer(state: AudioState = defaultState, action: A
                 (interval) => interval.clientID === state.player.contextMenu.clientID,
             ) ?
                 state.player.contextMenu.clientID : null;
-            const playIntervalOnceRequest = intervals.some(
-                (interval) => interval.clientID === state.player.playIntervalOnceRequest?.intervalID,
-            ) ? state.player.playIntervalOnceRequest : null;
-
             return {
                 ...state,
                 player: {
@@ -352,7 +379,6 @@ export default function audioReducer(state: AudioState = defaultState, action: A
                         ...state.player.contextMenu,
                         clientID: contextMenuClientID,
                     },
-                    playIntervalOnceRequest,
                 },
             };
         }

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -29,6 +29,15 @@ export interface AudioState {
         zoom: number;
         volume: number;
         loop: boolean;
+        playbackRange: {
+            id: object;
+            start: number;
+            end: number;
+        } | null;
+        playbackRangeSource: {
+            rangeID: object;
+            intervalID: number;
+        } | null;
         fitIntervalRequest: { clientID: number } | null;
         intervals: AudioIntervalState[];
         activeIntervalID: number | null;
@@ -46,7 +55,6 @@ export interface AudioState {
         activeLabelId: number | null;
         audioLoadRequest: object | null;
         seekRequest: { time: number } | null;
-        playIntervalOnceRequest: { intervalID: number } | null;
     };
 }
 

--- a/tests/cypress/e2e/audio_workspace/case_audio_31_interval_playback.js
+++ b/tests/cypress/e2e/audio_workspace/case_audio_31_interval_playback.js
@@ -8,6 +8,7 @@ import { taskName, firstLabelName } from '../../support/const_audio';
 
 context('Audio annotation. Interval playback behavior.', () => {
     const caseId = 'audio_31';
+    const CURSOR_TOLERANCE_PX = 6;
 
     beforeEach(() => {
         cy.prepareUserSession();
@@ -23,6 +24,103 @@ context('Audio annotation. Interval playback behavior.', () => {
         cy.get('.cvat-audio-region-item').should('have.length', 1);
     };
 
+    const expectCursorAtIntervalEnd = () => {
+        cy.getAudioWaveformCursor().then(($cursor) => {
+            cy.getAudioRegion().should('have.length', 1).then(($region) => {
+                const cursor = $cursor[0].getBoundingClientRect();
+                const region = $region[0].getBoundingClientRect();
+
+                expect(cursor.left).to.be.closeTo(region.right, CURSOR_TOLERANCE_PX);
+            });
+        });
+    };
+
+    const getIntervalBounds = () => cy.getAudioRegion().should('have.length', 1).then(($region) => {
+        const bounds = $region[0].getBoundingClientRect();
+        return { left: bounds.left, right: bounds.right };
+    });
+
+    const getCursorPosition = () => cy.getAudioWaveformCursor().then(($cursor) => (
+        $cursor[0].getBoundingClientRect().left
+    ));
+
+    const dragIntervalEndTo = (positionX) => {
+        cy.getAudioRegionHandle('right').then(($handle) => {
+            cy.getAudioWaveformViewport().then(($viewport) => {
+                const viewport = $viewport[0].getBoundingClientRect();
+                const handle = $handle[0].getBoundingClientRect();
+                const targetY = handle.top - viewport.top + handle.height / 2;
+
+                cy.wrap($handle).realMouseDown({
+                    position: 'center',
+                    button: 'left',
+                    scrollBehavior: false,
+                });
+                cy.wrap($viewport).realMouseMove(positionX - viewport.left, targetY, {
+                    scrollBehavior: false,
+                });
+                cy.wrap($viewport).realMouseUp({ button: 'left', scrollBehavior: false });
+            });
+        });
+    };
+
+    const seekWaveformAt = (positionX) => {
+        cy.getAudioWaveformViewport().then(($viewport) => {
+            const viewport = $viewport[0].getBoundingClientRect();
+            cy.clickRegionOnWaveform(positionX - viewport.left);
+        });
+    };
+
+    const seekMinimapAt = (fraction) => {
+        cy.get('#minimap').then(($minimap) => {
+            const minimap = $minimap[0].getBoundingClientRect();
+            cy.wrap($minimap).realClick({
+                x: minimap.width * fraction,
+                y: minimap.height / 2,
+                scrollBehavior: false,
+            });
+        });
+    };
+
+    const seekWithinInterval = (source) => {
+        getIntervalBounds().then(({ left, right }) => {
+            if (source === 'waveform') {
+                seekWaveformAt(left + (right - left) / 2);
+                return;
+            }
+
+            cy.getAudioWaveformViewport().then(($viewport) => {
+                const viewport = $viewport[0].getBoundingClientRect();
+                const position = (left + (right - left) / 2 - viewport.left) / viewport.width;
+                seekMinimapAt(position);
+            });
+        });
+    };
+
+    const seekOutsideInterval = (source) => {
+        if (source === 'waveform') {
+            cy.getAudioWaveformViewport().then(($viewport) => {
+                const viewport = $viewport[0].getBoundingClientRect();
+                seekWaveformAt(viewport.left + viewport.width * 0.9);
+            });
+            return;
+        }
+
+        seekMinimapAt(0.9);
+    };
+
+    const expectCursorWithinInterval = () => {
+        cy.getAudioWaveformCursor().then(($cursor) => {
+            cy.getAudioRegion().should('have.length', 1).then(($region) => {
+                const cursor = $cursor[0].getBoundingClientRect();
+                const region = $region[0].getBoundingClientRect();
+
+                expect(cursor.left).to.be.at.least(region.left - CURSOR_TOLERANCE_PX);
+                expect(cursor.left).to.be.at.most(region.right + CURSOR_TOLERANCE_PX);
+            });
+        });
+    };
+
     describe(`Testing case "${caseId}"`, () => {
         it('Plays an interval once from a sidebar double-click', () => {
             createShortInterval();
@@ -31,6 +129,7 @@ context('Audio annotation. Interval playback behavior.', () => {
 
             cy.get('.cvat-player-pause-button').should('exist');
             cy.get('.cvat-player-play-button', { timeout: 8000 }).should('exist');
+            expectCursorAtIntervalEnd();
         });
 
         it('Plays an interval once from a canvas double-click', () => {
@@ -40,6 +139,7 @@ context('Audio annotation. Interval playback behavior.', () => {
             cy.get('.cvat-audio-region-item').first().should('have.class', 'cvat-audio-region-item-active');
             cy.get('.cvat-player-pause-button').should('exist');
             cy.get('.cvat-player-play-button', { timeout: 8000 }).should('exist');
+            expectCursorAtIntervalEnd();
         });
 
         it('Preserves play-once bounds across pause and resume', () => {
@@ -51,21 +151,106 @@ context('Audio annotation. Interval playback behavior.', () => {
 
             cy.get('.cvat-player-pause-button').should('exist');
             cy.get('.cvat-player-play-button', { timeout: 8000 }).should('exist');
+            expectCursorAtIntervalEnd();
         });
 
-        it('Loops an active interval instead of finishing at the end of the track', () => {
+        it('Loops a playing interval range', () => {
             createShortInterval();
-            cy.clickRegionOnWaveform(106);
 
-            cy.get('.cvat-audio-region-item').first().should('have.class', 'cvat-audio-region-item-active');
             cy.get('.cvat-audio-loop-control').click();
             cy.get('.cvat-audio-loop-control').should('have.class', 'cvat-active-canvas-control');
-            cy.get('.cvat-player-play-button').click();
+            cy.get('.cvat-audio-region-item').first().dblclick();
 
             cy.wait(6000);
             cy.get('.cvat-player-pause-button').should('exist');
+            expectCursorWithinInterval();
 
             cy.get('.cvat-player-pause-button').click();
+        });
+
+        it('Continues playback past the old end when the active interval is extended', () => {
+            cy.audioCreateRegionViaButton(firstLabelName, 100, 130);
+            getIntervalBounds().then(({ right: previousEnd }) => {
+                cy.get('.cvat-audio-region-item').first().dblclick();
+                cy.getAudioWaveformViewport().then(($viewport) => {
+                    const viewport = $viewport[0].getBoundingClientRect();
+                    const newEnd = Math.min(previousEnd + 50, viewport.right - 40);
+
+                    expect(newEnd).to.be.greaterThan(previousEnd + CURSOR_TOLERANCE_PX);
+                    dragIntervalEndTo(newEnd);
+                });
+
+                cy.getAudioRegion().should(($region) => {
+                    expect($region[0].getBoundingClientRect().right).to.be.greaterThan(
+                        previousEnd + CURSOR_TOLERANCE_PX,
+                    );
+                });
+                cy.getAudioWaveformCursor().should(($cursor) => {
+                    expect($cursor[0].getBoundingClientRect().left).to.be.greaterThan(
+                        previousEnd + CURSOR_TOLERANCE_PX,
+                    );
+                });
+                cy.get('.cvat-player-pause-button').should('exist');
+                cy.get('.cvat-player-play-button', { timeout: 12000 }).should('exist');
+                expectCursorAtIntervalEnd();
+            });
+        });
+
+        it('Stops and clears playback when the active interval is shrunk behind the playhead', () => {
+            cy.audioCreateRegionViaButton(firstLabelName, 100, 180);
+            getIntervalBounds().then(({ left }) => {
+                cy.get('.cvat-audio-region-item').first().dblclick();
+                cy.getAudioWaveformCursor().should(($cursor) => {
+                    expect($cursor[0].getBoundingClientRect().left).to.be.greaterThan(left + 15);
+                });
+
+                getCursorPosition().then((cursorPosition) => {
+                    dragIntervalEndTo(cursorPosition - 8);
+                });
+            });
+
+            cy.get('.cvat-player-play-button', { timeout: 8000 }).should('exist');
+            getCursorPosition().then((stoppedPosition) => {
+                cy.get('.cvat-player-play-button').click();
+                cy.getAudioWaveformCursor().should(($cursor) => {
+                    expect($cursor[0].getBoundingClientRect().left).to.be.greaterThan(
+                        stoppedPosition + CURSOR_TOLERANCE_PX,
+                    );
+                });
+                cy.get('.cvat-player-pause-button').click();
+            });
+        });
+
+        it('Stops interval playback when its source interval is deleted', () => {
+            cy.audioCreateRegionViaButton(firstLabelName, 100, 180);
+            cy.get('.cvat-audio-region-item').first().dblclick();
+            cy.get('.cvat-player-pause-button').should('exist');
+
+            cy.get('body').type('{del}');
+            cy.get('.cvat-audio-region-item').should('not.exist');
+            cy.get('.cvat-player-play-button', { timeout: 8000 }).should('exist');
+        });
+
+        ['waveform', 'minimap'].forEach((source) => {
+            it(`Preserves an interval range when seeking within it by ${source}`, () => {
+                cy.audioCreateRegionViaButton(firstLabelName, 100, 180);
+                cy.get('.cvat-audio-region-item').first().dblclick();
+                cy.get('.cvat-player-pause-button').should('exist');
+
+                seekWithinInterval(source);
+                cy.get('.cvat-player-pause-button').should('exist');
+                cy.get('.cvat-player-play-button', { timeout: 12000 }).should('exist');
+                expectCursorAtIntervalEnd();
+            });
+
+            it(`Cancels an interval range when seeking outside it by ${source}`, () => {
+                cy.audioCreateRegionViaButton(firstLabelName, 100, 130);
+                cy.get('.cvat-audio-region-item').first().dblclick();
+                cy.get('.cvat-player-pause-button').should('exist');
+
+                seekOutsideInterval(source);
+                cy.get('.cvat-player-play-button', { timeout: 8000 }).should('exist');
+            });
         });
     });
 });

--- a/tests/cypress/e2e/audio_workspace/case_audio_37_interval_actions.js
+++ b/tests/cypress/e2e/audio_workspace/case_audio_37_interval_actions.js
@@ -95,6 +95,7 @@ context('Audio annotation. Interval actions.', () => {
             cy.realPress(['Shift', 'Space']);
             cy.get('.cvat-player-pause-button').should('exist');
             cy.get('.cvat-player-play-button', { timeout: 8000 }).should('exist');
+            expectCursorAtIntervalBoundary('end');
         });
 
         it('Fits the selected interval into the waveform viewport with I', () => {
@@ -132,6 +133,7 @@ context('Audio annotation. Interval actions.', () => {
                     clickIntervalAction('playInterval');
                     cy.get('.cvat-player-pause-button').should('exist');
                     cy.get('.cvat-player-play-button', { timeout: 8000 }).should('exist');
+                    expectCursorAtIntervalBoundary('end');
                 });
 
                 it('Fits the selected interval into the waveform viewport from the menu', () => {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Automatic stop after playing an interval slightly misses the end. It uses `timeupdate` event to track the stop which is emitted at frame rate.

The fix uses stop parameter of `WaveSurfer` play method instead. When used with `WebAudio` backend it schedules to play a specific portion of the audio so the audio playback is precise and deterministic. The displayed end position was still jittery around the end so it's explicitly set to the end of interval when playback is finished.

The following rules currently apply:
* Pause/play of the interval playback keeps it
* Seek within the interval keeps its playback
* Seek outside drops the interval playback and audio stops

If the playback interval is resized/moved:
* If the current playback position is within the updated interval - it keeps the interval playback
* If it's outside of the updated interval - interval playback is dropped and audio stops

If the interval is removed - interval playback is dropped and audio stops

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Tested manually.
Added and adjusted e2e tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
