### PR TITLE
Audio: adjust import and export annotations dialogs for 1D

### DIFF
--- a/changelog.d/20260826_120153_aleksey.zinovyev_1d_import_export_opts.md
+++ b/changelog.d/20260826_120153_aleksey.zinovyev_1d_import_export_opts.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Removed unsupported "Save images" and "Convert masks to polygons" options
+  from import and export annotation dialogs for 1D
+  (<https://github.com/cvat-ai/cvat/pull/11081>)

--- a/cvat-ui/src/components/export-dataset/export-dataset-modal.tsx
+++ b/cvat-ui/src/components/export-dataset/export-dataset-modal.tsx
@@ -135,6 +135,10 @@ function ExportDatasetModal(props: Readonly<StateToProps>): JSX.Element {
         }
     }, [isBulkMode, instanceType, allTasks, allProjects, allJobs, instance]);
 
+    const canSaveImages = isBulkMode ?
+        selectedInstances.some((selectedInstance) => selectedInstance.dimension !== DimensionType.DIMENSION_1D) :
+        instance?.dimension !== DimensionType.DIMENSION_1D;
+
     const [nameTemplate, setNameTemplate] = useState('dataset_task_{{id}}');
 
     useEffect(() => {
@@ -186,6 +190,9 @@ function ExportDatasetModal(props: Readonly<StateToProps>): JSX.Element {
     const handleExport = useCallback(
         (values: FormValues): void => {
             const exportExtension = getExportExtension(dumpers, values.selectedFormat);
+            const shouldSaveImages = (target: ProjectOrTaskOrJob): boolean => (
+                target.dimension !== DimensionType.DIMENSION_1D && values.saveImages
+            );
             if (isBulkMode) {
                 dispatch(makeBulkOperationAsync<ProjectOrTaskOrJob>(
                     selectedInstances,
@@ -199,7 +206,7 @@ function ExportDatasetModal(props: Readonly<StateToProps>): JSX.Element {
                             exportDatasetAsync(
                                 inst,
                                 values.selectedFormat as string,
-                                values.saveImages,
+                                shouldSaveImages(inst),
                                 false, // always custom storage in bulk
                                 new Storage({
                                     location: values.targetStorage?.location,
@@ -232,7 +239,7 @@ function ExportDatasetModal(props: Readonly<StateToProps>): JSX.Element {
                 exportDatasetAsync(
                     instance as ProjectOrTaskOrJob,
                     values.selectedFormat as string,
-                    values.saveImages,
+                    shouldSaveImages(instance as ProjectOrTaskOrJob),
                     useDefaultTargetStorage,
                     useDefaultTargetStorage ? new Storage({
                         location: defaultStorageLocation,
@@ -337,7 +344,7 @@ function ExportDatasetModal(props: Readonly<StateToProps>): JSX.Element {
                     </Select>
                 </Form.Item>
                 {
-                    instance?.dimension !== DimensionType.DIMENSION_1D &&
+                    canSaveImages &&
                     <Space>
                         <Form.Item
                             className='cvat-modal-export-switch-use-default-storage'

--- a/cvat-ui/src/components/export-dataset/export-dataset-modal.tsx
+++ b/cvat-ui/src/components/export-dataset/export-dataset-modal.tsx
@@ -29,6 +29,7 @@ import { makeBulkOperationAsync } from 'actions/bulk-actions';
 import {
     Dumper, ProjectOrTaskOrJob, Job, Project,
     Storage, StorageData, StorageLocation, Task,
+    DimensionType,
 } from 'cvat-core-wrapper';
 
 type FormValues = {
@@ -335,16 +336,19 @@ function ExportDatasetModal(props: Readonly<StateToProps>): JSX.Element {
                             )}
                     </Select>
                 </Form.Item>
-                <Space>
-                    <Form.Item
-                        className='cvat-modal-export-switch-use-default-storage'
-                        name='saveImages'
-                        valuePropName='checked'
-                    >
-                        <Switch className='cvat-modal-export-save-images' />
-                    </Form.Item>
-                    <Text strong>Save images</Text>
-                </Space>
+                {
+                    instance?.dimension !== DimensionType.DIMENSION_1D &&
+                    <Space>
+                        <Form.Item
+                            className='cvat-modal-export-switch-use-default-storage'
+                            name='saveImages'
+                            valuePropName='checked'
+                        >
+                            <Switch className='cvat-modal-export-save-images' />
+                        </Form.Item>
+                        <Text strong>Save images</Text>
+                    </Space>
+                }
                 {isBulkMode ? (
                     <Form.Item label={<Text strong>Name template</Text>} required>
                         <Input

--- a/cvat-ui/src/components/import-dataset/import-dataset-modal.tsx
+++ b/cvat-ui/src/components/import-dataset/import-dataset-modal.tsx
@@ -27,7 +27,7 @@ import Space from 'antd/lib/space';
 import Switch from 'antd/lib/switch';
 import {
     getCore, Job, Loader, Project, Storage, StorageData, StorageLocation,
-    Task,
+    Task, DimensionType,
 } from 'cvat-core-wrapper';
 import StorageField from 'components/storage/storage-field';
 import { createAction, ActionUnion } from 'utils/redux';
@@ -630,23 +630,26 @@ function ImportDatasetModal(props: StateToProps): JSX.Element {
                             )}
                     </Select>
                 </Form.Item>
-                <Space className='cvat-modal-import-switch-conv-mask-to-poly-container'>
-                    <Form.Item
-                        name='convMaskToPoly'
-                        valuePropName='checked'
-                        className='cvat-modal-import-switch-conv-mask-to-poly'
-                    >
-                        <Switch
-                            onChange={(value: boolean) => {
-                                dispatch(reducerActions.setConvMaskToPoly(value));
-                            }}
-                        />
-                    </Form.Item>
-                    <Text strong>Convert masks to polygons</Text>
-                    <CVATTooltip title='The option is relevant for formats that work with masks only'>
-                        <QuestionCircleOutlined />
-                    </CVATTooltip>
-                </Space>
+                {
+                    instance?.dimension !== DimensionType.DIMENSION_1D &&
+                    <Space className='cvat-modal-import-switch-conv-mask-to-poly-container'>
+                        <Form.Item
+                            name='convMaskToPoly'
+                            valuePropName='checked'
+                            className='cvat-modal-import-switch-conv-mask-to-poly'
+                        >
+                            <Switch
+                                onChange={(value: boolean) => {
+                                    dispatch(reducerActions.setConvMaskToPoly(value));
+                                }}
+                            />
+                        </Form.Item>
+                        <Text strong>Convert masks to polygons</Text>
+                        <CVATTooltip title='The option is relevant for formats that work with masks only'>
+                            <QuestionCircleOutlined />
+                        </CVATTooltip>
+                    </Space>
+                }
                 <Space className='cvat-modal-import-switch-use-default-storage-container'>
                     <Form.Item
                         name='useDefaultSettings'

--- a/cvat-ui/src/components/jobs-page/actions-menu-items.tsx
+++ b/cvat-ui/src/components/jobs-page/actions-menu-items.tsx
@@ -25,6 +25,7 @@ interface MenuItemsData {
     onGoToReplicas: (() => void) | null;
     startEditField: (key: string) => void;
     jobsToAct: Job[];
+    isExportAnnotationsDisabled: boolean;
 }
 
 enum MenuKeys {
@@ -62,6 +63,7 @@ export default function JobActionsItems(
         jobsToAct,
         onGoToParent,
         onGoToReplicas,
+        isExportAnnotationsDisabled,
     } = menuItemsData;
 
     const isBulkMode = jobsToAct.length > 1;
@@ -140,7 +142,7 @@ export default function JobActionsItems(
         key: MenuKeys.EXPORT_JOB,
         onClick: onExportAnnotations,
         label: withCount('Export annotations', MenuKeys.EXPORT_JOB),
-        disabled: isDisabled(MenuKeys.EXPORT_JOB),
+        disabled: isExportAnnotationsDisabled || isDisabled(MenuKeys.EXPORT_JOB),
     }, 60]);
 
     if (onMergeConsensusJob) {

--- a/cvat-ui/src/components/jobs-page/actions-menu.tsx
+++ b/cvat-ui/src/components/jobs-page/actions-menu.tsx
@@ -59,6 +59,8 @@ function JobActionsComponent(
     if (selectedIds.includes(jobInstance.id)) {
         jobsToAct = allJobs.filter((m) => selectedIds.includes(m.id));
     }
+    const isExportAnnotationsDisabled = isBulkMode &&
+        new Set(jobsToAct.map((job) => job.dimension)).size > 1;
 
     const {
         dropdownOpen,
@@ -229,6 +231,7 @@ function JobActionsComponent(
             onGoToParent: jobInstance.parentJobId ? onGoToParent : null,
             onGoToReplicas: jobInstance.replicasCount > 0 ? onGoToReplicas : null,
             jobsToAct,
+            isExportAnnotationsDisabled,
         }, props);
     }
 

--- a/cvat-ui/src/components/projects-page/actions-menu-items.tsx
+++ b/cvat-ui/src/components/projects-page/actions-menu-items.tsx
@@ -18,6 +18,7 @@ interface MenuItemsData {
     onBackupProject: () => void;
     onDeleteProject: () => void;
     selectedIds: number[];
+    isExportDatasetDisabled: boolean;
 }
 
 export default function ProjectActionsItems(
@@ -33,6 +34,7 @@ export default function ProjectActionsItems(
         onBackupProject,
         onDeleteProject,
         selectedIds = [],
+        isExportDatasetDisabled,
     } = menuItemsData;
 
     const isBulkMode = selectedIds.length > 1;
@@ -46,7 +48,7 @@ export default function ProjectActionsItems(
         key: 'export-dataset',
         onClick: onExportDataset,
         label: withCount('Export dataset', 'export-dataset'),
-        disabled: isDisabled('export-dataset'),
+        disabled: isExportDatasetDisabled || isDisabled('export-dataset'),
     }, 0]);
 
     menuItems.push([{

--- a/cvat-ui/src/components/projects-page/actions-menu.tsx
+++ b/cvat-ui/src/components/projects-page/actions-menu.tsx
@@ -55,6 +55,12 @@ function ProjectActionsComponent(props: Readonly<Props>): JSX.Element {
     }), shallowEqual);
 
     const isBulkMode = selectedIds.length > 1;
+    const isExportDatasetDisabled = isBulkMode &&
+        new Set(
+            currentProjects
+                .filter((project) => selectedIds.includes(project.id))
+                .map((project) => project.dimension),
+        ).size > 1;
     const {
         dropdownOpen,
         editField,
@@ -217,6 +223,7 @@ function ProjectActionsComponent(props: Readonly<Props>): JSX.Element {
             onBackupProject,
             onDeleteProject,
             selectedIds,
+            isExportDatasetDisabled,
         }, props);
     }
 

--- a/cvat-ui/src/components/tasks-page/actions-menu-items.tsx
+++ b/cvat-ui/src/components/tasks-page/actions-menu-items.tsx
@@ -26,6 +26,7 @@ interface MenuItemsData {
     onDeleteTask: () => void;
     startEditField: (key: string) => void;
     selectedIds: number[];
+    isExportDatasetDisabled: boolean;
 }
 
 const bulkAllowedKeys = ['edit_assignee', 'backup_task', 'export_task_dataset', 'delete_task', 'edit_organization'];
@@ -48,6 +49,7 @@ export default function TaskActionsItems(menuItemsData: MenuItemsData, taskMenuP
         onRunAutoAnnotation,
         onMoveTaskToProject,
         onDeleteTask,
+        isExportDatasetDisabled,
     } = menuItemsData;
 
     const isBulkMode = selectedIds.length > 1;
@@ -66,7 +68,7 @@ export default function TaskActionsItems(menuItemsData: MenuItemsData, taskMenuP
         key: 'export_task_dataset',
         onClick: onExportDataset,
         label: withCount('Export task dataset', 'export_task_dataset'),
-        disabled: isDisabled('export_task_dataset'),
+        disabled: isExportDatasetDisabled || isDisabled('export_task_dataset'),
     }, 10]);
 
     if (onOpenBugTracker) {

--- a/cvat-ui/src/components/tasks-page/actions-menu.tsx
+++ b/cvat-ui/src/components/tasks-page/actions-menu.tsx
@@ -63,6 +63,12 @@ function TaskActionsComponent(props: Readonly<Props>): JSX.Element {
     }), shallowEqual);
 
     const isBulkMode = selectedIds.length > 1;
+    const isExportDatasetDisabled = isBulkMode &&
+        new Set(
+            currentTasks
+                .filter((task) => selectedIds.includes(task.id))
+                .map((task) => task.dimension),
+        ).size > 1;
     const {
         dropdownOpen,
         editField,
@@ -268,6 +274,7 @@ function TaskActionsComponent(props: Readonly<Props>): JSX.Element {
             onMoveTaskToProject,
             onDeleteTask,
             selectedIds,
+            isExportDatasetDisabled,
         }, props);
     }
 

--- a/tests/cypress/e2e/audio_workspace/case_audio_29_import_tsv_annotations.js
+++ b/tests/cypress/e2e/audio_workspace/case_audio_29_import_tsv_annotations.js
@@ -35,6 +35,8 @@ context('Audio annotation. Import transcriptions from a TSV file.', () => {
             cy.intercept('GET', '/api/jobs/**/annotations?**').as('uploadAnnotationsGet');
 
             cy.interactMenu('Upload annotations');
+            // Option for 2D export is not present
+            cy.contains('.cvat-modal-import-dataset', 'Convert masks to polygons').should('not.exist');
             cy.get('.cvat-modal-import-dataset').find('.cvat-modal-import-select').click();
             cy.contains('.cvat-modal-import-dataset-option-item', format).click();
             cy.get('.cvat-modal-import-select').should('contain.text', format);

--- a/tests/cypress/e2e/audio_workspace/case_audio_39_export_dialog_options.js
+++ b/tests/cypress/e2e/audio_workspace/case_audio_39_export_dialog_options.js
@@ -1,0 +1,42 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName } from '../../support/const_audio';
+
+context('Audio annotation. Export annotations.', () => {
+    const caseId = 'audio_39';
+
+    before(() => {
+        cy.prepareUserSession();
+        cy.openAudioJob(taskName);
+    });
+
+    describe(`Testing case "${caseId}"`, () => {
+        it('Export job dataset successfully exports annotations', () => {
+            cy.interactMenu('Export job dataset');
+
+            // non-applicable 2D options are hidden
+            cy.get('.cvat-modal-export-job').should('be.visible').within(() => {
+                cy.get('.cvat-modal-export-save-images').should('not.exist');
+                cy.contains('Save images').should('not.exist');
+            });
+
+            cy.get('.cvat-modal-export-job').find('.cvat-modal-export-select').click();
+            cy.get('.ant-select-dropdown').not('.ant-select-dropdown-hidden').within(() => {
+                cy.get('.cvat-modal-export-option-item').should('have.length', 1).click();
+            });
+            cy.get('.cvat-modal-export-job').contains('button', 'OK').click();
+
+            cy.get('.cvat-modal-export-job').should('not.exist');
+            cy.get('.cvat-notification-notice-export-job-start').should('be.visible');
+            cy.closeNotification('.cvat-notification-notice-export-job-start');
+            cy.get('.cvat-notification-notice-export-job-finished', { timeout: 60000 })
+                .should('be.visible')
+                .and('contain.text', 'Export is finished');
+            cy.closeNotification('.cvat-notification-notice-export-job-finished');
+        });
+    });
+});


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Import and export annotation dialogs contain configurations non-relevant for audio (1D). Sometimes they may also lead a failed operation. E.g. trying to export audio annotations with `Save images` option enabled leads to an error.

This change removes `Save images` option from the export dialog and `Convert masks to polygons` option from the import dialog for 1D jobs/tasks/projects. 

#### Import
Before:
<img width="521" height="523" alt="ImportOld" src="https://github.com/user-attachments/assets/69a84e2a-6e0b-49ec-bfe1-8448aa9cb0b5" />

After:
<img width="518" height="485" alt="ImportNew" src="https://github.com/user-attachments/assets/78cb79a3-d519-48e6-a0a0-0c7ff62a519e" />

#### Export
Before:
<img width="520" height="362" alt="ExportOld" src="https://github.com/user-attachments/assets/e7e810fd-ba59-4111-854d-ce3312550100" />

After:
<img width="521" height="323" alt="ExportNew" src="https://github.com/user-attachments/assets/2ca36960-5994-4a79-9ee5-fff51028a7cc" />

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Tested manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
