### PR TITLE
Prevent corrupted chunks during resumed downloads

### DIFF
--- a/changelog.d/20260826_120000_codex_validate_initial_chunk_size.md
+++ b/changelog.d/20260826_120000_codex_validate_initial_chunk_size.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - Fixed corrupted annotation chunks after interrupted or resumed downloads
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/11083>)

--- a/changelog.d/20260826_120000_codex_validate_initial_chunk_size.md
+++ b/changelog.d/20260826_120000_codex_validate_initial_chunk_size.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed corrupted annotation chunks after interrupted or resumed downloads
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/cvat-core/src/download.worker.ts
+++ b/cvat-core/src/download.worker.ts
@@ -27,6 +27,11 @@ class DownloadReadError extends Error {
     }
 }
 
+interface ChunkIdentity {
+    checksum: string;
+    updatedDate: string;
+}
+
 function sleep(timeout: number): Promise<void> {
     return new Promise((resolve) => {
         setTimeout(resolve, timeout);
@@ -90,6 +95,32 @@ function headersToObject(headers: Headers): Record<string, string> {
     return Object.fromEntries([...headers.entries()]);
 }
 
+function getExpectedSize(headers: Record<string, string>): number | null {
+    // X-Chunk-Size describes the decoded chunk assembled by this worker and is not affected by HTTP compression.
+    const chunkSize = headers['x-chunk-size'];
+    if (typeof chunkSize === 'undefined') {
+        return null;
+    }
+
+    const parsedChunkSize = Number(chunkSize);
+    return Number.isInteger(parsedChunkSize) && parsedChunkSize >= 0 ? parsedChunkSize : null;
+}
+
+function getChunkIdentity(headers: Record<string, string>): ChunkIdentity {
+    // The update date identifies the chunk generation, while the checksum also guards against stale cached content.
+    const checksum = headers['x-checksum'];
+    const updatedDate = headers['x-updated-date'];
+    if (!checksum || !updatedDate) {
+        throw new Error('Missing chunk identity headers');
+    }
+
+    return { checksum, updatedDate };
+}
+
+function isSameChunk(first: ChunkIdentity, second: ChunkIdentity): boolean {
+    return first.checksum === second.checksum && first.updatedDate === second.updatedDate;
+}
+
 function mergeChunks(chunks: Uint8Array[], totalLength: number): ArrayBuffer {
     const data = new Uint8Array(totalLength);
     let offset = 0;
@@ -132,10 +163,11 @@ async function fetchData(url: string, requestConfig): Promise<{
     headers: Record<string, string>;
 }> {
     const requestUrl = appendParams(url, requestConfig.params);
-    const chunks: Uint8Array[] = [];
+    let chunks: Uint8Array[] = [];
     let receivedBytes = 0;
     let responseHeaders: Record<string, string> = {};
     let expectedSize: number | null = null;
+    let chunkIdentity: ChunkIdentity | null = null;
 
     let retry = 0;
     while (retry <= MAX_NO_PROGRESS_RETRIES) {
@@ -177,9 +209,26 @@ async function fetchData(url: string, requestConfig): Promise<{
                     throw new Error(`Unexpected response status: ${response.status}`);
                 }
             } else {
-                expectedSize = null;
+                // A truncated initial response can end without a stream read error. Keep the full chunk size so
+                // the incomplete response is resumed instead of being accepted as a successful download.
+                expectedSize = getExpectedSize(responseHeaders);
             }
 
+            const responseChunkIdentity = getChunkIdentity(responseHeaders);
+            if (chunkIdentity && !isSameChunk(chunkIdentity, responseChunkIdentity)) {
+                // The partial bytes and retry history belong to an outdated chunk. Discard them and immediately
+                // start a new full download; waiting or applying the previous retry count would only delay recovery.
+                await response.body?.cancel();
+                chunks = [];
+                receivedBytes = 0;
+                responseHeaders = {};
+                expectedSize = null;
+                chunkIdentity = null;
+                retry = 0;
+                continue;
+            }
+
+            chunkIdentity = responseChunkIdentity;
             receivedBytes = await readResponse(response, chunks, receivedBytes);
 
             if (expectedSize !== null && receivedBytes > expectedSize) {

--- a/cvat-core/src/download.worker.ts
+++ b/cvat-core/src/download.worker.ts
@@ -95,17 +95,6 @@ function headersToObject(headers: Headers): Record<string, string> {
     return Object.fromEntries([...headers.entries()]);
 }
 
-function getExpectedSize(headers: Record<string, string>): number | null {
-    // X-Chunk-Size describes the decoded chunk assembled by this worker and is not affected by HTTP compression.
-    const chunkSize = headers['x-chunk-size'];
-    if (typeof chunkSize === 'undefined') {
-        return null;
-    }
-
-    const parsedChunkSize = Number(chunkSize);
-    return Number.isInteger(parsedChunkSize) && parsedChunkSize >= 0 ? parsedChunkSize : null;
-}
-
 function getChunkIdentity(headers: Record<string, string>): ChunkIdentity {
     // The update date identifies the chunk generation, while the checksum also guards against stale cached content.
     const checksum = headers['x-checksum'];
@@ -175,9 +164,9 @@ async function fetchData(url: string, requestConfig): Promise<{
         const receivedBytesBeforeRequest = receivedBytes;
         try {
             const headers = new Headers(requestConfig.headers ?? {});
-            if (receivedBytes) {
-                headers.set('Range', `bytes=${receivedBytes}-`);
-            }
+            // Request the entire chunk as an open-ended range on the first attempt as well. This makes the server
+            // provide the full decoded chunk size in Content-Range independently of HTTP content encoding.
+            headers.set('Range', `bytes=${receivedBytes}-`);
 
             response = await fetch(requestUrl, {
                 method: 'GET',
@@ -197,22 +186,15 @@ async function fetchData(url: string, requestConfig): Promise<{
                 throw new DownloadError(await response.text(), response.status);
             }
 
-            if (receivedBytes) {
-                if (response.status === 206) {
-                    const contentRange = parseContentRange(response.headers.get('content-range'));
-                    if (!contentRange || contentRange.start !== receivedBytes) {
-                        throw new Error('Unexpected Content-Range header');
-                    }
-
-                    expectedSize = contentRange.total;
-                } else {
-                    throw new Error(`Unexpected response status: ${response.status}`);
-                }
-            } else {
-                // A truncated initial response can end without a stream read error. Keep the full chunk size so
-                // the incomplete response is resumed instead of being accepted as a successful download.
-                expectedSize = getExpectedSize(responseHeaders);
+            if (response.status !== 206) {
+                throw new Error(`Unexpected response status: ${response.status}`);
             }
+
+            const contentRange = parseContentRange(responseHeaders['content-range'] ?? null);
+            if (!contentRange || contentRange.start !== receivedBytes || contentRange.total === null) {
+                throw new Error('Unexpected Content-Range header');
+            }
+            expectedSize = contentRange.total;
 
             const responseChunkIdentity = getChunkIdentity(responseHeaders);
             if (chunkIdentity && !isSameChunk(chunkIdentity, responseChunkIdentity)) {
@@ -251,12 +233,12 @@ async function fetchData(url: string, requestConfig): Promise<{
                 throw new Error(`Received fewer bytes than expected: ${receivedBytes}/${expectedSize}`);
             }
 
-            if (expectedSize === null || receivedBytes === expectedSize) {
+            if (receivedBytes === expectedSize) {
                 return {
                     data: mergeChunks(chunks, receivedBytes),
                     headers: {
                         ...responseHeaders,
-                        ...(expectedSize !== null ? { 'content-length': `${expectedSize}` } : {}),
+                        'content-length': `${expectedSize}`,
                     },
                 };
             }

--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -167,7 +167,6 @@ slogger = ServerLogManager(__name__)
 _UPLOAD_PARSER_CLASSES = api_settings.DEFAULT_PARSER_CLASSES + [MultiPartParser]
 
 _DATA_CHECKSUM_HEADER_NAME = "X-Checksum"
-_DATA_SIZE_HEADER_NAME = "X-Chunk-Size"
 _DATA_UPDATED_DATE_HEADER_NAME = "X-Updated-Date"
 _RETRY_AFTER_TIMEOUT = 10
 
@@ -874,10 +873,6 @@ class _DataGetter(metaclass=ABCMeta):
     _CHUNK_HEADER_BYTES_LENGTH = 1000
     "The number of significant bytes from the chunk header, used for checksum computation"
 
-    def _get_chunk_size(self, chunk_data: DataWithMeta) -> int:
-        """Return the decoded chunk size exposed to clients independently of HTTP compression."""
-        return len(chunk_data.data.getbuffer())
-
     def _get_chunk_checksum(self, chunk_data: DataWithMeta) -> str:
         data = chunk_data.data.getbuffer()
         size_checksum = zlib.crc32(str(len(data)).encode())
@@ -885,13 +880,11 @@ class _DataGetter(metaclass=ABCMeta):
 
     def _make_chunk_response_headers(
         self,
-        size: int,
         checksum: str,
         updated_date: datetime,
     ) -> dict[str, str]:
         return {
             _DATA_CHECKSUM_HEADER_NAME: str(checksum or ""),
-            _DATA_SIZE_HEADER_NAME: str(size),
             _DATA_UPDATED_DATE_HEADER_NAME: serializers.DateTimeField().to_representation(
                 updated_date
             ),
@@ -931,7 +924,6 @@ class _TaskDataGetter(_DataGetter):
 
     def _get_chunk_response_headers(self, chunk_data: DataWithMeta) -> dict[str, str]:
         return self._make_chunk_response_headers(
-            self._get_chunk_size(chunk_data),
             self._get_chunk_checksum(chunk_data),
             self._db_task.get_chunks_updated_date(),
         )
@@ -1007,9 +999,7 @@ class _JobDataGetter(_DataGetter):
 
     def _get_chunk_response_headers(self, chunk_data: DataWithMeta) -> dict[str, str]:
         return self._make_chunk_response_headers(
-            self._get_chunk_size(chunk_data),
-            self._get_chunk_checksum(chunk_data),
-            self._db_job.segment.chunks_updated_date,
+            self._get_chunk_checksum(chunk_data), self._db_job.segment.chunks_updated_date
         )
 
 
@@ -1608,14 +1598,6 @@ class TaskViewSet(
                 required=False,
                 response=[200, 206],
                 description="Data checksum, applicable for chunks only",
-            ),
-            OpenApiParameter(
-                _DATA_SIZE_HEADER_NAME,
-                location=OpenApiParameter.HEADER,
-                type=OpenApiTypes.INT,
-                required=False,
-                response=[200, 206],
-                description="Full data size in bytes, applicable for chunks only",
             ),
             OpenApiParameter(
                 _DATA_UPDATED_DATE_HEADER_NAME,

--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -167,6 +167,7 @@ slogger = ServerLogManager(__name__)
 _UPLOAD_PARSER_CLASSES = api_settings.DEFAULT_PARSER_CLASSES + [MultiPartParser]
 
 _DATA_CHECKSUM_HEADER_NAME = "X-Checksum"
+_DATA_SIZE_HEADER_NAME = "X-Chunk-Size"
 _DATA_UPDATED_DATE_HEADER_NAME = "X-Updated-Date"
 _RETRY_AFTER_TIMEOUT = 10
 
@@ -873,6 +874,10 @@ class _DataGetter(metaclass=ABCMeta):
     _CHUNK_HEADER_BYTES_LENGTH = 1000
     "The number of significant bytes from the chunk header, used for checksum computation"
 
+    def _get_chunk_size(self, chunk_data: DataWithMeta) -> int:
+        """Return the decoded chunk size exposed to clients independently of HTTP compression."""
+        return len(chunk_data.data.getbuffer())
+
     def _get_chunk_checksum(self, chunk_data: DataWithMeta) -> str:
         data = chunk_data.data.getbuffer()
         size_checksum = zlib.crc32(str(len(data)).encode())
@@ -880,11 +885,13 @@ class _DataGetter(metaclass=ABCMeta):
 
     def _make_chunk_response_headers(
         self,
+        size: int,
         checksum: str,
         updated_date: datetime,
     ) -> dict[str, str]:
         return {
             _DATA_CHECKSUM_HEADER_NAME: str(checksum or ""),
+            _DATA_SIZE_HEADER_NAME: str(size),
             _DATA_UPDATED_DATE_HEADER_NAME: serializers.DateTimeField().to_representation(
                 updated_date
             ),
@@ -924,6 +931,7 @@ class _TaskDataGetter(_DataGetter):
 
     def _get_chunk_response_headers(self, chunk_data: DataWithMeta) -> dict[str, str]:
         return self._make_chunk_response_headers(
+            self._get_chunk_size(chunk_data),
             self._get_chunk_checksum(chunk_data),
             self._db_task.get_chunks_updated_date(),
         )
@@ -999,7 +1007,9 @@ class _JobDataGetter(_DataGetter):
 
     def _get_chunk_response_headers(self, chunk_data: DataWithMeta) -> dict[str, str]:
         return self._make_chunk_response_headers(
-            self._get_chunk_checksum(chunk_data), self._db_job.segment.chunks_updated_date
+            self._get_chunk_size(chunk_data),
+            self._get_chunk_checksum(chunk_data),
+            self._db_job.segment.chunks_updated_date,
         )
 
 
@@ -1598,6 +1608,14 @@ class TaskViewSet(
                 required=False,
                 response=[200, 206],
                 description="Data checksum, applicable for chunks only",
+            ),
+            OpenApiParameter(
+                _DATA_SIZE_HEADER_NAME,
+                location=OpenApiParameter.HEADER,
+                type=OpenApiTypes.INT,
+                required=False,
+                response=[200, 206],
+                description="Full data size in bytes, applicable for chunks only",
             ),
             OpenApiParameter(
                 _DATA_UPDATED_DATE_HEADER_NAME,

--- a/tests/cypress/e2e/actions_tasks/chunk_download_retry.js
+++ b/tests/cypress/e2e/actions_tasks/chunk_download_retry.js
@@ -17,6 +17,11 @@ context('Retry chunk downloads on annotation page', () => {
         cy.visit('/auth/login');
         cy.login();
         cy.url().should('contain', '/tasks');
+    });
+
+    beforeEach(() => {
+        taskId = null;
+        jobId = null;
         cy.headlessCreateTask({
             labels: [{ name: labelName, attributes: [], type: 'any' }],
             name: taskName,
@@ -35,7 +40,7 @@ context('Retry chunk downloads on annotation page', () => {
         });
     });
 
-    after(() => {
+    afterEach(() => {
         if (taskId) {
             cy.headlessDeleteTask(taskId);
         }

--- a/tests/cypress/e2e/actions_tasks/chunk_download_retry.js
+++ b/tests/cypress/e2e/actions_tasks/chunk_download_retry.js
@@ -102,10 +102,14 @@ context('Retry chunk downloads on annotation page', () => {
                 req.continue((res) => {
                     const responseSize = res.body.byteLength ?? res.body.length;
                     truncatedSize = Math.floor(responseSize / 2);
-                    // eslint-disable-next-line no-param-reassign
-                    res.body = res.body.slice(0, truncatedSize);
-                    // eslint-disable-next-line no-param-reassign
-                    res.headers['content-length'] = `${truncatedSize}`;
+                    res.send({
+                        statusCode: res.statusCode,
+                        body: res.body.slice(0, truncatedSize),
+                        headers: {
+                            ...res.headers,
+                            'content-length': `${truncatedSize}`,
+                        },
+                    });
                 });
             } else {
                 expect(req.headers.range).to.equal(`bytes=${truncatedSize}-`);
@@ -145,10 +149,14 @@ context('Retry chunk downloads on annotation page', () => {
                 req.continue((res) => {
                     const responseSize = res.body.byteLength ?? res.body.length;
                     truncatedSize = Math.floor(responseSize / 2);
-                    // eslint-disable-next-line no-param-reassign
-                    res.body = res.body.slice(0, truncatedSize);
-                    // eslint-disable-next-line no-param-reassign
-                    res.headers['content-length'] = `${truncatedSize}`;
+                    res.send({
+                        statusCode: res.statusCode,
+                        body: res.body.slice(0, truncatedSize),
+                        headers: {
+                            ...res.headers,
+                            'content-length': `${truncatedSize}`,
+                        },
+                    });
                 });
             } else if (chunkRequests === 2) {
                 expect(req.headers.range).to.equal(`bytes=${truncatedSize}-`);

--- a/tests/cypress/e2e/actions_tasks/chunk_download_retry.js
+++ b/tests/cypress/e2e/actions_tasks/chunk_download_retry.js
@@ -52,6 +52,7 @@ context('Retry chunk downloads on annotation page', () => {
             },
         }, (req) => {
             chunkRequests++;
+            expect(req.headers.range).to.equal('bytes=0-');
 
             if (chunkRequests <= failedAttempts) {
                 req.reply({
@@ -68,13 +69,106 @@ context('Retry chunk downloads on annotation page', () => {
         for (let attempt = 0; attempt < failedAttempts; attempt++) {
             cy.wait('@getJobChunk').its('error').should('exist');
         }
-        cy.wait('@getJobChunk').its('response.statusCode').should('equal', 200);
+        cy.wait('@getJobChunk').its('response.statusCode').should('equal', 206);
 
         cy.get('.cvat-canvas-container').should('exist').and('be.visible');
         cy.get('#cvat_canvas_background').should('exist').and('be.visible');
         cy.get('.cvat-notification-notice-fetch-frame-data-from-the-server-failed').should('not.exist');
         cy.then(() => {
             expect(chunkRequests).to.be.at.least(failedAttempts + 1);
+        });
+    });
+
+    it('resumes a chunk download after a cleanly truncated response', () => {
+        let chunkRequests = 0;
+        let truncatedSize = 0;
+
+        cy.intercept({
+            method: 'GET',
+            pathname: `/api/jobs/${jobId}/data`,
+            query: {
+                type: 'chunk',
+            },
+        }, (req) => {
+            chunkRequests++;
+
+            if (chunkRequests === 1) {
+                expect(req.headers.range).to.equal('bytes=0-');
+                req.continue((res) => {
+                    const responseSize = res.body.byteLength ?? res.body.length;
+                    truncatedSize = Math.floor(responseSize / 2);
+                    // eslint-disable-next-line no-param-reassign
+                    res.body = res.body.slice(0, truncatedSize);
+                    // eslint-disable-next-line no-param-reassign
+                    res.headers['content-length'] = `${truncatedSize}`;
+                });
+            } else {
+                expect(req.headers.range).to.equal(`bytes=${truncatedSize}-`);
+                req.continue();
+            }
+        }).as('getTruncatedJobChunk');
+        cy.intercept('GET', `/tasks/${taskId}/jobs/${jobId}`).as('visitAnnotationView');
+
+        cy.visit(`/tasks/${taskId}/jobs/${jobId}`);
+        cy.wait('@visitAnnotationView');
+        cy.wait('@getTruncatedJobChunk').its('response.statusCode').should('equal', 206);
+        cy.wait('@getTruncatedJobChunk').its('response.statusCode').should('equal', 206);
+
+        cy.get('.cvat-canvas-container').should('exist').and('be.visible');
+        cy.get('#cvat_canvas_background').should('exist').and('be.visible');
+        cy.get('.cvat-notification-notice-fetch-frame-data-from-the-server-failed').should('not.exist');
+        cy.then(() => {
+            expect(chunkRequests).to.equal(2);
+        });
+    });
+
+    it('restarts a chunk download when the chunk changes before resuming', () => {
+        let chunkRequests = 0;
+        let truncatedSize = 0;
+
+        cy.intercept({
+            method: 'GET',
+            pathname: `/api/jobs/${jobId}/data`,
+            query: {
+                type: 'chunk',
+            },
+        }, (req) => {
+            chunkRequests++;
+
+            if (chunkRequests === 1) {
+                expect(req.headers.range).to.equal('bytes=0-');
+                req.continue((res) => {
+                    const responseSize = res.body.byteLength ?? res.body.length;
+                    truncatedSize = Math.floor(responseSize / 2);
+                    // eslint-disable-next-line no-param-reassign
+                    res.body = res.body.slice(0, truncatedSize);
+                    // eslint-disable-next-line no-param-reassign
+                    res.headers['content-length'] = `${truncatedSize}`;
+                });
+            } else if (chunkRequests === 2) {
+                expect(req.headers.range).to.equal(`bytes=${truncatedSize}-`);
+                req.continue((res) => {
+                    // eslint-disable-next-line no-param-reassign
+                    res.headers['x-checksum'] = `${res.headers['x-checksum']}-changed`;
+                });
+            } else {
+                expect(req.headers.range).to.equal('bytes=0-');
+                req.continue();
+            }
+        }).as('getChangedJobChunk');
+        cy.intercept('GET', `/tasks/${taskId}/jobs/${jobId}`).as('visitAnnotationView');
+
+        cy.visit(`/tasks/${taskId}/jobs/${jobId}`);
+        cy.wait('@visitAnnotationView');
+        cy.wait('@getChangedJobChunk').its('response.statusCode').should('equal', 206);
+        cy.wait('@getChangedJobChunk').its('response.statusCode').should('equal', 206);
+        cy.wait('@getChangedJobChunk').its('response.statusCode').should('equal', 206);
+
+        cy.get('.cvat-canvas-container').should('exist').and('be.visible');
+        cy.get('#cvat_canvas_background').should('exist').and('be.visible');
+        cy.get('.cvat-notification-notice-fetch-frame-data-from-the-server-failed').should('not.exist');
+        cy.then(() => {
+            expect(chunkRequests).to.equal(3);
         });
     });
 });


### PR DESCRIPTION
### Motivation and context

The chunk download worker preserves data received before a connection interruption. It stores successfully read byte arrays and tracks their total size. After a stream error, it requests the remaining data using:

```http
Range: bytes=<receivedBytes>-
```

The worker then appends the resumed response to the preserved prefix, avoiding a complete re-download of a potentially large chunk.

This behavior had two integrity gaps:

- The initial response did not provide a reliable expected size. If it ended cleanly but prematurely, the worker could accept an incomplete chunk.
- A chunk could be regenerated between requests. The worker could then combine a prefix from the old chunk with a suffix from the new chunk, producing a corrupted archive.

The worker now sends an open-ended range on every attempt, including the initial request:

```http
Range: bytes=0-
```

CVAT returns `206 Partial Content` and includes the complete decoded chunk size in `Content-Range`. The same response validation is therefore used for initial and resumed requests, independently of HTTP content encoding.

The worker also preserves the chunk checksum and update version from the initial response. Before appending resumed data, it verifies that both values remain unchanged. If the chunk has changed, the worker cancels the response, discards the preserved data, and immediately restarts from `bytes=0-`.

The required range and identity headers are also allowed and exposed through CORS.

### How has this been tested?

- Manually

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- [ ] ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [ ] ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.