### PR TITLE
Support backing cloud storage for videos (S3 only)

### DIFF
--- a/changelog.d/20260826_131916_roman_video_in_backing_cs.md
+++ b/changelog.d/20260826_131916_roman_video_in_backing_cs.md
@@ -1,0 +1,5 @@
+### Added
+
+- S3-like cloud storages can now be used as backing cloud storage for
+  video tasks
+  (<https://github.com/cvat-ai/cvat/pull/11087>)

--- a/cvat/apps/engine/backup.py
+++ b/cvat/apps/engine/backup.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 import io
+import itertools
 import mimetypes
 import os
 import re
@@ -522,8 +523,6 @@ class TaskExporter(_ExporterBase, _TaskBackupBase):
                 assert False, f"Unknown media type '{media_type}' with mode '{mode}'"
 
     def _write_data_from_cloud_storage(self, zip_object: ZipFile, target_dir: str) -> None:
-        assert not hasattr(self._db_data, "video"), "Only images can be stored in cloud storage"
-
         target_data_dir = os.path.join(target_dir, self.DATA_DIRNAME)
         data_dir = self._db_data.get_upload_dirname()
 
@@ -532,7 +531,10 @@ class TaskExporter(_ExporterBase, _TaskBackupBase):
         files_for_local_copy = []
 
         media_files_to_download: list[PurePath] = []
-        for media_file in self._db_data.related_files.all():
+        for media_file in itertools.chain(
+            self._db_data.related_files.all(),
+            [self._db_data.video] if hasattr(self._db_data, "video") else [],
+        ):
             media_path = PurePath(media_file.path)
 
             local_path = os.path.join(data_dir, media_path)

--- a/cvat/apps/engine/cache.py
+++ b/cvat/apps/engine/cache.py
@@ -805,7 +805,7 @@ class MediaCache:
         db_data = db_task.require_data()
 
         if hasattr(db_data, "video"):
-            source_path = db_data.get_raw_data_dirname() / db_data.video.path
+            source_path = db_data.get_openable(db_data.video.path)
 
             manifest_path = db_data.get_manifest_path()
             reader = VideoReaderWithManifest(

--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import functools
+import io
 import json
 import os
 from abc import ABC, abstractmethod
@@ -16,7 +17,7 @@ from enum import Enum
 from io import BytesIO
 from pathlib import Path, PurePath
 from queue import Queue
-from typing import Any, BinaryIO, Concatenate, ParamSpec, TypeVar
+from typing import IO, Any, BinaryIO, Concatenate, ParamSpec, TypeVar
 
 import boto3
 from azure.core.exceptions import HttpResponseError, ServiceRequestError
@@ -177,6 +178,11 @@ class CloudStorageClient(ABC):
     @abstractmethod
     def _download_fileobj_to_stream(self, key: str, stream: BinaryIO, /) -> None:
         pass
+
+    supports_streaming = False
+
+    def get_file_stream(self, key: str, /, *, offset: int) -> tuple[Any, int]:
+        raise NotImplementedError()
 
     @validate_file_status
     @validate_bucket_status
@@ -390,6 +396,9 @@ class CloudStorageClient(ABC):
     @abstractmethod
     def supported_actions(self):
         pass
+
+    def get_openable(self, key: str, /) -> NamedOpenable:
+        return _CloudStorageOpenable(self, key)
 
 
 class HeaderFirstDownloader(ABC):
@@ -806,6 +815,12 @@ class S3CloudStorageClient(CloudStorageClient):
                     slogger.glob.error(f"{str(ex)}. Key: {key}, bucket: {self.name}")
             raise
 
+    supports_streaming = True
+
+    def get_file_stream(self, key: str, /, *, offset: int) -> tuple[Any, int]:
+        obj = self._client.get_object(Bucket=self.bucket.name, Key=key, Range=f"bytes={offset}-")
+        return obj["Body"], obj["ContentLength"] + offset
+
     def bulk_delete(self, files: Sequence[str]) -> None:
         def delete_batch(batch: Sequence[str]):
             delete_request = {"Objects": [{"Key": f} for f in batch], "Quiet": True}
@@ -1167,6 +1182,13 @@ class SubdirectoryCloudStorageClient(CloudStorageClient):
         assert key is not None
         return self.underlying.upload_file(file_path, self._map_key(key))
 
+    @property
+    def supports_streaming(self) -> bool:
+        return self.underlying.supports_streaming
+
+    def get_file_stream(self, key: str, /, *, offset: int) -> tuple[Any, int]:
+        return self.underlying.get_file_stream(self._map_key(key), offset=offset)
+
     def bulk_delete(self, files: Sequence[str]) -> None:
         self.underlying.bulk_delete(list(map(self._map_key, files)))
 
@@ -1315,3 +1337,149 @@ def export_resource_to_cloud_storage(
     db_storage.get_client().upload_file(Path(file_path), rq_job_meta.result_filename)
 
     return file_path
+
+
+class _CloudStorageOpenable(NamedOpenable):
+    def __init__(self, storage: CloudStorageClient, key: str) -> None:
+        self._storage = storage
+        self._key = key
+
+    def open(self, mode: str) -> IO[bytes]:
+        assert mode == "rb"
+        return _CloudStorageFile(self._storage, self._key)
+
+    def __fspath__(self) -> str:
+        return self._key
+
+
+class _CloudStorageFile(io.IOBase):
+    """
+    A file-like object that reads data from a cloud storage service.
+
+    The implementation works as follows:
+
+    We always hold an open stream resulting from a "read blob" request to the service.
+    We also maintain a "logical offset" that represents the current position as seen by the client,
+    and a "stream offset" that represents the actual position in the stream.
+
+    When seeking, we only update the logical offset. This is because this class is used in
+    conjunction with FFmpeg, which loves to seek to the end of the file and back to determine
+    the size. If we tried to synchronize the stream offset on every seek, it would be unbearably
+    slow.
+
+    Instead, we only synchronize the stream offset with the logical offset when a read is requested.
+    We do it in one of two ways:
+
+    * If we need to seek forward a small distance (<= _SKIP_THRESHOLD), we read and discard
+      enough bytes to get there. This avoids the latency of making a new request.
+
+    * Otherwise, we reopen the stream at the logical offset (using a range request).
+    """
+
+    _SKIP_THRESHOLD = 1 << 20
+    _READ_TRIES = 3
+
+    def __init__(self, storage: CloudStorageClient, key: str) -> None:
+        self._storage = storage
+        self._key = key
+
+        self._logical_offset = self._stream_offset = 0
+        self._stream, self._length = self._storage.get_file_stream(self._key, offset=0)
+
+    def _reopen_stream(self) -> None:
+        self._stream.close()
+        self._stream, new_length = self._storage.get_file_stream(
+            self._key, offset=self._logical_offset
+        )
+        self._stream_offset = self._logical_offset
+
+        if new_length != self._length:
+            raise RuntimeError(
+                f"File length changed from {self._length} to {new_length} while being read"
+            )
+
+    def readable(self) -> bool:
+        return True
+
+    def _read_from_stream(self, size: int) -> bytes:
+        result = self._stream.read(size)
+        self._stream_offset += len(result)
+        return result
+
+    def _put_stream_at_logical_offset(self):
+        # synchronize the stream offset with the logical offset
+        lag = self._logical_offset - self._stream_offset
+
+        if 0 < lag <= self._SKIP_THRESHOLD:
+            try:
+                self._read_from_stream(lag)
+            except Exception:
+                self._reopen_stream()
+            else:
+                if self._logical_offset != self._stream_offset:
+                    # This should never happen; somehow the stream is shorter than expected.
+                    # Try to recover by reopening the stream.
+                    self._reopen_stream()
+        elif lag != 0:
+            self._reopen_stream()
+
+    def read(self, size: int = -1) -> bytes:
+        if self._logical_offset >= self._length:
+            return b""
+
+        if size < 0:
+            expected_result_size = self._length - self._logical_offset
+        else:
+            expected_result_size = min(size, self._length - self._logical_offset)
+
+        self._put_stream_at_logical_offset()
+
+        result = b""
+
+        last_ex = None
+
+        for _ in range(self._READ_TRIES):
+            try:
+                piece = self._read_from_stream(expected_result_size - len(result))
+            except Exception as ex:
+                last_ex = ex
+            else:
+                last_ex = None
+                self._logical_offset += len(piece)
+                result += piece
+
+                if len(result) == expected_result_size:
+                    return result
+
+                # We might get here if the stream ends early. It shouldn't, since we read less than
+                # the expected stream length, but we're talking to an external service, so anything
+                # could happen. We'll treat this the same as an error (except we'll keep whatever
+                # data we did get).
+
+            self._reopen_stream()
+
+        if last_ex:
+            raise last_ex
+        raise RuntimeError("Truncated stream received from cloud storage service")
+
+    def seekable(self) -> bool:
+        return True
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        match whence:
+            case io.SEEK_SET:
+                self._logical_offset = offset
+            case io.SEEK_CUR:
+                self._logical_offset = self._logical_offset + offset
+            case io.SEEK_END:
+                self._logical_offset = self._length + offset
+            case _:
+                assert False, f"invalid whence value {whence}"
+
+        return self._logical_offset
+
+    def tell(self) -> int:
+        return self._logical_offset
+
+    def close(self) -> None:
+        self._stream.close()

--- a/cvat/apps/engine/management/commands/movetasktobackingcs.py
+++ b/cvat/apps/engine/management/commands/movetasktobackingcs.py
@@ -58,8 +58,10 @@ class Command(BaseCommand):
                 f" (#{data.local_storage_backing_cs_id})"
             )
 
-        if not data.supports_backing_cs():
-            raise CommandError(f"Task #{task.id} does not support backing cloud storage")
+        if not data.supports_backing_cs(backing_cs):
+            raise CommandError(
+                f"Task #{task.id} does not support backing cloud storage #{backing_cs.id}"
+            )
 
         data.move_to_backing_cs(backing_cs)
         return True

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -634,15 +634,22 @@ class Data(models.Model):
 
         return None
 
-    def supports_backing_cs(self) -> bool:
-        return (
-            self.storage == StorageChoice.LOCAL
-            and self.storage_method == StorageMethodChoice.CACHE
-            and self.images.exists()
-        )
+    def supports_backing_cs(self, db_storage: CloudStorage) -> bool:
+        if not (
+            self.storage == StorageChoice.LOCAL and self.storage_method == StorageMethodChoice.CACHE
+        ):
+            return False
+
+        if self.images.exists():
+            return True
+
+        if hasattr(self, "video") and db_storage.get_client().supports_streaming:
+            return True
+
+        return False
 
     def move_to_backing_cs(self, backing_cs: CloudStorage) -> None:
-        assert self.supports_backing_cs()
+        assert self.supports_backing_cs(backing_cs)
         assert not self.local_storage_backing_cs_id
 
         self.local_storage_backing_cs = backing_cs

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -38,6 +38,7 @@ from cvat.utils import django_database as db_utils
 if TYPE_CHECKING:
     from cvat.apps.engine.cloud_provider import CloudStorageClient
     from cvat.apps.organizations.models import Organization
+    from utils.dataset_manifest.utils import NamedOpenable
 
 
 class SafeCharField(models.CharField):
@@ -544,6 +545,12 @@ class Data(models.Model):
 
     def get_static_cache_dirname(self, quality: FrameQuality) -> Path:
         return self.get_data_dirname() / quality.name.lower()
+
+    def get_openable(self, rel_path: str) -> NamedOpenable:
+        if storage_client := self.get_cloud_storage_client():
+            return storage_client.get_openable(rel_path)
+
+        return self.get_raw_data_dirname() / rel_path
 
     def get_chunk_type(self, quality: FrameQuality) -> DataChoice:
         if quality == FrameQuality.ORIGINAL:

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -643,7 +643,14 @@ class Data(models.Model):
         if self.images.exists():
             return True
 
-        if hasattr(self, "video") and db_storage.get_client().supports_streaming:
+        # Video tasks without manifests technically work with backing CS too,
+        # but reading the video from the beginning each time is too slow in practice,
+        # so we disallow it.
+        if (
+            hasattr(self, "video")
+            and db_storage.get_client().supports_streaming
+            and self.get_manifest_path().exists()
+        ):
             return True
 
         return False

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -2062,7 +2062,11 @@ def initialize_task(
     if not (is_data_in_cloud and is_backup_restore):
         _create_task_preview(db_task)
 
-    _move_to_backing_cs_if_configured(db_data)
+    # TODO: remove the condition.
+    # We don't yet have production experience with videos in backing CS,
+    # so let's be cautious and not move them automatically.
+    if db_task.mode != models.TaskMode.INTERPOLATION:
+        _move_to_backing_cs_if_configured(db_data)
 
 
 def _create_task_preview(db_task: models.Task):

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -2236,9 +2236,9 @@ def _create_static_chunks(
                 progress_updater.update_progress(segment_idx / len(db_segments))
 
 
-def _move_to_backing_cs_if_configured(db_data):
+def _move_to_backing_cs_if_configured(db_data: models.Data) -> None:
     backing_cs_id = settings.DEFAULT_BACKING_CS_ID
-    if backing_cs_id is not None and db_data.supports_backing_cs():
+    if backing_cs_id is not None:
         try:
             backing_cs = models.CloudStorage.objects.get(pk=backing_cs_id)
         except models.CloudStorage.DoesNotExist:
@@ -2246,4 +2246,5 @@ def _move_to_backing_cs_if_configured(db_data):
                 f"Cloud storage #{backing_cs_id} (configured as default backing CS) does not exist"
             )
         else:
-            db_data.move_to_backing_cs(backing_cs)
+            if db_data.supports_backing_cs(backing_cs):
+                db_data.move_to_backing_cs(backing_cs)

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -1908,6 +1908,11 @@ class _CloudStorageTestBase(ApiTestBase):
             def upload_file(self, file_path: Path, key: str | None = None, /) -> None:
                 self._files[key] = file_path.read_bytes()
 
+            def get_file_stream(self, key: str, /, *, offset: int) -> tuple[BytesIO, int]:
+                stream = io.BytesIO(self._files[key])
+                stream.seek(offset)
+                return stream, len(self._files[key])
+
             def bulk_delete(self, files: Sequence[str]) -> None:
                 for key in files:
                     del self._files[key]
@@ -2102,10 +2107,12 @@ class ProjectCloudBackupAPINoStaticChunksTestCase(ProjectBackupAPITestCase, _Clo
         if cls.MAKE_LIGHTWEIGHT_BACKUP or settings.MEDIA_CACHE_ALLOW_STATIC_CACHE:
             # should not load anything from CS anymore
 
-            def disabled(*args):
+            def disabled(*args, **kwargs):
                 raise RuntimeError("Disabled!")
 
             cls.mock_aws._download_fileobj_to_stream = disabled
+            cls.mock_aws._download_range_of_bytes = disabled
+            cls.mock_aws.get_file_stream = disabled
 
     def _compare_tasks(self, original_task, imported_task):
         super()._compare_tasks(original_task, imported_task)

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -8206,6 +8206,7 @@ class TaskChangeCloudStorageTestCase(_CloudStorageTestBase):
 
 class TaskBackingCloudStorageTestCase(_CloudStorageTestBase, ExportApiTestBase):
     _IMAGE_PATHS = ["test_1.jpg", "test_2.jpg", "related_images/test_1_jpg/context_1.jpg"]
+    _VIDEO_PATH = "test.mp4"
 
     @classmethod
     def setUpTestData(cls):
@@ -8213,7 +8214,7 @@ class TaskBackingCloudStorageTestCase(_CloudStorageTestBase, ExportApiTestBase):
         cls.client = APIClient()
         cls.cloud_storage_id = cls._create_cloud_storage()
 
-    def _create_local_task(self):
+    def _create_local_task(self, *, mode=TaskMode.ANNOTATION):
         data = {
             "name": "my local task #1",
             "owner_id": self.owner.id,
@@ -8222,61 +8223,74 @@ class TaskBackingCloudStorageTestCase(_CloudStorageTestBase, ExportApiTestBase):
             "labels": [{"name": "person"}],
         }
 
-        f = io.BytesIO()
-        with zipfile.ZipFile(f, "w") as zip_file:
-            for p in self._IMAGE_PATHS:
-                zip_file.writestr(p, generate_random_image_file(p)[1].getbuffer())
+        if mode == TaskMode.ANNOTATION:
+            media_file = io.BytesIO()
+            with zipfile.ZipFile(media_file, "w") as zip_file:
+                for p in self._IMAGE_PATHS:
+                    zip_file.writestr(p, generate_random_image_file(p)[1].getbuffer())
 
-        f.seek(0)
-        f.name = "test.zip"
+            media_file.seek(0)
+            media_file.name = "test.zip"
+        else:
+            self.assertEqual(mode, TaskMode.INTERPOLATION)
+            media_file = generate_video_file(self._VIDEO_PATH)[1]
 
-        image_data = {"client_files[0]": f, "image_quality": 75}
+        image_data = {"client_files[0]": media_file, "image_quality": 75}
         return self._create_task(data, image_data)
 
     def test_can_move_to_backing_cs(self):
-        # Set up task.
-        task = self._create_local_task()
-        task_id = task["id"]
+        for mode in (TaskMode.ANNOTATION, TaskMode.INTERPOLATION):
+            with self.subTest(mode=mode):
+                # Set up task.
+                task = self._create_local_task(mode=mode)
+                task_id = task["id"]
 
-        data = Data.objects.get(task__id=task_id)
-        upload_dir = data.get_upload_dirname()
+                data = Data.objects.get(task__id=task_id)
+                upload_dir = data.get_upload_dirname()
 
-        self.assertTrue(data.images.exists())
-        self.assertTrue(data.related_files.exists())
+                def local_path(rel_path):
+                    return upload_dir / rel_path
 
-        def local_path(rel_path):
-            return upload_dir / rel_path
+                def cloud_key(rel_path):
+                    return PurePath(f"data/{data.id}/raw", rel_path).as_posix()
 
-        def cloud_key(rel_path):
-            return PurePath(f"data/{data.id}/raw", rel_path).as_posix()
+                if mode == TaskMode.ANNOTATION:
+                    self.assertTrue(data.images.exists())
+                    self.assertTrue(data.related_files.exists())
+                    media = [(p, local_path(p).read_bytes()) for p in self._IMAGE_PATHS]
+                else:
+                    self.assertTrue(hasattr(data, "video"))
+                    media = [(self._VIDEO_PATH, local_path(self._VIDEO_PATH).read_bytes())]
 
-        images = [(p, local_path(p).read_bytes()) for p in self._IMAGE_PATHS]
-        self.assertTrue(local_path(Data.MANIFEST_FILENAME).exists())
+                self.assertTrue(local_path(Data.MANIFEST_FILENAME).exists())
 
-        # Move the task to backing cloud storage.
-        with self.captureOnCommitCallbacks(execute=True):
-            data.move_to_backing_cs(CloudStorage.objects.get(id=self.cloud_storage_id))
+                # Move the task to backing cloud storage.
+                with self.captureOnCommitCallbacks(execute=True):
+                    data.move_to_backing_cs(CloudStorage.objects.get(id=self.cloud_storage_id))
 
-        self.assertEqual(data.local_storage_backing_cs_id, self.cloud_storage_id)
+                self.assertEqual(data.local_storage_backing_cs_id, self.cloud_storage_id)
 
-        for image_rel_path, image_bytes in images:
-            self.assertFalse(local_path(image_rel_path).exists())
-            self.assertEqual(self.mock_aws.retrieve_file(cloud_key(image_rel_path)), image_bytes)
-        self.assertFalse(local_path("related_images").exists())
+                for media_rel_path, media_bytes in media:
+                    self.assertFalse(local_path(media_rel_path).exists())
+                    self.assertEqual(
+                        self.mock_aws.retrieve_file(cloud_key(media_rel_path)), media_bytes
+                    )
 
-        # The manifest should still be in the local FS.
-        self.assertTrue(local_path(Data.MANIFEST_FILENAME).exists())
-        self.assertFalse(self.mock_aws.file_exists(cloud_key(Data.MANIFEST_FILENAME)))
+                self.assertFalse(local_path("related_images").exists())
 
-        # Move the task back.
-        with self.captureOnCommitCallbacks(execute=True):
-            data.move_from_backing_cs()
+                # The manifest should still be in the local FS.
+                self.assertTrue(local_path(Data.MANIFEST_FILENAME).exists())
+                self.assertFalse(self.mock_aws.file_exists(cloud_key(Data.MANIFEST_FILENAME)))
 
-        self.assertEqual(data.local_storage_backing_cs_id, None)
+                # Move the task back.
+                with self.captureOnCommitCallbacks(execute=True):
+                    data.move_from_backing_cs()
 
-        for image_rel_path, image_bytes in images:
-            self.assertEqual(local_path(image_rel_path).read_bytes(), image_bytes)
-            self.assertFalse(self.mock_aws.file_exists(cloud_key(image_rel_path)))
+                self.assertEqual(data.local_storage_backing_cs_id, None)
+
+                for media_rel_path, media_bytes in media:
+                    self.assertEqual(local_path(media_rel_path).read_bytes(), media_bytes)
+                    self.assertFalse(self.mock_aws.file_exists(cloud_key(media_rel_path)))
 
     def test_creation_with_default_backing_cs(self):
         with (

--- a/tests/python/rest_api/_test_base.py
+++ b/tests/python/rest_api/_test_base.py
@@ -673,6 +673,7 @@ class TestTasksBase:
         start_frame: int | None = None,
         stop_frame: int | None = None,
         step: int | None = None,
+        use_cache: bool | None = None,
         video_file: IO[bytes] | None = None,
         chapters: Sequence[dict] | None = None,
     ) -> tuple[VideoTaskSpec, int]:
@@ -720,6 +721,9 @@ class TestTasksBase:
 
         if step is not None:
             data_params["frame_filter"] = f"step={step}"
+
+        if use_cache is not None:
+            data_params["use_cache"] = use_cache
 
         def get_video_file() -> io.BytesIO:
             return io.BytesIO(video_data)
@@ -774,6 +778,24 @@ class TestTasksBase:
             stop_frame=stop_frame,
             step=step,
         )
+
+    @fixture(scope="class")
+    @parametrize(
+        "cloud_storage_id",
+        [pytest.param(5, marks=[pytest.mark.with_external_services])],
+    )
+    def fxt_backing_cs_video_task(
+        self,
+        request: pytest.FixtureRequest,
+        cloud_storage_id: int,
+    ) -> tuple[ITaskSpec, int]:
+        spec, task_id = self._uploaded_video_task_fxt_base(request=request, use_cache=True)
+
+        container_exec_cvat(
+            request, ["./manage.py", "movetasktobackingcs", str(task_id), str(cloud_storage_id)]
+        )
+
+        return spec, task_id
 
     def _compute_annotation_segment_params(self, task_spec: ITaskSpec) -> list[tuple[int, int]]:
         segment_params = []
@@ -891,6 +913,7 @@ class TestTasksBase:
             fixture_ref("fxt_uploaded_video_task_without_manifest"),
             fixture_ref("fxt_uploaded_video_task_with_segments"),
             fixture_ref("fxt_uploaded_video_task_with_segments_start_stop_step"),
+            fixture_ref("fxt_backing_cs_video_task"),
         ]
         + _tasks_with_honeypots_cases
         + _tasks_with_simple_gt_job_cases

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -1704,31 +1704,50 @@ class TestTaskBackups:
         task_id = next(t for t in tasks if t["media_type"] == "audio")["id"]
         self._test_can_export_backup(task_id)
 
-    @pytest.mark.with_external_services
-    def test_can_export_and_import_backup_with_backing_cs(self, request, cloud_storages):
+    def _test_can_export_and_import_backup_with_backing_cs(
+        self, request, task, cloud_storages, expected_file_suffixes
+    ):
         cloud_storage_id = next(cs["id"] for cs in cloud_storages if cs["resource"] == "backingcs")
 
-        with make_sdk_client(self.user) as client:
-            task = client.tasks.create_from_data(
-                models.TaskWriteRequest(name="Canvas3D"),
-                [SHARE_DIR / "test_canvas3d.zip"],
-                data_params={"use_cache": True},
-            )
+        container_exec_cvat(
+            request, ["./manage.py", "movetasktobackingcs", str(task.id), str(cloud_storage_id)]
+        )
 
-            container_exec_cvat(
-                request, ["./manage.py", "movetasktobackingcs", str(task.id), str(cloud_storage_id)]
-            )
+        backup_path = self.tmp_dir / "backup.zip"
+        task.download_backup(backup_path)
 
-            backup_path = self.tmp_dir / "backup.zip"
-            task.download_backup(backup_path)
+        with zipfile.ZipFile(backup_path) as zip_file:
+            names = zip_file.namelist()
 
-            with zipfile.ZipFile(backup_path) as zip_file:
-                names = zip_file.namelist()
+            for ext in expected_file_suffixes:
+                assert any(name.endswith(ext) for name in names)
 
-                assert any(name.endswith(".pcd") for name in names)
-                assert any(name.endswith(".png") for name in names)
+        self._test_can_restore_task_from_backup(task.id, backup_file=backup_path)
 
-            self._test_can_restore_task_from_backup(task.id, backup_file=backup_path)
+    @pytest.mark.with_external_services
+    def test_can_export_and_import_backup_with_images_in_backing_cs(self, request, cloud_storages):
+        task = self.client.tasks.create_from_data(
+            models.TaskWriteRequest(name="Canvas3D"),
+            [SHARE_DIR / "test_canvas3d.zip"],
+            data_params={"use_cache": True},
+        )
+
+        self._test_can_export_and_import_backup_with_backing_cs(
+            request, task, cloud_storages, (".pcd", ".png")
+        )
+
+    @pytest.mark.with_external_services
+    def test_can_export_and_import_backup_with_video_in_backing_cs(
+        self, request, tasks, cloud_storages
+    ):
+        task_id = next(
+            t for t in tasks if t["media_type"] == "image" if t["mode"] == "interpolation"
+        )["id"]
+        task = self.client.tasks.retrieve(task_id)
+
+        self._test_can_export_and_import_backup_with_backing_cs(
+            request, task, cloud_storages, (".mp4",)
+        )
 
     def _test_can_restore_task_from_backup(
         self,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This extends the existing backing CS feature to tasks with videos. As this is not yet battle-tested, videos do not yet get automatically uploaded to the default backing CS (if one is configured).

The implementation works via a new file-like class that reads data directly from cloud storage. When a task uses backing CS, we pass an object of this class to PyAV instead of a real file.

Strangely, Boto3 seems to be the only one of the cloud SDKs to provide a simple streaming download function, so this feature is limited to S3 at the moment.

In addition, only tasks with manifests can be moved to backing CS. This is because the backup logic of reading the entire video from the beginning when a manifest is missing is too slow to be practical.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Automatic tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- ~~[ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
