### PR TITLE
Collect chunk download bandwidth telemetry on page exit

### DIFF
--- a/cvat-core/src/download.worker.ts
+++ b/cvat-core/src/download.worker.ts
@@ -8,6 +8,7 @@
 const MAX_NO_PROGRESS_RETRIES = 10;
 const BASE_RETRY_DELAY_MS = 1000;
 const MAX_RETRY_DELAY_MS = 60000;
+const MIN_CHUNK_SIZE_FOR_TELEMETRY_BYTES = 2 * 1024 * 1024;
 
 class DownloadError extends Error {
     public code: number;
@@ -20,16 +21,24 @@ class DownloadError extends Error {
 
 class DownloadReadError extends Error {
     public receivedBytes: number;
+    public downloadTimeMs: number;
 
-    constructor(message: string, receivedBytes: number) {
+    constructor(message: string, receivedBytes: number, downloadTimeMs: number) {
         super(message);
         this.receivedBytes = receivedBytes;
+        this.downloadTimeMs = downloadTimeMs;
     }
 }
 
 interface ChunkIdentity {
     checksum: string;
     updatedDate: string;
+}
+
+interface DownloadTelemetry {
+    chunkSizeBytes: number;
+    downloadTimeMs: number;
+    retries: number;
 }
 
 function sleep(timeout: number): Promise<void> {
@@ -125,7 +134,9 @@ async function readResponse(
     response: Response,
     chunks: Uint8Array[],
     receivedBytes: number,
-): Promise<number> {
+): Promise<{ receivedBytes: number; downloadTimeMs: number }> {
+    // fetch() has already resolved, so this timer excludes server-side chunk preparation.
+    const downloadStartedAt = performance.now();
     const reader = response.body.getReader();
     let nextReceivedBytes = receivedBytes;
 
@@ -134,12 +145,19 @@ async function readResponse(
         try {
             result = await reader.read();
         } catch (error) {
-            throw new DownloadReadError(error instanceof Error ? error.message : `${error}`, nextReceivedBytes);
+            throw new DownloadReadError(
+                error instanceof Error ? error.message : `${error}`,
+                nextReceivedBytes,
+                performance.now() - downloadStartedAt,
+            );
         }
 
         const { done, value } = result;
         if (done) {
-            return nextReceivedBytes;
+            return {
+                receivedBytes: nextReceivedBytes,
+                downloadTimeMs: performance.now() - downloadStartedAt,
+            };
         }
 
         chunks.push(value);
@@ -150,32 +168,28 @@ async function readResponse(
 async function fetchData(url: string, requestConfig): Promise<{
     data: ArrayBuffer;
     headers: Record<string, string>;
+    telemetry?: DownloadTelemetry;
 }> {
     const requestUrl = appendParams(url, requestConfig.params);
-    let chunks: Uint8Array[] = [];
+    const chunks: Uint8Array[] = [];
     let receivedBytes = 0;
-    let responseHeaders: Record<string, string> = {};
-    let expectedSize: number | null = null;
     let chunkIdentity: ChunkIdentity | null = null;
+    let requestCount = 0;
+    let bodyDownloadTimeMs = 0;
 
     let retry = 0;
     while (retry <= MAX_NO_PROGRESS_RETRIES) {
         let response: Response | null = null;
         const receivedBytesBeforeRequest = receivedBytes;
+
+        requestCount++;
         try {
             const headers = new Headers(requestConfig.headers ?? {});
             // Request the entire chunk as an open-ended range on the first attempt as well. This makes the server
             // provide the full decoded chunk size in Content-Range independently of HTTP content encoding.
             headers.set('Range', `bytes=${receivedBytes}-`);
 
-            response = await fetch(requestUrl, {
-                method: 'GET',
-                credentials: 'include',
-                headers,
-            });
-
-            responseHeaders = headersToObject(response.headers);
-
+            response = await fetch(requestUrl, { method: 'GET', credentials: 'include', headers });
             if (!response.ok) {
                 if (retry < MAX_NO_PROGRESS_RETRIES && shouldRetry(response)) {
                     await sleep(getRetryDelay(response, retry));
@@ -190,34 +204,33 @@ async function fetchData(url: string, requestConfig): Promise<{
                 throw new Error(`Unexpected response status: ${response.status}`);
             }
 
+            const responseHeaders = headersToObject(response.headers);
             const contentRange = parseContentRange(responseHeaders['content-range'] ?? null);
             if (!contentRange || contentRange.start !== receivedBytes || contentRange.total === null) {
                 throw new Error('Unexpected Content-Range header');
             }
-            expectedSize = contentRange.total;
+            const expectedSize = contentRange.total;
 
-            const responseChunkIdentity = getChunkIdentity(responseHeaders);
-            if (chunkIdentity && !isSameChunk(chunkIdentity, responseChunkIdentity)) {
-                // The partial bytes and retry history belong to an outdated chunk. Discard them and immediately
-                // start a new full download; waiting or applying the previous retry count would only delay recovery.
-                await response.body?.cancel();
-                chunks = [];
-                receivedBytes = 0;
-                responseHeaders = {};
-                expectedSize = null;
-                chunkIdentity = null;
-                retry = 0;
-                continue;
+            if (chunkIdentity) {
+                if (!isSameChunk(chunkIdentity, getChunkIdentity(responseHeaders))) {
+                    // Start a new download immediately because partial data, retries,
+                    // and timing belong to an old chunk.
+                    await response.body?.cancel();
+                    return fetchData(url, requestConfig);
+                }
+            } else {
+                chunkIdentity = getChunkIdentity(responseHeaders);
             }
 
-            chunkIdentity = responseChunkIdentity;
-            receivedBytes = await readResponse(response, chunks, receivedBytes);
+            const readResult = await readResponse(response, chunks, receivedBytes);
+            receivedBytes = readResult.receivedBytes;
+            bodyDownloadTimeMs += readResult.downloadTimeMs;
 
-            if (expectedSize !== null && receivedBytes > expectedSize) {
+            if (receivedBytes > expectedSize) {
                 throw new Error(`Received more bytes than expected: ${receivedBytes}/${expectedSize}`);
             }
 
-            if (expectedSize !== null && receivedBytes < expectedSize) {
+            if (receivedBytes < expectedSize) {
                 if (receivedBytes > receivedBytesBeforeRequest) {
                     retry = 0;
                     await sleep(getRetryDelay(response, retry));
@@ -234,17 +247,27 @@ async function fetchData(url: string, requestConfig): Promise<{
             }
 
             if (receivedBytes === expectedSize) {
+                const telemetry = receivedBytes >= MIN_CHUNK_SIZE_FOR_TELEMETRY_BYTES ? {
+                    chunkSizeBytes: receivedBytes,
+                    // Includes body reading across resumed requests because every received part belongs to the chunk.
+                    downloadTimeMs: bodyDownloadTimeMs,
+                    retries: requestCount - 1,
+                } : undefined;
+
                 return {
                     data: mergeChunks(chunks, receivedBytes),
                     headers: {
                         ...responseHeaders,
                         'content-length': `${expectedSize}`,
                     },
+                    telemetry,
                 };
             }
         } catch (error) {
             if (error instanceof DownloadReadError) {
                 receivedBytes = error.receivedBytes;
+                // The partial bytes remain available for resuming, so include the time spent downloading them.
+                bodyDownloadTimeMs += error.downloadTimeMs;
             }
 
             if (retry < MAX_NO_PROGRESS_RETRIES && (error instanceof DownloadReadError || shouldRetry(response))) {
@@ -271,6 +294,7 @@ onmessage = (e) => {
             postMessage({
                 responseData: response.data,
                 headers: response.headers,
+                telemetry: response.telemetry,
                 id: e.data.id,
                 isSuccess: true,
             });

--- a/cvat-core/src/logger.ts
+++ b/cvat-core/src/logger.ts
@@ -33,25 +33,6 @@ interface IgnoreRule {
     update: (previousEvent: Event, currentPayload: JSONEventPayload) => JSONEventPayload;
 }
 
-interface BandwidthInfo {
-    totalDownloadBytes: number;
-    totalDownloadTimeMs: number;
-    totalDownloadRetries: number;
-}
-
-function makeBandwidthPayload(bandwidthInfo: BandwidthInfo): JSONEventPayload {
-    const totalDownloadedMegabits = (bandwidthInfo.totalDownloadBytes * 8) / 1_000_000;
-    const totalDownloadTimeSeconds = bandwidthInfo.totalDownloadTimeMs / 1000;
-
-    return {
-        obj_name: 'chunk_download_bandwidth',
-        ...bandwidthInfo,
-        ...(bandwidthInfo.totalDownloadTimeMs ? {
-            bandwidthMbps: totalDownloadedMegabits / totalDownloadTimeSeconds,
-        } : {}),
-    };
-}
-
 function clientIdGen(): string {
     let val = null;
     try {
@@ -165,7 +146,8 @@ class Logger {
         }
 
         const event = makeEvent(EventScope.debugInfo, {
-            ...makeBandwidthPayload(bandwidthInfo),
+            obj_name: 'chunk_download_bandwidth',
+            ...bandwidthInfo,
             client_id: this.clientID,
             is_active: this.isActiveChecker(),
         });

--- a/cvat-core/src/logger.ts
+++ b/cvat-core/src/logger.ts
@@ -33,6 +33,25 @@ interface IgnoreRule {
     update: (previousEvent: Event, currentPayload: JSONEventPayload) => JSONEventPayload;
 }
 
+interface BandwidthInfo {
+    totalDownloadBytes: number;
+    totalDownloadTimeMs: number;
+    totalDownloadRetries: number;
+}
+
+function makeBandwidthPayload(bandwidthInfo: BandwidthInfo): JSONEventPayload {
+    const totalDownloadedMegabits = (bandwidthInfo.totalDownloadBytes * 8) / 1_000_000;
+    const totalDownloadTimeSeconds = bandwidthInfo.totalDownloadTimeMs / 1000;
+
+    return {
+        obj_name: 'chunk_download_bandwidth',
+        ...bandwidthInfo,
+        ...(bandwidthInfo.totalDownloadTimeMs ? {
+            bandwidthMbps: totalDownloadedMegabits / totalDownloadTimeSeconds,
+        } : {}),
+    };
+}
+
 function clientIdGen(): string {
     let val = null;
     try {
@@ -135,6 +154,28 @@ class Logger {
         const result = await PluginRegistry.apiWrapper.call(this, Logger.prototype.save);
         return result;
     }
+
+    public saveCriticalEvents(): void {
+        // Critical page-exit delivery must start synchronously, so this path intentionally bypasses plugin wrappers
+        // and does not read or update the regular event collection, save lock, or lastSentEvent chain.
+
+        const bandwidthInfo = serverProxy.server.getAndResetBandwidthInfo();
+        if (!bandwidthInfo.totalDownloadBytes) {
+            return;
+        }
+
+        const event = makeEvent(EventScope.debugInfo, {
+            ...makeBandwidthPayload(bandwidthInfo),
+            client_id: this.clientID,
+            is_active: this.isActiveChecker(),
+        });
+        event.validatePayload();
+
+        serverProxy.events.save({
+            events: [event.dump()],
+            timestamp: new Date().toISOString(),
+        }, { keepalive: true }).catch(() => {});
+    }
 }
 
 Object.defineProperties(Logger.prototype.configure, {
@@ -157,7 +198,7 @@ Object.defineProperties(Logger.prototype.log, {
     implementation: {
         writable: false,
         enumerable: false,
-        value: async function implementation(
+        value: function implementation(
             this: Logger,
             scope: EventScope,
             payload: JSONEventPayload,
@@ -228,13 +269,14 @@ Object.defineProperties(Logger.prototype.save, {
             }
 
             const collectionToSend = [...this.collection];
+
             try {
                 this.saving = true;
                 this.collection = [];
                 await serverProxy.events.save({
                     events: collectionToSend.map((event) => event.dump()),
-                    previous_event: this.lastSentEvent?.dump(),
                     timestamp: new Date().toISOString(),
+                    previous_event: this.lastSentEvent?.dump(),
                 });
 
                 this.lastSentEvent = collectionToSend[collectionToSend.length - 1];

--- a/cvat-core/src/server-proxy.ts
+++ b/cvat-core/src/server-proxy.ts
@@ -52,6 +52,12 @@ type Params = {
 
 type HealthCheckResponse = Record<string, string>;
 
+const totalBandwidthInfo = {
+    totalDownloadBytes: 0,
+    totalDownloadTimeMs: 0,
+    totalDownloadRetries: 0,
+};
+
 tus.defaultOptions.storeFingerprintForResuming = false;
 
 function enableOrganization(): { org: string } {
@@ -304,7 +310,11 @@ class WorkerWrappedAxios {
             if (e.data.id in requests) {
                 try {
                     if (e.data.isSuccess) {
-                        requests[e.data.id].resolve({ data: e.data.responseData, headers: e.data.headers });
+                        requests[e.data.id].resolve({
+                            data: e.data.responseData,
+                            headers: e.data.headers,
+                            telemetry: e.data.telemetry,
+                        });
                     } else {
                         let response: AxiosResponse | undefined;
                         let code: AxiosError['code'];
@@ -1733,10 +1743,26 @@ async function getData(jid: number, chunk: number, quality: ChunkQuality): Promi
             responseType: 'arraybuffer',
         });
 
+        if (response.telemetry) {
+            totalBandwidthInfo.totalDownloadBytes += response.telemetry.chunkSizeBytes;
+            totalBandwidthInfo.totalDownloadTimeMs += response.telemetry.downloadTimeMs;
+            totalBandwidthInfo.totalDownloadRetries += response.telemetry.retries;
+        }
+
         return response.data;
     } catch (errorData) {
         throw generateError(errorData);
     }
+}
+
+function getAndResetBandwidthInfo(): typeof totalBandwidthInfo {
+    const result = { ...totalBandwidthInfo };
+
+    totalBandwidthInfo.totalDownloadBytes = 0;
+    totalBandwidthInfo.totalDownloadTimeMs = 0;
+    totalBandwidthInfo.totalDownloadRetries = 0;
+
+    return result;
 }
 
 interface AudioChunkResponse {
@@ -1900,13 +1926,17 @@ async function uploadAnnotations(
 
 async function saveEvents(events: {
     events: SerializedEvent[];
-    previous_event?: SerializedEvent;
     timestamp: string;
-}): Promise<void> {
+    previous_event?: SerializedEvent;
+}, options: { keepalive?: boolean } = {}): Promise<void> {
     const { backendAPI } = config;
 
     try {
-        await Axios.post(`${backendAPI}/events`, events);
+        await Axios.post(`${backendAPI}/events`, events, options.keepalive ? {
+            // The fetch adapter can keep this best-effort request alive while the page is being unloaded.
+            adapter: 'fetch',
+            fetchOptions: { keepalive: true },
+        } : undefined);
     } catch (errorData) {
         throw generateError(errorData);
     }
@@ -2700,6 +2730,7 @@ export default Object.freeze({
         userAgreements,
         installedApps,
         apiSchema: getApiSchema,
+        getAndResetBandwidthInfo,
     }),
 
     projects: Object.freeze({

--- a/cvat-ui/src/utils/event-recorder.ts
+++ b/cvat-ui/src/utils/event-recorder.ts
@@ -61,6 +61,7 @@ class EventRecorder {
 
     public initSave(): void {
         if (this.#savingTimeout) return;
+        window.addEventListener('pagehide', this.saveBeforePageExit);
         this.#savingTimeout = window.setTimeout(() => {
             const scheduleSave = (): void => {
                 this.#savingTimeout = null;
@@ -80,6 +81,7 @@ class EventRecorder {
     }
 
     public cancelSave(): void {
+        window.removeEventListener('pagehide', this.saveBeforePageExit);
         if (this.#savingTimeout) {
             window.clearTimeout(this.#savingTimeout);
             this.#savingTimeout = null;
@@ -89,6 +91,10 @@ class EventRecorder {
     public set logger(logger: Logger | null) {
         this.#logger = logger;
     }
+
+    private saveBeforePageExit = (): void => {
+        core.logger.saveCriticalEvents();
+    };
 
     private filterClassName(cls: string): string {
         if (typeof cls === 'string') {


### PR DESCRIPTION
### Motivation and context

Chunk download performance can vary significantly between users, but the client currently provides no aggregated information about actual transfer speed or interrupted downloads.

This change:

- Collects telemetry for successfully downloaded chunks of at least 2 MiB.
- Measures response body download time separately from server-side chunk preparation.
- Aggregates downloaded bytes, body download time, and retry count across the browser tab lifetime.
- Calculates aggregate bandwidth in Mbps.
- Sends a single `debug:info` event named `chunk_download_bandwidth` on page exit.
- Uses a best-effort fetch keepalive request so delivery can continue while the document is being unloaded.
- Keeps critical telemetry separate from the regular logger collection, plugin wrappers, save locking, and `lastSentEvent` chaining.

Regular event saving behavior is unchanged.

### How has this been tested?
- Manually

### Checklist

- [x] I submit my changes into the `develop` branch
- [ ] ~~I have created a changelog fragment~~
- [ ] ~~I have updated the documentation accordingly~~
- [ ] ~~I have added tests to cover my changes~~
- [ ] ~~I have linked related issues~~
 
### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.