### PR TITLE
Exclude inactive tab from bandwidth telemetry

### DIFF
--- a/cvat-core/src/server-proxy.ts
+++ b/cvat-core/src/server-proxy.ts
@@ -58,6 +58,20 @@ const totalBandwidthInfo = {
     totalDownloadRetries: 0,
 };
 
+// A download may start and finish while the page is visible but be throttled while it is hidden.
+// Track visibility transitions to exclude such downloads from bandwidth telemetry.
+let pageVisibilityCounter = 0;
+
+function isPageVisible(): boolean {
+    return typeof document === 'undefined' || document.visibilityState === 'visible';
+}
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', () => {
+        pageVisibilityCounter++;
+    });
+}
+
 tus.defaultOptions.storeFingerprintForResuming = false;
 
 function enableOrganization(): { org: string } {
@@ -1731,6 +1745,8 @@ async function getImageContext(jid: number, frame: number): Promise<ArrayBuffer>
 
 async function getData(jid: number, chunk: number, quality: ChunkQuality): Promise<ArrayBuffer> {
     const { backendAPI } = config;
+    const pageWasVisible = isPageVisible();
+    const pageVisibilityVersionAtStart = pageVisibilityCounter;
 
     try {
         const response = await (workerAxios as any).get(`${backendAPI}/jobs/${jid}/data`, {
@@ -1743,7 +1759,10 @@ async function getData(jid: number, chunk: number, quality: ChunkQuality): Promi
             responseType: 'arraybuffer',
         });
 
-        if (response.telemetry) {
+        const pageWasVisibleThroughoutDownload = pageWasVisible &&
+            isPageVisible() && pageVisibilityCounter === pageVisibilityVersionAtStart;
+
+        if (response.telemetry && pageWasVisibleThroughoutDownload) {
             totalBandwidthInfo.totalDownloadBytes += response.telemetry.chunkSizeBytes;
             totalBandwidthInfo.totalDownloadTimeMs += response.telemetry.downloadTimeMs;
             totalBandwidthInfo.totalDownloadRetries += response.telemetry.retries;


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
When tab is inactive, browser usually slowdown/freezes process on this tab. Including bandwidth. So, it makes statistics less relevant. 


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
