### PR TITLE
Drop "before_update" and "changes" from webhook payloads

### DIFF
--- a/changelog.d/20260828_120000_aleksei_sosov_drop_webhook_before_update_and_changes.md
+++ b/changelog.d/20260828_120000_aleksei_sosov_drop_webhook_before_update_and_changes.md
@@ -1,0 +1,12 @@
+### Deprecated
+
+- \[Server API\] The `changed_fields` field of webhook delivery responses is
+  deprecated. It is kept for historical deliveries and is always empty for
+  new ones
+  (<https://github.com/cvat-ai/cvat/pull/11104>)
+
+### Removed
+
+- \[Server API\] Webhook payloads for `update:<resource>` events no longer
+  contain the `before_update` and `changes` keys.
+  (<https://github.com/cvat-ai/cvat/pull/11104>)

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -1325,7 +1325,7 @@ class JobQuerySet(models.QuerySet):
         return self.annotate(child_jobs__count=models.Count("child_job"))
 
 
-class Job(DirtyFieldsMixin, TimestampedModel, AssignableModel, FileSystemRelatedModel):
+class Job(TimestampedModel, AssignableModel, FileSystemRelatedModel):
     objects = JobQuerySet.as_manager()
 
     segment = models.ForeignKey(Segment, on_delete=models.CASCADE)
@@ -1727,7 +1727,7 @@ class Profile(models.Model):
     )
 
 
-class Issue(DirtyFieldsMixin, TimestampedModel, AssignableModel):
+class Issue(TimestampedModel, AssignableModel):
     frame = models.PositiveIntegerField()
     position = FloatArrayField()
     job = models.ForeignKey(
@@ -1755,7 +1755,7 @@ class Issue(DirtyFieldsMixin, TimestampedModel, AssignableModel):
         return self.job_id
 
 
-class Comment(DirtyFieldsMixin, TimestampedModel):
+class Comment(TimestampedModel):
     issue = models.ForeignKey(
         Issue, related_name="comments", related_query_name="comment", on_delete=models.CASCADE
     )

--- a/cvat/apps/organizations/models.py
+++ b/cvat/apps/organizations/models.py
@@ -6,7 +6,6 @@
 from datetime import timedelta
 
 from allauth.account.adapter import get_adapter
-from dirtyfields import DirtyFieldsMixin
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ImproperlyConfigured
@@ -18,7 +17,7 @@ from drf_spectacular.utils import extend_schema_field
 from cvat.apps.engine.models import TimestampedModel
 
 
-class Organization(DirtyFieldsMixin, TimestampedModel):
+class Organization(TimestampedModel):
     slug = models.SlugField(max_length=16, blank=False, unique=True)
     name = models.CharField(max_length=64, blank=True)
     description = models.TextField(blank=True)
@@ -35,7 +34,7 @@ class Organization(DirtyFieldsMixin, TimestampedModel):
         default_permissions = ()
 
 
-class Membership(DirtyFieldsMixin, models.Model):
+class Membership(models.Model):
     WORKER = "worker"
     SUPERVISOR = "supervisor"
     MAINTAINER = "maintainer"
@@ -63,7 +62,7 @@ class Membership(DirtyFieldsMixin, models.Model):
 
 
 # Inspired by https://github.com/bee-keeper/django-invitations
-class Invitation(DirtyFieldsMixin, models.Model):
+class Invitation(models.Model):
     key = models.CharField(max_length=64, primary_key=True)
     created_date = models.DateTimeField(auto_now_add=True)
     sent_date = models.DateTimeField(null=True)

--- a/cvat/apps/webhooks/models.py
+++ b/cvat/apps/webhooks/models.py
@@ -113,6 +113,7 @@ class WebhookDelivery(TimestampedModel):
     attempt = models.PositiveIntegerField(null=True)
     request_duration = models.PositiveIntegerField(null=True)
 
+    # deprecated, kept for historical deliveries
     changed_fields = models.CharField(max_length=4096, default="")
 
     request = models.JSONField(default=dict)

--- a/cvat/apps/webhooks/serializers.py
+++ b/cvat/apps/webhooks/serializers.py
@@ -168,6 +168,7 @@ class WebhookWriteSerializer(WriteOnceMixin, serializers.ModelSerializer):
         return db_webhook
 
 
+@extend_schema_serializer(deprecate_fields=["changed_fields"])
 class WebhookDeliveryReadSerializer(serializers.ModelSerializer):
     webhook_id = serializers.IntegerField(read_only=True)
 

--- a/cvat/apps/webhooks/services.py
+++ b/cvat/apps/webhooks/services.py
@@ -65,7 +65,6 @@ def send_webhook(
         webhook_id=webhook.id,
         event=payload["event"],
         status_code=status_code,
-        changed_fields=",".join(list(payload.get("before_update", {}).keys())),
         redelivery=redelivery,
         request=payload,
         response=response,

--- a/cvat/apps/webhooks/signals.py
+++ b/cvat/apps/webhooks/signals.py
@@ -2,14 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
-import json
 from typing import TypeVar
 
 from django.db import transaction
 from django.db.models import Model
 from django.db.models.signals import post_delete, post_save, pre_delete
 from django.dispatch import receiver
-from rest_framework.renderers import JSONRenderer
 
 from cvat.apps.engine.models import Comment, Issue, Job, Project, Task
 from cvat.apps.events.handlers import (
@@ -53,55 +51,59 @@ def post_save_resource_event(
     if event_key_ not in (a[0] for a in EventKeyChoice.choices()):
         return
 
-    dirty_fields: dict[str, dict] = {
-        instance._meta.get_field(field).attname: value
-        for field, value in instance.get_dirty_fields(
-            verbose=True,
-            check_relationship=True,
-        ).items()
-    }
-
-    if update_fields is not None:
-        update_fields = {instance._meta.get_field(field).attname for field in update_fields}
-
-        dirty_fields = {
-            field: value for field, value in dirty_fields.items() if field in update_fields
+    if isinstance(instance, (Project, Task)) and not created:
+        dirty_fields: dict[str, dict] = {
+            instance._meta.get_field(field).attname: value
+            for field, value in instance.get_dirty_fields(
+                verbose=True,
+                check_relationship=True,
+            ).items()
         }
 
-    old_instance = utils.recreate_old_instance(instance=instance, dirty_fields=dirty_fields)
+        if update_fields is not None:
+            update_fields = {instance._meta.get_field(field).attname for field in update_fields}
 
-    # consider task and project transfers as deletion in one organization and creation in another
-    if (
-        isinstance(instance, (Project, Task))
-        and not created
-        and resolve_organization_id(old_instance) != resolve_organization_id(instance)
-    ):
-        new_org_id = resolve_organization_id(instance)
-        new_project_id = resolve_project_id(instance)
+            dirty_fields = {
+                field: value for field, value in dirty_fields.items() if field in update_fields
+            }
 
-        old_org_id = resolve_organization_id(old_instance)
-        old_project_id = resolve_project_id(old_instance)
+        old_instance = utils.recreate_old_instance(instance=instance, dirty_fields=dirty_fields)
 
-        webhooks_per_event_key = {
-            event_key_: select_webhooks(
-                event_key=event_key_,
-                organization_id=new_org_id,
-                project_id=new_project_id,
-                select_for_org=False,
-            ),
-            event_key(action="delete", resource=resource_name): select_webhooks(
-                event_key=event_key(action="delete", resource=resource_name),
-                organization_id=old_org_id,
-                project_id=old_project_id,
-                select_for_project=False,
-            ),
-            event_key(action="create", resource=resource_name): select_webhooks(
-                event_key=event_key(action="create", resource=resource_name),
-                organization_id=new_org_id,
-                project_id=new_project_id,
-                select_for_project=False,
-            ),
-        }
+        # consider task and project transfers as deletion in one organization and creation in another
+        if resolve_organization_id(instance) != resolve_organization_id(old_instance):
+            new_org_id = resolve_organization_id(instance)
+            old_org_id = resolve_organization_id(old_instance)
+            new_project_id = resolve_project_id(instance)
+            old_project_id = resolve_project_id(old_instance)
+
+            webhooks_per_event_key = {
+                event_key_: select_webhooks(
+                    event_key=event_key_,
+                    organization_id=new_org_id,
+                    project_id=new_project_id,
+                    select_for_org=False,
+                ),
+                event_key(action="delete", resource=resource_name): select_webhooks(
+                    event_key=event_key(action="delete", resource=resource_name),
+                    organization_id=old_org_id,
+                    project_id=old_project_id,
+                    select_for_project=False,
+                ),
+                event_key(action="create", resource=resource_name): select_webhooks(
+                    event_key=event_key(action="create", resource=resource_name),
+                    organization_id=new_org_id,
+                    project_id=new_project_id,
+                    select_for_project=False,
+                ),
+            }
+        else:
+            webhooks_per_event_key = {
+                event_key_: select_webhooks(
+                    event_key=event_key_,
+                    organization_id=resolve_organization_id(instance),
+                    project_id=resolve_project_id(instance),
+                ),
+            }
     else:
         webhooks_per_event_key = {
             event_key_: select_webhooks(
@@ -121,19 +123,6 @@ def post_save_resource_event(
         "sender": utils.get_sender(instance=instance),
     }
 
-    if not created:
-        # TODO: backward compatibility, remove in future releases
-        _before_update = {field: value["saved"] for field, value in dirty_fields.items()}
-
-        _changes = {
-            field: {"from": value["saved"], "to": value["current"]}
-            for field, value in dirty_fields.items()
-        }
-        changes_payload_part = {
-            "before_update": json.loads(JSONRenderer().render(_before_update)),
-            "changes": json.loads(JSONRenderer().render(_changes)),
-        }
-
     webhook_payload_pairs = [
         (
             webhook,
@@ -141,7 +130,6 @@ def post_save_resource_event(
                 "event": event_key,
                 "webhook_id": webhook.id,
                 **_webhook_payload,
-                **(changes_payload_part if event_key.startswith("update") else {}),
             },
         )
         for event_key, webhooks in webhooks_per_event_key.items()

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -13449,6 +13449,7 @@ components:
         changed_fields:
           type: string
           readOnly: true
+          deprecated: true
         request:
           readOnly: true
         response:

--- a/tests/python/rest_api/test_webhooks_sender.py
+++ b/tests/python/rest_api/test_webhooks_sender.py
@@ -10,7 +10,7 @@ import pytest
 from deepdiff import DeepDiff
 
 from shared.fixtures.data import Container
-from shared.fixtures.init import CVAT_ROOT_DIR
+from shared.fixtures.init import CVAT_DB_DIR, CVAT_ROOT_DIR
 from shared.utils.config import delete_method, get_method, patch_method, post_method
 from shared.utils.helpers import generate_image_files
 
@@ -123,11 +123,6 @@ class TestWebhookProjectEvents:
 
         assert payload["event"] == events[0]
         assert payload["sender"]["username"] == "admin1"
-        assert payload["before_update"]["name"] == project["name"]
-        assert payload["changes"]["name"] == {
-            "from": project["name"],
-            "to": patch_data["name"],
-        }
 
         project.update(patch_data)
         assert (
@@ -212,20 +207,6 @@ class TestWebhookIntersection:
         assert deliveries_1["count"] == deliveries_2["count"] == 1
 
         assert payload_1["project"]["name"] == payload_2["project"]["name"] == patch_data["name"]
-
-        assert (
-            payload_1["before_update"]["name"]
-            == payload_2["before_update"]["name"]
-            == post_data["name"]
-        )
-        assert payload_1["changes"]["name"] == {
-            "from": post_data["name"],
-            "to": patch_data["name"],
-        }
-        assert payload_2["changes"]["name"] == {
-            "from": post_data["name"],
-            "to": patch_data["name"],
-        }
 
         assert payload_1["webhook_id"] == webhook_id_1
         assert payload_2["webhook_id"] == webhook_id_2
@@ -326,11 +307,6 @@ class TestWebhookTaskEvents:
         deliveries, payload = get_deliveries(webhook_id=webhook_id)
 
         assert deliveries["count"] == 1
-        assert payload["before_update"]["assignee_id"] == tasks[task_id]["assignee"]["id"]
-        assert payload["changes"]["assignee_id"] == {
-            "from": tasks[task_id]["assignee"]["id"],
-            "to": assignee_id,
-        }
         assert payload["task"]["assignee"]["id"] == assignee_id
 
     def test_webhook_create_and_delete_task(self, organizations):
@@ -407,11 +383,6 @@ class TestWebhookJobEvents:
         deliveries, payload = get_deliveries(webhook_id)
 
         assert deliveries["count"] == 1
-        assert payload["before_update"]["assignee_id"] is None
-        assert payload["changes"]["assignee_id"] == {
-            "from": None,
-            "to": patch_data["assignee"],
-        }
         assert payload["job"]["assignee"]["id"] == patch_data["assignee"]
 
     def test_webhook_update_job_stage(self, jobs, tasks):
@@ -428,11 +399,6 @@ class TestWebhookJobEvents:
 
         deliveries, payload = get_deliveries(webhook_id)
         assert deliveries["count"] == 1
-        assert payload["before_update"]["stage"] == job["stage"]
-        assert payload["changes"]["stage"] == {
-            "from": job["stage"],
-            "to": patch_data["stage"],
-        }
         assert payload["job"]["stage"] == patch_data["stage"]
 
     def test_webhook_update_job_state(self, jobs, tasks):
@@ -453,11 +419,6 @@ class TestWebhookJobEvents:
 
         deliveries, payload = get_deliveries(webhook_id)
         assert deliveries["count"] == 1
-        assert payload["before_update"]["state"] == job["state"]
-        assert payload["changes"]["state"] == {
-            "from": job["state"],
-            "to": patch_data["state"],
-        }
         assert payload["job"]["state"] == patch_data["state"]
 
 
@@ -481,11 +442,6 @@ class TestWebhookIssueEvents:
         deliveries, payload = get_deliveries(webhook_id)
 
         assert deliveries["count"] == 1
-        assert payload["before_update"]["resolved"] == issue["resolved"]
-        assert payload["changes"]["resolved"] == {
-            "from": issue["resolved"],
-            "to": patch_data["resolved"],
-        }
         assert payload["issue"]["resolved"] == patch_data["resolved"]
 
     def test_webhook_update_issue_position(self, issues, jobs, tasks):
@@ -506,11 +462,6 @@ class TestWebhookIssueEvents:
         deliveries, payload = get_deliveries(webhook_id)
 
         assert deliveries["count"] == 1
-        assert payload["before_update"]["position"] == issue["position"]
-        assert payload["changes"]["position"] == {
-            "from": issue["position"],
-            "to": patch_data["position"],
-        }
         assert payload["issue"]["position"] == patch_data["position"]
 
     @pytest.mark.parametrize("org_id", (2,))
@@ -578,11 +529,6 @@ class TestWebhookMembershipEvents:
         deliveries, payload = get_deliveries(webhook_id)
 
         assert deliveries["count"] == 1
-        assert payload["before_update"]["role"] == membership["role"]
-        assert payload["changes"]["role"] == {
-            "from": membership["role"],
-            "to": patch_data["role"],
-        }
         assert payload["membership"]["role"] == patch_data["role"]
 
     def test_webhook_delete_membership(self, memberships):
@@ -621,11 +567,6 @@ class TestWebhookOrganizationEvents:
         deliveries, payload = get_deliveries(webhook_id)
 
         assert deliveries["count"] == 1
-        assert payload["before_update"]["name"] == organizations[org_id]["name"]
-        assert payload["changes"]["name"] == {
-            "from": organizations[org_id]["name"],
-            "to": patch_data["name"],
-        }
         assert payload["organization"]["name"] == patch_data["name"]
 
 
@@ -650,11 +591,6 @@ class TestWebhookCommentEvents:
         deliveries, payload = get_deliveries(webhook_id)
 
         assert deliveries["count"] == 1
-        assert payload["before_update"]["message"] == comment["message"]
-        assert payload["changes"]["message"] == {
-            "from": comment["message"],
-            "to": patch_data["message"],
-        }
 
         comment.update(patch_data)
         assert (
@@ -731,6 +667,46 @@ class TestGetWebhookDeliveries:
         )
         assert response.status_code == HTTPStatus.FORBIDDEN
 
+    def test_get_old_delivery(self):
+        # NOTE: "old" == seeded in the test DB before `changed_fields` and the
+        # "before_update" payload key were dropped; such deliveries must keep both.
+        with open(CVAT_DB_DIR / "data.json") as f:
+            db_records = json.load(f)
+
+        old_delivery = next(
+            {**r["fields"], "id": r["pk"]}
+            for r in db_records
+            if r["model"] == "webhooks.webhookdelivery" and r["fields"]["changed_fields"]
+        )
+
+        response = get_method("admin1", f"webhooks/{old_delivery['webhook']}/deliveries")
+        assert response.status_code == HTTPStatus.OK
+
+        actual_delivery = next(
+            d for d in response.json()["results"] if d["id"] == old_delivery["id"]
+        )
+
+        assert actual_delivery["changed_fields"] == old_delivery["changed_fields"]
+        assert "before_update" in actual_delivery["request"]
+
+    def test_get_new_delivery(self, tasks):
+        task_id, project_id = next(
+            (task["id"], task["project_id"]) for task in tasks if task["project_id"] is not None
+        )
+
+        webhook_id = create_webhook(["update:task"], "project", project_id=project_id)["id"]
+
+        patch_data = {"name": "new task name"}
+        response = patch_method("admin1", f"tasks/{task_id}", patch_data)
+        assert response.status_code == HTTPStatus.OK
+
+        deliveries, payload = get_deliveries(webhook_id)
+        assert payload["task"]["name"] == patch_data["name"]
+
+        new_delivery = deliveries["results"][0]
+        assert new_delivery["changed_fields"] == ""
+        assert "before_update" not in new_delivery["request"]
+
 
 @pytest.mark.usefixtures("restore_db_per_function")
 class TestWebhookPing:
@@ -797,15 +773,6 @@ class TestWebhookRedelivery:
 
         assert deliveries_1["results"][0]["redelivery"] is False
         assert deliveries_2["results"][0]["redelivery"] is True
-
-        assert payload_1["changes"]["name"] == {
-            "from": project["name"],
-            "to": patch_data["name"],
-        }
-        assert payload_2["changes"]["name"] == {
-            "from": project["name"],
-            "to": patch_data["name"],
-        }
 
         project.update(patch_data)
         assert (


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context

Correctly computing the before_update/changes part of the payload is one of the most complex pieces of the webhook implementation: it requires dirty-field tracking on every affected model, snapshotting state before each save, and keeping all of that correct across every code path that touches those models. Meanwhile, the practical value of this data is doubtful — we are not aware of any consumer that actually relies on "this field changed from A to B" in webhook payloads; the number may well be literally zero.

Given that trade-off, we are removing the complex diff-tracking logic now. This significantly simplifies both the current code and the upcoming webhook work. If a real demand for change tracking ever appears, we can bring it back deliberately, designed against an actual use case.

This PR only removes the `before_update`/`changes` diff-tracking keys from webhook payloads:

- Webhook payloads for `update:<resource>` events no longer include `before_update` and `changes`.
- `WebhookDelivery.changed_fields` is kept on the model (deprecated) for historical deliveries only; new deliveries always store `changed_fields=""`.
- `dirty_fields` computation in `post_save_resource_event` is now only performed for `Project`/`Task` (needed to detect cross-organization transfers), since it's no longer needed to build a diff payload for any other resource type.

### How has this been tested?

- Updated `tests/python/rest_api/test_webhooks_sender.py`: removed `before_update`/`changes` assertions from the existing project/task/job/issue/membership/organization/comment/redelivery webhook tests.
- Updated `tests/python/shared/assets/cvat_db/data.json` fixtures to match (`changed_fields` now stored as `""` explicitly instead of a computed diff).

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- [x] ~~I have updated the documentation accordingly~~ (no user-facing docs beyond the changelog)
- [x] I have added tests to cover my changes
- [ ] I have linked related issues

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
