### PR TITLE
deps: bump nltk to 3.10.3 (PYSEC-2026-3726, CVE-2026-62383)

### DIFF
--- a/cvat/requirements/base.txt
+++ b/cvat/requirements/base.txt
@@ -179,7 +179,7 @@ networkx==3.4.2
     # via datumaro
 nibabel==5.3.2
     # via datumaro
-nltk==3.10.0
+nltk==3.10.3
     # via datumaro
 oauthlib==3.3.1
     # via django-allauth


### PR DESCRIPTION
Updates `nltk` to address PYSEC-2026-3726 / CVE-2026-62383.

Evidence:
- `cvat/requirements/base.txt` referenced `nltk==3.10.0`
- osv-scanner reported PYSEC-2026-3726 against nltk 3.10.0 before the update
- updated version: `nltk==3.10.3`

Validation:
- osv-scanner no longer reports PYSEC-2026-3726 against the updated requirements (nltk 3.10.3 is clear of all published nltk advisories)
- `nltk==3.10.3` installs and imports cleanly on Python 3.11. The server pytest suite (`pytest tests/python`) needs the full datumaro/docker environment from CI and was not run locally.

Scope: dependency bump only (`cvat/requirements/base.txt`, one line). The file is generated by pip-compile-multi from `base.in`; nltk comes in transitively via datumaro, so the change is the single pinned line, no regeneration needed.