### PR TITLE
Fix blank canvas when drawing or editing masks on HiDPI displays with large images

### DIFF
--- a/changelog.d/20260830_015412_YzYhhhstudy_fix_mask_hidpi.md
+++ b/changelog.d/20260830_015412_YzYhhhstudy_fix_mask_hidpi.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Fixed blank canvas when drawing or editing masks on HiDPI displays with large images:
+  the mask drawing layer could exceed the browser's maximum canvas area.
+  (<https://github.com/cvat-ai/cvat/pull/11111>)

--- a/cvat-canvas/src/typescript/masksHandler.ts
+++ b/cvat-canvas/src/typescript/masksHandler.ts
@@ -421,6 +421,7 @@ export class MasksHandlerImpl implements MasksHandler {
             fireRightClick: true,
             selection: false,
             defaultCursor: 'inherit',
+            enableRetinaScaling: false,
         });
         this.canvas.imageSmoothingEnabled = false;
         this.drawnObjects = this.createDrawnObjectsArray();


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Fixes #11110

On HiDPI displays, entering mask drawing or editing mode with a sufficiently
large image can turn the complete canvas area opaque white.

Fabric enables Retina scaling by default, so the backing dimensions of the mask
editing canvas are multiplied by `window.devicePixelRatio`. For a
`12600 × 9000` image at `devicePixelRatio = 2`, the lower and upper Fabric
canvases attempt to use `25200 × 18000` backing stores, or 453,600,000 pixels
each.

This exceeds Chromium's practical maximum 2D canvas area of 268,435,456 pixels.
The allocation fails silently, subsequent drawing operations become no-ops, and
the failed Fabric canvases remain above the normally rendered background image
as an opaque white layer.

This PR disables Retina scaling only for the Fabric canvas used by the mask
drawing and editing handler:

```ts
this.canvas = new fabric.Canvas(canvas, {
    containerClass: 'cvat_masks_canvas_wrapper',
    fireRightClick: true,
    selection: false,
    defaultCursor: 'inherit',
    enableRetinaScaling: false,
});
```

The logical canvas continues to use image-pixel coordinates, while its backing
store is no longer multiplied by the display DPR. The source change is one line
in `cvat-canvas/src/typescript/masksHandler.ts`.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Manual testing was performed using the same client and job that originally
reproduced the issue.

Test environment:

- self-hosted CVAT v2.71.0;
- Chrome 151 on macOS;
- browser zoom: 100%;
- `window.devicePixelRatio`: 2;
- image size: `12600 × 9000`.

Before the change:

- entering brush mode or editing an existing mask made the complete canvas area
  opaque white;
- the background image and edited mask disappeared;
- brush strokes were not visible;
- no relevant console exception was produced.

After the change:

- `window.devicePixelRatio` remains 2;
- lower Fabric canvas backing size is `12600 × 9000`;
- upper Fabric canvas backing size is `12600 × 9000`;
- the image and edited mask remain visible;
- drawing and editing work normally;
- changes can be saved successfully.

The observed canvas values after the change were:

```js
[
  {
    className: 'lower-canvas',
    backingWidth: 12600,
    backingHeight: 9000,
    cssWidth: 12600,
    cssHeight: 9000
  },
  {
    className: 'upper-canvas',
    backingWidth: 12600,
    backingHeight: 9000,
    cssWidth: 12600,
    cssHeight: 9000
  }
]
```

A DPR 1 regression check was also performed, and mask drawing/editing continued
to work normally.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- ~~[ ] I have updated the documentation accordingly~~ — Not applicable: this change does not modify the user-facing workflow or API.
- ~~[ ] I have added tests to cover my changes~~ — The defect depends on a browser hard canvas-area limit and a real HiDPI backing-store allocation; it was covered by the manual browser regression test described above.
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
