### PR TITLE
fix(engine): export to cloud storage respects the storage's configured prefix

### DIFF
--- a/changelog.d/20260831_063617_adhavan18_export_cloud_storage_prefix.md
+++ b/changelog.d/20260831_063617_adhavan18_export_cloud_storage_prefix.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Exporting a dataset or backup to a cloud storage location now respects
+  the storage's configured prefix instead of always landing at the bucket root.
+  (<https://github.com/cvat-ai/cvat/pull/11112>)

--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -158,6 +158,17 @@ class CloudStorageClient(ABC):
         self.prefix = prefix
         self.proxies = None if is_trusted else PROXIES_FOR_UNTRUSTED_URLS
 
+    def key_with_prefix(self, key: str) -> str:
+        """Join a bare key onto the configured prefix, if there is one.
+
+        upload_file()/upload_fileobj() take the key as-is: unlike list_files_on_one_page(),
+        they have no way to tell a caller-supplied key that already includes the prefix from
+        one that does not, so this exists for callers that generate their own key (e.g.
+        export_resource_to_cloud_storage()) rather than obtaining one from a prefix-aware
+        listing.
+        """
+        return f"{self.prefix.rstrip('/')}/{key}" if self.prefix else key
+
     @property
     @abstractmethod
     def name(self) -> str:
@@ -1334,7 +1345,8 @@ def export_resource_to_cloud_storage(
     file_path = func(*args, **kwargs)
     rq_job_meta = ExportRQMeta.for_job(rq_job)
 
-    db_storage.get_client().upload_file(Path(file_path), rq_job_meta.result_filename)
+    client = db_storage.get_client()
+    client.upload_file(Path(file_path), client.key_with_prefix(rq_job_meta.result_filename))
 
     return file_path
 

--- a/cvat/apps/engine/tests/test_cloud_provider.py
+++ b/cvat/apps/engine/tests/test_cloud_provider.py
@@ -1,0 +1,115 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from cvat.apps.engine.cloud_provider import (
+    CloudStorageClient,
+    export_resource_to_cloud_storage,
+)
+
+
+class _FakeCloudStorageClient(CloudStorageClient):
+    """Minimal concrete CloudStorageClient for testing key_with_prefix() and
+    export_resource_to_cloud_storage() without a real S3/Azure/GCS backend."""
+
+    def __init__(self, *, prefix=None):
+        super().__init__(prefix=prefix)
+        self.uploaded = []
+
+    @property
+    def name(self):
+        return "fake"
+
+    def get_status(self):
+        raise NotImplementedError
+
+    def get_file_status(self, key, /):
+        raise NotImplementedError
+
+    def get_file_last_modified(self, key, /):
+        raise NotImplementedError
+
+    def _download_fileobj_to_stream(self, key, stream, /):
+        raise NotImplementedError
+
+    def upload_fileobj(self, file_obj, key, /):
+        raise NotImplementedError
+
+    def upload_file(self, file_path, key=None, /):
+        self.uploaded.append((file_path, key))
+
+    def bulk_delete(self, files):
+        raise NotImplementedError
+
+    def _list_raw_content_on_one_page(self, prefix="", *, next_token=None, page_size=None):
+        raise NotImplementedError
+
+
+class TestKeyWithPrefix(unittest.TestCase):
+    def test_no_prefix_returns_key_unchanged(self):
+        client = _FakeCloudStorageClient(prefix=None)
+        self.assertEqual(client.key_with_prefix("task_1_backup.zip"), "task_1_backup.zip")
+
+    def test_prefix_is_joined_onto_the_key(self):
+        client = _FakeCloudStorageClient(prefix="exports/2026")
+        self.assertEqual(
+            client.key_with_prefix("task_1_backup.zip"), "exports/2026/task_1_backup.zip"
+        )
+
+    def test_trailing_slash_on_prefix_does_not_double(self):
+        client = _FakeCloudStorageClient(prefix="exports/2026/")
+        self.assertEqual(
+            client.key_with_prefix("task_1_backup.zip"), "exports/2026/task_1_backup.zip"
+        )
+
+
+class TestExportResourceToCloudStorageRespectsPrefix(unittest.TestCase):
+    """Regression test for the export path silently ignoring the storage's configured
+    prefix: upload_file() takes the key as-is, and only export_resource_to_cloud_storage()
+    generates its own key rather than obtaining one from prefix-aware listing, so it is the
+    one call site that needs the prefix applied explicitly."""
+
+    def test_upload_key_includes_the_configured_prefix(self):
+        client = _FakeCloudStorageClient(prefix="exports/2026")
+        db_storage = mock.Mock()
+        db_storage.get_client.return_value = client
+
+        with (
+            mock.patch("cvat.apps.engine.cloud_provider.get_current_job", return_value=mock.Mock()),
+            mock.patch("cvat.apps.engine.cloud_provider.ExportRQMeta") as mock_rq_meta,
+        ):
+            mock_rq_meta.for_job.return_value = mock.Mock(result_filename="task_1_backup.zip")
+
+            result = export_resource_to_cloud_storage(db_storage, lambda: "/tmp/local_backup.zip")
+
+        self.assertEqual(result, "/tmp/local_backup.zip")
+        self.assertEqual(len(client.uploaded), 1)
+        uploaded_path, uploaded_key = client.uploaded[0]
+        self.assertEqual(uploaded_path, Path("/tmp/local_backup.zip"))
+        # The bug this pins: before the fix, the key was the bare result_filename,
+        # landing every export at the bucket root instead of under the storage's
+        # configured prefix.
+        self.assertEqual(uploaded_key, "exports/2026/task_1_backup.zip")
+
+    def test_no_prefix_configured_uploads_the_bare_filename(self):
+        client = _FakeCloudStorageClient(prefix=None)
+        db_storage = mock.Mock()
+        db_storage.get_client.return_value = client
+
+        with (
+            mock.patch("cvat.apps.engine.cloud_provider.get_current_job", return_value=mock.Mock()),
+            mock.patch("cvat.apps.engine.cloud_provider.ExportRQMeta") as mock_rq_meta,
+        ):
+            mock_rq_meta.for_job.return_value = mock.Mock(result_filename="task_1_backup.zip")
+
+            export_resource_to_cloud_storage(db_storage, lambda: "/tmp/local_backup.zip")
+
+        self.assertEqual(client.uploaded[0][1], "task_1_backup.zip")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation and context

Closes #10237. Exporting a project/task/job dataset or backup to a cloud storage location silently ignores the storage's configured `prefix`: the export always lands at the bucket root instead of under the folder the user configured.

`export_resource_to_cloud_storage()` uploads under the bare `result_filename` (e.g. `task_1_backup.zip`). `upload_file()`/`upload_fileobj()` take the key as-is on every provider (S3/Azure/GCS); `self.prefix` is only ever read by `list_files_on_one_page()`, so nothing applies it on the upload path. `import_resource_from_cloud_storage()` is unaffected: it takes an explicit key obtained from prefix-aware listing, which already includes the prefix, so export is the one call site that generates its own key rather than being handed one.

An earlier attempt at this (#10280) was opened against `db_storage_to_storage_instance`, which no longer exists after the refactor to `db_storage.get_client()`, and was closed unmerged.

### How has this been tested?

Added `cvat/apps/engine/tests/test_cloud_provider.py`: pure `unittest.TestCase`, no Django test DB or real cloud SDK calls. `TestKeyWithPrefix` covers the new `CloudStorageClient.key_with_prefix()` helper directly (no prefix, a prefix, and a prefix with a trailing slash, to confirm no double slash). `TestExportResourceToCloudStorageRespectsPrefix` drives `export_resource_to_cloud_storage()` against a minimal fake `CloudStorageClient` with `get_current_job`/`ExportRQMeta` mocked, and asserts the uploaded key includes the configured prefix (and that an unconfigured prefix still uploads the bare filename, unchanged from today).

I was not able to run this suite in my local environment: `cvat/apps/engine/cloud_provider.py` needs Django settings plus the full `boto3`/`azure-storage-blob`/`google-cloud-storage` stack (`cvat/requirements/base.txt` is 342 packages), which I didn't want to stand up just to run a handful of unit tests. I verified the change by directly reading the full call chain instead: `get_client()` → `get_cloud_storage_client()` (module-level, `cloud_provider.py`) constructs the raw provider client with `prefix=specific_attributes.get("prefix")`, confirmed each concrete `upload_file` ignores it, confirmed `self.prefix` has no other reader in the file besides listing, and manually traced both new tests' assertions against `key_with_prefix()`'s implementation. Both the fix and the test file parse cleanly (`ast.parse`). Flagging this gap rather than claiming a local run that didn't happen — CI should confirm it either way.

### Checklist
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- [ ] I have updated the documentation accordingly <!-- no user-facing behavior to document beyond the bugfix itself -->
- [x] I have added tests to cover my changes
- [x] I have linked related issues

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
