### PR TITLE
Fix/frame filter without hiding annotations

### DIFF
--- a/changelog.d/9956_frame_filter_toggle.md
+++ b/changelog.d/9956_frame_filter_toggle.md
@@ -2,4 +2,4 @@
 
 - Added "Filter frames" and "Filter annotations" checkboxes to the annotation filters modal
   to allow independent control of frame navigation filtering and annotation visibility filtering.
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/11117>)

--- a/changelog.d/9956_frame_filter_toggle.md
+++ b/changelog.d/9956_frame_filter_toggle.md
@@ -1,0 +1,6 @@
+### feature
+
+- Add "Filter frames" and "Filter annotations" checkboxes to the annotation filters modal.
+  When "Filter annotations" is disabled, navigation still uses the configured filters
+  but all annotations on the displayed frame remain visible.
+  (<https://github.com/cvat-ai/cvat/issues/9956>)

--- a/changelog.d/9956_frame_filter_toggle.md
+++ b/changelog.d/9956_frame_filter_toggle.md
@@ -1,4 +1,4 @@
-### feature
+### Added
 
 - Add "Filter frames" and "Filter annotations" checkboxes to the annotation filters modal.
   When "Filter annotations" is disabled, navigation still uses the configured filters

--- a/changelog.d/9956_frame_filter_toggle.md
+++ b/changelog.d/9956_frame_filter_toggle.md
@@ -1,6 +1,5 @@
 ### Added
 
-- Add "Filter frames" and "Filter annotations" checkboxes to the annotation filters modal.
-  When "Filter annotations" is disabled, navigation still uses the configured filters
-  but all annotations on the displayed frame remain visible.
-  (<https://github.com/cvat-ai/cvat/issues/9956>)
+- Added "Filter frames" and "Filter annotations" checkboxes to the annotation filters modal
+  to allow independent control of frame navigation filtering and annotation visibility filtering.
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/cvat-ui/src/actions/annotation-actions.ts
+++ b/cvat-ui/src/actions/annotation-actions.ts
@@ -34,6 +34,8 @@ import { loadAudioDataAsync } from './audio-actions';
 
 interface AnnotationsParameters {
     filters: object[];
+    filterFrames: boolean;
+    filterAnnotations: boolean;
     frame: number;
     showAllInterpolationTracks: boolean;
     showGroundTruth: boolean;
@@ -57,7 +59,7 @@ export function receiveAnnotationsParameters(): AnnotationsParameters {
     const state: CombinedState = getStore().getState();
     const {
         annotation: {
-            annotations: { filters },
+            annotations: { filters, filterFrames, filterAnnotations },
             player: {
                 frame: { number: frame },
             },
@@ -72,6 +74,8 @@ export function receiveAnnotationsParameters(): AnnotationsParameters {
 
     return {
         filters,
+        filterFrames,
+        filterAnnotations,
         frame,
         jobInstance: jobInstance as Job,
         groundTruthInstance,
@@ -142,6 +146,8 @@ export enum AnnotationActionTypes {
     UNDO_ACTION_FAILED = 'UNDO_ACTION_FAILED',
     REDO_ACTION_FAILED = 'REDO_ACTION_FAILED',
     CHANGE_ANNOTATIONS_FILTERS = 'CHANGE_ANNOTATIONS_FILTERS',
+    SWITCH_FILTER_FRAMES = 'SWITCH_FILTER_FRAMES',
+    SWITCH_FILTER_ANNOTATIONS = 'SWITCH_FILTER_ANNOTATIONS',
     CHANGE_SHOW_SEARCH_FRAMES_MODAL = 'CHANGE_SHOW_SEARCH_FRAMES_MODAL',
     FETCH_ANNOTATIONS_SUCCESS = 'FETCH_ANNOTATIONS_SUCCESS',
     FETCH_ANNOTATIONS_FAILED = 'FETCH_ANNOTATIONS_FAILED',
@@ -331,13 +337,14 @@ async function fetchAnnotations(predefinedFrame?: number): Promise<{
     history: CombinedState['annotation']['annotations']['history'];
 }> {
     const {
-        filters, frame, showAllInterpolationTracks, jobInstance,
+        filters, filterAnnotations, frame, showAllInterpolationTracks, jobInstance,
         showGroundTruth, groundTruthInstance, validationLayout,
         workspace,
     } = receiveAnnotationsParameters();
 
     const fetchFrame = typeof predefinedFrame === 'undefined' ? frame : predefinedFrame;
-    let states = await jobInstance.annotations.get(fetchFrame, showAllInterpolationTracks, filters);
+    const displayFilters = filterAnnotations ? filters : [];
+    let states = await jobInstance.annotations.get(fetchFrame, showAllInterpolationTracks, displayFilters);
 
     if (jobInstance.type !== JobType.GROUND_TRUTH && showGroundTruth && groundTruthInstance) {
         let gtFrame: number | null = fetchFrame;
@@ -347,7 +354,7 @@ async function fetchAnnotations(predefinedFrame?: number): Promise<{
         }
 
         if (gtFrame !== null) {
-            let gtStates = await groundTruthInstance.annotations.get(gtFrame, showAllInterpolationTracks, filters);
+            let gtStates = await groundTruthInstance.annotations.get(gtFrame, showAllInterpolationTracks, displayFilters);
 
             if (workspace === Workspace.REVIEW) {
                 gtStates = presentStatesAsGroundTruth(gtStates);
@@ -362,7 +369,7 @@ async function fetchAnnotations(predefinedFrame?: number): Promise<{
     }
 
     const intervals = jobInstance.dimension === DimensionType.DIMENSION_1D ?
-        await jobInstance.annotations.intervals(filters) : [];
+        await jobInstance.annotations.intervals(displayFilters) : [];
     const history = await jobInstance.actions.get();
 
     return {
@@ -400,6 +407,20 @@ export function changeAnnotationsFilters(filters: object[]): AnyAction {
     return {
         type: AnnotationActionTypes.CHANGE_ANNOTATIONS_FILTERS,
         payload: { filters },
+    };
+}
+
+export function switchFilterFrames(checked: boolean): AnyAction {
+    return {
+        type: AnnotationActionTypes.SWITCH_FILTER_FRAMES,
+        payload: { checked },
+    };
+}
+
+export function switchFilterAnnotations(checked: boolean): AnyAction {
+    return {
+        type: AnnotationActionTypes.SWITCH_FILTER_ANNOTATIONS,
+        payload: { checked },
     };
 }
 
@@ -1501,21 +1522,22 @@ export function searchAnnotationsAsync(
                     player: { showDeletedFrames },
                 },
                 annotation: {
-                    annotations: { filters },
+                    annotations: { filters, filterFrames },
                 },
             } = getState();
 
-            const frame = await sessionInstance.annotations
-                .search(
-                    frameFrom,
-                    frameTo,
-                    {
-                        allowDeletedFrames: showDeletedFrames,
-                        ...(
-                            generalFilters ? { generalFilters } : { annotationsFilters: filters }
-                        ),
-                    },
-                );
+            const searchParameters: {
+                allowDeletedFrames: boolean;
+                annotationsFilters?: object[];
+                generalFilters?: {
+                    isEmptyFrame: boolean;
+                };
+            } = {
+                allowDeletedFrames: showDeletedFrames,
+                ...(generalFilters ? { generalFilters } : (filterFrames ? { annotationsFilters: filters } : {})),
+            };
+
+            const frame = await sessionInstance.annotations.search(frameFrom, frameTo, searchParameters);
             if (frame !== null) {
                 dispatch(changeFrameAsync(frame));
             }

--- a/cvat-ui/src/actions/annotation-actions.ts
+++ b/cvat-ui/src/actions/annotation-actions.ts
@@ -1534,8 +1534,13 @@ export function searchAnnotationsAsync(
                 };
             } = {
                 allowDeletedFrames: showDeletedFrames,
-                ...(generalFilters ? { generalFilters } : (filterFrames ? { annotationsFilters: filters } : {})),
             };
+
+            if (generalFilters) {
+                searchParameters.generalFilters = generalFilters;
+            } else if (filterFrames) {
+                searchParameters.annotationsFilters = filters;
+            }
 
             const frame = await sessionInstance.annotations.search(frameFrom, frameTo, searchParameters);
             if (frame !== null) {

--- a/cvat-ui/src/components/annotation-page/top-bar/filters-modal.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/filters-modal.tsx
@@ -21,11 +21,12 @@ import { DownOutlined } from '@ant-design/icons';
 import Popover from 'antd/lib/popover';
 import Menu from 'antd/lib/menu';
 import Button from 'antd/lib/button';
+import Checkbox from 'antd/lib/checkbox';
 import Modal from 'antd/lib/modal';
 import Typography from 'antd/lib/typography';
 import { CombinedState } from 'reducers';
 import { Label } from 'cvat-core-wrapper';
-import { changeAnnotationsFilters, fetchAnnotationsAsync, showFilters } from 'actions/annotation-actions';
+import { changeAnnotationsFilters, fetchAnnotationsAsync, showFilters, switchFilterFrames, switchFilterAnnotations } from 'actions/annotation-actions';
 
 const { FieldDropdown } = AntdWidgets;
 
@@ -134,11 +135,13 @@ const getKeypointAttributesSubfields = (labels: Label[]): Record<string, any> =>
 };
 
 function FiltersModalComponent(): JSX.Element {
-    const { labels, activeFilters, visible } = useSelector(
+    const { labels, activeFilters, visible, filterFrames, filterAnnotations } = useSelector(
         (state: CombinedState) => ({
             labels: state.annotation.job.labels,
             activeFilters: state.annotation.annotations.filters,
             visible: state.annotation.filtersPanelVisible,
+            filterFrames: state.annotation.annotations.filterFrames,
+            filterAnnotations: state.annotation.annotations.filterAnnotations,
         }),
         shallowEqual,
     );
@@ -347,6 +350,10 @@ function FiltersModalComponent(): JSX.Element {
     }, [visible]);
 
     const applyFilters = (filtersData: object[]): void => {
+        if (!filtersData.length) {
+            dispatch(switchFilterFrames(true));
+            dispatch(switchFilterAnnotations(true));
+        }
         dispatch(changeAnnotationsFilters(filtersData));
         dispatch(fetchAnnotationsAsync());
         dispatch(showFilters(false));
@@ -499,6 +506,26 @@ function FiltersModalComponent(): JSX.Element {
                         <DownOutlined />
                     </Button>
                 </Popover>
+            </div>
+            <div className='cvat-filters-modal-options' style={{ marginBottom: 16 }}>
+                <Checkbox
+                    checked={filterFrames}
+                    onChange={(event) => dispatch(switchFilterFrames(event.target.checked))}
+                    disabled={!isModalConfirmable()}
+                >
+                    Filter frames
+                </Checkbox>
+                <Checkbox
+                    checked={filterAnnotations}
+                    onChange={(event) => {
+                        dispatch(switchFilterAnnotations(event.target.checked));
+                        dispatch(fetchAnnotationsAsync());
+                    }}
+                    disabled={!isModalConfirmable()}
+                    style={{ marginLeft: 16 }}
+                >
+                    Filter annotations
+                </Checkbox>
             </div>
             {!!config.fields && (
                 <>

--- a/cvat-ui/src/components/annotation-page/top-bar/filters-modal.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/filters-modal.tsx
@@ -26,7 +26,13 @@ import Modal from 'antd/lib/modal';
 import Typography from 'antd/lib/typography';
 import { CombinedState } from 'reducers';
 import { Label } from 'cvat-core-wrapper';
-import { changeAnnotationsFilters, fetchAnnotationsAsync, showFilters, switchFilterFrames, switchFilterAnnotations } from 'actions/annotation-actions';
+import {
+    changeAnnotationsFilters,
+    fetchAnnotationsAsync,
+    showFilters,
+    switchFilterFrames,
+    switchFilterAnnotations,
+} from 'actions/annotation-actions';
 
 const { FieldDropdown } = AntdWidgets;
 
@@ -135,7 +141,9 @@ const getKeypointAttributesSubfields = (labels: Label[]): Record<string, any> =>
 };
 
 function FiltersModalComponent(): JSX.Element {
-    const { labels, activeFilters, visible, filterFrames, filterAnnotations } = useSelector(
+    const {
+        labels, activeFilters, visible, filterFrames, filterAnnotations,
+    } = useSelector(
         (state: CombinedState) => ({
             labels: state.annotation.job.labels,
             activeFilters: state.annotation.annotations.filters,

--- a/cvat-ui/src/reducers/annotation-reducer.ts
+++ b/cvat-ui/src/reducers/annotation-reducer.ts
@@ -404,6 +404,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
             if (!hiddenByFrame.has(number)) {
                 hiddenByFrame.set(number, new Set<number>());
             }
+            const displayFilters = state.annotations.filterAnnotations ? state.annotations.filters : [];
 
             return {
                 ...state,
@@ -426,7 +427,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                     highlightedConflict: null,
                     states,
                     initialized: true,
-                    renderData: getAnnotationsRenderData(states, state.annotations.filters),
+                    renderData: getAnnotationsRenderData(states, displayFilters),
                     history,
                     zLayer: {
                         ...state.annotations.zLayer,
@@ -660,6 +661,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                 }
             }
             const [minZ, maxZ] = computeZRange(nextStates);
+            const displayFilters = state.annotations.filterAnnotations ? state.annotations.filters : [];
 
             return {
                 ...state,
@@ -671,7 +673,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                         max: maxZ,
                     },
                     states: nextStates,
-                    renderData: getAnnotationsRenderData(nextStates, state.annotations.filters),
+                    renderData: getAnnotationsRenderData(nextStates, displayFilters),
                     history,
                 },
             };
@@ -758,6 +760,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
             const nextStates = state.annotations.states.filter(
                 (_objectState: ObjectState) => _objectState.clientID !== objectState.clientID,
             );
+            const displayFilters = state.annotations.filterAnnotations ? state.annotations.filters : [];
 
             return {
                 ...state,
@@ -766,7 +769,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                     history,
                     activatedStateID: null,
                     states: nextStates,
-                    renderData: getAnnotationsRenderData(nextStates, state.annotations.filters),
+                    renderData: getAnnotationsRenderData(nextStates, displayFilters),
                 },
                 canvas: {
                     ...state.canvas,
@@ -930,13 +933,14 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
             };
         }
         case AnnotationActionTypes.UPLOAD_JOB_ANNOTATIONS_SUCCESS: {
+            const displayFilters = state.annotations.filterAnnotations ? state.annotations.filters : [];
             return {
                 ...state,
                 annotations: {
                     ...state.annotations,
                     history: { undo: [], redo: [] },
                     states: [],
-                    renderData: getAnnotationsRenderData([], state.annotations.filters),
+                    renderData: getAnnotationsRenderData([], displayFilters),
                     activatedStateID: null,
                     activatedElementID: null,
                     activatedAttributeID: null,
@@ -1182,6 +1186,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                 return state;
             }
             const nextStates = state.annotations.states.filter((_state) => !_state.isGroundTruth);
+            const displayFilters = state.annotations.filterAnnotations ? state.annotations.filters : [];
 
             return {
                 ...state,
@@ -1189,7 +1194,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                 annotations: {
                     ...state.annotations,
                     states: nextStates,
-                    renderData: getAnnotationsRenderData(nextStates, state.annotations.filters),
+                    renderData: getAnnotationsRenderData(nextStates, displayFilters),
                     activatedStateID: null,
                     activatedAttributeID: null,
 

--- a/cvat-ui/src/reducers/annotation-reducer.ts
+++ b/cvat-ui/src/reducers/annotation-reducer.ts
@@ -150,6 +150,8 @@ const defaultState: AnnotationState = {
         collapsedAll: true,
         states: [],
         filters: [],
+        filterFrames: true,
+        filterAnnotations: true,
         renderData: {
             visibleSkeletonElements: {},
         },
@@ -292,6 +294,8 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                 annotations: {
                     ...state.annotations,
                     filters,
+                    filterFrames: true,
+                    filterAnnotations: true,
                     initialized: false,
                     zLayer: {
                         ...state.annotations.zLayer,
@@ -992,6 +996,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
             const { states, history } = action.payload;
             const [minZ, maxZ] = computeZRange(states);
             const currentZLayer = state.annotations.initialized ? state.annotations.zLayer.cur : maxZ;
+            const displayFilters = state.annotations.filterAnnotations ? state.annotations.filters : [];
 
             return {
                 ...state,
@@ -999,7 +1004,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                     ...state.annotations,
                     activatedStateID: updateActivatedStateID(states, activatedStateID),
                     states,
-                    renderData: getAnnotationsRenderData(states, state.annotations.filters),
+                    renderData: getAnnotationsRenderData(states, displayFilters),
                     history,
                     initialized: true,
                     zLayer: {
@@ -1022,12 +1027,35 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
         }
         case AnnotationActionTypes.CHANGE_ANNOTATIONS_FILTERS: {
             const { filters } = action.payload;
+            const displayFilters = state.annotations.filterAnnotations ? filters : [];
             return {
                 ...state,
                 annotations: {
                     ...state.annotations,
                     filters,
-                    renderData: getAnnotationsRenderData(state.annotations.states, filters),
+                    renderData: getAnnotationsRenderData(state.annotations.states, displayFilters),
+                },
+            };
+        }
+        case AnnotationActionTypes.SWITCH_FILTER_FRAMES: {
+            const { checked } = action.payload;
+            return {
+                ...state,
+                annotations: {
+                    ...state.annotations,
+                    filterFrames: checked,
+                },
+            };
+        }
+        case AnnotationActionTypes.SWITCH_FILTER_ANNOTATIONS: {
+            const { checked } = action.payload;
+            const displayFilters = checked ? state.annotations.filters : [];
+            return {
+                ...state,
+                annotations: {
+                    ...state.annotations,
+                    filterAnnotations: checked,
+                    renderData: getAnnotationsRenderData(state.annotations.states, displayFilters),
                 },
             };
         }

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -964,6 +964,8 @@ export interface AnnotationState {
         collapsedAll: boolean;
         states: any[];
         filters: object[];
+        filterFrames: boolean;
+        filterAnnotations: boolean;
         renderData: RenderData;
         resetGroupFlag: boolean;
         initialized: boolean;

--- a/tests/cypress/e2e/actions_tasks3/case_119_filter_toggle_functionality.js
+++ b/tests/cypress/e2e/actions_tasks3/case_119_filter_toggle_functionality.js
@@ -1,0 +1,240 @@
+// Copyright (C) CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName } from '../../support/const';
+
+/**
+ * Tests for issue #9956:
+ * "An option to filter frames without hiding annotations in UI"
+ *
+ * Two independent toggles are added to the annotation filters modal:
+ *   - "Filter frames"      controls whether filtered navigation (NavigationType.FILTERED)
+ *                          skips frames that do not match the active annotation query.
+ *   - "Filter annotations" controls whether only matching annotations are
+ *                          rendered on the current frame.
+ *
+ * Frame layout used in these tests:
+ *   Frame 0: one rectangle with labelMatch, one rectangle with labelOther
+ *   Frame 1: one rectangle with labelOther only  (no matching annotation)
+ *   Frame 2: one rectangle with labelMatch only
+ *
+ * Active filter applied: Label == labelMatch
+ *
+ * This layout allows unambiguous testing of all four toggle combinations.
+ *
+ * Navigation behavior confirmed from cvat-core/src/annotations-collection.ts:
+ *   - filterFrames=true  + FILTERED nav → jumps to next frame matching the query (frame 2, skipping 1)
+ *   - filterFrames=false + FILTERED nav → jumps to immediate next non-deleted frame (frame 1)
+ */
+
+context('Filter frame/annotation toggle functionality.', () => {
+    const caseId = '119';
+    const labelMatch = 'filter_toggle_match';
+    const labelOther = 'filter_toggle_other';
+
+    const matchRect = {
+        points: 'By 2 Points',
+        type: 'Shape',
+        labelName: labelMatch,
+        firstX: 100,
+        firstY: 100,
+        secondX: 200,
+        secondY: 200,
+    };
+    const otherRect = {
+        points: 'By 2 Points',
+        type: 'Shape',
+        labelName: labelOther,
+        firstX: 300,
+        firstY: 100,
+        secondX: 400,
+        secondY: 200,
+    };
+
+    // Shape IDs are assigned sequentially; capture them dynamically to avoid brittle hardcoding.
+    let matchIdFrame0 = null;
+    let otherIdFrame0 = null;
+    let otherIdFrame1 = null;
+    let matchIdFrame2 = null;
+
+    function applyLabelFilter() {
+        cy.addFiltersRule(0);
+        cy.setFilter({
+            groupIndex: 0,
+            ruleIndex: 0,
+            field: 'Label',
+            operator: '==',
+            value: labelMatch,
+            submit: true,
+        });
+    }
+
+    function activateFilteredNavForward() {
+        // Switch nav mode to FILTERED by right-clicking the next button
+        // and selecting the filtered option from the context popover.
+        // This is the same pattern used in issue_2485_navigation_empty_frames.js.
+        cy.get('.cvat-player-next-button').rightclick();
+        cy.get('.cvat-player-next-filtered-inlined-button').click();
+    }
+
+    function activateRegularNavForward() {
+        cy.get('.cvat-player-next-button-filtered').rightclick();
+        cy.get('.cvat-player-next-inlined-button').click();
+    }
+
+    function openFiltersModal() {
+        cy.checkFiltersModalOpened();
+    }
+
+    function checkCheckbox(label, expectedChecked) {
+        cy.contains('.cvat-filters-modal-options label', label)
+            .find('input[type="checkbox"]')
+            .should(expectedChecked ? 'be.checked' : 'not.be.checked');
+    }
+
+    function toggleCheckbox(label) {
+        cy.contains('.cvat-filters-modal-options label', label).click();
+    }
+
+    before(() => {
+        cy.prepareUserSession();
+        cy.openTask(taskName);
+        cy.addNewLabel({ name: labelMatch });
+        cy.addNewLabel({ name: labelOther });
+        cy.openJob();
+
+        // Frame 0: matching + other shape
+        cy.createRectangle(matchRect);
+        cy.createRectangle(otherRect);
+        cy.get('.cvat_canvas_shape').then(($shapes) => {
+            const ids = Array.from($shapes).map((el) => Number(el.id.match(/\d+$/)[0]));
+            [matchIdFrame0, otherIdFrame0] = ids.slice(-2);
+        });
+
+        // Frame 1: other shape only (no matching annotation)
+        cy.goCheckFrameNumber(1);
+        cy.createRectangle({ ...otherRect, firstX: 100, firstY: 100, secondX: 200, secondY: 200 });
+        cy.get('.cvat_canvas_shape').last().then(($el) => {
+            otherIdFrame1 = Number($el.attr('id').match(/\d+$/)[0]);
+        });
+
+        // Frame 2: matching shape only
+        cy.goCheckFrameNumber(2);
+        cy.createRectangle({ ...matchRect, firstX: 500, firstY: 100, secondX: 600, secondY: 200 });
+        cy.get('.cvat_canvas_shape').last().then(($el) => {
+            matchIdFrame2 = Number($el.attr('id').match(/\d+$/)[0]);
+        });
+
+        cy.goCheckFrameNumber(0);
+    });
+
+    after(() => {
+        cy.clearFilters();
+    });
+
+    beforeEach(() => {
+        cy.hideTooltips();
+        cy.goCheckFrameNumber(0);
+    });
+
+    describe(`Testing case "${caseId}" — Filter toggle behaviors`, () => {
+        it('TEST 1 — Default: both toggles are enabled after applying a filter (backward compatibility)', () => {
+            applyLabelFilter();
+
+            // With both toggles on (default), only matching shapes appear.
+            cy.get(`#cvat_canvas_shape_${matchIdFrame0}`).should('exist');
+            cy.get(`#cvat-objects-sidebar-state-item-${matchIdFrame0}`).should('exist');
+            cy.get(`#cvat_canvas_shape_${otherIdFrame0}`).should('not.exist');
+            cy.get(`#cvat-objects-sidebar-state-item-${otherIdFrame0}`).should('not.exist');
+
+            // Verify defaults via modal
+            openFiltersModal();
+            checkCheckbox('Filter frames', true);
+            checkCheckbox('Filter annotations', true);
+            cy.contains('.cvat-filters-modal-visible button', 'Cancel').click();
+
+            cy.clearFilters();
+        });
+
+        it('TEST 2 — Filter annotations OFF: non-matching shapes remain visible on current frame', () => {
+            applyLabelFilter();
+
+            // Disable "Filter annotations" via the modal while a filter is active
+            openFiltersModal();
+            toggleCheckbox('Filter annotations');
+            cy.contains('.cvat-filters-modal-visible button', 'Cancel').click();
+
+            // All shapes on frame 0 must now be visible
+            cy.get(`#cvat_canvas_shape_${matchIdFrame0}`).should('exist');
+            cy.get(`#cvat_canvas_shape_${otherIdFrame0}`).should('exist');
+            cy.get(`#cvat-objects-sidebar-state-item-${matchIdFrame0}`).should('exist');
+            cy.get(`#cvat-objects-sidebar-state-item-${otherIdFrame0}`).should('exist');
+
+            cy.clearFilters();
+        });
+
+        it('TEST 3 — Filter frames ON + filtered nav: navigation skips non-matching frame', () => {
+            applyLabelFilter();
+
+            // Confirm Filter frames is ON (default)
+            openFiltersModal();
+            checkCheckbox('Filter frames', true);
+            cy.contains('.cvat-filters-modal-visible button', 'Cancel').click();
+
+            // Activate filtered navigation mode
+            activateFilteredNavForward();
+
+            // From frame 0, filtered nav should jump to frame 2 (skipping frame 1 which has no match)
+            cy.get('.cvat-player-next-button-filtered').click({ force: true });
+            cy.checkFrameNum(2);
+            cy.get(`#cvat_canvas_shape_${matchIdFrame2}`).should('exist');
+
+            // Restore regular navigation
+            activateRegularNavForward();
+            cy.clearFilters();
+        });
+
+        it('TEST 4 — Filter frames OFF + filtered nav: navigation goes to immediate next frame', () => {
+            applyLabelFilter();
+
+            // Disable "Filter frames" via the modal
+            openFiltersModal();
+            toggleCheckbox('Filter frames');
+            cy.contains('.cvat-filters-modal-visible button', 'Cancel').click();
+
+            // Activate filtered navigation mode
+            activateFilteredNavForward();
+
+            // From frame 0, with filterFrames=false the core returns the immediate next
+            // non-deleted frame regardless of annotation query (verified in annotations-collection.ts line 1710)
+            cy.get('.cvat-player-next-button-filtered').click({ force: true });
+            cy.checkFrameNum(1);
+
+            // Restore regular navigation
+            activateRegularNavForward();
+            cy.clearFilters();
+        });
+
+        it('TEST 5 — Clear filters resets both toggles to enabled', () => {
+            applyLabelFilter();
+
+            // Disable both toggles
+            openFiltersModal();
+            toggleCheckbox('Filter frames');
+            toggleCheckbox('Filter annotations');
+            cy.contains('.cvat-filters-modal-visible button', 'Cancel').click();
+
+            // Clear filters (uses the Clear filters button inside the modal)
+            cy.clearFilters();
+
+            // Reopen modal: both toggles should be back to true
+            openFiltersModal();
+            checkCheckbox('Filter frames', true);
+            checkCheckbox('Filter annotations', true);
+            cy.contains('.cvat-filters-modal-visible button', 'Cancel').click();
+        });
+    });
+});


### PR DESCRIPTION
## Motivation and context

Closes #9956.

Currently, annotation filters in CVAT affect both frame navigation and annotation visibility. This makes it impossible to navigate between frames matching a filter while keeping all annotations visible for context.

This PR decouples these behaviors by introducing two independent controls.

## Changes

- Added **Filter frames** toggle to control whether active filters affect frame navigation and search.
- Added **Filter annotations** toggle to control whether active filters affect annotation visibility.
- Both toggles default to enabled to preserve existing behavior.
- Toggles are reset when filters are cleared or a new job is loaded.
- Updated annotation render data handling to respect the `filterAnnotations` setting consistently.

## Testing

- [x] Verified git diff formatting and whitespace with `git diff --check`.
- [x] Reviewed Redux state flow and affected render paths.
- [ ] Automated lint/tests were not completed locally due to Corepack/Yarn permission issues on Windows.

## Checklist

- [x] I submit my changes into the `develop` branch.
- [x] I have created a changelog fragment.
- [ ] I have updated the documentation accordingly.