### PR TITLE
Validate the function ID in the `POST /api/lambda/requests` endpoint

### DIFF
--- a/changelog.d/20260901_120421_roman_HEAD.md
+++ b/changelog.d/20260901_120421_roman_HEAD.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Calls to the `POST /api/lambda/requests` endpoint with an invalid
+  function ID no longer crash
+  (<https://github.com/cvat-ai/cvat/pull/11118>)

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -9,6 +9,7 @@ import base64
 import io
 import json
 import os
+import re
 import textwrap
 from copy import deepcopy
 from datetime import timedelta
@@ -1321,7 +1322,7 @@ def return_response(success_code=status.HTTP_200_OK):
     ),
 )
 class FunctionViewSet(viewsets.ViewSet):
-    lookup_value_regex = "[a-zA-Z0-9_.-]+"
+    lookup_value_regex = "[a-zA-Z0-9][a-zA-Z0-9_.-]*"
     lookup_field = "func_id"
     iam_supports_organization_params = False
     iam_permission_class = LambdaPermission
@@ -1498,6 +1499,9 @@ class RequestViewSet(viewsets.ViewSet):
                 + "with wrong arguments ({})".format(str(err)),
                 code=status.HTTP_400_BAD_REQUEST,
             )
+
+        if not re.fullmatch(FunctionViewSet.lookup_value_regex, function):
+            raise serializers.ValidationError("Function ID is invalid")
 
         db_task = Task.objects.get(pk=task)
 

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -3337,7 +3337,7 @@ paths:
         name: func_id
         schema:
           type: string
-          pattern: ^[a-zA-Z0-9_.-]+$
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$
         required: true
       tags:
       - lambda
@@ -3370,7 +3370,7 @@ paths:
         name: func_id
         schema:
           type: string
-          pattern: ^[a-zA-Z0-9_.-]+$
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$
         required: true
       tags:
       - lambda


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This endpoint performs a `LambdaGateway.get` call with the user-supplied function ID, which gets appended to the Nuclio root URL without any escaping. This means that a malicious user can use this to send GET requests to arbitrary Nuclio endpoints by adding strings like `/` and `..`.

As far as I can tell, this doesn't really accomplish anything for the attacker, since a) it can only make GET requests, and b) the endpoint will then immediately crash in the `LambdaFunction` constructor because of missing fields in the response, so the attacker won't even be able to examine Nuclio's response. So there is no real security impact.

Still, it's prudent to disallow users from making requests to unintended internal endpoints, so do that by validating the function ID against the same regex we're using for the `/api/function/{id}/call` endpoint and also tightening up that regex to disallow IDs like `.` and `..`.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
