### PR TITLE
Improve drawing performance for brush tool

### DIFF
--- a/changelog.d/20260831_223649_jonas_3875_drawing_perf_many_polygon.md
+++ b/changelog.d/20260831_223649_jonas_3875_drawing_perf_many_polygon.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Improve performance while using the brush tool for larger segments
+  (<https://github.com/cvat-ai/cvat/pull/11119>)

--- a/cvat-canvas/src/typescript/masksHandler.ts
+++ b/cvat-canvas/src/typescript/masksHandler.ts
@@ -24,6 +24,8 @@ interface WrappingBBox {
 type DrawnObject = fabric.Polygon | fabric.Circle | fabric.Rect | fabric.Line | fabric.Image;
 type HistoryAction = DrawnObject[];
 
+type CanvasWithTopContext = fabric.Canvas & { contextTop: CanvasRenderingContext2D };
+
 export interface MasksHandler {
     draw(drawData: DrawData): void;
     edit(state: MasksEditData): void;
@@ -83,11 +85,40 @@ export class MasksHandlerImpl implements MasksHandler {
         this.vectorDrawHandler.draw({ enabled: false }, this.geometry);
     }
 
+    private get topContext(): CanvasRenderingContext2D {
+        return (this.canvas as CanvasWithTopContext).contextTop;
+    }
+
+    private disableImageSmoothing(): void {
+        this.canvas.imageSmoothingEnabled = false;
+        this.canvas.getContext().imageSmoothingEnabled = false;
+        this.topContext.imageSmoothingEnabled = false;
+    }
+
+    private renderObject(ctx: CanvasRenderingContext2D, object: DrawnObject): void {
+        const [a, b, c, d, e, f] = this.canvas.viewportTransform;
+        ctx.save();
+        ctx.transform(a, b, c, d, e, f);
+        object.render(ctx);
+        ctx.restore();
+    }
+
+    private renderDrawnObject(object: DrawnObject): void {
+        this.renderObject(this.canvas.getContext(), object);
+    }
+
+    private renderBrushMarker(): void {
+        const ctx = this.topContext;
+        this.canvas.clearContext(ctx);
+        if (this.brushMarker) {
+            this.renderObject(ctx, this.brushMarker);
+        }
+    }
+
     private removeBrushMarker(): void {
         if (this.brushMarker) {
-            this.canvas.remove(this.brushMarker);
             this.brushMarker = null;
-            this.canvas.renderAll();
+            this.canvas.clearContext(this.topContext);
         }
     }
 
@@ -96,6 +127,7 @@ export class MasksHandlerImpl implements MasksHandler {
             const common = {
                 evented: false,
                 selectable: false,
+                objectCaching: false,
                 opacity: 0.75,
                 left: this.latestMousePos.x - this.tool.size / 2,
                 top: this.latestMousePos.y - this.tool.size / 2,
@@ -112,7 +144,7 @@ export class MasksHandlerImpl implements MasksHandler {
             });
 
             this.canvas.defaultCursor = 'none';
-            this.canvas.add(this.brushMarker);
+            this.renderBrushMarker();
         } else {
             this.canvas.defaultCursor = 'inherit';
         }
@@ -227,13 +259,12 @@ export class MasksHandlerImpl implements MasksHandler {
     }
 
     private imageDataFromCanvas(wrappingBBox: WrappingBBox): Uint8ClampedArray {
-        const imageData = this.canvas.toCanvasElement()
-            .getContext('2d').getImageData(
-                wrappingBBox.left,
-                wrappingBBox.top,
-                wrappingBBox.right - wrappingBBox.left + 1,
-                wrappingBBox.bottom - wrappingBBox.top + 1,
-            ).data;
+        const imageData = this.canvas.getContext().getImageData(
+            wrappingBBox.left,
+            wrappingBBox.top,
+            wrappingBBox.right - wrappingBBox.left + 1,
+            wrappingBBox.bottom - wrappingBBox.top + 1,
+        ).data;
         return imageData;
     }
 
@@ -363,13 +394,7 @@ export class MasksHandlerImpl implements MasksHandler {
             return;
         }
         const wrappingBbox = this.getDrawnObjectsWrappingBox();
-        if (this.brushMarker) {
-            this.canvas.remove(this.brushMarker);
-        }
         const imageData = this.imageDataFromCanvas(wrappingBbox);
-        if (this.brushMarker) {
-            this.canvas.add(this.brushMarker);
-        }
         const rle = imageDataToRLE(imageData);
         const isEmptyMask = rle.length < 2;
         this.tool.onBlockUpdated({
@@ -421,8 +446,11 @@ export class MasksHandlerImpl implements MasksHandler {
             fireRightClick: true,
             selection: false,
             defaultCursor: 'inherit',
+            enableRetinaScaling: false,
+            renderOnAddRemove: false,
         });
-        this.canvas.imageSmoothingEnabled = false;
+        this.disableImageSmoothing();
+        this.canvas.calcViewportBoundaries();
         this.drawnObjects = this.createDrawnObjectsArray();
         this.clearHistory();
 
@@ -518,8 +546,7 @@ export class MasksHandlerImpl implements MasksHandler {
             if (this.brushMarker) {
                 this.brushMarker.left = position.x - tool.size / 2;
                 this.brushMarker.top = position.y - tool.size / 2;
-                this.canvas.bringToFront(this.brushMarker);
-                this.canvas.renderAll();
+                this.renderBrushMarker();
             }
 
             if (isMouseDown && !this.isHidden && !isBrushSizeChanging && ['brush', 'eraser'].includes(tool?.type)) {
@@ -529,6 +556,12 @@ export class MasksHandlerImpl implements MasksHandler {
                 const commonProperties = {
                     selectable: false,
                     evented: false,
+                    /*
+                        Every stroke is rendered exactly once, when it is created. Caching it
+                        would allocate an offscreen canvas per stroke, and a mask easily
+                        consists of thousands of them.
+                    */
+                    objectCaching: false,
                     globalCompositeOperation: tool.type === 'eraser' ? 'destination-out' : 'xor',
                 };
 
@@ -555,6 +588,7 @@ export class MasksHandlerImpl implements MasksHandler {
 
                 if (['brush', 'eraser'].includes(tool?.type)) {
                     this.addDrawnObject(shape);
+                    this.renderDrawnObject(shape);
                 }
 
                 // add line to smooth the mask
@@ -576,10 +610,10 @@ export class MasksHandlerImpl implements MasksHandler {
 
                         if (['brush', 'eraser'].includes(tool?.type)) {
                             this.addDrawnObject(line);
+                            this.renderDrawnObject(line);
                         }
                     }
                 }
-                this.canvas.renderAll();
             } else if (tool?.type.startsWith('polygon-') && this.drawablePolygon) {
                 // update the polygon position
                 const points = this.drawablePolygon.get('points');
@@ -615,6 +649,10 @@ export class MasksHandlerImpl implements MasksHandler {
             this.canvas.setHeight(height);
             this.canvas.setWidth(width);
             this.canvas.setDimensions({ width, height });
+
+            this.disableImageSmoothing();
+            this.canvas.renderAll();
+            this.renderBrushMarker();
         }
 
         topCanvas.style.top = `${top}px`;

--- a/tests/cypress/e2e/features/slice_join.js
+++ b/tests/cypress/e2e/features/slice_join.js
@@ -124,7 +124,7 @@ context('Slice and join tools', { scrollBehavior: false }, () => {
             cy.sliceShape('#cvat_canvas_shape_1', [[1, 1], [150, 230], [300, 230]]);
             checkSliceSuccess();
 
-            cy.joinShapes(['#cvat_canvas_shape_2', '#cvat_canvas_shape_3'], [[1, 1], [1, 1]]);
+            cy.joinShapes(['#cvat_canvas_shape_2', '#cvat_canvas_shape_3'], [[2, 2], [2, 2]]);
             checkJoinSuccess();
         });
 


### PR DESCRIPTION
The brush tool was creating a lot of individual objects that needed to be tracked by fabric. Fabric repaints the while canvas whenever the pointer moves during drawing, leading to significant perforamnce problems on larger annotations.

This change moves the painting (and thus the expensive repainting) to a separate context that is purely additive, allowing for fast additions without any need for repainting. Thereforce the app keeps beeing fast when using the brush tool.

### Motivation and context
#3875

### How has this been tested?
Draw lines using the brush tool for some time. Before this change the UI will start to lag at some point. After this change it should stay fast all the way.

### Checklist
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
