### PR TITLE
Allow full responses for initial chunk range requests

### DIFF
--- a/changelog.d/20260901_081900_sekachev.bs_fix_response_code.md
+++ b/changelog.d/20260901_081900_sekachev.bs_fix_response_code.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - Annotation images failing to load when a server or proxy ignores a chunk range request
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/11121>)

--- a/changelog.d/20260901_081900_sekachev.bs_fix_response_code.md
+++ b/changelog.d/20260901_081900_sekachev.bs_fix_response_code.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Annotation images failing to load when a server or proxy ignores a chunk range request
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/cvat-core/src/download.worker.ts
+++ b/cvat-core/src/download.worker.ts
@@ -200,11 +200,33 @@ async function fetchData(url: string, requestConfig): Promise<{
                 throw new DownloadError(await response.text(), response.status);
             }
 
+            const responseHeaders = headersToObject(response.headers);
+            if (response.status === 200 && receivedBytes === 0) {
+                chunkIdentity = getChunkIdentity(responseHeaders);
+                const readResult = await readResponse(response, chunks, receivedBytes);
+                receivedBytes = readResult.receivedBytes;
+                bodyDownloadTimeMs += readResult.downloadTimeMs;
+
+                const telemetry = receivedBytes >= MIN_CHUNK_SIZE_FOR_TELEMETRY_BYTES ? {
+                    chunkSizeBytes: receivedBytes,
+                    downloadTimeMs: bodyDownloadTimeMs,
+                    retries: requestCount - 1,
+                } : undefined;
+
+                return {
+                    data: mergeChunks(chunks, receivedBytes),
+                    headers: {
+                        ...responseHeaders,
+                        'content-length': `${receivedBytes}`,
+                    },
+                    telemetry,
+                };
+            }
+
             if (response.status !== 206) {
                 throw new Error(`Unexpected response status: ${response.status}`);
             }
 
-            const responseHeaders = headersToObject(response.headers);
             const contentRange = parseContentRange(responseHeaders['content-range'] ?? null);
             if (!contentRange || contentRange.start !== receivedBytes || contentRange.total === null) {
                 throw new Error('Unexpected Content-Range header');


### PR DESCRIPTION
Allow full responses for initial chunk range requests

### Motivation and context

Some users cannot load annotation images because a server, proxy, or cache may ignore the `Range` header and return a full response with status `200 OK` instead of `206 Partial Content`.

Accept full `200` responses only when no chunk bytes have been received yet. Partial downloads still require `206` to prevent corrupting data by appending a full response to previously downloaded bytes.

The chunk identity and decoded body length are preserved for safe retries and telemetry.

### How has this been tested?

- Manually


### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.