### PR TITLE
SDK Domain Examples (Final Part)

### DIFF
--- a/cvat-sdk/examples/README.md
+++ b/cvat-sdk/examples/README.md
@@ -40,6 +40,7 @@ Conventions:
 | `task_inspect_and_export.py` | Inspect a task; export its dataset and event-log analytics | `--task-id`, `--export-format` |
 | `task_import_annotations.py` | Import an annotations file into an existing task | `--task-id`, `--annotations-file`, `--import-format` |
 | `task_edit_annotations.py` | Bulk-edit a task's annotations: relabel or delete objects by label | `--task-id`, `--relabel` or `--delete-label` |
+| `task_create_with_validation.py` | Create a task with a ground truth validation set and upload the ground truth into it | `--image-dir`, `--validation-frame` or `--frame-count`, `--gt-annotations`, `--gt-format`, `--cleanup` |
 | `job_list.py` | List a task's or project's jobs with stage/state/assignee; optional CSV report | `--task-id` or `--project-id`, `--stage`, `--state`, `--csv` |
 | `job_assign.py` | Round-robin assign unassigned jobs; CSV report | `--task-id`, `--org` or `--org-id`, `--assignees` or `--search` |
 | `job_workflow.py` | Batch-advance completed jobs to the next stage | `--from-stage`, `--task-id` |

--- a/cvat-sdk/examples/README.md
+++ b/cvat-sdk/examples/README.md
@@ -38,6 +38,7 @@ Conventions:
 | `dataset_bulk_export.py` | Export many tasks at once, locally and/or to a bucket, with a CSV manifest | `--project-id` and/or `--task-id`, `--status`, `--output-dir`, `--cloud-storage-id`, `--jobs`, `--skip-existing` |
 | `task_create_from_cloud.py` | Create a task from bucket object keys | `--cloud-storage-id`, `--cloud-keys`, `--cleanup` |
 | `tasks_bulk_from_cloud.py` | Bulk-create tasks in a project, from bucket object keys or wildcard patterns | `--cloud-storage-id`, `--project-id`, `--task` (repeat), `--task-pattern` (repeat), `--manifest`, `--cleanup` |
+| `task_create_subtasks.py` | Create one task per object type / label group over the same images | `--image-dir`, `--subtask` (repeat), `--segment-size`, `--cleanup` |
 | `task_inspect_and_export.py` | Inspect a task; export its dataset and event-log analytics | `--task-id`, `--export-format` |
 | `task_import_annotations.py` | Import an annotations file into an existing task | `--task-id`, `--annotations-file`, `--import-format` |
 | `task_edit_annotations.py` | Bulk-edit a task's annotations: relabel or delete objects by label | `--task-id`, `--relabel` or `--delete-label` |

--- a/cvat-sdk/examples/README.md
+++ b/cvat-sdk/examples/README.md
@@ -39,6 +39,7 @@ Conventions:
 | `task_create_from_cloud.py` | Create a task from bucket object keys | `--cloud-storage-id`, `--cloud-keys`, `--cleanup` |
 | `tasks_bulk_from_cloud.py` | Bulk-create tasks in a project, from bucket object keys or wildcard patterns | `--cloud-storage-id`, `--project-id`, `--task` (repeat), `--task-pattern` (repeat), `--manifest`, `--cleanup` |
 | `task_create_subtasks.py` | Create one task per object type / label group over the same images | `--image-dir`, `--subtask` (repeat), `--segment-size`, `--cleanup` |
+| `task_create_job_mapping.py` | Create a task with an explicit file-to-job mapping and verify it from the server | `--image-dir`, `--job` (repeat) or `--files-per-job`, `--output`, `--cleanup` |
 | `task_inspect_and_export.py` | Inspect a task; export its dataset and event-log analytics | `--task-id`, `--export-format` |
 | `task_import_annotations.py` | Import an annotations file into an existing task | `--task-id`, `--annotations-file`, `--import-format` |
 | `task_edit_annotations.py` | Bulk-edit a task's annotations: relabel or delete objects by label | `--task-id`, `--relabel` or `--delete-label` |

--- a/cvat-sdk/examples/README.md
+++ b/cvat-sdk/examples/README.md
@@ -34,6 +34,7 @@ Conventions:
 | `project_restore.py` | Restore a project from a backup zip | `--backup`, `--cleanup` |
 | `project_export_dataset.py` | Export a project's tasks individually (all, or a `--task-id` list), locally and to a bucket | `--project-id`, `--cloud-storage-id`, `--export-format`, `--task-id` (optional, space-separated) |
 | `dataset_incremental_download.py` | Export only the project tasks that changed since the previous run | `--project-id`, `--state`, `--output-dir`, `--export-format`, `--with-images` |
+| `dataset_bulk_export.py` | Export many tasks at once, locally and/or to a bucket, with a CSV manifest | `--project-id` and/or `--task-id`, `--status`, `--output-dir`, `--cloud-storage-id`, `--jobs`, `--skip-existing` |
 | `task_create_from_cloud.py` | Create a task from bucket object keys | `--cloud-storage-id`, `--cloud-keys`, `--cleanup` |
 | `tasks_bulk_from_cloud.py` | Bulk-create tasks in a project, from bucket object keys or wildcard patterns | `--cloud-storage-id`, `--project-id`, `--task` (repeat), `--task-pattern` (repeat), `--manifest`, `--cleanup` |
 | `task_inspect_and_export.py` | Inspect a task; export its dataset and event-log analytics | `--task-id`, `--export-format` |

--- a/cvat-sdk/examples/README.md
+++ b/cvat-sdk/examples/README.md
@@ -33,6 +33,7 @@ Conventions:
 | `project_backup.py` | Download a backup zip of an existing project | `--project-id`, `--output` |
 | `project_restore.py` | Restore a project from a backup zip | `--backup`, `--cleanup` |
 | `project_export_dataset.py` | Export a project's tasks individually (all, or a `--task-id` list), locally and to a bucket | `--project-id`, `--cloud-storage-id`, `--export-format`, `--task-id` (optional, space-separated) |
+| `dataset_incremental_download.py` | Export only the project tasks that changed since the previous run | `--project-id`, `--state`, `--output-dir`, `--export-format`, `--with-images` |
 | `task_create_from_cloud.py` | Create a task from bucket object keys | `--cloud-storage-id`, `--cloud-keys`, `--cleanup` |
 | `tasks_bulk_from_cloud.py` | Bulk-create tasks in a project, from bucket object keys or wildcard patterns | `--cloud-storage-id`, `--project-id`, `--task` (repeat), `--task-pattern` (repeat), `--manifest`, `--cleanup` |
 | `task_inspect_and_export.py` | Inspect a task; export its dataset and event-log analytics | `--task-id`, `--export-format` |

--- a/cvat-sdk/examples/README.md
+++ b/cvat-sdk/examples/README.md
@@ -42,6 +42,7 @@ Conventions:
 | `task_edit_annotations.py` | Bulk-edit a task's annotations: relabel or delete objects by label | `--task-id`, `--relabel` or `--delete-label` |
 | `task_create_with_validation.py` | Create a task with a ground truth validation set and upload the ground truth into it | `--image-dir`, `--validation-frame` or `--frame-count`, `--gt-annotations`, `--gt-format`, `--cleanup` |
 | `task_create_with_honeypots.py` | Create a task whose annotation jobs carry ground truth frames; refresh or retire them | `--image-dir`, `--pool-frame` or `--pool-frame-count`, `--honeypots-per-job`, `--refresh`, `--disable-frame`, `--cleanup` |
+| `task_add_gt_frames.py` | Add a ground truth job with an exact frame list to an existing task | `--task-id`, `--frame` or `--frame-name`, `--replace`, `--cleanup` |
 | `job_list.py` | List a task's or project's jobs with stage/state/assignee; optional CSV report | `--task-id` or `--project-id`, `--stage`, `--state`, `--csv` |
 | `job_assign.py` | Round-robin assign unassigned jobs; CSV report | `--task-id`, `--org` or `--org-id`, `--assignees` or `--search` |
 | `job_workflow.py` | Batch-advance completed jobs to the next stage | `--from-stage`, `--task-id` |

--- a/cvat-sdk/examples/README.md
+++ b/cvat-sdk/examples/README.md
@@ -30,6 +30,7 @@ Conventions:
 | `project_create_and_list.py` | Create, list, filter, retrieve, rename a project | `--name`, `--labels`, `--cleanup` |
 | `project_add_labels.py` | Add labels (optionally with attributes) to an existing project | `--project-id`, `--labels`, `--attr` (repeat) |
 | `project_annotation_stats.py` | Aggregate object counts per label/type across a project's tasks; CSV report | `--project-id` |
+| `project_data_lint.py` | Lint a project's annotations: out-of-bounds shapes, tiny boxes, duplicates, empty frames/jobs, unused labels | `--project-id`, `--task-id`, `--min-box-area`, `--output`, `--no-fail` |
 | `project_backup.py` | Download a backup zip of an existing project | `--project-id`, `--output` |
 | `project_restore.py` | Restore a project from a backup zip | `--backup`, `--cleanup` |
 | `project_export_dataset.py` | Export a project's tasks individually (all, or a `--task-id` list), locally and to a bucket | `--project-id`, `--cloud-storage-id`, `--export-format`, `--task-id` (optional, space-separated) |

--- a/cvat-sdk/examples/README.md
+++ b/cvat-sdk/examples/README.md
@@ -41,6 +41,7 @@ Conventions:
 | `task_import_annotations.py` | Import an annotations file into an existing task | `--task-id`, `--annotations-file`, `--import-format` |
 | `task_edit_annotations.py` | Bulk-edit a task's annotations: relabel or delete objects by label | `--task-id`, `--relabel` or `--delete-label` |
 | `task_create_with_validation.py` | Create a task with a ground truth validation set and upload the ground truth into it | `--image-dir`, `--validation-frame` or `--frame-count`, `--gt-annotations`, `--gt-format`, `--cleanup` |
+| `task_create_with_honeypots.py` | Create a task whose annotation jobs carry ground truth frames; refresh or retire them | `--image-dir`, `--pool-frame` or `--pool-frame-count`, `--honeypots-per-job`, `--refresh`, `--disable-frame`, `--cleanup` |
 | `job_list.py` | List a task's or project's jobs with stage/state/assignee; optional CSV report | `--task-id` or `--project-id`, `--stage`, `--state`, `--csv` |
 | `job_assign.py` | Round-robin assign unassigned jobs; CSV report | `--task-id`, `--org` or `--org-id`, `--assignees` or `--search` |
 | `job_workflow.py` | Batch-advance completed jobs to the next stage | `--from-stage`, `--task-id` |

--- a/cvat-sdk/examples/README.md
+++ b/cvat-sdk/examples/README.md
@@ -30,11 +30,11 @@ Conventions:
 | `project_create_and_list.py` | Create, list, filter, retrieve, rename a project | `--name`, `--labels`, `--cleanup` |
 | `project_add_labels.py` | Add labels (optionally with attributes) to an existing project | `--project-id`, `--labels`, `--attr` (repeat) |
 | `project_annotation_stats.py` | Aggregate object counts per label/type across a project's tasks; CSV report | `--project-id` |
-| `project_data_lint.py` | Lint a project's annotations: out-of-bounds shapes, tiny boxes, duplicates, empty frames/jobs, unused labels | `--project-id`, `--task-id`, `--min-box-area`, `--output`, `--no-fail` |
+| `project_data_lint.py` | Lint a project's annotations: out-of-bounds shapes, tiny boxes, duplicates, objects on removed or out-of-range frames, unused labels | `--project-id`, `--task-id`, `--min-box-area`, `--output`, `--no-fail` |
 | `project_backup.py` | Download a backup zip of an existing project | `--project-id`, `--output` |
 | `project_restore.py` | Restore a project from a backup zip | `--backup`, `--cleanup` |
 | `project_export_dataset.py` | Export a project's tasks individually (all, or a `--task-id` list), locally and to a bucket | `--project-id`, `--cloud-storage-id`, `--export-format`, `--task-id` (optional, space-separated) |
-| `dataset_incremental_download.py` | Export only the project tasks that changed since the previous run | `--project-id`, `--state`, `--output-dir`, `--export-format`, `--with-images` |
+| `dataset_incremental_download.py` | Export only the project tasks that changed since the previous run | `--project-id`, `--updated-after`, `--output-dir`, `--export-format`, `--with-images` |
 | `dataset_bulk_export.py` | Export many tasks at once, locally and/or to a bucket, with a CSV manifest | `--project-id` and/or `--task-id`, `--status`, `--output-dir`, `--cloud-storage-id`, `--jobs`, `--skip-existing` |
 | `task_create_from_cloud.py` | Create a task from bucket object keys | `--cloud-storage-id`, `--cloud-keys`, `--cleanup` |
 | `tasks_bulk_from_cloud.py` | Bulk-create tasks in a project, from bucket object keys or wildcard patterns | `--cloud-storage-id`, `--project-id`, `--task` (repeat), `--task-pattern` (repeat), `--manifest`, `--cleanup` |

--- a/cvat-sdk/examples/README.md
+++ b/cvat-sdk/examples/README.md
@@ -42,6 +42,7 @@ Conventions:
 | `task_create_job_mapping.py` | Create a task with an explicit file-to-job mapping and verify it from the server | `--image-dir`, `--job` (repeat) or `--files-per-job`, `--output`, `--cleanup` |
 | `task_inspect_and_export.py` | Inspect a task; export its dataset and event-log analytics | `--task-id`, `--export-format` |
 | `task_import_annotations.py` | Import an annotations file into an existing task | `--task-id`, `--annotations-file`, `--import-format` |
+| `task_import_annotations_from_cloud.py` | Import an annotations file into an existing task directly from a registered cloud storage | `--task-id`, `--filename`, `--cloud-storage-id`, `--import-format`, `--import-mode`, `--no-file-check` |
 | `task_edit_annotations.py` | Bulk-edit a task's annotations: relabel or delete objects by label | `--task-id`, `--relabel` or `--delete-label` |
 | `task_create_with_validation.py` | Create a task with a ground truth validation set and upload the ground truth into it | `--image-dir`, `--validation-frame` or `--frame-count`, `--gt-annotations`, `--gt-format`, `--cleanup` |
 | `task_create_with_honeypots.py` | Create a task whose annotation jobs carry ground truth frames; refresh or retire them | `--image-dir`, `--pool-frame` or `--pool-frame-count`, `--honeypots-per-job`, `--refresh`, `--disable-frame`, `--cleanup` |

--- a/cvat-sdk/examples/dataset_bulk_export.py
+++ b/cvat-sdk/examples/dataset_bulk_export.py
@@ -1,0 +1,221 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+"""Export many task datasets in one run: pick the tasks by project, by id, or by
+status, write them locally and/or straight to a cloud storage, and record every
+result in a CSV manifest.
+
+A failing task does not stop the run - it is recorded in the manifest and the
+script exits with code 1 at the end, so a pipeline still sees the failure.
+
+Steps:
+  1. Resolve the selection (--project-id, --task-id, --status).
+  2. Export each task to --output-dir and/or to --cloud-storage-id, skipping the
+     ones already exported when --skip-existing is passed.
+  3. Write the manifest and report how many tasks were exported, skipped, failed.
+
+With --jobs > 1 the exports run in worker threads. Each worker builds its OWN
+client: a cvat_sdk Client is not safe to share between threads.
+
+Usage (run ``python dataset_bulk_export.py --help`` for the full list of options):
+  python dataset_bulk_export.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --project-id 7 --output-dir datasets --jobs 4
+  python dataset_bulk_export.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --task-id 10 11 12 --cloud-storage-id 3 --output-dir datasets
+"""
+
+import argparse
+import csv
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from cvat_sdk import make_client
+from cvat_sdk.core.proxies.types import Location
+
+# One client per worker thread, created on first use in that thread.
+_thread_state = threading.local()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--host", required=True, help="CVAT server URL, e.g. 'https://app.cvat.ai'")
+    parser.add_argument(
+        "--token",
+        required=True,
+        help="Personal Access Token (CVAT UI: Profile -> Security)",
+    )
+    parser.add_argument("--project-id", type=int, help="export every task of this project")
+    parser.add_argument(
+        "--task-id", type=int, nargs="+", metavar="ID", help="export these task ids"
+    )
+    parser.add_argument(
+        "--status",
+        choices=["annotation", "validation", "completed"],
+        help="export only the tasks in this status",
+    )
+    parser.add_argument(
+        "--output-dir", type=Path, help="directory to write the exported datasets to"
+    )
+    parser.add_argument(
+        "--cloud-storage-id",
+        type=int,
+        help="also export straight to this registered cloud storage (see cloud_storage_register.py)",
+    )
+    parser.add_argument(
+        "--export-format",
+        default="COCO 1.0",
+        help="exporter name, e.g. 'COCO 1.0' (default: '%(default)s')",
+    )
+    parser.add_argument(
+        "--jobs", type=int, default=1, help="number of parallel exports (default: %(default)s)"
+    )
+    parser.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="skip tasks whose output file is already in --output-dir (resume a run)",
+    )
+    parser.add_argument("--with-images", action="store_true", help="include images in the exports")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("bulk_export.csv"),
+        help="path to write the manifest to (default: %(default)s)",
+    )
+    return parser.parse_args()
+
+
+def select_tasks(client, args: argparse.Namespace) -> list:
+    """The tasks to export, as (id, name, status) triples."""
+    if args.project_id:
+        filters = {"project_id": args.project_id}
+        if args.status:
+            filters["status"] = args.status
+        tasks = client.tasks.list(**filters)
+        by_id = {task.id: task for task in tasks}
+        if args.task_id:
+            missing = [str(tid) for tid in args.task_id if tid not in by_id]
+            if missing:
+                sys.exit(f"Task id(s) {', '.join(missing)} not found in project {args.project_id}")
+            tasks = [by_id[tid] for tid in args.task_id]
+        return [(task.id, task.name, str(task.status)) for task in tasks]
+
+    # A bare --task-id may name an id that does not exist (or does not match
+    # --status): that must surface as one failed export in the manifest, the
+    # same way a bad id in export_one does, not as a crash during selection.
+    selected = []
+    for task_id in args.task_id:
+        try:
+            task = client.tasks.retrieve(task_id)
+        except Exception:
+            selected.append((task_id, "", ""))
+            continue
+        if args.status and str(task.status) != args.status:
+            continue
+        selected.append((task.id, task.name, str(task.status)))
+    return selected
+
+
+def worker_client(host: str, token: str):
+    """The calling thread's own client - never share one between threads."""
+    client = getattr(_thread_state, "client", None)
+    if client is None:
+        client = _thread_state.client = make_client(host, access_token=token)
+    return client
+
+
+def export_one(args: argparse.Namespace, task_id: int, name: str, status: str) -> dict:
+    row = {
+        "task_id": task_id,
+        "name": name,
+        "status": status,
+        "destination": "",
+        "path": "",
+        "bytes": "",
+        "error": "",
+    }
+    local_path = args.output_dir / f"task_{task_id}.zip" if args.output_dir else None
+
+    if args.skip_existing and local_path and local_path.exists():
+        row["destination"] = "skipped"
+        row["path"] = str(local_path)
+        print(f"Skipped task {task_id} ({local_path} exists)")
+        return row
+
+    try:
+        client = worker_client(args.host, args.token)
+        task = client.tasks.retrieve(task_id)
+        destinations = []
+
+        if local_path:
+            task.export_dataset(
+                args.export_format,
+                local_path,
+                include_images=args.with_images,
+                location=Location.LOCAL,
+            )
+            destinations.append("local")
+            row["path"] = str(local_path)
+            row["bytes"] = local_path.stat().st_size
+
+        if args.cloud_storage_id:
+            task.export_dataset(
+                args.export_format,
+                f"task_{task_id}.zip",
+                include_images=args.with_images,
+                location=Location.CLOUD_STORAGE,
+                cloud_storage_id=args.cloud_storage_id,
+            )
+            destinations.append(f"cloud storage {args.cloud_storage_id}")
+
+        row["destination"] = ", ".join(destinations)
+        print(f"Exported task {task_id} {name!r} -> {row['destination']}")
+    except Exception as error:  # one bad task must not abort the whole run
+        row["error"] = f"{type(error).__name__}: {error}"
+        print(f"FAILED task {task_id} {name!r}: {row['error']}")
+
+    return row
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.project_id and not args.task_id:
+        sys.exit("Select what to export: pass --project-id and/or --task-id")
+    if not args.output_dir and not args.cloud_storage_id:
+        sys.exit("Select a destination: pass --output-dir and/or --cloud-storage-id")
+    if args.output_dir:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    with make_client(args.host, access_token=args.token) as client:
+        selection = select_tasks(client, args)
+    if not selection:
+        sys.exit("The selection is empty; nothing to export")
+    print(f"Exporting {len(selection)} task(s) with {args.jobs} worker(s)")
+
+    if args.jobs > 1:
+        with ThreadPoolExecutor(max_workers=args.jobs) as pool:
+            rows = list(pool.map(lambda task: export_one(args, *task), selection))
+    else:
+        rows = [export_one(args, *task) for task in selection]
+
+    rows.sort(key=lambda row: row["task_id"])
+    with args.output.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    failed = [row for row in rows if row["error"]]
+    skipped = [row for row in rows if row["destination"] == "skipped"]
+    exported = len(rows) - len(failed) - len(skipped)
+    print(
+        f"Exported {exported} of {len(rows)} task(s); {len(skipped)} skipped, {len(failed)} failed"
+    )
+    print(f"Wrote {args.output.resolve()}")
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/cvat-sdk/examples/dataset_bulk_export.py
+++ b/cvat-sdk/examples/dataset_bulk_export.py
@@ -35,7 +35,6 @@ from pathlib import Path
 from cvat_sdk import make_client
 from cvat_sdk.core.proxies.types import Location
 
-# One client per worker thread, created on first use in that thread.
 _thread_state = threading.local()
 
 
@@ -102,9 +101,6 @@ def select_tasks(client, args: argparse.Namespace) -> list:
             tasks = [by_id[tid] for tid in args.task_id]
         return [(task.id, task.name, str(task.status)) for task in tasks]
 
-    # A bare --task-id may name an id that does not exist (or does not match
-    # --status): that must surface as one failed export in the manifest, the
-    # same way a bad id in export_one does, not as a crash during selection.
     selected = []
     for task_id in args.task_id:
         try:

--- a/cvat-sdk/examples/dataset_bulk_export.py
+++ b/cvat-sdk/examples/dataset_bulk_export.py
@@ -100,8 +100,6 @@ def select_tasks(client, args: argparse.Namespace) -> list:
             try:
                 task = client.tasks.retrieve(task_id)
             except Exception:
-                # Keep it in the selection: export_one records the failure in the
-                # manifest, which beats aborting a long run over one bad id.
                 selected.append((task_id, "", ""))
                 continue
             if args.project_id and task.project_id != args.project_id:
@@ -112,7 +110,6 @@ def select_tasks(client, args: argparse.Namespace) -> list:
             selected.append((task.id, task.name, str(task.status)))
         return selected
 
-    # A whole project: the server does the filtering.
     filters = {"project_id": args.project_id}
     if args.status:
         filters["status"] = args.status

--- a/cvat-sdk/examples/dataset_bulk_export.py
+++ b/cvat-sdk/examples/dataset_bulk_export.py
@@ -87,31 +87,36 @@ def parse_args() -> argparse.Namespace:
 
 
 def select_tasks(client, args: argparse.Namespace) -> list:
-    """The tasks to export, as (id, name, status) triples."""
-    if args.project_id:
-        filters = {"project_id": args.project_id}
-        if args.status:
-            filters["status"] = args.status
-        tasks = client.tasks.list(**filters)
-        by_id = {task.id: task for task in tasks}
-        if args.task_id:
-            missing = [str(tid) for tid in args.task_id if tid not in by_id]
-            if missing:
-                sys.exit(f"Task id(s) {', '.join(missing)} not found in project {args.project_id}")
-            tasks = [by_id[tid] for tid in args.task_id]
-        return [(task.id, task.name, str(task.status)) for task in tasks]
+    """The tasks to export, as (id, name, status) triples.
 
-    selected = []
-    for task_id in args.task_id:
-        try:
-            task = client.tasks.retrieve(task_id)
-        except Exception:
-            selected.append((task_id, "", ""))
-            continue
-        if args.status and str(task.status) != args.status:
-            continue
-        selected.append((task.id, task.name, str(task.status)))
-    return selected
+    --task-id names the tasks, --project-id takes the whole project, and giving
+    both means "these ids, which must be in that project". --status is applied
+    after the ids are resolved, so a task that exists but is in another status is
+    reported as filtered out rather than as missing - two different mistakes.
+    """
+    if args.task_id:
+        selected = []
+        for task_id in args.task_id:
+            try:
+                task = client.tasks.retrieve(task_id)
+            except Exception:
+                # Keep it in the selection: export_one records the failure in the
+                # manifest, which beats aborting a long run over one bad id.
+                selected.append((task_id, "", ""))
+                continue
+            if args.project_id and task.project_id != args.project_id:
+                sys.exit(f"Task id {task_id} is not in project {args.project_id}")
+            if args.status and str(task.status) != args.status:
+                print(f"Skipping task {task_id}: status is {task.status}, not {args.status}")
+                continue
+            selected.append((task.id, task.name, str(task.status)))
+        return selected
+
+    # A whole project: the server does the filtering.
+    filters = {"project_id": args.project_id}
+    if args.status:
+        filters["status"] = args.status
+    return [(task.id, task.name, str(task.status)) for task in client.tasks.list(**filters)]
 
 
 def worker_client(host: str, token: str):

--- a/cvat-sdk/examples/dataset_incremental_download.py
+++ b/cvat-sdk/examples/dataset_incremental_download.py
@@ -1,0 +1,141 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+"""Download a project's task datasets incrementally: export only the tasks that
+changed since the previous run, tracked in a local state file.
+
+Steps:
+  1. Load the state file (or start from scratch) and check it belongs to this
+     server and project.
+  2. Ask the server for the tasks updated after the last run - the
+     ``updated_date__gt`` lookup becomes a server-side filter - and add any task
+     that the state file has never seen.
+  3. Report state entries whose tasks no longer exist on the server.
+  4. Export each selected task, saving the state right after every successful
+     export, so an interrupted run resumes instead of downloading everything again.
+
+Usage (run ``python dataset_incremental_download.py --help`` for the full list of options):
+  python dataset_incremental_download.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --project-id 7 --output-dir datasets --state incremental_state.json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from cvat_sdk import make_client
+from cvat_sdk.core.proxies.types import Location
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--host", required=True, help="CVAT server URL, e.g. 'https://app.cvat.ai'")
+    parser.add_argument(
+        "--token",
+        required=True,
+        help="Personal Access Token (CVAT UI: Profile -> Security)",
+    )
+    parser.add_argument(
+        "--project-id", type=int, required=True, help="id of an existing project, e.g. 7"
+    )
+    parser.add_argument(
+        "--state",
+        type=Path,
+        default=Path("incremental_state.json"),
+        help="file that remembers what was downloaded (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("datasets"),
+        help="directory to write the exported datasets to (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--export-format",
+        default="COCO 1.0",
+        help="exporter name, e.g. 'COCO 1.0' (default: '%(default)s')",
+    )
+    parser.add_argument(
+        "--with-images",
+        action="store_true",
+        help="include images in the exported datasets (slower, much larger)",
+    )
+    return parser.parse_args()
+
+
+def load_state(path: Path, host: str, project_id: int) -> dict:
+    """The previous run's result, or an empty state for the first run."""
+    if not path.exists():
+        return {"server": host, "project_id": project_id, "last_sync": None, "tasks": {}}
+
+    state = json.loads(path.read_text())
+    if state.get("server") != host or state.get("project_id") != project_id:
+        sys.exit(
+            f"State file {path} belongs to project {state.get('project_id')} "
+            f"on {state.get('server')!r}. Use a different --state file."
+        )
+    return state
+
+
+def save_state(path: Path, state: dict) -> None:
+    path.write_text(json.dumps(state, indent=2, sort_keys=True))
+
+
+def main() -> None:
+    args = parse_args()
+    with make_client(args.host, access_token=args.token) as client:
+        state = load_state(args.state, args.host, args.project_id)
+        known = state["tasks"]
+        last_sync = state["last_sync"]
+
+        # 2. What is on the server now, and what of it changed since the last run.
+        tasks = client.tasks.list(project_id=args.project_id)
+        if last_sync:
+            # The `field__op` keyword becomes a server-side filter, so the server
+            # does the comparison and only the changed tasks come back.
+            changed_ids = {
+                task.id
+                for task in client.tasks.list(
+                    project_id=args.project_id, updated_date__gt=last_sync
+                )
+            }
+        else:
+            changed_ids = {task.id for task in tasks}
+
+        selected = [task for task in tasks if task.id in changed_ids or str(task.id) not in known]
+
+        # 3. Tasks that were downloaded before and are gone now.
+        for task_id in sorted(set(known) - {str(task.id) for task in tasks}, key=int):
+            print(f"Task {task_id} no longer exists on the server (kept in {args.state})")
+
+        if not selected:
+            print(f"Nothing changed since {last_sync}")
+            return
+
+        # 4. Export, remembering each success immediately.
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        for task in selected:
+            path = args.output_dir / f"task_{task.id}.zip"
+            # A re-export replaces the previous file; the downloader refuses to
+            # write over an existing one.
+            path.unlink(missing_ok=True)
+            task.export_dataset(
+                args.export_format,
+                path,
+                include_images=args.with_images,
+                location=Location.LOCAL,
+            )
+            print(f"Exported task {task.id} {task.name!r} -> {path.resolve()}")
+
+            known[str(task.id)] = task.updated_date.isoformat()
+            state["last_sync"] = max(filter(None, [state["last_sync"], known[str(task.id)]]))
+            save_state(args.state, state)
+
+        print(f"Downloaded {len(selected)} task dataset(s) into {args.output_dir.resolve()}")
+        print(f"State written to {args.state.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cvat-sdk/examples/dataset_incremental_download.py
+++ b/cvat-sdk/examples/dataset_incremental_download.py
@@ -118,8 +118,6 @@ def main() -> None:
         args.output_dir.mkdir(parents=True, exist_ok=True)
         for task in selected:
             path = args.output_dir / f"task_{task.id}.zip"
-            # A re-export replaces the previous file; the downloader refuses to
-            # write over an existing one.
             path.unlink(missing_ok=True)
             task.export_dataset(
                 args.export_format,

--- a/cvat-sdk/examples/dataset_incremental_download.py
+++ b/cvat-sdk/examples/dataset_incremental_download.py
@@ -3,26 +3,23 @@
 # SPDX-License-Identifier: MIT
 
 """Download a project's task datasets incrementally: export only the tasks that
-changed since the previous run, tracked in a local state file.
+changed since the previous run.
+
+Pass --updated-after with the timestamp stored by your pipeline, or omit it
+for a full download. The script does not store synchronization state.
 
 Steps:
-  1. Load the state file (or start from scratch) and check it belongs to this
-     server and project.
-  2. Ask the server for the tasks updated after the last run - the
-     ``updated_date__gt`` lookup becomes a server-side filter - and add any task
-     that the state file has never seen.
-  3. Report state entries whose tasks no longer exist on the server.
-  4. Export each selected task, saving the state right after every successful
-     export, so an interrupted run resumes instead of downloading everything again.
+  1. Ask the server for the project's tasks updated after the given timestamp.
+  2. Export each selected task, replacing its previous local archive.
 
 Usage (run ``python dataset_incremental_download.py --help`` for the full list of options):
   python dataset_incremental_download.py --host 'https://app.cvat.ai' --token '<your token>' \\
-      --project-id 7 --output-dir datasets --state incremental_state.json
+      --project-id 7 --output-dir datasets
+  python dataset_incremental_download.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --project-id 7 --updated-after '2026-09-01T00:00:00+00:00'
 """
 
 import argparse
-import json
-import sys
 from pathlib import Path
 
 from cvat_sdk import make_client
@@ -41,10 +38,9 @@ def parse_args() -> argparse.Namespace:
         "--project-id", type=int, required=True, help="id of an existing project, e.g. 7"
     )
     parser.add_argument(
-        "--state",
-        type=Path,
-        default=Path("incremental_state.json"),
-        help="file that remembers what was downloaded (default: %(default)s)",
+        "--updated-after",
+        metavar="TIMESTAMP",
+        help="export tasks updated after this ISO 8601 timestamp; omit to export all tasks",
     )
     parser.add_argument(
         "--output-dir",
@@ -65,58 +61,23 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_state(path: Path, host: str, project_id: int) -> dict:
-    """The previous run's result, or an empty state for the first run."""
-    if not path.exists():
-        return {"server": host, "project_id": project_id, "last_sync": None, "tasks": {}}
-
-    state = json.loads(path.read_text())
-    if state.get("server") != host or state.get("project_id") != project_id:
-        sys.exit(
-            f"State file {path} belongs to project {state.get('project_id')} "
-            f"on {state.get('server')!r}. Use a different --state file."
-        )
-    return state
-
-
-def save_state(path: Path, state: dict) -> None:
-    path.write_text(json.dumps(state, indent=2, sort_keys=True))
-
-
 def main() -> None:
     args = parse_args()
     with make_client(args.host, access_token=args.token) as client:
-        state = load_state(args.state, args.host, args.project_id)
-        known = state["tasks"]
-        last_sync = state["last_sync"]
-
-        # 2. What is on the server now, and what of it changed since the last run.
-        tasks = client.tasks.list(project_id=args.project_id)
-        if last_sync:
-            # The `field__op` keyword becomes a server-side filter, so the server
-            # does the comparison and only the changed tasks come back.
-            changed_ids = {
-                task.id
-                for task in client.tasks.list(
-                    project_id=args.project_id, updated_date__gt=last_sync
-                )
-            }
-        else:
-            changed_ids = {task.id for task in tasks}
-
-        selected = [task for task in tasks if task.id in changed_ids or str(task.id) not in known]
-
-        # 3. Tasks that were downloaded before and are gone now.
-        for task_id in sorted(set(known) - {str(task.id) for task in tasks}, key=int):
-            print(f"Task {task_id} no longer exists on the server (kept in {args.state})")
-
-        if not selected:
-            print(f"Nothing changed since {last_sync}")
+        filters = {"project_id": args.project_id}
+        if args.updated_after:
+            filters["updated_date__gt"] = args.updated_after
+        tasks = client.tasks.list(**filters)
+        if not tasks:
+            print(
+                f"No tasks to export after {args.updated_after}"
+                if args.updated_after
+                else f"Project {args.project_id} has no tasks to export"
+            )
             return
 
-        # 4. Export, remembering each success immediately.
         args.output_dir.mkdir(parents=True, exist_ok=True)
-        for task in selected:
+        for task in tasks:
             path = args.output_dir / f"task_{task.id}.zip"
             path.unlink(missing_ok=True)
             task.export_dataset(
@@ -127,12 +88,7 @@ def main() -> None:
             )
             print(f"Exported task {task.id} {task.name!r} -> {path.resolve()}")
 
-            known[str(task.id)] = task.updated_date.isoformat()
-            state["last_sync"] = max(filter(None, [state["last_sync"], known[str(task.id)]]))
-            save_state(args.state, state)
-
-        print(f"Downloaded {len(selected)} task dataset(s) into {args.output_dir.resolve()}")
-        print(f"State written to {args.state.resolve()}")
+        print(f"Downloaded {len(tasks)} task dataset(s) into {args.output_dir.resolve()}")
 
 
 if __name__ == "__main__":

--- a/cvat-sdk/examples/project_data_lint.py
+++ b/cvat-sdk/examples/project_data_lint.py
@@ -29,8 +29,6 @@ from pathlib import Path
 
 from cvat_sdk import make_client
 
-# Shapes whose points are plain x/y pairs. Masks carry RLE data and skeletons carry
-# their points in sub-elements, so the geometry checks skip them.
 GEOMETRY_TYPES = {"rectangle", "polygon", "polyline", "points"}
 SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
 
@@ -39,7 +37,6 @@ SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
 class Finding:
     severity: str
     check: str
-    # Project-wide findings leave the location fields empty, hence the str union.
     task_id: int | str
     job_id: int | str
     frame: int | str

--- a/cvat-sdk/examples/project_data_lint.py
+++ b/cvat-sdk/examples/project_data_lint.py
@@ -1,0 +1,259 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+"""Lint a project's annotations before exporting them: find shapes that leave the
+frame, boxes with (almost) no area, duplicated objects, frames nobody annotated,
+jobs marked completed with nothing in them, and labels nobody used.
+
+Every finding has a severity. The script exits 1 when any error-severity finding
+exists, so it can gate a pipeline; --no-fail turns that off.
+
+Steps:
+  1. Retrieve the project, its labels, and the tasks to inspect.
+  2. For each task, read the frame sizes, the jobs, and the annotations.
+  3. Run the checks and collect the findings.
+  4. Print them grouped by severity, write the CSV report, and set the exit code.
+
+Usage (run ``python project_data_lint.py --help`` for the full list of options):
+  python project_data_lint.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --project-id 7 --min-box-area 16
+"""
+
+import argparse
+import csv
+import sys
+from collections import Counter
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+
+from cvat_sdk import make_client
+
+# Shapes whose points are plain x/y pairs. Masks carry RLE data and skeletons carry
+# their points in sub-elements, so the geometry checks skip them.
+GEOMETRY_TYPES = {"rectangle", "polygon", "polyline", "points"}
+SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
+
+
+@dataclass
+class Finding:
+    severity: str
+    check: str
+    # Project-wide findings leave the location fields empty, hence the str union.
+    task_id: int | str
+    job_id: int | str
+    frame: int | str
+    label: str
+    detail: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--host", required=True, help="CVAT server URL, e.g. 'https://app.cvat.ai'")
+    parser.add_argument(
+        "--token",
+        required=True,
+        help="Personal Access Token (CVAT UI: Profile -> Security)",
+    )
+    parser.add_argument(
+        "--project-id", type=int, required=True, help="id of an existing project, e.g. 7"
+    )
+    parser.add_argument(
+        "--task-id",
+        type=int,
+        nargs="+",
+        metavar="ID",
+        help="lint only these task ids (must belong to the project); "
+        "omit to lint every task in the project",
+    )
+    parser.add_argument(
+        "--min-box-area",
+        type=float,
+        default=4.0,
+        help="rectangles smaller than this many square pixels are errors (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data_lint.csv"),
+        help="path to write the CSV report to (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--no-fail", action="store_true", help="always exit 0, even when errors were found"
+    )
+    return parser.parse_args()
+
+
+def iter_objects(annotations):
+    """(frame, label_id, type, points) for tags, shapes, and every track keyframe.
+
+    Objects marked `outside` are skipped: they are intentionally out of view.
+    """
+    for tag in annotations.tags:
+        yield tag.frame, tag.label_id, "tag", []
+    for shape in annotations.shapes:
+        if getattr(shape, "outside", False):
+            continue
+        yield shape.frame, shape.label_id, str(shape.type), list(shape.points)
+    for track in annotations.tracks:
+        for shape in track.shapes:
+            if shape.outside:
+                continue
+            yield shape.frame, track.label_id, str(shape.type), list(shape.points)
+
+
+def lint_task(task, label_names: dict[int, str], min_box_area: float):
+    """The findings for one task, plus how often each label was used in it."""
+    frames = task.get_frames_info()
+    jobs = task.get_jobs()
+    job_of_frame = {}
+    for job in jobs:
+        for frame in range(job.start_frame, job.stop_frame + 1):
+            job_of_frame.setdefault(frame, job.id)
+
+    findings: list[Finding] = []
+    label_usage = Counter()
+    annotated_frames = set()
+    seen = set()
+
+    for frame, label_id, type_, points in iter_objects(task.get_annotations()):
+        label = label_names.get(label_id, str(label_id))
+        label_usage[label] += 1
+        annotated_frames.add(frame)
+        job_id = job_of_frame.get(frame, "")
+
+        key = (frame, label_id, type_, tuple(round(value, 3) for value in points))
+        if points and key in seen:
+            findings.append(
+                Finding(
+                    "error",
+                    "duplicate-object",
+                    task.id,
+                    job_id,
+                    frame,
+                    label,
+                    f"a second {type_} with identical points on this frame",
+                )
+            )
+        seen.add(key)
+
+        if frame >= len(frames):
+            continue
+        meta = frames[frame]
+
+        if type_ in GEOMETRY_TYPES and points:
+            xs, ys = points[0::2], points[1::2]
+            if min(xs) < 0 or min(ys) < 0 or max(xs) > meta.width or max(ys) > meta.height:
+                findings.append(
+                    Finding(
+                        "error",
+                        "out-of-bounds",
+                        task.id,
+                        job_id,
+                        frame,
+                        label,
+                        f"{type_} spans x {min(xs):.1f}..{max(xs):.1f}, "
+                        f"y {min(ys):.1f}..{max(ys):.1f} in a {meta.width}x{meta.height} frame",
+                    )
+                )
+
+        if type_ == "rectangle" and len(points) == 4:
+            area = abs(points[2] - points[0]) * abs(points[3] - points[1])
+            if area < min_box_area:
+                findings.append(
+                    Finding(
+                        "error",
+                        "degenerate-box",
+                        task.id,
+                        job_id,
+                        frame,
+                        label,
+                        f"area {area:.2f} px2 is below --min-box-area {min_box_area}",
+                    )
+                )
+
+    for frame, meta in enumerate(frames):
+        if frame not in annotated_frames:
+            findings.append(
+                Finding(
+                    "warning",
+                    "empty-frame",
+                    task.id,
+                    job_of_frame.get(frame, ""),
+                    frame,
+                    "",
+                    f"{meta.name} has no objects",
+                )
+            )
+
+    for job in jobs:
+        job_frames = range(job.start_frame, job.stop_frame + 1)
+        if str(job.state) == "completed" and not annotated_frames.intersection(job_frames):
+            findings.append(
+                Finding(
+                    "warning",
+                    "completed-but-empty",
+                    task.id,
+                    job.id,
+                    "",
+                    "",
+                    f"job is completed but frames {job.start_frame}-{job.stop_frame} are empty",
+                )
+            )
+
+    return findings, label_usage
+
+
+def main() -> None:
+    args = parse_args()
+    with make_client(args.host, access_token=args.token) as client:
+        project = client.projects.retrieve(args.project_id)
+        label_names = {label.id: label.name for label in project.get_labels()}
+
+        tasks_by_id = {task.id: task for task in project.get_tasks()}
+        if args.task_id:
+            missing = [str(tid) for tid in args.task_id if tid not in tasks_by_id]
+            if missing:
+                sys.exit(f"Task id(s) {', '.join(missing)} not found in project {project.id}")
+            tasks = [tasks_by_id[tid] for tid in args.task_id]
+        else:
+            tasks = list(tasks_by_id.values())
+        if not tasks:
+            sys.exit(f"Project {project.id} has no tasks to lint")
+
+        findings: list[Finding] = []
+        usage = Counter()
+        for task in tasks:
+            task_findings, task_usage = lint_task(task, label_names, args.min_box_area)
+            findings.extend(task_findings)
+            usage.update(task_usage)
+
+        for name in sorted(set(label_names.values()) - set(usage)):
+            findings.append(
+                Finding("info", "unused-label", "", "", "", name, "no objects in the linted tasks")
+            )
+
+    findings.sort(key=lambda f: (SEVERITY_ORDER[f.severity], f.check, str(f.task_id), str(f.frame)))
+    for finding in findings:
+        location = f"task {finding.task_id}" if finding.task_id != "" else "project"
+        if finding.frame != "":
+            location += f" frame {finding.frame}"
+        print(f"{finding.severity} {finding.check}: {location}: {finding.detail}")
+
+    with args.output.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=[field.name for field in fields(Finding)])
+        writer.writeheader()
+        writer.writerows(asdict(finding) for finding in findings)
+
+    counts = Counter(finding.severity for finding in findings)
+    print(
+        f"Found {len(findings)} issue(s): {counts['error']} error(s), "
+        f"{counts['warning']} warning(s), {counts['info']} info"
+    )
+    print(f"Wrote {args.output.resolve()}")
+    if counts["error"] and not args.no_fail:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/cvat-sdk/examples/project_data_lint.py
+++ b/cvat-sdk/examples/project_data_lint.py
@@ -3,15 +3,15 @@
 # SPDX-License-Identifier: MIT
 
 """Lint a project's annotations before exporting them: find shapes that leave the
-frame, boxes with (almost) no area, duplicated objects, frames nobody annotated,
-jobs marked completed with nothing in them, and labels nobody used.
+frame, boxes with (almost) no area, duplicated objects, objects stranded on
+removed frames, and labels nobody used.
 
 Every finding has a severity. The script exits 1 when any error-severity finding
 exists, so it can gate a pipeline; --no-fail turns that off.
 
 Steps:
   1. Retrieve the project, its labels, and the tasks to inspect.
-  2. For each task, read the frame sizes, the jobs, and the annotations.
+  2. For each task, read the frame metadata, the jobs, and the annotations.
   3. Run the checks and collect the findings.
   4. Print them grouped by severity, write the CSV report, and set the exit code.
 
@@ -30,7 +30,7 @@ from pathlib import Path
 from cvat_sdk import make_client
 
 GEOMETRY_TYPES = {"rectangle", "polygon", "polyline", "points"}
-SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
+SEVERITY_ORDER = {"error": 0, "info": 1}
 
 
 @dataclass
@@ -101,7 +101,13 @@ def iter_objects(annotations):
 
 def lint_task(task, label_names: dict[int, str], min_box_area: float):
     """The findings for one task, plus how often each label was used in it."""
-    frames = task.get_frames_info()
+    meta = task.get_meta()
+    # An image task reports one entry in `frames` per frame; a video task reports
+    # a single entry for the whole video. `size` is the frame count either way.
+    frame_count = meta.size
+    per_frame_meta = str(task.data_original_chunk_type) == "imageset"
+    deleted_frames = set(meta.deleted_frames)
+
     jobs = task.get_jobs()
     job_of_frame = {}
     for job in jobs:
@@ -110,13 +116,13 @@ def lint_task(task, label_names: dict[int, str], min_box_area: float):
 
     findings: list[Finding] = []
     label_usage = Counter()
-    annotated_frames = set()
     seen = set()
 
     for frame, label_id, type_, points in iter_objects(task.get_annotations()):
-        label = label_names.get(label_id, str(label_id))
+        # Every linted task belongs to the project, and a task in a project uses
+        # the project's labels, so the id is always one of them.
+        label = label_names[label_id]
         label_usage[label] += 1
-        annotated_frames.add(frame)
         job_id = job_of_frame.get(frame, "")
 
         key = (frame, label_id, type_, tuple(round(value, 3) for value in points))
@@ -134,13 +140,32 @@ def lint_task(task, label_names: dict[int, str], min_box_area: float):
             )
         seen.add(key)
 
-        if frame >= len(frames):
+        if frame in deleted_frames or frame >= frame_count:
+            # These objects are omitted from dataset exports.
+            reason = (
+                "was removed from the task"
+                if frame in deleted_frames
+                else f"is past the task's last frame {frame_count - 1}"
+            )
+            findings.append(
+                Finding(
+                    "error",
+                    "dead-object",
+                    task.id,
+                    job_id,
+                    frame,
+                    label,
+                    f"{type_} sits on frame {frame}, which {reason}",
+                )
+            )
             continue
-        meta = frames[frame]
+
+        frame_meta = meta.frames[frame if per_frame_meta else 0]
 
         if type_ in GEOMETRY_TYPES and points:
             xs, ys = points[0::2], points[1::2]
-            if min(xs) < 0 or min(ys) < 0 or max(xs) > meta.width or max(ys) > meta.height:
+            width, height = frame_meta.width, frame_meta.height
+            if min(xs) < 0 or min(ys) < 0 or max(xs) > width or max(ys) > height:
                 findings.append(
                     Finding(
                         "error",
@@ -150,7 +175,7 @@ def lint_task(task, label_names: dict[int, str], min_box_area: float):
                         frame,
                         label,
                         f"{type_} spans x {min(xs):.1f}..{max(xs):.1f}, "
-                        f"y {min(ys):.1f}..{max(ys):.1f} in a {meta.width}x{meta.height} frame",
+                        f"y {min(ys):.1f}..{max(ys):.1f} in a {width}x{height} frame",
                     )
                 )
 
@@ -169,36 +194,28 @@ def lint_task(task, label_names: dict[int, str], min_box_area: float):
                     )
                 )
 
-    for frame, meta in enumerate(frames):
-        if frame not in annotated_frames:
-            findings.append(
-                Finding(
-                    "warning",
-                    "empty-frame",
-                    task.id,
-                    job_of_frame.get(frame, ""),
-                    frame,
-                    "",
-                    f"{meta.name} has no objects",
-                )
-            )
-
-    for job in jobs:
-        job_frames = range(job.start_frame, job.stop_frame + 1)
-        if str(job.state) == "completed" and not annotated_frames.intersection(job_frames):
-            findings.append(
-                Finding(
-                    "warning",
-                    "completed-but-empty",
-                    task.id,
-                    job.id,
-                    "",
-                    "",
-                    f"job is completed but frames {job.start_frame}-{job.stop_frame} are empty",
-                )
-            )
-
     return findings, label_usage
+
+
+def select_tasks(client, project, task_ids: list[int] | None) -> list:
+    """The project's tasks, or just the requested ones.
+
+    With --task-id the tasks are retrieved by id: listing every task of a large
+    project only to throw most of them away would be a waste.
+    """
+    if not task_ids:
+        return list(project.get_tasks())
+
+    tasks = []
+    for task_id in task_ids:
+        try:
+            task = client.tasks.retrieve(task_id)
+        except Exception:
+            task = None
+        if task is None or task.project_id != project.id:
+            sys.exit(f"Task id {task_id} was not found in project {project.id}")
+        tasks.append(task)
+    return tasks
 
 
 def main() -> None:
@@ -207,14 +224,7 @@ def main() -> None:
         project = client.projects.retrieve(args.project_id)
         label_names = {label.id: label.name for label in project.get_labels()}
 
-        tasks_by_id = {task.id: task for task in project.get_tasks()}
-        if args.task_id:
-            missing = [str(tid) for tid in args.task_id if tid not in tasks_by_id]
-            if missing:
-                sys.exit(f"Task id(s) {', '.join(missing)} not found in project {project.id}")
-            tasks = [tasks_by_id[tid] for tid in args.task_id]
-        else:
-            tasks = list(tasks_by_id.values())
+        tasks = select_tasks(client, project, args.task_id)
         if not tasks:
             sys.exit(f"Project {project.id} has no tasks to lint")
 
@@ -243,10 +253,7 @@ def main() -> None:
         writer.writerows(asdict(finding) for finding in findings)
 
     counts = Counter(finding.severity for finding in findings)
-    print(
-        f"Found {len(findings)} issue(s): {counts['error']} error(s), "
-        f"{counts['warning']} warning(s), {counts['info']} info"
-    )
+    print(f"Found {len(findings)} issue(s): {counts['error']} error(s), {counts['info']} info")
     print(f"Wrote {args.output.resolve()}")
     if counts["error"] and not args.no_fail:
         sys.exit(1)

--- a/cvat-sdk/examples/project_data_lint.py
+++ b/cvat-sdk/examples/project_data_lint.py
@@ -141,7 +141,6 @@ def lint_task(task, label_names: dict[int, str], min_box_area: float):
         seen.add(key)
 
         if frame in deleted_frames or frame >= frame_count:
-            # These objects are omitted from dataset exports.
             reason = (
                 "was removed from the task"
                 if frame in deleted_frames

--- a/cvat-sdk/examples/task_add_gt_frames.py
+++ b/cvat-sdk/examples/task_add_gt_frames.py
@@ -2,8 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""Add a ground truth job to an existing task with an exact frame list - the
-frames you choose, not a random sample.
+"""Add a ground truth job to an existing task with an exact frame list you choose.
 
 Steps:
   1. Retrieve the task and resolve the requested frames: indexes (--frame) or

--- a/cvat-sdk/examples/task_add_gt_frames.py
+++ b/cvat-sdk/examples/task_add_gt_frames.py
@@ -1,0 +1,117 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+"""Add a ground truth job to an existing task with an exact frame list - the
+frames you choose, not a random sample.
+
+Steps:
+  1. Retrieve the task and resolve the requested frames: indexes (--frame) or
+     file names (--frame-name, matched against the task's frame list).
+  2. Refuse to touch an existing ground truth job unless --replace is given,
+     because deleting one discards its annotations.
+  3. Create the ground truth job with the "manual" frame selection method.
+  4. Read the task's validation layout back and print the frames the server
+     recorded, so you can see the request landed exactly as asked.
+
+Usage (run ``python task_add_gt_frames.py --help`` for the full list of options):
+  python task_add_gt_frames.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --task-id 42 --frame 0 17 42
+  python task_add_gt_frames.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --task-id 42 --frame-name 'img_001.png' 'img_042.png'
+"""
+
+import argparse
+import sys
+
+from cvat_sdk import make_client, models
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--host", required=True, help="CVAT server URL, e.g. 'https://app.cvat.ai'")
+    parser.add_argument(
+        "--token",
+        required=True,
+        help="Personal Access Token (CVAT UI: Profile -> Security)",
+    )
+    parser.add_argument(
+        "--task-id", type=int, required=True, help="id of an existing task, e.g. 42"
+    )
+    frames = parser.add_mutually_exclusive_group(required=True)
+    frames.add_argument(
+        "--frame", type=int, nargs="+", metavar="N", help="frame indexes to use as ground truth"
+    )
+    frames.add_argument(
+        "--frame-name", nargs="+", metavar="NAME", help="frame file names to use as ground truth"
+    )
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="delete an existing ground truth job first (discards its annotations)",
+    )
+    parser.add_argument(
+        "--cleanup", action="store_true", help="delete the created ground truth job at the end"
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    with make_client(args.host, access_token=args.token) as client:
+        task = client.tasks.retrieve(args.task_id)
+        frames_info = task.get_frames_info()
+
+        # 1. Resolve the requested frames to task frame indexes.
+        if args.frame_name:
+            index_by_name = {frame.name: index for index, frame in enumerate(frames_info)}
+            unknown = [name for name in args.frame_name if name not in index_by_name]
+            if unknown:
+                sys.exit(f"Frame name(s) {', '.join(unknown)} not found in task {task.id}")
+            frames = sorted({index_by_name[name] for name in args.frame_name})
+        else:
+            out_of_range = [f for f in args.frame if not 0 <= f < len(frames_info)]
+            if out_of_range:
+                sys.exit(
+                    f"Frame(s) {out_of_range} out of range: task {task.id} "
+                    f"has {len(frames_info)} frames"
+                )
+            frames = sorted(set(args.frame))
+
+        # 2. An existing ground truth job is never replaced silently.
+        existing = client.jobs.list(task_id=task.id, type="ground_truth")
+        if existing:
+            if not args.replace:
+                sys.exit(
+                    f"Task {task.id} already has a ground truth job ({existing[0].id}). "
+                    "Pass --replace to delete it first - its annotations will be lost."
+                )
+            client.api_client.jobs_api.destroy(existing[0].id)
+            print(f"Deleted the previous ground truth job {existing[0].id}")
+
+        # 3. "manual" frame selection means: exactly these frames.
+        job, _ = client.api_client.jobs_api.create(
+            models.JobWriteRequest(
+                type="ground_truth",
+                task_id=task.id,
+                frame_selection_method="manual",
+                frames=frames,
+            )
+        )
+        names = [frames_info[index].name for index in frames]
+        print(f"Created ground truth job {job.id} with {len(frames)} frames: {', '.join(names)}")
+
+        # 4. What the server recorded.
+        layout, _ = client.api_client.tasks_api.retrieve_validation_layout(task.id)
+        print(f"Validation frames: {sorted(layout.validation_frames)}")
+        print("Upload the ground truth with: task_create_with_validation.py --gt-annotations ...")
+
+        if args.cleanup:
+            client.api_client.jobs_api.destroy(job.id)
+            print(f"Deleted ground truth job {job.id}")
+        else:
+            print("Keeping the ground truth job; pass --cleanup to delete it")
+
+
+if __name__ == "__main__":
+    main()

--- a/cvat-sdk/examples/task_create_job_mapping.py
+++ b/cvat-sdk/examples/task_create_job_mapping.py
@@ -1,0 +1,162 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+"""Create a task whose jobs are defined by you, file by file, instead of by a
+frame count: one job per camera, per scene, per delivery batch.
+
+Two ways to group:
+  --job FILE [FILE ...]   one job per occurrence, in the given file order
+  --files-per-job N       chunk the sorted directory listing into jobs of N files
+
+Steps:
+  1. Build the file groups and check them against --image-dir: every file must
+     exist, appear once, and belong to a job.
+  2. Create the task with the job_file_mapping data parameter.
+  3. Read the jobs back from the server and print/write the resulting mapping,
+     so what you see is what the server built, not what was requested.
+
+job_file_mapping implies predefined file ordering and works with images, not video.
+
+Usage (run ``python task_create_job_mapping.py --help`` for the full list of options):
+  python task_create_job_mapping.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --image-dir ./images \\
+      --job 'cam1_001.png' 'cam1_002.png' --job 'cam2_001.png' 'cam2_002.png'
+  python task_create_job_mapping.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --image-dir ./images --files-per-job 50
+"""
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+from cvat_sdk import make_client, models
+from cvat_sdk.core.proxies.tasks import ResourceType
+
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--host", required=True, help="CVAT server URL, e.g. 'https://app.cvat.ai'")
+    parser.add_argument(
+        "--token",
+        required=True,
+        help="Personal Access Token (CVAT UI: Profile -> Security)",
+    )
+    parser.add_argument(
+        "--image-dir", type=Path, required=True, help="directory with the task's images"
+    )
+    grouping = parser.add_mutually_exclusive_group(required=True)
+    grouping.add_argument(
+        "--job",
+        action="append",
+        nargs="+",
+        metavar="FILE",
+        help="the files of one job (repeat for more jobs)",
+    )
+    grouping.add_argument("--files-per-job", type=int, help="chunk the directory into jobs of N")
+    parser.add_argument("--name", default="Task with a job file mapping", help="task name")
+    parser.add_argument(
+        "--labels", nargs="+", default=["object"], metavar="NAME", help="label names to create"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("job_file_mapping.csv"),
+        help="path to write the resulting mapping to (default: %(default)s)",
+    )
+    parser.add_argument("--cleanup", action="store_true", help="delete the created task at the end")
+    return parser.parse_args()
+
+
+def build_groups(args: argparse.Namespace, available: list[str]) -> list[list[str]]:
+    """The file groups to send as job_file_mapping, validated against the directory."""
+    if args.files_per_job:
+        if args.files_per_job < 1:
+            sys.exit("--files-per-job must be at least 1")
+        return [
+            available[start : start + args.files_per_job]
+            for start in range(0, len(available), args.files_per_job)
+        ]
+
+    groups = [list(group) for group in args.job]
+    known = set(available)
+    assigned = []
+    for group in groups:
+        assigned.extend(group)
+
+    unknown = [name for name in assigned if name not in known]
+    if unknown:
+        sys.exit(f"File(s) {', '.join(unknown)} not found in {args.image_dir}")
+
+    duplicates = sorted({name for name in assigned if assigned.count(name) > 1})
+    if duplicates:
+        sys.exit(f"File(s) {', '.join(duplicates)} appear in more than one job")
+
+    unassigned = sorted(known - set(assigned))
+    if unassigned:
+        sys.exit(
+            f"File(s) {', '.join(unassigned)} are not assigned to any job. "
+            "Every file in --image-dir must belong to exactly one --job."
+        )
+    return groups
+
+
+def main() -> None:
+    args = parse_args()
+    available = sorted(
+        p.name for p in args.image_dir.iterdir() if p.suffix.lower() in IMAGE_SUFFIXES
+    )
+    if not available:
+        sys.exit(f"No images found in {args.image_dir}")
+
+    groups = build_groups(args, available)
+    resources = [args.image_dir / name for group in groups for name in group]
+    print(f"Requesting {len(groups)} job(s) over {len(resources)} file(s)")
+
+    with make_client(args.host, access_token=args.token) as client:
+        task = client.tasks.create_from_data(
+            spec=models.TaskWriteRequest(
+                name=args.name,
+                labels=[models.PatchedLabelRequest(name=name) for name in args.labels],
+            ),
+            resource_type=ResourceType.LOCAL,
+            resources=resources,
+            data_params={"job_file_mapping": groups},
+        )
+        print(f"Created task {task.id} with {task.size} frames: {args.host}/tasks/{task.id}")
+
+        # 3. The mapping the server actually built.
+        rows = []
+        for job in sorted(task.get_jobs(), key=lambda job: job.start_frame):
+            names = [frame.name for frame in job.get_frames_info()]
+            print(f"  job {job.id} frames {job.start_frame}-{job.stop_frame}: {', '.join(names)}")
+            rows.extend(
+                {
+                    "job_id": job.id,
+                    "start_frame": job.start_frame,
+                    "stop_frame": job.stop_frame,
+                    "file_name": name,
+                }
+                for name in names
+            )
+
+        with args.output.open("w", newline="") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=["job_id", "start_frame", "stop_frame", "file_name"]
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+        print(f"Wrote {args.output.resolve()}")
+
+        if args.cleanup:
+            task.remove()
+            print(f"Deleted task {task.id}")
+        else:
+            print("Keeping the task; pass --cleanup to delete it")
+
+
+if __name__ == "__main__":
+    main()

--- a/cvat-sdk/examples/task_create_job_mapping.py
+++ b/cvat-sdk/examples/task_create_job_mapping.py
@@ -125,7 +125,6 @@ def main() -> None:
         task = client.tasks.create_from_data(
             spec=models.TaskWriteRequest(
                 name=args.name,
-                # One label makes the resulting task ready for annotation.
                 labels=[models.PatchedLabelRequest(name="object")],
             ),
             resource_type=ResourceType.LOCAL,
@@ -134,7 +133,7 @@ def main() -> None:
         )
         print(f"Created task {task.id} with {task.size} frames: {args.host}/tasks/{task.id}")
 
-        # 3. The mapping the server actually built: one row per file, carrying
+        # 3. The mapping is built using one row per file, carrying
         # the frame that file ended up on. A job's frames come back in order,
         # so the frame is the job's start plus the file's position in it.
         rows = []

--- a/cvat-sdk/examples/task_create_job_mapping.py
+++ b/cvat-sdk/examples/task_create_job_mapping.py
@@ -7,7 +7,9 @@ frame count: one job per camera, per scene, per delivery batch.
 
 Two ways to group:
   --job FILE [FILE ...]   one job per occurrence, in the given file order
-  --files-per-job N       chunk the sorted directory listing into jobs of N files
+  --files-per-job N       a count, not a file list: chunk the sorted directory
+                          listing into jobs of N files each, the explicit
+                          equivalent of the task's segment_size
 
 Steps:
   1. Build the file groups and check them against --image-dir: every file must
@@ -56,11 +58,14 @@ def parse_args() -> argparse.Namespace:
         metavar="FILE",
         help="the files of one job (repeat for more jobs)",
     )
-    grouping.add_argument("--files-per-job", type=int, help="chunk the directory into jobs of N")
-    parser.add_argument("--name", default="Task with a job file mapping", help="task name")
-    parser.add_argument(
-        "--labels", nargs="+", default=["object"], metavar="NAME", help="label names to create"
+    grouping.add_argument(
+        "--files-per-job",
+        type=int,
+        metavar="N",
+        help="number of files per job: chunk the sorted directory listing into jobs of N "
+        "files each (the explicit equivalent of the task's segment_size)",
     )
+    parser.add_argument("--name", default="Task with a job file mapping", help="task name")
     parser.add_argument(
         "--output",
         type=Path,
@@ -120,7 +125,8 @@ def main() -> None:
         task = client.tasks.create_from_data(
             spec=models.TaskWriteRequest(
                 name=args.name,
-                labels=[models.PatchedLabelRequest(name=name) for name in args.labels],
+                # One label makes the resulting task ready for annotation.
+                labels=[models.PatchedLabelRequest(name="object")],
             ),
             resource_type=ResourceType.LOCAL,
             resources=resources,
@@ -128,25 +134,20 @@ def main() -> None:
         )
         print(f"Created task {task.id} with {task.size} frames: {args.host}/tasks/{task.id}")
 
-        # 3. The mapping the server actually built.
+        # 3. The mapping the server actually built: one row per file, carrying
+        # the frame that file ended up on. A job's frames come back in order,
+        # so the frame is the job's start plus the file's position in it.
         rows = []
         for job in sorted(task.get_jobs(), key=lambda job: job.start_frame):
             names = [frame.name for frame in job.get_frames_info()]
             print(f"  job {job.id} frames {job.start_frame}-{job.stop_frame}: {', '.join(names)}")
             rows.extend(
-                {
-                    "job_id": job.id,
-                    "start_frame": job.start_frame,
-                    "stop_frame": job.stop_frame,
-                    "file_name": name,
-                }
-                for name in names
+                {"job_id": job.id, "frame": job.start_frame + offset, "file_name": name}
+                for offset, name in enumerate(names)
             )
 
         with args.output.open("w", newline="") as f:
-            writer = csv.DictWriter(
-                f, fieldnames=["job_id", "start_frame", "stop_frame", "file_name"]
-            )
+            writer = csv.DictWriter(f, fieldnames=["job_id", "frame", "file_name"])
             writer.writeheader()
             writer.writerows(rows)
         print(f"Wrote {args.output.resolve()}")

--- a/cvat-sdk/examples/task_create_subtasks.py
+++ b/cvat-sdk/examples/task_create_subtasks.py
@@ -35,7 +35,6 @@ from cvat_sdk import make_client, models
 from cvat_sdk.core.proxies.tasks import ResourceType
 
 IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
-# Skeletons need sub-labels, which a one-line spec cannot express.
 LABEL_TYPES = {
     "any",
     "cuboid",

--- a/cvat-sdk/examples/task_create_subtasks.py
+++ b/cvat-sdk/examples/task_create_subtasks.py
@@ -1,0 +1,136 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+"""Split annotation work over one set of images into several subtasks, one per
+object type and label group, so boxes, polygons, and tags are annotated in
+parallel by different people instead of all at once in one crowded task.
+
+Each --subtask spec is 'NAME:TYPE:label1,label2': the subtask's name, the shape
+type its labels are drawn with, and the labels themselves.
+
+The subtasks are standalone tasks, not tasks inside one project: tasks in a
+project share the project's label set, so a per-subtask label set cannot exist
+inside a single project.
+
+Steps:
+  1. Parse and validate every --subtask spec before creating anything.
+  2. Collect the images from --image-dir.
+  3. Create one task per spec, with that spec's labels typed to its shape type.
+  4. Print a summary of what each subtask got.
+
+Usage (run ``python task_create_subtasks.py --help`` for the full list of options):
+  python task_create_subtasks.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --image-dir ./images \\
+      --subtask 'boxes:rectangle:car,person' \\
+      --subtask 'roads:polygon:road,lane' \\
+      --subtask 'weather:tag:rain,snow'
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from cvat_sdk import make_client, models
+from cvat_sdk.core.proxies.tasks import ResourceType
+
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+# Skeletons need sub-labels, which a one-line spec cannot express.
+LABEL_TYPES = {
+    "any",
+    "cuboid",
+    "ellipse",
+    "mask",
+    "points",
+    "polygon",
+    "polyline",
+    "rectangle",
+    "tag",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--host", required=True, help="CVAT server URL, e.g. 'https://app.cvat.ai'")
+    parser.add_argument(
+        "--token",
+        required=True,
+        help="Personal Access Token (CVAT UI: Profile -> Security)",
+    )
+    parser.add_argument(
+        "--image-dir", type=Path, required=True, help="directory with the images to split"
+    )
+    parser.add_argument(
+        "--subtask",
+        action="append",
+        required=True,
+        metavar="NAME:TYPE:LABELS",
+        help="one subtask, e.g. 'boxes:rectangle:car,person' (repeat for more)",
+    )
+    parser.add_argument("--segment-size", type=int, help="frames per job, in every subtask")
+    parser.add_argument(
+        "--cleanup", action="store_true", help="delete the created subtasks at the end"
+    )
+    return parser.parse_args()
+
+
+def parse_subtask(spec: str) -> tuple[str, str, list[str]]:
+    """'boxes:rectangle:car,person' -> ('boxes', 'rectangle', ['car', 'person'])."""
+    name, _, rest = spec.partition(":")
+    type_, _, labels = rest.partition(":")
+    names = [label.strip() for label in labels.split(",") if label.strip()]
+    if not (name and type_ and names):
+        sys.exit(f"Bad --subtask {spec!r}: expected 'NAME:TYPE:label1,label2'")
+    if type_ not in LABEL_TYPES:
+        sys.exit(
+            f"Unknown label type {type_!r} in --subtask {spec!r}. "
+            f"Choose one of: {', '.join(sorted(LABEL_TYPES))}"
+        )
+    return name, type_, names
+
+
+def main() -> None:
+    args = parse_args()
+    # 1. Validate every spec first, so a typo in the last one costs nothing.
+    specs = [parse_subtask(spec) for spec in args.subtask]
+
+    # 2. The same images go into every subtask.
+    images = sorted(p for p in args.image_dir.iterdir() if p.suffix.lower() in IMAGE_SUFFIXES)
+    if not images:
+        sys.exit(f"No images found in {args.image_dir}")
+
+    created = []
+    with make_client(args.host, access_token=args.token) as client:
+        try:
+            for name, type_, label_names in specs:
+                task = client.tasks.create_from_data(
+                    spec=models.TaskWriteRequest(
+                        name=name,
+                        labels=[
+                            models.PatchedLabelRequest(name=label, type=type_)
+                            for label in label_names
+                        ],
+                        **({"segment_size": args.segment_size} if args.segment_size else {}),
+                    ),
+                    resource_type=ResourceType.LOCAL,
+                    resources=images,
+                )
+                created.append(task)
+                print(
+                    f"Created subtask {name!r} as task {task.id} "
+                    f"({type_}: {', '.join(label_names)}, {len(task.get_jobs())} job(s)): "
+                    f"{args.host}/tasks/{task.id}"
+                )
+            print(f"Created {len(created)} subtask(s) from {len(images)} image(s)")
+        finally:
+            # Clean up whatever was created, including after a mid-run failure.
+            if args.cleanup:
+                for task in created:
+                    task.remove()
+                    print(f"Deleted task {task.id}")
+            elif created:
+                print("Keeping the subtasks; pass --cleanup to delete them")
+
+
+if __name__ == "__main__":
+    main()

--- a/cvat-sdk/examples/task_create_with_honeypots.py
+++ b/cvat-sdk/examples/task_create_with_honeypots.py
@@ -1,0 +1,179 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+"""Create a task with honeypots: a pool of ground truth frames, a few of which
+are mixed into every annotation job, so each annotator's work can be scored
+against known answers without a separate review pass.
+
+Steps:
+  1. Collect the images from --image-dir.
+  2. Create the task with validation_params in "gt_pool" mode: the pool frames
+     (--pool-frame or --pool-frame-count) plus how many of them each annotation
+     job gets (--honeypots-per-job).
+  3. Print the layout the server built: the pool, and per annotation job which
+     honeypot frame stands in for which pool frame.
+  4. Optionally maintain the layout: --refresh reshuffles which pool frames land
+     in which job, --disable-frame retires a bad pool frame.
+
+Honeypots need an image task (not video). The task grows by the injected frames,
+and its segment_size reads back as 0, meaning "custom segments".
+
+Usage (run ``python task_create_with_honeypots.py --help`` for the full list of options):
+  python task_create_with_honeypots.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --image-dir ./images --pool-frame-count 20 --honeypots-per-job 2 --segment-size 50
+  python task_create_with_honeypots.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --image-dir ./images --pool-frame-count 20 --honeypots-per-job 2 --refresh
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from cvat_sdk import make_client, models
+from cvat_sdk.core.proxies.tasks import ResourceType
+
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--host", required=True, help="CVAT server URL, e.g. 'https://app.cvat.ai'")
+    parser.add_argument(
+        "--token",
+        required=True,
+        help="Personal Access Token (CVAT UI: Profile -> Security)",
+    )
+    parser.add_argument(
+        "--image-dir", type=Path, required=True, help="directory with the task's images"
+    )
+    parser.add_argument("--name", default="Task with honeypots", help="task name")
+    parser.add_argument(
+        "--labels", nargs="+", default=["object"], metavar="NAME", help="label names to create"
+    )
+    parser.add_argument("--segment-size", type=int, help="frames per annotation job")
+    pool = parser.add_mutually_exclusive_group(required=True)
+    pool.add_argument(
+        "--pool-frame", nargs="+", metavar="NAME", help="exact file names to use as pool frames"
+    )
+    pool.add_argument("--pool-frame-count", type=int, help="number of randomly chosen pool frames")
+    parser.add_argument(
+        "--honeypots-per-job",
+        type=int,
+        required=True,
+        help="pool frames mixed into each annotation job",
+    )
+    parser.add_argument(
+        "--refresh", action="store_true", help="reshuffle which pool frames land in which job"
+    )
+    parser.add_argument(
+        "--disable-frame",
+        type=int,
+        nargs="+",
+        metavar="FRAME",
+        help="retire these pool frames (frame indexes, as printed by this script)",
+    )
+    parser.add_argument("--cleanup", action="store_true", help="delete the created task at the end")
+    return parser.parse_args()
+
+
+def collect_images(image_dir: Path) -> list[Path]:
+    images = sorted(p for p in image_dir.iterdir() if p.suffix.lower() in IMAGE_SUFFIXES)
+    if not images:
+        sys.exit(f"No images found in {image_dir}")
+    return images
+
+
+def print_layout(client, task_id: int) -> models.ITaskValidationLayoutRead:
+    """The server's honeypot layout: the pool, and job -> (honeypot <- pool frame)."""
+    layout, _ = client.api_client.tasks_api.retrieve_validation_layout(task_id)
+    print(f"Validation pool frames: {list(layout.validation_frames)}")
+    print(f"Disabled frames: {list(layout.disabled_frames)}")
+
+    real_by_honeypot = dict(zip(layout.honeypot_frames, layout.honeypot_real_frames))
+    for job in sorted(client.jobs.list(task_id=task_id, type="annotation"), key=lambda j: j.id):
+        pairs = [
+            f"{honeypot}<-{real}"
+            for honeypot, real in real_by_honeypot.items()
+            if job.start_frame <= honeypot <= job.stop_frame
+        ]
+        print(f"  job {job.id} frames {job.start_frame}-{job.stop_frame}: {', '.join(pairs)}")
+    return layout
+
+
+def main() -> None:
+    args = parse_args()
+    images = collect_images(args.image_dir)
+
+    # 2. "gt_pool" mode injects pool frames into every annotation job.
+    validation_params = {
+        "mode": "gt_pool",
+        "frames_per_job_count": args.honeypots_per_job,
+    }
+    if args.pool_frame:
+        available = {path.name for path in images}
+        unknown = [name for name in args.pool_frame if name not in available]
+        if unknown:
+            sys.exit(f"Frame(s) {', '.join(unknown)} not in {args.image_dir}")
+        validation_params["frame_selection_method"] = "manual"
+        validation_params["frames"] = list(args.pool_frame)
+    else:
+        if args.pool_frame_count >= len(images):
+            sys.exit(f"--pool-frame-count must be smaller than the {len(images)} images available")
+        validation_params["frame_selection_method"] = "random_uniform"
+        validation_params["frame_count"] = args.pool_frame_count
+
+    with make_client(args.host, access_token=args.token) as client:
+        task = client.tasks.create_from_data(
+            spec=models.TaskWriteRequest(
+                name=args.name,
+                labels=[models.PatchedLabelRequest(name=name) for name in args.labels],
+                **({"segment_size": args.segment_size} if args.segment_size else {}),
+            ),
+            resource_type=ResourceType.LOCAL,
+            resources=images,
+            # "gt_pool" requires the task's frames to be laid out randomly, so
+            # annotators cannot learn "this position is always a honeypot".
+            data_params={"validation_params": validation_params, "sorting_method": "random"},
+        )
+        print(f"Created task {task.id} with {task.size} frames: {args.host}/tasks/{task.id}")
+
+        # 3. What the server actually built.
+        layout = print_layout(client, task.id)
+
+        # 4. Maintenance operations, each followed by the new layout.
+        if args.refresh:
+            client.api_client.tasks_api.partial_update_validation_layout(
+                task.id,
+                patched_task_validation_layout_write_request=(
+                    models.PatchedTaskValidationLayoutWriteRequest(
+                        frame_selection_method="random_uniform"
+                    )
+                ),
+            )
+            print("Refreshed the honeypots")
+            layout = print_layout(client, task.id)
+
+        if args.disable_frame:
+            unknown = [f for f in args.disable_frame if f not in layout.validation_frames]
+            if unknown:
+                sys.exit(f"Frame(s) {unknown} are not pool frames of task {task.id}")
+            disabled = sorted(set(layout.disabled_frames) | set(args.disable_frame))
+            client.api_client.tasks_api.partial_update_validation_layout(
+                task.id,
+                patched_task_validation_layout_write_request=(
+                    models.PatchedTaskValidationLayoutWriteRequest(disabled_frames=disabled)
+                ),
+            )
+            print(f"Retired pool frame(s) {args.disable_frame}")
+            print_layout(client, task.id)
+
+        if args.cleanup:
+            task.remove()
+            print(f"Deleted task {task.id}")
+        else:
+            print("Keeping the task; pass --cleanup to delete it")
+
+
+if __name__ == "__main__":
+    main()

--- a/cvat-sdk/examples/task_create_with_validation.py
+++ b/cvat-sdk/examples/task_create_with_validation.py
@@ -126,9 +126,6 @@ def main() -> None:
         if not gt_jobs:
             sys.exit(f"Task {task.id} has no ground truth job; check validation_params")
         gt_job = gt_jobs[0]
-        # The GT job's own frame list is padded with "placeholder.jpg" entries to
-        # mirror the task's full frame range, so the real validation frames come
-        # from the validation layout instead.
         layout, _ = client.api_client.tasks_api.retrieve_validation_layout(task.id)
         task_frames = task.get_frames_info()
         frame_names = [task_frames[index].name for index in layout.validation_frames]

--- a/cvat-sdk/examples/task_create_with_validation.py
+++ b/cvat-sdk/examples/task_create_with_validation.py
@@ -1,0 +1,162 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+"""Create a task with a ground truth validation set (a "gold set") and upload
+the ground truth annotations into it.
+
+The validation frames are moved into a separate ground truth job, which the
+annotators never see. Quality reports compare the annotation jobs against it.
+
+Steps:
+  1. Collect the images from --image-dir.
+  2. Create the task with validation_params in "gt" mode: either the exact
+     frames you name (--validation-frame) or a random sample (--frame-count,
+     reproducible with --random-seed).
+  3. Find the created ground truth job and print its frames.
+  4. Upload --gt-annotations into that job and print how many objects landed.
+
+Usage (run ``python task_create_with_validation.py --help`` for the full list of options):
+  python task_create_with_validation.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --image-dir ./images --validation-frame 'img_001.png' 'img_042.png' \\
+      --gt-annotations ground_truth.zip --gt-format 'COCO 1.0'
+  python task_create_with_validation.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --image-dir ./images --frame-count 20 --random-seed 42
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from cvat_sdk import make_client, models
+from cvat_sdk.core.proxies.tasks import ResourceType
+
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--host", required=True, help="CVAT server URL, e.g. 'https://app.cvat.ai'")
+    parser.add_argument(
+        "--token",
+        required=True,
+        help="Personal Access Token (CVAT UI: Profile -> Security)",
+    )
+    parser.add_argument(
+        "--image-dir", type=Path, required=True, help="directory with the task's images"
+    )
+    parser.add_argument("--name", default="Task with a validation set", help="task name")
+    parser.add_argument(
+        "--labels",
+        nargs="+",
+        default=["object"],
+        metavar="NAME",
+        help="label names to create (default: %(default)s)",
+    )
+    parser.add_argument("--segment-size", type=int, help="frames per annotation job")
+    frames = parser.add_mutually_exclusive_group(required=True)
+    frames.add_argument(
+        "--validation-frame",
+        nargs="+",
+        metavar="NAME",
+        help="exact file names to use as validation frames",
+    )
+    frames.add_argument(
+        "--frame-count", type=int, help="number of randomly chosen validation frames"
+    )
+    parser.add_argument(
+        "--random-seed", type=int, help="seed for --frame-count, for a reproducible split"
+    )
+    parser.add_argument(
+        "--gt-annotations", type=Path, help="annotations file to upload into the ground truth job"
+    )
+    parser.add_argument(
+        "--gt-format",
+        default="COCO 1.0",
+        help="importer name for --gt-annotations (default: '%(default)s')",
+    )
+    parser.add_argument("--cleanup", action="store_true", help="delete the created task at the end")
+    return parser.parse_args()
+
+
+def collect_images(image_dir: Path) -> list[Path]:
+    images = sorted(p for p in image_dir.iterdir() if p.suffix.lower() in IMAGE_SUFFIXES)
+    if not images:
+        sys.exit(f"No images found in {image_dir}")
+    return images
+
+
+def main() -> None:
+    args = parse_args()
+    images = collect_images(args.image_dir)
+
+    # 2. "gt" mode puts the validation frames into a separate ground truth job.
+    validation_params = {"mode": "gt"}
+    if args.validation_frame:
+        available = {path.name for path in images}
+        unknown = [name for name in args.validation_frame if name not in available]
+        if unknown:
+            sys.exit(f"Frame(s) {', '.join(unknown)} not in {args.image_dir}")
+        validation_params["frame_selection_method"] = "manual"
+        validation_params["frames"] = list(args.validation_frame)
+    else:
+        if args.frame_count >= len(images):
+            sys.exit(f"--frame-count must be smaller than the {len(images)} images available")
+        validation_params["frame_selection_method"] = "random_uniform"
+        validation_params["frame_count"] = args.frame_count
+        if args.random_seed is not None:
+            validation_params["random_seed"] = args.random_seed
+
+    with make_client(args.host, access_token=args.token) as client:
+        spec = models.TaskWriteRequest(
+            name=args.name,
+            labels=[models.PatchedLabelRequest(name=name) for name in args.labels],
+            **({"segment_size": args.segment_size} if args.segment_size else {}),
+        )
+        task = client.tasks.create_from_data(
+            spec=spec,
+            resource_type=ResourceType.LOCAL,
+            resources=images,
+            data_params={"validation_params": validation_params},
+        )
+        print(f"Created task {task.id} with {task.size} frames: {args.host}/tasks/{task.id}")
+
+        # 3. The ground truth job the server built from validation_params.
+        gt_jobs = client.jobs.list(task_id=task.id, type="ground_truth")
+        if not gt_jobs:
+            sys.exit(f"Task {task.id} has no ground truth job; check validation_params")
+        gt_job = gt_jobs[0]
+        # The GT job's own frame list is padded with "placeholder.jpg" entries to
+        # mirror the task's full frame range, so the real validation frames come
+        # from the validation layout instead.
+        layout, _ = client.api_client.tasks_api.retrieve_validation_layout(task.id)
+        task_frames = task.get_frames_info()
+        frame_names = [task_frames[index].name for index in layout.validation_frames]
+        print(f"Ground truth job {gt_job.id}: {len(frame_names)} frames")
+        print(f"Validation frames: {', '.join(frame_names)}")
+
+        # 4. Upload the ground truth itself.
+        if args.gt_annotations:
+            formats, _ = client.api_client.server_api.retrieve_annotation_formats()
+            importers = [f.name for f in formats.importers]
+            if args.gt_format not in importers:
+                sys.exit(
+                    f"Unknown import format {args.gt_format!r}. "
+                    f"Choose one of: {', '.join(importers)}"
+                )
+            gt_job.import_annotations(args.gt_format, args.gt_annotations)
+            annotations = gt_job.get_annotations()
+            count = len(annotations.tags) + len(annotations.shapes) + len(annotations.tracks)
+            print(f"Imported {count} objects into ground truth job {gt_job.id}")
+        else:
+            print("No --gt-annotations given; the ground truth job is empty")
+
+        if args.cleanup:
+            task.remove()
+            print(f"Deleted task {task.id}")
+        else:
+            print("Keeping the task; pass --cleanup to delete it")
+
+
+if __name__ == "__main__":
+    main()

--- a/cvat-sdk/examples/task_import_annotations_from_cloud.py
+++ b/cvat-sdk/examples/task_import_annotations_from_cloud.py
@@ -1,0 +1,168 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+"""Import annotations into an existing task straight from a registered cloud
+storage: the server pulls the file out of the bucket itself, nothing is
+uploaded from this machine. Handy when a model writes its predictions to a
+bucket, or when the annotation archive is too big to push through your own
+connection.
+
+The high-level Task.import_annotations() always uploads a local file, so the
+import request is made with the low-level API (client.api_client.tasks_api)
+and awaited with client.wait_for_completion.
+
+Steps:
+  1. Retrieve the task and count the objects it already has.
+  2. Fetch the server's import format list and validate --import-format.
+  3. Resolve the storage to read from: --cloud-storage-id, or the task's own
+     source storage when the flag is omitted.
+  4. Check that --filename really is in the bucket, to fail with a clear
+     message instead of a failed background job.
+  5. Start the import and wait for the background request to finish.
+  6. Count the objects again to show what the import added.
+
+Register a bucket first with cloud_storage_register.py to get the storage id.
+
+Usage (run ``python task_import_annotations_from_cloud.py --help`` for the full list of options):
+  python task_import_annotations_from_cloud.py --host 'https://app.cvat.ai' --token '<your token>' \\
+      --task-id 42 --cloud-storage-id 7 --filename 'annotations/task_42.zip' \\
+      --import-format 'COCO 1.0'
+"""
+
+import argparse
+import json
+import sys
+
+from cvat_sdk import make_client
+from cvat_sdk.core.proxies.types import Location
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--host", required=True, help="CVAT server URL, e.g. 'https://app.cvat.ai'")
+    parser.add_argument(
+        "--token",
+        required=True,
+        help="Personal Access Token (CVAT UI: Profile -> Security)",
+    )
+    parser.add_argument(
+        "--task-id", type=int, required=True, help="id of an existing task, e.g. 42"
+    )
+    parser.add_argument(
+        "--filename",
+        required=True,
+        help="object key of the annotation file in the bucket, e.g. 'annotations/task_42.zip'",
+    )
+    parser.add_argument(
+        "--cloud-storage-id",
+        type=int,
+        help="a registered cloud storage id (see cloud_storage_register.py); "
+        "omit to use the source storage configured in the task",
+    )
+    parser.add_argument(
+        "--import-format",
+        default="COCO 1.0",
+        help="importer name, e.g. 'COCO 1.0' (default: '%(default)s')",
+    )
+    parser.add_argument(
+        "--import-mode",
+        choices=["replace", "append"],
+        default="replace",
+        help="replace the task's annotations or add to them (default: '%(default)s')",
+    )
+    parser.add_argument(
+        "--no-file-check",
+        action="store_true",
+        help="skip the bucket listing of step 4 (e.g. when the credentials may only read "
+        "objects, not list them)",
+    )
+    return parser.parse_args()
+
+
+def count_objects(task) -> int:
+    """All annotation objects of a task: tags, shapes, and tracks."""
+    annotations = task.get_annotations()
+    return len(annotations.tags) + len(annotations.shapes) + len(annotations.tracks)
+
+
+def resolve_cloud_storage_id(task, requested_id: int | None) -> int:
+    """The explicitly requested storage, or the one configured in the task."""
+    if requested_id is not None:
+        return requested_id
+
+    storage = task.source_storage
+    if not storage or storage.location.value != Location.CLOUD_STORAGE.value:
+        sys.exit(f"Task {task.id} has no cloud source storage configured; pass --cloud-storage-id")
+    return storage.cloud_storage_id
+
+
+def bucket_contains(api, cloud_storage_id: int, key: str) -> bool:
+    """Whether the bucket has an object with this key.
+
+    retrieve_content_v2 lists one "directory" of the bucket per call and
+    returns the names inside it, so the key is split into prefix + name.
+    """
+    prefix, _, name = key.rpartition("/")
+    next_token = None
+    while True:
+        content, _ = api.retrieve_content_v2(
+            cloud_storage_id,
+            **({"prefix": f"{prefix}/"} if prefix else {}),
+            **({"next_token": next_token} if next_token else {}),
+        )
+        if any(entry.type.value == "REG" and entry.name == name for entry in content.content):
+            return True
+        if not content.next:
+            return False
+        next_token = content.next
+
+
+def main() -> None:
+    args = parse_args()
+    with make_client(args.host, access_token=args.token) as client:
+        # 1. The state before the import, to compare against.
+        task = client.tasks.retrieve(args.task_id)
+        print(f"Task {task.id}: {count_objects(task)} objects before import")
+
+        # 2. Validate the format against the server's list.
+        formats, _ = client.api_client.server_api.retrieve_annotation_formats()
+        names = [f.name for f in formats.importers]
+        if args.import_format not in names:
+            sys.exit(
+                f"Unknown import format {args.import_format!r}. Choose one of: {', '.join(names)}"
+            )
+
+        # 3. Where to read from.
+        cloud_storage_id = resolve_cloud_storage_id(task, args.cloud_storage_id)
+        print(f"Reading {args.filename!r} from cloud storage {cloud_storage_id}")
+
+        # 4. A missing key would only surface as a failed background job.
+        if not args.no_file_check and not bucket_contains(
+            client.api_client.cloudstorages_api, cloud_storage_id, args.filename
+        ):
+            sys.exit(f"{args.filename!r} was not found in cloud storage {cloud_storage_id}")
+
+        # 5. location=cloud_storage makes the server fetch the file itself; the
+        # response only starts a background request, whose id is awaited below.
+        _, response = client.api_client.tasks_api.create_annotations(
+            task.id,
+            format=args.import_format,
+            filename=args.filename,
+            location=Location.CLOUD_STORAGE,
+            cloud_storage_id=cloud_storage_id,
+            import_mode=args.import_mode,
+        )
+        rq_id = json.loads(response.data).get("rq_id") if response.data else None
+        if not rq_id:
+            sys.exit("The server did not return a request id (rq_id) for the import")
+
+        client.wait_for_completion(rq_id, log_prefix=f"Task {task.id} annotation import")
+        print(f"Imported {args.filename} as {args.import_format!r} ({args.import_mode})")
+
+        # 6. Re-read the annotations, so the count is the server's state.
+        print(f"Task {task.id}: {count_objects(task)} objects after import")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/content/en/docs/api_sdk/sdk/examples/_index.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/_index.md
@@ -30,6 +30,10 @@ All examples are tested in the latest SDK version.
 - [Authenticate](authentication) — `auth_token.py`, `auth_profile.py`, `auth_cli.py`
 - [Projects](projects) — create/list, backup, restore, dataset export
 - [Tasks](tasks) — create from a bucket, bulk-create in a project,
-  inspect and export
+  inspect and export, subtasks by object type, explicit job file mapping
 - [Jobs](jobs) — list jobs, round-robin assignment, batch-advance stages
+- [Annotations](annotations) — import, bulk-edit, per-label statistics, linting
+- [Ground truth](ground-truth) — validation sets, honeypots, specific ground truth frames
+- [Datasets](datasets) — incremental download, bulk export
 - [Cloud storage](cloud-storage) — attach an S3-compatible bucket
+- [Webhooks](webhooks) — register and ping a webhook, receive deliveries locally

--- a/site/content/en/docs/api_sdk/sdk/examples/_index.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/_index.md
@@ -32,7 +32,7 @@ All examples are tested in the latest SDK version.
 - [Tasks](tasks) — create from a bucket, bulk-create in a project,
   inspect and export, subtasks by object type, explicit job file mapping
 - [Jobs](jobs) — list jobs, round-robin assignment, batch-advance stages
-- [Annotations](annotations) — import, bulk-edit, per-label statistics, linting
+- [Annotations](annotations) — import from a file or a bucket, bulk-edit, per-label statistics, linting
 - [Ground truth](ground-truth) — validation sets, honeypots, specific ground truth frames
 - [Datasets](datasets) — incremental download, bulk export
 - [Cloud storage](cloud-storage) — attach an S3-compatible bucket

--- a/site/content/en/docs/api_sdk/sdk/examples/annotations.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/annotations.md
@@ -2,14 +2,15 @@
 title: 'Annotation recipes'
 linkTitle: 'Annotations'
 weight: 5
-description: 'Import annotations into a task, edit them in bulk, and aggregate annotation statistics over a project'
+description: 'Import annotations into a task, edit them in bulk, aggregate statistics, and lint a project'
 ---
 
-Three recipes: `task_import_annotations.py` loads an annotation file into an
+Four recipes: `task_import_annotations.py` loads an annotation file into an
 existing task, `task_edit_annotations.py` reads a task's annotations, applies
 a bulk edit, and writes it back, and `project_annotation_stats.py` walks a
 project's tasks and aggregates object counts per label and type into a CSV
-report.
+report, and `project_data_lint.py` checks a project's annotations for broken
+geometry, duplicates, and empty work before you export it.
 
 ## Import annotations into a task
 
@@ -85,6 +86,38 @@ python project_annotation_stats.py --host 'https://app.cvat.ai' --token '<your t
 
 {{< include-code "assets/sdk-examples/project_annotation_stats.py" >}}
 
+## Lint a project's data and annotations
+
+Walks a project's tasks and reports six classes of problem, each with a
+severity: shapes that leave the frame, rectangles with (almost) no area, and
+duplicated objects are errors; frames nobody annotated and jobs marked
+completed with nothing in them are warnings; labels nobody used are info.
+Findings are printed grouped by severity and written to `data_lint.csv`. The
+script exits 1 when any error exists, so it can gate an export pipeline —
+`--no-fail` turns that off.
+
+Masks and skeletons are skipped by the geometry checks (their points are not
+plain x/y pairs), and objects marked `outside` are skipped everywhere.
+
+| Flag | Required | Meaning |
+| --- | --- | --- |
+| `--host` | yes | Server URL |
+| `--token` | yes | Personal Access Token |
+| `--project-id` | yes | Id of the project to lint |
+| `--task-id ID [ID ...]` | no | Lint only these tasks of the project |
+| `--min-box-area` | no | Rectangles below this many px² are errors (default `4`) |
+| `--output` | no | CSV report path (default `data_lint.csv`) |
+| `--no-fail` | no | Exit 0 even when errors were found |
+
+```bash
+python project_data_lint.py --host 'https://app.cvat.ai' --token '<your token>' \
+    --project-id 7 --min-box-area 16
+```
+
+### The script
+
+{{< include-code "assets/sdk-examples/project_data_lint.py" >}}
+
 _Other SDK options:_
 
 | SDK method / parameter | What it adds |
@@ -97,6 +130,8 @@ _Other SDK options:_
 | `Task.update_annotations(PatchedLabeledDataRequest(...), action=AnnotationUpdateAction.CREATE \| UPDATE \| DELETE)` | Partial update: create, update, or delete only the objects in the request. |
 | `Task.remove_annotations(ids=[...])` | Delete specific objects by id — or all of them when `ids` is omitted. |
 | `Project.get_annotations()` | Read the annotations of every task in a project in one call. |
+| `Task.get_frames_info()` | Frame names and sizes — what the geometry checks compare against. |
+| `Task.get_jobs()` | Job frame ranges and states, so a finding can name the job to fix. |
 
 _Notes:_
 
@@ -104,7 +139,9 @@ _Notes:_
   `task.get_labels()` maps names to ids.
 - Both editing recipes re-read the annotations after writing, so the printed
   "after" counts show the server's state, not the client's intention.
+- The linter reads only; fix what it reports with `task_edit_annotations.py` or in the UI.
 - Full recipes:
   [`task_import_annotations.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_import_annotations.py),
   [`task_edit_annotations.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_edit_annotations.py),
-  [`project_annotation_stats.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/project_annotation_stats.py).
+  [`project_annotation_stats.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/project_annotation_stats.py),
+  [`project_data_lint.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/project_data_lint.py).

--- a/site/content/en/docs/api_sdk/sdk/examples/annotations.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/annotations.md
@@ -2,15 +2,17 @@
 title: 'Annotation recipes'
 linkTitle: 'Annotations'
 weight: 5
-description: 'Import annotations into a task, edit them in bulk, aggregate statistics, and lint a project'
+description: 'Import annotations into a task from a file or a bucket, edit them in bulk, aggregate statistics, and lint a project'
 ---
 
-Four recipes: `task_import_annotations.py` loads an annotation file into an
-existing task, `task_edit_annotations.py` reads a task's annotations, applies
-a bulk edit, and writes it back, and `project_annotation_stats.py` walks a
-project's tasks and aggregates object counts per label and type into a CSV
-report, and `project_data_lint.py` checks a project's annotations for broken
-geometry, duplicates, and empty work before you export it.
+Five recipes: `task_import_annotations.py` loads an annotation file into an
+existing task, `task_import_annotations_from_cloud.py` does the same with a
+file that stays in a registered cloud storage, `task_edit_annotations.py`
+reads a task's annotations, applies a bulk edit, and writes it back,
+`project_annotation_stats.py` walks a project's tasks and aggregates object
+counts per label and type into a CSV report, and `project_data_lint.py`
+checks a project's annotations for broken geometry, duplicates, and empty
+work before you export it.
 
 ## Import annotations into a task
 
@@ -35,6 +37,53 @@ python task_import_annotations.py --host 'https://app.cvat.ai' --token '<your to
 ### The script
 
 {{< include-code "assets/sdk-examples/task_import_annotations.py" >}}
+
+## Import annotations from a cloud storage
+
+Imports an annotation file that is already in a registered bucket: CVAT
+downloads the object itself, so nothing is uploaded from the machine running
+the script. Useful when a model writes its predictions to the bucket, or when
+the archive is too big to push through your own connection.
+
+The high-level `Task.import_annotations()` always uploads a local file, so this
+recipe posts the import request through the low-level
+`client.api_client.tasks_api` with `location=Location.CLOUD_STORAGE` and awaits
+the returned `rq_id` with `client.wait_for_completion()`.
+
+Before starting the import, the recipe checks that the object key really is in
+the bucket — otherwise a typo would only show up as a failed background
+request. Pass `--no-file-check` to skip that listing (for example when the
+credentials may read objects but not list them).
+
+| Flag | Required | Meaning |
+| --- | --- | --- |
+| `--host` | yes | Server URL |
+| `--token` | yes | Personal Access Token |
+| `--task-id` | yes | Id of the task to import into |
+| `--filename` | yes | Object key in the bucket, e.g. `'annotations/task_42.zip'` |
+| `--cloud-storage-id` | no | Registered cloud storage id; omit to use the task's own source storage |
+| `--import-format` | no | Importer name (default `'COCO 1.0'`) |
+| `--import-mode` | no | `replace` (default) or `append` |
+| `--no-file-check` | no | Skip the bucket listing that verifies `--filename` |
+
+```bash
+# explicit bucket
+python task_import_annotations_from_cloud.py --host 'https://app.cvat.ai' --token '<your token>' \
+    --task-id 42 --cloud-storage-id 7 --filename 'annotations/task_42.zip' \
+    --import-format 'COCO 1.0'
+
+# the bucket configured as the task's source storage, adding to the existing objects
+python task_import_annotations_from_cloud.py --host 'https://app.cvat.ai' --token '<your token>' \
+    --task-id 42 --filename 'predictions/task_42.zip' --import-mode append
+```
+
+Register the bucket first with
+[`cloud_storage_register.py`](/docs/api_sdk/sdk/examples/cloud-storage/) to get
+the storage id.
+
+### The script
+
+{{< include-code "assets/sdk-examples/task_import_annotations_from_cloud.py" >}}
 
 ## Read, edit, and write back annotations
 
@@ -137,6 +186,9 @@ _Other SDK options:_
 | `Task.import_annotations(..., conv_mask_to_poly=True)` | Convert imported masks to polygons on the fly. |
 | `Task.import_annotations(..., pbar=ProgressReporter())` | Report upload progress (a `cvat_sdk.core.progress.ProgressReporter`). |
 | `Job.import_annotations(format_name, path)` | The same import scoped to a single job. |
+| `jobs_api.create_annotations(id, format=..., filename=..., location=..., cloud_storage_id=...)` | The bucket import scoped to a single job. |
+| `projects_api.create_dataset(id, format=..., filename=..., location=..., cloud_storage_id=...)` | Import a whole dataset into a project from a bucket. |
+| `cloudstorages_api.retrieve_content_v2(id, prefix=...)` | List a bucket's objects — how the recipe checks the key before importing. |
 | `Task.set_annotations(LabeledDataRequest(...))` | Replace a task's annotations with the given objects. |
 | `Task.update_annotations(PatchedLabeledDataRequest(...), action=AnnotationUpdateAction.CREATE \| UPDATE \| DELETE)` | Partial update: create, update, or delete only the objects in the request. |
 | `Task.remove_annotations(ids=[...])` | Delete specific objects by id — or all of them when `ids` is omitted. |
@@ -151,8 +203,15 @@ _Notes:_
 - Both editing recipes re-read the annotations after writing, so the printed
   "after" counts show the server's state, not the client's intention.
 - The linter reads only; fix what it reports with `task_edit_annotations.py` or in the UI.
+- A bucket import is a background request: the POST only returns an `rq_id`,
+  and the annotations appear once `client.wait_for_completion()` returns. A
+  missing key or wrong credentials surface as a failed request, not as an error
+  on the POST.
+- `--filename` is the object key as seen from the bucket root, including any
+  "directory" prefix.
 - Full recipes:
   [`task_import_annotations.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_import_annotations.py),
+  [`task_import_annotations_from_cloud.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_import_annotations_from_cloud.py),
   [`task_edit_annotations.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_edit_annotations.py),
   [`project_annotation_stats.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/project_annotation_stats.py),
   [`project_data_lint.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/project_data_lint.py).

--- a/site/content/en/docs/api_sdk/sdk/examples/annotations.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/annotations.md
@@ -88,23 +88,34 @@ python project_annotation_stats.py --host 'https://app.cvat.ai' --token '<your t
 
 ## Lint a project's data and annotations
 
-Walks a project's tasks and reports six classes of problem, each with a
-severity: shapes that leave the frame, rectangles with (almost) no area, and
-duplicated objects are errors; frames nobody annotated and jobs marked
-completed with nothing in them are warnings; labels nobody used are info.
-Findings are printed grouped by severity and written to `data_lint.csv`. The
-script exits 1 when any error exists, so it can gate an export pipeline —
-`--no-fail` turns that off.
+Walks a project's tasks and runs five checks. Findings have a severity
+and are printed grouped by severity and written to
+`data_lint.csv`. The script exits 1 when any error exists, so it can gate an
+export pipeline — `--no-fail` turns that off.
+
+| Check | Severity | What it means |
+| --- | --- | --- |
+| `out-of-bounds` | error | The shape leaves the frame |
+| `degenerate-box` | error | The rectangle has (almost) no area |
+| `duplicate-object` | error | An identical object on the same frame |
+| `dead-object` | error | The object is on a deleted frame or beyond the last task frame and is omitted from dataset exports |
+| `unused-label` | info | The label was never used |
+
+Empty frames and completed jobs without objects can be valid negative
+examples, so the script does not report them as problems.
 
 Masks and skeletons are skipped by the geometry checks (their points are not
 plain x/y pairs), and objects marked `outside` are skipped everywhere.
+Geometry checks inspect individual shapes and track keyframes; they do not
+interpolate tracks. Video frame counts come from the task's `size`, because
+a video reports one metadata entry for the whole file.
 
 | Flag | Required | Meaning |
 | --- | --- | --- |
 | `--host` | yes | Server URL |
 | `--token` | yes | Personal Access Token |
 | `--project-id` | yes | Id of the project to lint |
-| `--task-id ID [ID ...]` | no | Lint only these tasks of the project |
+| `--task-id ID [ID ...]` | no | Lint only these tasks of the project; they are retrieved by id, so a big project is not listed |
 | `--min-box-area` | no | Rectangles below this many px² are errors (default `4`) |
 | `--output` | no | CSV report path (default `data_lint.csv`) |
 | `--no-fail` | no | Exit 0 even when errors were found |

--- a/site/content/en/docs/api_sdk/sdk/examples/cloud-storage.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/cloud-storage.md
@@ -1,7 +1,7 @@
 ---
 title: 'Cloud storage recipes'
 linkTitle: 'Cloud storage'
-weight: 6
+weight: 8
 description: 'Attach an S3-compatible bucket to CVAT via the low-level cloud storages API'
 ---
 

--- a/site/content/en/docs/api_sdk/sdk/examples/datasets.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/datasets.md
@@ -1,0 +1,41 @@
+---
+title: 'Dataset recipes'
+linkTitle: 'Datasets'
+weight: 7
+description: 'Download only what changed, and export many tasks in one run'
+---
+
+Two recipes for getting datasets out of CVAT at scale:
+`dataset_incremental_download.py` re-exports only the tasks that changed since
+its previous run, and `dataset_bulk_export.py` exports a whole selection of
+tasks in one go, with a manifest and resume. For exporting a single project's
+tasks locally and to a bucket, see
+[`project_export_dataset.py`](../projects#export-a-projects-tasks-as-datasets).
+
+## Download only what changed
+
+Keeps a small JSON state file next to the exports. On each run it asks the
+server for the project's tasks updated after the previous run — the
+`updated_date__gt` keyword becomes a server-side filter — exports only those,
+and records each task's `updated_date` immediately after its export succeeds,
+so an interrupted run resumes instead of starting over. Tasks that vanished
+from the server are reported, not silently forgotten.
+
+| Flag | Required | Meaning |
+| --- | --- | --- |
+| `--host` | yes | Server URL |
+| `--token` | yes | Personal Access Token |
+| `--project-id` | yes | Id of the project to track |
+| `--state` | no | State file (default `incremental_state.json`) |
+| `--output-dir` | no | Where the exports go (default `datasets`) |
+| `--export-format` | no | Exporter name (default `'COCO 1.0'`) |
+| `--with-images` | no | Include images — much larger and slower |
+
+```bash
+python dataset_incremental_download.py --host 'https://app.cvat.ai' --token '<your token>' \
+    --project-id 7 --output-dir datasets
+```
+
+### The script
+
+{{< include-code "assets/sdk-examples/dataset_incremental_download.py" >}}

--- a/site/content/en/docs/api_sdk/sdk/examples/datasets.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/datasets.md
@@ -39,3 +39,58 @@ python dataset_incremental_download.py --host 'https://app.cvat.ai' --token '<yo
 ### The script
 
 {{< include-code "assets/sdk-examples/dataset_incremental_download.py" >}}
+
+## Export many tasks in one run
+
+Picks tasks by project, by explicit ids, by status, or a combination, and
+exports each one to a local directory, to a registered cloud storage, or both.
+Every result — including failures — lands in a CSV manifest, and one failing
+task never aborts the run: the script finishes the rest and exits 1.
+`--skip-existing` makes an interrupted run resumable, and `--jobs N` exports
+in parallel with **one client per worker thread**, because a `Client` is not
+safe to share across threads.
+
+| Flag | Required | Meaning |
+| --- | --- | --- |
+| `--host` | yes | Server URL |
+| `--token` | yes | Personal Access Token |
+| `--project-id` | one of `--project-id` / `--task-id` | Export every task of this project |
+| `--task-id ID [ID ...]` | one of `--project-id` / `--task-id` | Export these task ids |
+| `--status` | no | Keep only tasks in `annotation`, `validation`, or `completed` |
+| `--output-dir` | one of `--output-dir` / `--cloud-storage-id` | Local destination |
+| `--cloud-storage-id` | one of `--output-dir` / `--cloud-storage-id` | Cloud destination |
+| `--export-format` | no | Exporter name (default `'COCO 1.0'`) |
+| `--jobs` | no | Parallel exports (default `1`) |
+| `--skip-existing` | no | Skip tasks already exported into `--output-dir` |
+| `--with-images` | no | Include images |
+| `--output` | no | Manifest path (default `bulk_export.csv`) |
+
+```bash
+python dataset_bulk_export.py --host 'https://app.cvat.ai' --token '<your token>' \
+    --project-id 7 --output-dir datasets --jobs 4
+```
+
+### The script
+
+{{< include-code "assets/sdk-examples/dataset_bulk_export.py" >}}
+
+_Other SDK options:_
+
+| SDK method / parameter | What it adds |
+| --- | --- |
+| `Task.export_dataset(..., include_images=True)` | Ship the media with the annotations. |
+| `Task.export_dataset(..., location=Location.CLOUD_STORAGE, cloud_storage_id=N)` | Write the result to a bucket instead of downloading it. |
+| `Project.export_dataset(format_name, path)` | One archive for a whole project instead of per-task archives. |
+| `Job.export_dataset(format_name, path)` | The same export scoped to a single job. |
+| `Task.download_backup(path)` | A backup (data + annotations + settings) rather than a dataset. |
+| `client.tasks.list(updated_date__gt=..., status=..., name__contains=...)` | Server-side selection; see the [filtering guide](../../highlevel-api). |
+
+_Notes:_
+
+- `updated_date` changes when a task's fields, data, or annotations change, so it
+  is what the incremental recipe keys on.
+- The state file is plain JSON — delete it to force a full re-download, or keep
+  one per project.
+- Full recipes:
+  [`dataset_incremental_download.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/dataset_incremental_download.py),
+  [`dataset_bulk_export.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/dataset_bulk_export.py).

--- a/site/content/en/docs/api_sdk/sdk/examples/datasets.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/datasets.md
@@ -7,33 +7,55 @@ description: 'Download only what changed, and export many tasks in one run'
 
 Two recipes for getting datasets out of CVAT at scale:
 `dataset_incremental_download.py` re-exports only the tasks that changed since
-its previous run, and `dataset_bulk_export.py` exports a whole selection of
+a supplied timestamp, and `dataset_bulk_export.py` exports a whole selection of
 tasks in one go, with a manifest and resume. For exporting a single project's
 tasks locally and to a bucket, see
 [`project_export_dataset.py`](../projects#export-a-projects-tasks-as-datasets).
 
+## Export a task or project
+
+The core calls are `task.export_dataset(...)` and `project.export_dataset(...)`:
+
+```python
+from cvat_sdk import make_client
+from cvat_sdk.core.proxies.types import Location
+
+with make_client("https://app.cvat.ai", access_token="<your token>") as client:
+    task = client.tasks.retrieve(10)
+    task.export_dataset("COCO 1.0", "task_10.zip", include_images=False, location=Location.LOCAL)
+
+    project = client.projects.retrieve(7)
+    project.export_dataset("COCO 1.0", "project_7.zip", include_images=False, location=Location.LOCAL)
+```
+
+Each call downloads one archive. The recipes below add incremental selection
+or exports of multiple tasks to this basic workflow.
+
 ## Download only what changed
 
-Keeps a small JSON state file next to the exports. On each run it asks the
-server for the project's tasks updated after the previous run — the
-`updated_date__gt` keyword becomes a server-side filter — exports only those,
-and records each task's `updated_date` immediately after its export succeeds,
-so an interrupted run resumes instead of starting over. Tasks that vanished
-from the server are reported, not silently forgotten.
+Pass `--updated-after` to export tasks changed after an ISO 8601 timestamp.
+The `updated_date__gt` filter selects those tasks on the server. Omit the
+option for a full download. Each selected task replaces its previous archive.
+
+Your pipeline owns the synchronization timestamp and its storage, whether
+that is a file, a database, or another service. Advance the timestamp only
+after all exports succeed; retry a failed run with the same timestamp. Choose
+a checkpoint from before the run, using a clock consistent with the server,
+so changes made during export are included on the next run.
 
 | Flag | Required | Meaning |
 | --- | --- | --- |
 | `--host` | yes | Server URL |
 | `--token` | yes | Personal Access Token |
 | `--project-id` | yes | Id of the project to track |
-| `--state` | no | State file (default `incremental_state.json`) |
+| `--updated-after` | no | Export tasks updated after this ISO 8601 timestamp, e.g. `'2026-09-01T00:00:00+00:00'` |
 | `--output-dir` | no | Where the exports go (default `datasets`) |
 | `--export-format` | no | Exporter name (default `'COCO 1.0'`) |
 | `--with-images` | no | Include images — much larger and slower |
 
 ```bash
 python dataset_incremental_download.py --host 'https://app.cvat.ai' --token '<your token>' \
-    --project-id 7 --output-dir datasets
+    --project-id 7 --output-dir datasets --updated-after '2026-09-01T00:00:00+00:00'
 ```
 
 ### The script
@@ -56,7 +78,7 @@ safe to share across threads.
 | `--token` | yes | Personal Access Token |
 | `--project-id` | one of `--project-id` / `--task-id` | Export every task of this project |
 | `--task-id ID [ID ...]` | one of `--project-id` / `--task-id` | Export these task ids |
-| `--status` | no | Keep only tasks in `annotation`, `validation`, or `completed` |
+| `--status` | no | Keep only tasks in `annotation`, `validation`, or `completed`; with `--task-id` it is applied after the ids are resolved, so an id in another status is reported as filtered out rather than as missing |
 | `--output-dir` | one of `--output-dir` / `--cloud-storage-id` | Local destination |
 | `--cloud-storage-id` | one of `--output-dir` / `--cloud-storage-id` | Cloud destination |
 | `--export-format` | no | Exporter name (default `'COCO 1.0'`) |
@@ -89,8 +111,7 @@ _Notes:_
 
 - `updated_date` changes when a task's fields, data, or annotations change, so it
   is what the incremental recipe keys on.
-- The state file is plain JSON — delete it to force a full re-download, or keep
-  one per project.
+- Omit `--updated-after` to force a full re-download.
 - Full recipes:
   [`dataset_incremental_download.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/dataset_incremental_download.py),
   [`dataset_bulk_export.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/dataset_bulk_export.py).

--- a/site/content/en/docs/api_sdk/sdk/examples/ground-truth.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/ground-truth.md
@@ -85,3 +85,56 @@ python task_create_with_honeypots.py --host 'https://app.cvat.ai' --token '<your
 ### The script
 
 {{< include-code "assets/sdk-examples/task_create_with_honeypots.py" >}}
+
+## Choose exactly which frames are ground truth
+
+Adds a ground truth job to a task that already exists, with the frames you
+name — by index (`--frame`) or by file name (`--frame-name`, resolved through
+the task's frame list). A task can hold one ground truth job, so the recipe
+refuses to overwrite an existing one unless `--replace` is passed: deleting a
+ground truth job discards its annotations. Afterwards it reads the task's
+validation layout back, so the printed frame list is the server's.
+
+| Flag | Required | Meaning |
+| --- | --- | --- |
+| `--host` | yes | Server URL |
+| `--token` | yes | Personal Access Token |
+| `--task-id` | yes | Id of the task to add the ground truth job to |
+| `--frame N [N ...]` | one of `--frame` / `--frame-name` | Frame indexes |
+| `--frame-name NAME [NAME ...]` | one of `--frame` / `--frame-name` | Frame file names |
+| `--replace` | no | Delete an existing ground truth job first |
+| `--cleanup` | no | Delete the created ground truth job at the end (never the task) |
+
+```bash
+python task_add_gt_frames.py --host 'https://app.cvat.ai' --token '<your token>' \
+    --task-id 42 --frame 0 17 42
+```
+
+### The script
+
+{{< include-code "assets/sdk-examples/task_add_gt_frames.py" >}}
+
+_Other SDK options:_
+
+| SDK method / parameter | What it adds |
+| --- | --- |
+| `validation_params={"mode": "gt", "frame_selection_method": "random_per_job", "frames_per_job_count": N}` | Sample validation frames per annotation job instead of task-wide. |
+| `validation_params={..., "frame_share": 0.1}` / `"frames_per_job_share"` | Express the sample as a share instead of a count. |
+| `JobWriteRequest(type="ground_truth", frame_selection_method="random_uniform", frame_count=N)` | Add a ground truth job with a random sample to an existing task. |
+| `jobs_api.partial_update_validation_layout(job_id, ...)` | Change the honeypots of one annotation job instead of the whole task. |
+| `tasks_api.retrieve_validation_layout(task_id)` | Read the pool, honeypots, and disabled frames at any time. |
+| `Job.import_annotations(format_name, path)` | Upload ground truth into a ground truth job. |
+
+_Notes:_
+
+- `gt` mode moves the validation frames into a separate ground truth job;
+  `gt_pool` mode copies pool frames into the annotation jobs. Only `gt_pool`
+  makes annotators encounter validation frames while working.
+- Validation frames are referenced by **file name** in `validation_params` and by
+  **frame index** in `JobWriteRequest` and the validation layout API.
+- Quality reports use whatever the ground truth job holds, so upload the ground
+  truth before comparing.
+- Full recipes:
+  [`task_create_with_validation.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_create_with_validation.py),
+  [`task_create_with_honeypots.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_create_with_honeypots.py),
+  [`task_add_gt_frames.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_add_gt_frames.py).

--- a/site/content/en/docs/api_sdk/sdk/examples/ground-truth.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/ground-truth.md
@@ -46,3 +46,42 @@ python task_create_with_validation.py --host 'https://app.cvat.ai' --token '<you
 ### The script
 
 {{< include-code "assets/sdk-examples/task_create_with_validation.py" >}}
+
+## Create a task with honeypots
+
+Creates the task with `validation_params` in `gt_pool` mode: a pool of ground
+truth frames, `--honeypots-per-job` of which are mixed into every annotation
+job. Then it prints the layout the server actually built — the pool, and per
+job which honeypot frame stands in for which pool frame — so you can see what
+the annotators will get. `--refresh` reshuffles that mapping (useful once
+annotators start recognizing the honeypots), and `--disable-frame` retires a
+pool frame whose ground truth turned out to be wrong.
+
+Honeypots need an image task, not a video one. The pool is appended after the
+task's own frames, so the task grows by the injected frames, and
+`segment_size` reads back as `0`, which means "custom segments". `gt_pool`
+also requires the task's frames to be laid out with `sorting_method: random`,
+so annotators cannot learn "this position is always a honeypot" — the recipe
+sets this automatically.
+
+| Flag | Required | Meaning |
+| --- | --- | --- |
+| `--host` | yes | Server URL |
+| `--token` | yes | Personal Access Token |
+| `--image-dir` | yes | Directory with the task's images |
+| `--pool-frame NAME [NAME ...]` | one of `--pool-frame` / `--pool-frame-count` | Exact pool frames |
+| `--pool-frame-count N` | one of `--pool-frame` / `--pool-frame-count` | Randomly sample N pool frames |
+| `--honeypots-per-job` | yes | Pool frames mixed into each annotation job |
+| `--refresh` | no | Reshuffle which pool frames land in which job |
+| `--disable-frame FRAME [FRAME ...]` | no | Retire pool frames by index |
+| `--name`, `--labels`, `--segment-size` | no | Task name, labels, frames per annotation job |
+| `--cleanup` | no | Delete the created task at the end |
+
+```bash
+python task_create_with_honeypots.py --host 'https://app.cvat.ai' --token '<your token>' \
+    --image-dir ./images --pool-frame-count 20 --honeypots-per-job 2 --segment-size 50
+```
+
+### The script
+
+{{< include-code "assets/sdk-examples/task_create_with_honeypots.py" >}}

--- a/site/content/en/docs/api_sdk/sdk/examples/ground-truth.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/ground-truth.md
@@ -1,0 +1,48 @@
+---
+title: 'Ground truth recipes'
+linkTitle: 'Ground truth'
+weight: 6
+description: 'Create validation sets and honeypots, and choose exactly which frames are ground truth'
+---
+
+Three recipes for the quality-control side of a task:
+`task_create_with_validation.py` creates a task with a gold set and uploads the
+ground truth into it, `task_create_with_honeypots.py` builds a task whose every
+annotation job carries validation frames, and `task_add_gt_frames.py` adds a
+ground truth job with an exact frame list to a task that already exists.
+
+## Create a task with a gold set
+
+Creates the task with `validation_params` in `gt` mode, so the validation
+frames move into a separate ground truth job that annotators never see. Pick
+the frames by name (`--validation-frame`) or let the server sample them
+(`--frame-count`, reproducible with `--random-seed`). The recipe then uploads
+`--gt-annotations` into that ground truth job and reports how many objects
+landed — after this, quality reports can compare the annotation jobs against it.
+
+The ground truth job's own frame list is padded with placeholder entries to
+mirror the task's full frame range, so the recipe reads the real validation
+frames from the task's validation layout instead of the job's frame list.
+
+| Flag | Required | Meaning |
+| --- | --- | --- |
+| `--host` | yes | Server URL |
+| `--token` | yes | Personal Access Token |
+| `--image-dir` | yes | Directory with the task's images |
+| `--validation-frame NAME [NAME ...]` | one of `--validation-frame` / `--frame-count` | Exact validation frames |
+| `--frame-count N` | one of `--validation-frame` / `--frame-count` | Randomly sample N validation frames |
+| `--random-seed` | no | Makes `--frame-count` reproducible |
+| `--gt-annotations` | no | Annotations file to upload into the ground truth job |
+| `--gt-format` | no | Importer name (default `'COCO 1.0'`) |
+| `--name`, `--labels`, `--segment-size` | no | Task name, labels, frames per annotation job |
+| `--cleanup` | no | Delete the created task at the end |
+
+```bash
+python task_create_with_validation.py --host 'https://app.cvat.ai' --token '<your token>' \
+    --image-dir ./images --validation-frame 'img_001.png' 'img_042.png' \
+    --gt-annotations ground_truth.zip --gt-format 'COCO 1.0'
+```
+
+### The script
+
+{{< include-code "assets/sdk-examples/task_create_with_validation.py" >}}

--- a/site/content/en/docs/api_sdk/sdk/examples/tasks.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/tasks.md
@@ -5,11 +5,14 @@ weight: 3
 description: 'Create one task or a batch of tasks from a bucket; inspect and export existing tasks'
 ---
 
-Three recipes cover the task lifecycle: `task_create_from_cloud.py` creates one
+Five recipes cover the task lifecycle: `task_create_from_cloud.py` creates one
 task from object keys already in a registered bucket,
 `tasks_bulk_from_cloud.py` creates a whole batch of tasks in a project from
-that same bucket, and `task_inspect_and_export.py` inspects an existing task,
-exports its dataset locally, and reports analytics from its event log.
+that same bucket, `task_inspect_and_export.py` inspects an existing task,
+exports its dataset locally, and reports analytics from its event log,
+`task_create_subtasks.py` splits one set of images into subtasks by object
+type, and `task_create_job_mapping.py` creates a task with an explicit
+file-to-job mapping.
 
 ## Create a task from cloud object keys
 
@@ -103,6 +106,43 @@ python task_inspect_and_export.py --host 'https://app.cvat.ai' --token '<your to
 ### The script
 
 {{< include-code "assets/sdk-examples/task_inspect_and_export.py" >}}
+
+## Split work into subtasks by object type
+
+Creates one task per `--subtask 'NAME:TYPE:label1,label2'` spec over the same
+images, with that spec's labels typed to its shape type. Boxes, polygons, and
+tags then get annotated in parallel, each in a task that shows only the labels
+its annotator needs.
+
+The subtasks are **standalone tasks, not tasks inside one project**: tasks in a
+project share the project's label set, so a per-subtask label set cannot exist
+inside a single project — the SDK rejects labels on a task that has a
+`project_id`. Every spec is validated before anything is created, and
+`--cleanup` deletes the subtasks created so far even if a later one fails.
+
+| Flag | Required | Meaning |
+| --- | --- | --- |
+| `--host` | yes | Server URL |
+| `--token` | yes | Personal Access Token |
+| `--image-dir` | yes | Directory with the images to split |
+| `--subtask NAME:TYPE:LABELS` | yes | One subtask; repeat for more |
+| `--segment-size` | no | Frames per job, in every subtask |
+| `--cleanup` | no | Delete the created subtasks at the end |
+
+`TYPE` is one of `rectangle`, `polygon`, `polyline`, `points`, `ellipse`,
+`cuboid`, `mask`, `tag`, `any`.
+
+```bash
+python task_create_subtasks.py --host 'https://app.cvat.ai' --token '<your token>' \
+    --image-dir ./images \
+    --subtask 'boxes:rectangle:car,person' \
+    --subtask 'roads:polygon:road,lane' \
+    --subtask 'weather:tag:rain,snow'
+```
+
+### The script
+
+{{< include-code "assets/sdk-examples/task_create_subtasks.py" >}}
 
 _Other SDK options:_
 

--- a/site/content/en/docs/api_sdk/sdk/examples/tasks.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/tasks.md
@@ -144,6 +144,42 @@ python task_create_subtasks.py --host 'https://app.cvat.ai' --token '<your token
 
 {{< include-code "assets/sdk-examples/task_create_subtasks.py" >}}
 
+## Decide which files go into which job
+
+Normally CVAT cuts a task into jobs of `segment_size` frames. The
+`job_file_mapping` data parameter replaces that with an explicit grouping: one
+job per camera, per scene, or per delivery batch. Group the files yourself with
+repeated `--job` flags, or chunk the directory with `--files-per-job N`.
+
+Every file in `--image-dir` must belong to exactly one job — unknown files,
+duplicates, and leftovers are rejected before the task is created. Afterwards
+the recipe reads the jobs back from the server and writes
+`job_file_mapping.csv`, so the mapping you see is the one that exists.
+
+`job_file_mapping` implies predefined file ordering and works with images, not
+video.
+
+| Flag | Required | Meaning |
+| --- | --- | --- |
+| `--host` | yes | Server URL |
+| `--token` | yes | Personal Access Token |
+| `--image-dir` | yes | Directory with the task's images |
+| `--job FILE [FILE ...]` | one of `--job` / `--files-per-job` | The files of one job; repeat for more |
+| `--files-per-job N` | one of `--job` / `--files-per-job` | Chunk the directory into jobs of N files |
+| `--name`, `--labels` | no | Task name and labels |
+| `--output` | no | Mapping CSV path (default `job_file_mapping.csv`) |
+| `--cleanup` | no | Delete the created task at the end |
+
+```bash
+python task_create_job_mapping.py --host 'https://app.cvat.ai' --token '<your token>' \
+    --image-dir ./images \
+    --job 'cam1_001.png' 'cam1_002.png' --job 'cam2_001.png' 'cam2_002.png'
+```
+
+### The script
+
+{{< include-code "assets/sdk-examples/task_create_job_mapping.py" >}}
+
 _Other SDK options:_
 
 | SDK method / parameter | What it adds |
@@ -163,6 +199,9 @@ _Other SDK options:_
 | `Task.export_dataset(filename=<directory>)` | Pass a directory as `filename` for a local export and the server-generated file name is used. |
 | `Task.export_dataset(..., location=Location.CLOUD_STORAGE, cloud_storage_id=<int>)` | Export straight to a registered cloud storage instead of downloading locally. |
 | `client.api_client.events_api.create_export(project_id=, job_id=, user_id=, _from=, to=)` | Scope or time-bound the event-log export beyond a single task. |
+| `data_params={"job_file_mapping": [[...], [...]]}` | Define each job's files explicitly instead of using `segment_size`. |
+| `PatchedLabelRequest(name=..., type="polygon")` | Restrict a label to one shape type, as the subtask recipe does. |
+| `Job.get_frames_info()` | The frames a job really holds, names included. |
 
 _Notes:_
 
@@ -176,4 +215,6 @@ _Notes:_
 - Full recipes:
   [`task_create_from_cloud.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_create_from_cloud.py),
   [`tasks_bulk_from_cloud.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/tasks_bulk_from_cloud.py),
-  [`task_inspect_and_export.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_inspect_and_export.py).
+  [`task_inspect_and_export.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_inspect_and_export.py),
+  [`task_create_subtasks.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_create_subtasks.py),
+  [`task_create_job_mapping.py`](https://github.com/cvat-ai/cvat/tree/develop/cvat-sdk/examples/task_create_job_mapping.py).

--- a/site/content/en/docs/api_sdk/sdk/examples/tasks.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/tasks.md
@@ -149,12 +149,17 @@ python task_create_subtasks.py --host 'https://app.cvat.ai' --token '<your token
 Normally CVAT cuts a task into jobs of `segment_size` frames. The
 `job_file_mapping` data parameter replaces that with an explicit grouping: one
 job per camera, per scene, or per delivery batch. Group the files yourself with
-repeated `--job` flags, or chunk the directory with `--files-per-job N`.
+repeated `--job` flags, or chunk the directory with `--files-per-job N` — a
+count of files, the explicit equivalent of `segment_size`.
 
 Every file in `--image-dir` must belong to exactly one job — unknown files,
 duplicates, and leftovers are rejected before the task is created. Afterwards
 the recipe reads the jobs back from the server and writes
-`job_file_mapping.csv`, so the mapping you see is the one that exists.
+`job_file_mapping.csv`, one `job_id,frame,file_name` row per file: the mapping
+you see is the one that exists, and every file names the frame it actually
+landed on. Frame numbers are zero-based indexes within the task.
+
+The example creates one `object` label so the task is ready for annotation.
 
 `job_file_mapping` implies predefined file ordering and works with images, not
 video.
@@ -165,8 +170,8 @@ video.
 | `--token` | yes | Personal Access Token |
 | `--image-dir` | yes | Directory with the task's images |
 | `--job FILE [FILE ...]` | one of `--job` / `--files-per-job` | The files of one job; repeat for more |
-| `--files-per-job N` | one of `--job` / `--files-per-job` | Chunk the directory into jobs of N files |
-| `--name`, `--labels` | no | Task name and labels |
+| `--files-per-job N` | one of `--job` / `--files-per-job` | Number of files per job: chunk the directory into jobs of N files each |
+| `--name` | no | Task name |
 | `--output` | no | Mapping CSV path (default `job_file_mapping.csv`) |
 | `--cleanup` | no | Delete the created task at the end |
 

--- a/site/content/en/docs/api_sdk/sdk/examples/webhooks.md
+++ b/site/content/en/docs/api_sdk/sdk/examples/webhooks.md
@@ -1,7 +1,7 @@
 ---
 title: 'Webhook recipes'
 linkTitle: 'Webhooks'
-weight: 7
+weight: 9
 description: 'Register a webhook for task events and monitor task status changes live with a local receiver'
 ---
 

--- a/tests/python/sdk/test_examples.py
+++ b/tests/python/sdk/test_examples.py
@@ -424,6 +424,84 @@ class TestExamples:
         )
         assert "not in" in result.stderr
 
+    @pytest.mark.timeout(180)
+    def test_honeypot_task_injects_pool_frames_into_every_job(self):
+        image_dir = self.make_image_dir(6)
+
+        result = self.run_recipe(
+            "task_create_with_honeypots.py",
+            args=[
+                "--image-dir",
+                str(image_dir),
+                "--pool-frame-count",
+                "2",
+                "--honeypots-per-job",
+                "1",
+                "--segment-size",
+                "2",
+            ],
+            with_cleanup=False,
+        )
+
+        task_id = self.created_task_id(result.stdout)
+        layout, _ = self.client.api_client.tasks_api.retrieve_validation_layout(task_id)
+        assert str(layout.mode) == "gt_pool"
+        assert len(layout.validation_frames) == 2
+        annotation_jobs = self.client.jobs.list(task_id=task_id, type="annotation")
+        assert len(layout.honeypot_frames) == len(annotation_jobs)
+        for job in annotation_jobs:
+            assert f"job {job.id} frames" in result.stdout
+        self.client.tasks.retrieve(task_id).remove()
+
+    @pytest.mark.timeout(180)
+    def test_honeypot_refresh_changes_the_mapping(self):
+        image_dir = self.make_image_dir(6)
+        result = self.run_recipe(
+            "task_create_with_honeypots.py",
+            args=[
+                "--image-dir",
+                str(image_dir),
+                "--pool-frame-count",
+                "2",
+                "--honeypots-per-job",
+                "1",
+                "--segment-size",
+                "2",
+                "--refresh",
+            ],
+            with_cleanup=False,
+        )
+
+        assert "Refreshed the honeypots" in result.stdout
+        assert result.stdout.count("Validation pool frames:") == 2
+        self.client.tasks.retrieve(self.created_task_id(result.stdout)).remove()
+
+    @pytest.mark.timeout(180)
+    def test_honeypot_disable_frame(self):
+        image_dir = self.make_image_dir(6)
+
+        # The pool is appended after the original frames, so with 6 images and a
+        # 2-frame pool the pool always lands at indexes 6-7 - deterministic, unlike
+        # --pool-frame-count's own random selection of *which* images join the pool.
+        result = self.run_recipe(
+            "task_create_with_honeypots.py",
+            args=[
+                "--image-dir",
+                str(image_dir),
+                "--pool-frame",
+                "img_0.png",
+                "img_1.png",
+                "--honeypots-per-job",
+                "1",
+                "--segment-size",
+                "2",
+                "--disable-frame",
+                "6",
+            ],
+        )
+        assert "Disabled frames: [6]" in result.stdout
+        assert "Deleted task" in result.stdout
+
     def test_auth_token(self):
         result = self.run_recipe("auth_token.py", with_cleanup=False)
         assert f"Authenticated as {self.user}" in result.stdout

--- a/tests/python/sdk/test_examples.py
+++ b/tests/python/sdk/test_examples.py
@@ -763,6 +763,79 @@ class TestExamples:
             ["car", "person"],
         )
 
+    @pytest.mark.timeout(180)
+    def test_job_mapping_explicit_groups(self):
+        image_dir = self.make_image_dir(4)
+
+        result = self.run_recipe(
+            "task_create_job_mapping.py",
+            args=[
+                "--image-dir",
+                str(image_dir),
+                "--job",
+                "img_0.png",
+                "img_1.png",
+                "--job",
+                "img_2.png",
+                "--job",
+                "img_3.png",
+            ],
+            with_cleanup=False,
+        )
+
+        task_id = self.created_task_id(result.stdout)
+        task = self.client.tasks.retrieve(task_id)
+        jobs = sorted(task.get_jobs(), key=lambda job: job.start_frame)
+        assert [len(job.get_frames_info()) for job in jobs] == [2, 1, 1]
+        rows = self.read_manifest("job_file_mapping.csv")
+        assert [row["file_name"] for row in rows] == [
+            "img_0.png",
+            "img_1.png",
+            "img_2.png",
+            "img_3.png",
+        ]
+        task.remove()
+
+    @pytest.mark.timeout(180)
+    def test_job_mapping_files_per_job(self):
+        image_dir = self.make_image_dir(5)
+
+        result = self.run_recipe(
+            "task_create_job_mapping.py",
+            args=["--image-dir", str(image_dir), "--files-per-job", "2"],
+        )
+
+        assert result.stdout.count("job ") >= 3
+        assert "Deleted task" in result.stdout
+
+    def test_job_mapping_rejects_unassigned_files(self):
+        image_dir = self.make_image_dir(3)
+
+        result = self.run_recipe(
+            "task_create_job_mapping.py",
+            args=["--image-dir", str(image_dir), "--job", "img_0.png"],
+            expect_failure=True,
+        )
+        assert "not assigned to any job" in result.stderr
+
+    def test_job_mapping_rejects_unknown_file(self):
+        image_dir = self.make_image_dir(2)
+
+        result = self.run_recipe(
+            "task_create_job_mapping.py",
+            args=[
+                "--image-dir",
+                str(image_dir),
+                "--job",
+                "img_0.png",
+                "img_1.png",
+                "--job",
+                "ghost.png",
+            ],
+            expect_failure=True,
+        )
+        assert "ghost.png" in result.stderr
+
     def test_auth_token(self):
         result = self.run_recipe("auth_token.py", with_cleanup=False)
         assert f"Authenticated as {self.user}" in result.stdout

--- a/tests/python/sdk/test_examples.py
+++ b/tests/python/sdk/test_examples.py
@@ -55,6 +55,9 @@ def receiver_target_url() -> str:
 # The bucket content summary printed by cloud_storage_register.py.
 BUCKET_CONTENT_RE = re.compile(r"contains (\d+) entries in (\d+) page\(s\)")
 
+# The id line printed by the task-creating recipes.
+CREATED_TASK_RE = re.compile(r"Created task (\d+)")
+
 
 def load_recipe(name: str) -> types.ModuleType:
     """Import a recipe as a module, so a test can reuse its own helpers instead
@@ -318,6 +321,108 @@ class TestExamples:
             expect_failure=True,
         )
         assert "Select what to export" in result.stderr
+
+    def created_task_id(self, stdout: str) -> int:
+        match = CREATED_TASK_RE.search(stdout)
+        assert match, f"no created-task line in:\n{stdout}"
+        return int(match.group(1))
+
+    def make_gt_annotations_file(self, image_dir: Path) -> Path:
+        """A CVAT-format annotations archive with one box on img_0.png, built by
+        annotating a throwaway task made from the same files (so the frame names match).
+        """
+        source = self.make_task(name="GT source", resources=sorted(image_dir.iterdir()))
+        label_id = source.get_labels()[0].id
+        source.set_annotations(
+            models.LabeledDataRequest(
+                shapes=[
+                    models.LabeledShapeRequest(
+                        type="rectangle", frame=0, label_id=label_id, points=[1.0, 1.0, 4.0, 4.0]
+                    )
+                ]
+            )
+        )
+        path = self.tmp_path / "gt_annotations.zip"
+        source.export_dataset("CVAT for images 1.1", path, include_images=False)
+        return path
+
+    @pytest.mark.timeout(180)
+    def test_validation_task_uses_the_requested_frames(self):
+        image_dir = self.make_image_dir(4)
+
+        result = self.run_recipe(
+            "task_create_with_validation.py",
+            args=[
+                "--image-dir",
+                str(image_dir),
+                "--validation-frame",
+                "img_0.png",
+                "img_2.png",
+            ],
+            with_cleanup=False,
+        )
+
+        assert "Ground truth job" in result.stdout
+        task_id = self.created_task_id(result.stdout)
+        gt_jobs = self.client.jobs.list(task_id=task_id, type="ground_truth")
+        assert len(gt_jobs) == 1
+        # The GT job's own frame list is padded with placeholders to mirror the
+        # task's full frame range; the real validation frames come from the layout.
+        layout, _ = self.client.api_client.tasks_api.retrieve_validation_layout(task_id)
+        task_frames = self.client.tasks.retrieve(task_id).get_frames_info()
+        names = sorted(task_frames[index].name for index in layout.validation_frames)
+        assert names == ["img_0.png", "img_2.png"]
+        self.client.tasks.retrieve(task_id).remove()
+
+    @pytest.mark.timeout(180)
+    def test_validation_task_random_frame_count(self):
+        image_dir = self.make_image_dir(4)
+
+        result = self.run_recipe(
+            "task_create_with_validation.py",
+            args=["--image-dir", str(image_dir), "--frame-count", "2", "--random-seed", "42"],
+        )
+
+        assert "Ground truth job" in result.stdout
+        assert ": 2 frames" in result.stdout
+        assert "Deleted task" in result.stdout
+
+    @pytest.mark.timeout(180)
+    def test_validation_task_imports_ground_truth_annotations(self):
+        image_dir = self.make_image_dir(4)
+        annotations = self.make_gt_annotations_file(image_dir)
+
+        result = self.run_recipe(
+            "task_create_with_validation.py",
+            args=[
+                "--image-dir",
+                str(image_dir),
+                "--validation-frame",
+                "img_0.png",
+                "--gt-annotations",
+                str(annotations),
+                "--gt-format",
+                "CVAT 1.1",
+            ],
+            with_cleanup=False,
+        )
+
+        task_id = self.created_task_id(result.stdout)
+        gt_job = self.client.jobs.list(task_id=task_id, type="ground_truth")[0]
+        annotations_read = gt_job.get_annotations()
+        assert len(annotations_read.shapes) == 1
+        assert f"Imported 1 objects into ground truth job {gt_job.id}" in result.stdout
+        self.client.tasks.retrieve(task_id).remove()
+
+    def test_validation_task_rejects_unknown_frame(self):
+        image_dir = self.make_image_dir(2)
+
+        result = self.run_recipe(
+            "task_create_with_validation.py",
+            args=["--image-dir", str(image_dir), "--validation-frame", "nope.png"],
+            expect_failure=True,
+        )
+        assert "not in" in result.stderr
 
     def test_auth_token(self):
         result = self.run_recipe("auth_token.py", with_cleanup=False)

--- a/tests/python/sdk/test_examples.py
+++ b/tests/python/sdk/test_examples.py
@@ -502,6 +502,97 @@ class TestExamples:
         assert "Disabled frames: [6]" in result.stdout
         assert "Deleted task" in result.stdout
 
+    def gt_job_of(self, task_id: int):
+        jobs = self.client.jobs.list(task_id=task_id, type="ground_truth")
+        return jobs[0] if jobs else None
+
+    @pytest.mark.timeout(120)
+    def test_add_gt_frames_by_index(self):
+        task = self.make_task(
+            name="GT frames by index", resources=sorted(self.make_image_dir(4).iterdir())
+        )
+
+        result = self.run_recipe(
+            "task_add_gt_frames.py",
+            args=["--task-id", str(task.id), "--frame", "0", "2"],
+            with_cleanup=False,
+        )
+
+        assert "Created ground truth job" in result.stdout
+        layout, _ = self.client.api_client.tasks_api.retrieve_validation_layout(task.id)
+        assert sorted(layout.validation_frames) == [0, 2]
+
+    @pytest.mark.timeout(120)
+    def test_add_gt_frames_by_name(self):
+        task = self.make_task(
+            name="GT frames by name", resources=sorted(self.make_image_dir(4).iterdir())
+        )
+
+        self.run_recipe(
+            "task_add_gt_frames.py",
+            args=["--task-id", str(task.id), "--frame-name", "img_1.png", "img_3.png"],
+            with_cleanup=False,
+        )
+
+        layout, _ = self.client.api_client.tasks_api.retrieve_validation_layout(task.id)
+        assert sorted(layout.validation_frames) == [1, 3]
+
+    @pytest.mark.timeout(120)
+    def test_add_gt_frames_refuses_to_overwrite(self):
+        task = self.make_task(
+            name="GT frames twice", resources=sorted(self.make_image_dir(4).iterdir())
+        )
+        self.run_recipe(
+            "task_add_gt_frames.py",
+            args=["--task-id", str(task.id), "--frame", "0"],
+            with_cleanup=False,
+        )
+
+        refused = self.run_recipe(
+            "task_add_gt_frames.py",
+            args=["--task-id", str(task.id), "--frame", "1"],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+        assert "already has a ground truth job" in refused.stderr
+
+        replaced = self.run_recipe(
+            "task_add_gt_frames.py",
+            args=["--task-id", str(task.id), "--frame", "1", "--replace"],
+            with_cleanup=False,
+        )
+        assert "Created ground truth job" in replaced.stdout
+        layout, _ = self.client.api_client.tasks_api.retrieve_validation_layout(task.id)
+        assert sorted(layout.validation_frames) == [1]
+
+    def test_add_gt_frames_rejects_out_of_range(self):
+        task = self.make_task(
+            name="GT frames range", resources=sorted(self.make_image_dir(2).iterdir())
+        )
+
+        result = self.run_recipe(
+            "task_add_gt_frames.py",
+            args=["--task-id", str(task.id), "--frame", "99"],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+        assert "out of range" in result.stderr
+
+    @pytest.mark.timeout(120)
+    def test_add_gt_frames_cleanup_removes_only_the_job(self):
+        task = self.make_task(
+            name="GT frames cleanup", resources=sorted(self.make_image_dir(3).iterdir())
+        )
+
+        result = self.run_recipe(
+            "task_add_gt_frames.py",
+            args=["--task-id", str(task.id), "--frame", "0"],
+        )
+
+        assert "Deleted ground truth job" in result.stdout
+        assert self.gt_job_of(task.id) is None
+        assert self.client.tasks.retrieve(task.id).id == task.id
+
     def test_auth_token(self):
         result = self.run_recipe("auth_token.py", with_cleanup=False)
         assert f"Authenticated as {self.user}" in result.stdout

--- a/tests/python/sdk/test_examples.py
+++ b/tests/python/sdk/test_examples.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import csv
 import hashlib
 import hmac
 import importlib.util
@@ -230,6 +231,93 @@ class TestExamples:
 
         result = self.run_incremental(project.id)
         assert f"Task {task.id} no longer exists on the server" in result.stdout
+
+    def read_manifest(self, name: str = "bulk_export.csv") -> list[dict]:
+        with (self.tmp_path / name).open(newline="") as f:
+            return list(csv.DictReader(f))
+
+    def test_bulk_export_exports_every_task_of_a_project(self):
+        project = self.make_project()
+        first = self.make_task_in_project(project, name="Bulk A")
+        second = self.make_task_in_project(project, name="Bulk B")
+
+        result = self.run_recipe(
+            "dataset_bulk_export.py",
+            args=["--project-id", str(project.id), "--output-dir", "out"],
+            with_cleanup=False,
+        )
+
+        assert "Exported 2 of 2 task(s)" in result.stdout
+        for task in (first, second):
+            assert (self.tmp_path / "out" / f"task_{task.id}.zip").is_file()
+        rows = self.read_manifest()
+        assert {int(row["task_id"]) for row in rows} == {first.id, second.id}
+        assert all(row["error"] == "" for row in rows)
+
+    def test_bulk_export_explicit_task_ids(self):
+        project = self.make_project()
+        wanted = self.make_task_in_project(project, name="Wanted")
+        other = self.make_task_in_project(project, name="Other")
+
+        self.run_recipe(
+            "dataset_bulk_export.py",
+            args=["--task-id", str(wanted.id), "--output-dir", "out"],
+            with_cleanup=False,
+        )
+
+        assert (self.tmp_path / "out" / f"task_{wanted.id}.zip").is_file()
+        assert not (self.tmp_path / "out" / f"task_{other.id}.zip").exists()
+
+    def test_bulk_export_skips_existing(self):
+        project = self.make_project_with_task()
+        args = ["--project-id", str(project.id), "--output-dir", "out", "--skip-existing"]
+        self.run_recipe("dataset_bulk_export.py", args=args, with_cleanup=False)
+
+        result = self.run_recipe("dataset_bulk_export.py", args=args, with_cleanup=False)
+        assert "Skipped task" in result.stdout
+        assert "Exported 0 of 1 task(s)" in result.stdout
+
+    def test_bulk_export_continues_after_a_failure(self):
+        project = self.make_project()
+        good = self.make_task_in_project(project, name="Good")
+        missing_id = 10**9
+
+        result = self.run_recipe(
+            "dataset_bulk_export.py",
+            args=["--task-id", str(good.id), str(missing_id), "--output-dir", "out"],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+
+        assert f"Exported task {good.id}" in result.stdout
+        assert f"FAILED task {missing_id}" in result.stdout
+        assert (self.tmp_path / "out" / f"task_{good.id}.zip").is_file()
+        errors = [row for row in self.read_manifest() if row["error"]]
+        assert len(errors) == 1
+
+    @pytest.mark.timeout(180)
+    def test_bulk_export_with_two_workers(self):
+        project = self.make_project()
+        tasks = [self.make_task_in_project(project, name=f"Worker {i}") for i in range(2)]
+
+        result = self.run_recipe(
+            "dataset_bulk_export.py",
+            args=["--project-id", str(project.id), "--output-dir", "out", "--jobs", "2"],
+            with_cleanup=False,
+        )
+
+        assert "Exported 2 of 2 task(s)" in result.stdout
+        for task in tasks:
+            assert (self.tmp_path / "out" / f"task_{task.id}.zip").is_file()
+
+    def test_bulk_export_requires_a_selector(self):
+        result = self.run_recipe(
+            "dataset_bulk_export.py",
+            args=["--output-dir", "out"],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+        assert "Select what to export" in result.stderr
 
     def test_auth_token(self):
         result = self.run_recipe("auth_token.py", with_cleanup=False)

--- a/tests/python/sdk/test_examples.py
+++ b/tests/python/sdk/test_examples.py
@@ -22,6 +22,12 @@ from time import sleep
 
 import platformdirs
 import pytest
+from cvat_sdk import Client, models
+from cvat_sdk.core.auth import AuthStore, ProfileEntry
+from cvat_sdk.core.downloading import Downloader
+from cvat_sdk.core.proxies.projects import Project
+from cvat_sdk.core.proxies.tasks import ResourceType, Task
+
 from shared.utils.config import (
     BASE_URL,
     IMPORT_EXPORT_BUCKET_ID,
@@ -30,12 +36,6 @@ from shared.utils.config import (
     USER_PASS,
 )
 from shared.utils.helpers import generate_image_file
-
-from cvat_sdk import Client, models
-from cvat_sdk.core.auth import AuthStore, ProfileEntry
-from cvat_sdk.core.downloading import Downloader
-from cvat_sdk.core.proxies.projects import Project
-from cvat_sdk.core.proxies.tasks import ResourceType, Task
 
 EXAMPLES_DIR = Path(__file__).parents[3] / "cvat-sdk" / "examples"
 

--- a/tests/python/sdk/test_examples.py
+++ b/tests/python/sdk/test_examples.py
@@ -593,6 +593,116 @@ class TestExamples:
         assert self.gt_job_of(task.id) is None
         assert self.client.tasks.retrieve(task.id).id == task.id
 
+    def seed_lint_project(self):
+        """A project whose single task has one good box, one out-of-bounds box,
+        one zero-area box, and an unused label. Images are 5x10 (w x h).
+        """
+        project = self.make_project(name="Lint project", labels=("object", "unused"))
+        task = self.make_task_in_project(project, name="Lint task")
+        label_id = {label.name: label.id for label in task.get_labels()}["object"]
+        task.set_annotations(
+            models.LabeledDataRequest(
+                shapes=[
+                    models.LabeledShapeRequest(
+                        type="rectangle", frame=0, label_id=label_id, points=[1.0, 1.0, 4.0, 8.0]
+                    ),
+                    models.LabeledShapeRequest(
+                        type="rectangle", frame=0, label_id=label_id, points=[1.0, 1.0, 99.0, 8.0]
+                    ),
+                    models.LabeledShapeRequest(
+                        type="rectangle", frame=0, label_id=label_id, points=[2.0, 2.0, 2.0, 2.0]
+                    ),
+                ]
+            )
+        )
+        return project, task
+
+    def test_data_lint_reports_geometry_errors_and_fails(self):
+        project, task = self.seed_lint_project()
+
+        result = self.run_recipe(
+            "project_data_lint.py",
+            args=["--project-id", str(project.id)],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+
+        assert "error out-of-bounds" in result.stdout
+        assert "error degenerate-box" in result.stdout
+        assert "info unused-label" in result.stdout
+        rows = self.read_manifest("data_lint.csv")
+        checks = {row["check"] for row in rows}
+        assert {"out-of-bounds", "degenerate-box", "unused-label"} <= checks
+        assert all(int(row["task_id"]) == task.id for row in rows if row["task_id"])
+
+    def test_data_lint_no_fail_exits_zero(self):
+        project, _ = self.seed_lint_project()
+
+        result = self.run_recipe(
+            "project_data_lint.py",
+            args=["--project-id", str(project.id), "--no-fail"],
+            with_cleanup=False,
+        )
+        assert "error out-of-bounds" in result.stdout
+
+    def test_data_lint_reports_empty_frames_on_a_clean_project(self):
+        project = self.make_project(name="Clean project")
+        task = self.make_task_in_project(project, name="Clean task")
+        label_id = task.get_labels()[0].id
+        task.set_annotations(
+            models.LabeledDataRequest(
+                shapes=[
+                    models.LabeledShapeRequest(
+                        type="rectangle",
+                        frame=frame,
+                        label_id=label_id,
+                        points=[1.0, 1.0, 4.0, 8.0],
+                    )
+                    for frame in range(task.size)
+                ]
+            )
+        )
+
+        result = self.run_recipe(
+            "project_data_lint.py",
+            args=["--project-id", str(project.id)],
+            with_cleanup=False,
+        )
+
+        assert "0 error(s)" in result.stdout
+        assert "empty-frame" not in result.stdout
+
+    def test_data_lint_detects_duplicate_objects(self):
+        project = self.make_project(name="Duplicate project")
+        task = self.make_task_in_project(project, name="Duplicate task")
+        label_id = task.get_labels()[0].id
+        box = dict(type="rectangle", frame=0, label_id=label_id, points=[1.0, 1.0, 4.0, 8.0])
+        task.set_annotations(
+            models.LabeledDataRequest(
+                shapes=[models.LabeledShapeRequest(**box), models.LabeledShapeRequest(**box)]
+            )
+        )
+
+        result = self.run_recipe(
+            "project_data_lint.py",
+            args=["--project-id", str(project.id)],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+        assert "error duplicate-object" in result.stdout
+
+    def test_data_lint_rejects_a_task_outside_the_project(self):
+        project = self.make_project_with_task()
+        stranger = self.make_task(name="Stranger")
+
+        result = self.run_recipe(
+            "project_data_lint.py",
+            args=["--project-id", str(project.id), "--task-id", str(stranger.id)],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+        assert "not found in project" in result.stderr
+
     def test_auth_token(self):
         result = self.run_recipe("auth_token.py", with_cleanup=False)
         assert f"Authenticated as {self.user}" in result.stdout

--- a/tests/python/sdk/test_examples.py
+++ b/tests/python/sdk/test_examples.py
@@ -703,6 +703,66 @@ class TestExamples:
         )
         assert "not found in project" in result.stderr
 
+    @pytest.mark.timeout(180)
+    def test_subtasks_create_one_task_per_label_group(self):
+        image_dir = self.make_image_dir(2)
+
+        result = self.run_recipe(
+            "task_create_subtasks.py",
+            args=[
+                "--image-dir",
+                str(image_dir),
+                "--subtask",
+                "boxes:rectangle:car,person",
+                "--subtask",
+                "roads:polygon:road",
+            ],
+            with_cleanup=False,
+        )
+
+        assert "Created 2 subtask(s)" in result.stdout
+        ids = [int(match) for match in re.findall(r"as task (\d+)", result.stdout)]
+        assert len(ids) == 2
+        boxes, roads = (self.client.tasks.retrieve(task_id) for task_id in ids)
+        assert sorted((label.name, str(label.type)) for label in boxes.get_labels()) == [
+            ("car", "rectangle"),
+            ("person", "rectangle"),
+        ]
+        assert [(label.name, str(label.type)) for label in roads.get_labels()] == [
+            ("road", "polygon")
+        ]
+        for task_id in ids:
+            self.client.tasks.retrieve(task_id).remove()
+
+    def test_subtasks_reject_unknown_label_type(self):
+        image_dir = self.make_image_dir(2)
+
+        result = self.run_recipe(
+            "task_create_subtasks.py",
+            args=["--image-dir", str(image_dir), "--subtask", "boxes:square:car"],
+            expect_failure=True,
+        )
+        assert "square" in result.stderr
+        assert "Created subtask" not in result.stdout
+
+    def test_subtasks_reject_malformed_spec(self):
+        image_dir = self.make_image_dir(2)
+
+        result = self.run_recipe(
+            "task_create_subtasks.py",
+            args=["--image-dir", str(image_dir), "--subtask", "boxes-rectangle-car"],
+            expect_failure=True,
+        )
+        assert "NAME:TYPE:label" in result.stderr
+
+    def test_subtasks_parse_spec_helper(self):
+        recipe = load_recipe("task_create_subtasks.py")
+        assert recipe.parse_subtask("boxes:rectangle:car, person") == (
+            "boxes",
+            "rectangle",
+            ["car", "person"],
+        )
+
     def test_auth_token(self):
         result = self.run_recipe("auth_token.py", with_cleanup=False)
         assert f"Authenticated as {self.user}" in result.stdout

--- a/tests/python/sdk/test_examples.py
+++ b/tests/python/sdk/test_examples.py
@@ -21,12 +21,6 @@ from time import sleep
 
 import platformdirs
 import pytest
-from cvat_sdk import Client, models
-from cvat_sdk.core.auth import AuthStore, ProfileEntry
-from cvat_sdk.core.downloading import Downloader
-from cvat_sdk.core.proxies.projects import Project
-from cvat_sdk.core.proxies.tasks import ResourceType, Task
-
 from shared.utils.config import (
     BASE_URL,
     IMPORT_EXPORT_BUCKET_ID,
@@ -35,6 +29,12 @@ from shared.utils.config import (
     USER_PASS,
 )
 from shared.utils.helpers import generate_image_file
+
+from cvat_sdk import Client, models
+from cvat_sdk.core.auth import AuthStore, ProfileEntry
+from cvat_sdk.core.downloading import Downloader
+from cvat_sdk.core.proxies.projects import Project
+from cvat_sdk.core.proxies.tasks import ResourceType, Task
 
 EXAMPLES_DIR = Path(__file__).parents[3] / "cvat-sdk" / "examples"
 
@@ -166,6 +166,70 @@ class TestExamples:
         project = self.make_project()
         self.make_task_in_project(project)
         return project
+
+    def run_incremental(self, project_id: int, *, extra: list[str] | None = None):
+        return self.run_recipe(
+            "dataset_incremental_download.py",
+            args=["--project-id", str(project_id), "--state", "state.json"] + list(extra or []),
+            with_cleanup=False,
+        )
+
+    def test_incremental_download_first_run_exports_every_task(self):
+        project = self.make_project()
+        first = self.make_task_in_project(project, name="Incremental A")
+        second = self.make_task_in_project(project, name="Incremental B")
+
+        result = self.run_incremental(project.id)
+
+        assert f"Exported task {first.id}" in result.stdout
+        assert f"Exported task {second.id}" in result.stdout
+        assert "Downloaded 2 task dataset(s)" in result.stdout
+        for task in (first, second):
+            assert (self.tmp_path / "datasets" / f"task_{task.id}.zip").is_file()
+
+    def test_incremental_download_second_run_exports_nothing(self):
+        project = self.make_project_with_task()
+        self.run_incremental(project.id)
+
+        result = self.run_incremental(project.id)
+
+        assert "Nothing changed since" in result.stdout
+        assert "Exported task" not in result.stdout
+
+    def test_incremental_download_reexports_only_the_changed_task(self):
+        project = self.make_project()
+        untouched = self.make_task_in_project(project, name="Untouched")
+        touched = self.make_task_in_project(project, name="Touched")
+        self.run_incremental(project.id)
+
+        touched.update(models.PatchedTaskWriteRequest(name="Touched again"))
+
+        result = self.run_incremental(project.id)
+        assert f"Exported task {touched.id}" in result.stdout
+        assert f"Exported task {untouched.id}" not in result.stdout
+        assert "Downloaded 1 task dataset(s)" in result.stdout
+
+    def test_incremental_download_rejects_state_of_another_project(self):
+        first = self.make_project_with_task()
+        second = self.make_project_with_task()
+        self.run_incremental(first.id)
+
+        result = self.run_recipe(
+            "dataset_incremental_download.py",
+            args=["--project-id", str(second.id), "--state", "state.json"],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+        assert "belongs to project" in result.stderr
+
+    def test_incremental_download_reports_deleted_tasks(self):
+        project = self.make_project()
+        task = self.make_task_in_project(project, name="Doomed")
+        self.run_incremental(project.id)
+        task.remove()
+
+        result = self.run_incremental(project.id)
+        assert f"Task {task.id} no longer exists on the server" in result.stdout
 
     def test_auth_token(self):
         result = self.run_recipe("auth_token.py", with_cleanup=False)

--- a/tests/python/sdk/test_examples.py
+++ b/tests/python/sdk/test_examples.py
@@ -28,6 +28,7 @@ from cvat_sdk.core.auth import AuthStore, ProfileEntry
 from cvat_sdk.core.downloading import Downloader
 from cvat_sdk.core.proxies.projects import Project
 from cvat_sdk.core.proxies.tasks import ResourceType, Task
+from cvat_sdk.core.proxies.types import Location
 
 from shared.utils.config import (
     BASE_URL,
@@ -139,6 +140,44 @@ class TestExampleHelpers:
         findings, _ = recipe.lint_task(task, {1: "object"}, 4)
 
         assert findings == []
+
+    @staticmethod
+    def bucket_page(names: list[tuple[str, str]], next_token: str | None):
+        """One retrieve_content_v2 response: (name, type) entries plus a token."""
+        return (
+            types.SimpleNamespace(
+                content=[
+                    types.SimpleNamespace(name=name, type=types.SimpleNamespace(value=entry_type))
+                    for name, entry_type in names
+                ],
+                next=next_token,
+            ),
+            None,
+        )
+
+    def test_import_from_cloud_looks_up_a_key_across_pages(self):
+        recipe = load_recipe("task_import_annotations_from_cloud.py")
+        api = MagicMock()
+        api.retrieve_content_v2.side_effect = [
+            self.bucket_page([("other.zip", "REG")], "page-2"),
+            self.bucket_page([("task_42.zip", "REG")], None),
+        ]
+
+        assert recipe.bucket_contains(api, 7, "annotations/task_42.zip")
+
+        first, second = api.retrieve_content_v2.call_args_list
+        assert first.args == (7,) and first.kwargs == {"prefix": "annotations/"}
+        assert second.kwargs["next_token"] == "page-2"
+
+    def test_import_from_cloud_reports_a_key_the_bucket_does_not_have(self):
+        recipe = load_recipe("task_import_annotations_from_cloud.py")
+        api = MagicMock()
+        api.retrieve_content_v2.side_effect = [
+            self.bucket_page([("task_42.zip", "DIR"), ("task_43.zip", "REG")], None)
+        ]
+
+        assert not recipe.bucket_contains(api, 7, "task_42.zip")
+        assert api.retrieve_content_v2.call_args.kwargs == {}
 
     @pytest.mark.parametrize("watermark", [None, "2026-09-01T00:00:00+00:00"])
     @pytest.mark.parametrize("export_fails", [False, True])
@@ -277,14 +316,18 @@ class TestExamples:
         resources: list[Path] | None = None,
         segment_size: int | None = None,
         labels: tuple[str, ...] = ("object",),
+        source_storage: models.StorageRequest | None = None,
     ) -> Task:
         if resources is None:
             resources = sorted(self.make_image_dir().iterdir())
         return self.client.tasks.create_from_data(
+            # Storages can only be set while creating a task; a PATCH of
+            # source_storage is ignored by the server.
             spec=models.TaskWriteRequest(
                 name=name,
                 labels=[models.PatchedLabelRequest(name=label) for label in labels],
                 **({"segment_size": segment_size} if segment_size else {}),
+                **({"source_storage": source_storage} if source_storage else {}),
             ),
             resource_type=ResourceType.LOCAL,
             resources=resources,
@@ -1378,6 +1421,111 @@ class TestExamples:
                 str(task.id),
                 "--annotations-file",
                 str(annotations_file),
+                "--import-format",
+                "Bogus 9.9",
+            ],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+        assert "Unknown import format" in result.stderr
+
+    def export_annotations_to_bucket(self, task: Task, key: str) -> None:
+        """Put an annotation file into the test bucket, without a local copy."""
+        task.export_dataset(
+            "COCO 1.0",
+            key,
+            include_images=False,
+            location=Location.CLOUD_STORAGE,
+            cloud_storage_id=IMPORT_EXPORT_BUCKET_ID,
+        )
+
+    @pytest.mark.with_external_services
+    def test_task_import_annotations_from_cloud(self):
+        task = self.make_task()
+        self.seed_rectangle(task)
+        key = f"recipes/annotations_{task.id}.zip"
+        self.export_annotations_to_bucket(task, key)
+        task.remove_annotations()
+        assert not task.get_annotations().shapes
+
+        result = self.run_recipe(
+            "task_import_annotations_from_cloud.py",
+            args=[
+                "--task-id",
+                str(task.id),
+                "--cloud-storage-id",
+                str(IMPORT_EXPORT_BUCKET_ID),
+                "--filename",
+                key,
+            ],
+            with_cleanup=False,
+        )
+        assert f"Task {task.id}: 0 objects before import" in result.stdout
+        assert f"Reading '{key}' from cloud storage {IMPORT_EXPORT_BUCKET_ID}" in result.stdout
+        assert f"Task {task.id}: 1 objects after import" in result.stdout
+        assert len(task.get_annotations().shapes) == 1
+
+    @pytest.mark.with_external_services
+    def test_task_import_annotations_from_cloud_uses_the_task_source_storage(self):
+        task = self.make_task(
+            source_storage=models.StorageRequest(
+                location=models.LocationEnum("cloud_storage"),
+                cloud_storage_id=IMPORT_EXPORT_BUCKET_ID,
+            )
+        )
+        self.seed_rectangle(task)
+        key = f"annotations_{task.id}.zip"
+        self.export_annotations_to_bucket(task, key)
+        task.remove_annotations()
+
+        result = self.run_recipe(
+            "task_import_annotations_from_cloud.py",
+            args=["--task-id", str(task.id), "--filename", key],
+            with_cleanup=False,
+        )
+        assert f"Reading '{key}' from cloud storage {IMPORT_EXPORT_BUCKET_ID}" in result.stdout
+        assert len(task.get_annotations().shapes) == 1
+
+    @pytest.mark.with_external_services
+    def test_task_import_annotations_from_cloud_reports_a_missing_key(self):
+        task = self.make_task()
+        result = self.run_recipe(
+            "task_import_annotations_from_cloud.py",
+            args=[
+                "--task-id",
+                str(task.id),
+                "--cloud-storage-id",
+                str(IMPORT_EXPORT_BUCKET_ID),
+                "--filename",
+                "recipes/no_such_file.zip",
+            ],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+        assert "was not found in cloud storage" in result.stderr
+        assert not task.get_annotations().shapes
+
+    def test_task_import_annotations_from_cloud_requires_a_storage(self):
+        task = self.make_task()
+        result = self.run_recipe(
+            "task_import_annotations_from_cloud.py",
+            args=["--task-id", str(task.id), "--filename", "annotations.zip"],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+        assert "has no cloud source storage configured" in result.stderr
+
+    def test_task_import_annotations_from_cloud_rejects_unknown_format(self):
+        task = self.make_task()
+        result = self.run_recipe(
+            "task_import_annotations_from_cloud.py",
+            args=[
+                "--task-id",
+                str(task.id),
+                "--cloud-storage-id",
+                "1",
+                "--filename",
+                "annotations.zip",
                 "--import-format",
                 "Bogus 9.9",
             ],

--- a/tests/python/sdk/test_examples.py
+++ b/tests/python/sdk/test_examples.py
@@ -19,6 +19,7 @@ import urllib.request
 import zipfile
 from pathlib import Path
 from time import sleep
+from unittest.mock import MagicMock
 
 import platformdirs
 import pytest
@@ -35,7 +36,7 @@ from shared.utils.config import (
     MINIO_SECRET_KEY,
     USER_PASS,
 )
-from shared.utils.helpers import generate_image_file
+from shared.utils.helpers import generate_image_file, generate_video_file
 
 EXAMPLES_DIR = Path(__file__).parents[3] / "cvat-sdk" / "examples"
 
@@ -67,6 +68,136 @@ def load_recipe(name: str) -> types.ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+class TestExampleHelpers:
+    def test_data_lint_reports_an_object_past_the_last_frame(self):
+        # Exercise a corrupt response directly: the write API rejects this frame.
+        recipe = load_recipe("project_data_lint.py")
+        task = MagicMock(spec=Task)
+        task.id = 7
+        task.data_original_chunk_type = "imageset"
+        task.get_meta.return_value = types.SimpleNamespace(
+            size=2,
+            deleted_frames=[],
+            frames=[types.SimpleNamespace(width=10, height=10) for _ in range(2)],
+        )
+        task.get_jobs.return_value = []
+        task.get_annotations.return_value = models.LabeledDataRequest(
+            tags=[],
+            tracks=[],
+            shapes=[
+                models.LabeledShapeRequest(
+                    type="rectangle", frame=2, label_id=1, points=[1, 1, 4, 8]
+                )
+            ],
+        )
+
+        findings, _ = recipe.lint_task(task, {1: "object"}, 4)
+
+        assert len(findings) == 1
+        finding = findings[0]
+        assert (finding.severity, finding.check, finding.task_id, finding.frame) == (
+            "error",
+            "dead-object",
+            7,
+            2,
+        )
+        assert finding.detail == "rectangle sits on frame 2, which is past the task's last frame 1"
+
+    @pytest.mark.parametrize("with_track", [False, True])
+    def test_data_lint_accepts_empty_or_interpolated_completed_jobs(self, with_track: bool):
+        recipe = load_recipe("project_data_lint.py")
+        task = MagicMock(spec=Task)
+        task.id = 7
+        task.data_original_chunk_type = "video"
+        task.get_meta.return_value = types.SimpleNamespace(
+            size=4, deleted_frames=[], frames=[types.SimpleNamespace(width=10, height=10)]
+        )
+        task.get_jobs.return_value = [
+            types.SimpleNamespace(id=1, start_frame=0, stop_frame=1, state="completed"),
+            types.SimpleNamespace(id=2, start_frame=2, stop_frame=3, state="completed"),
+        ]
+        tracks = []
+        if with_track:
+            # The track remains visible across both jobs despite having just one keyframe.
+            tracks.append(
+                models.LabeledTrackRequest(
+                    frame=0,
+                    label_id=1,
+                    shapes=[
+                        models.TrackedShapeRequest(
+                            type="rectangle", frame=0, outside=False, points=[1, 1, 4, 8]
+                        )
+                    ],
+                )
+            )
+        task.get_annotations.return_value = models.LabeledDataRequest(
+            tags=[], shapes=[], tracks=tracks
+        )
+
+        findings, _ = recipe.lint_task(task, {1: "object"}, 4)
+
+        assert findings == []
+
+    @pytest.mark.parametrize("watermark", [None, "2026-09-01T00:00:00+00:00"])
+    @pytest.mark.parametrize("export_fails", [False, True])
+    def test_incremental_download_uses_caller_state(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+        watermark: str | None,
+        export_fails: bool,
+    ):
+        recipe = load_recipe("dataset_incremental_download.py")
+        monkeypatch.chdir(tmp_path)
+        # An old file must neither control this run nor be overwritten by it.
+        state_path = tmp_path / "incremental_state.json"
+        state_path.write_text("unrelated state")
+        output_dir = tmp_path / "datasets"
+        output_dir.mkdir()
+        archive = output_dir / "task_7.zip"
+        archive.write_bytes(b"old export")
+        client = MagicMock()
+        task = MagicMock(spec=Task)
+        task.id, task.name = 7, "Example"
+        client.tasks.list.return_value = [task]
+        monkeypatch.setattr(recipe, "make_client", lambda *args, **kwargs: client)
+        client.__enter__.return_value = client
+        argv = [
+            "recipe",
+            "--host",
+            "http://example.invalid",
+            "--token",
+            "dummy",
+            "--project-id",
+            "3",
+        ]
+        if watermark:
+            argv += ["--updated-after", watermark]
+        monkeypatch.setattr(sys, "argv", argv)
+
+        def export(format_name: str, path: Path, **kwargs) -> None:
+            assert not path.exists()
+            if export_fails:
+                raise RuntimeError("export failed")
+            path.write_bytes(b"new export")
+
+        task.export_dataset.side_effect = export
+        if export_fails:
+            with pytest.raises(RuntimeError, match="export failed"):
+                recipe.main()
+            assert "Downloaded" not in capsys.readouterr().out
+        else:
+            recipe.main()
+            assert archive.read_bytes() == b"new export"
+            assert "Downloaded 1 task dataset(s)" in capsys.readouterr().out
+        filters = {"project_id": 3}
+        if watermark:
+            filters["updated_date__gt"] = watermark
+        client.tasks.list.assert_called_once_with(**filters)
+        assert state_path.read_text() == "unrelated state"
 
 
 @pytest.fixture(scope="class")
@@ -166,6 +297,18 @@ class TestExamples:
             resources=sorted(self.make_image_dir().iterdir()),
         )
 
+    def make_video_task_in_project(
+        self, project: Project, *, num_frames: int = 4, name: str = "Recipe video task"
+    ) -> Task:
+        video = generate_video_file(num_frames)
+        path = self.tmp_path / video.name
+        path.write_bytes(video.getbuffer())
+        return self.client.tasks.create_from_data(
+            spec=models.TaskWriteRequest(name=name, project_id=project.id),
+            resource_type=ResourceType.LOCAL,
+            resources=[path],
+        )
+
     def make_project_with_task(self) -> Project:
         project = self.make_project()
         self.make_task_in_project(project)
@@ -174,7 +317,7 @@ class TestExamples:
     def run_incremental(self, project_id: int, *, extra: list[str] | None = None):
         return self.run_recipe(
             "dataset_incremental_download.py",
-            args=["--project-id", str(project_id), "--state", "state.json"] + list(extra or []),
+            args=["--project-id", str(project_id)] + list(extra or []),
             with_cleanup=False,
         )
 
@@ -193,47 +336,45 @@ class TestExamples:
 
     def test_incremental_download_second_run_exports_nothing(self):
         project = self.make_project_with_task()
+        watermark = max(task.updated_date for task in project.get_tasks()).isoformat()
         self.run_incremental(project.id)
 
-        result = self.run_incremental(project.id)
+        result = self.run_incremental(project.id, extra=["--updated-after", watermark])
 
-        assert "Nothing changed since" in result.stdout
+        assert f"No tasks to export after {watermark}" in result.stdout
         assert "Exported task" not in result.stdout
 
     def test_incremental_download_reexports_only_the_changed_task(self):
         project = self.make_project()
         untouched = self.make_task_in_project(project, name="Untouched")
         touched = self.make_task_in_project(project, name="Touched")
+        watermark = max(task.updated_date for task in project.get_tasks()).isoformat()
         self.run_incremental(project.id)
 
         touched.update(models.PatchedTaskWriteRequest(name="Touched again"))
 
-        result = self.run_incremental(project.id)
+        result = self.run_incremental(project.id, extra=["--updated-after", watermark])
         assert f"Exported task {touched.id}" in result.stdout
         assert f"Exported task {untouched.id}" not in result.stdout
         assert "Downloaded 1 task dataset(s)" in result.stdout
 
-    def test_incremental_download_rejects_state_of_another_project(self):
-        first = self.make_project_with_task()
-        second = self.make_project_with_task()
-        self.run_incremental(first.id)
+    def test_incremental_download_honours_a_given_watermark(self):
+        project = self.make_project_with_task()
+        watermark = "2100-01-01T00:00:00+00:00"
 
         result = self.run_recipe(
             "dataset_incremental_download.py",
-            args=["--project-id", str(second.id), "--state", "state.json"],
+            args=[
+                "--project-id",
+                str(project.id),
+                "--updated-after",
+                watermark,
+            ],
             with_cleanup=False,
-            expect_failure=True,
         )
-        assert "belongs to project" in result.stderr
 
-    def test_incremental_download_reports_deleted_tasks(self):
-        project = self.make_project()
-        task = self.make_task_in_project(project, name="Doomed")
-        self.run_incremental(project.id)
-        task.remove()
-
-        result = self.run_incremental(project.id)
-        assert f"Task {task.id} no longer exists on the server" in result.stdout
+        assert f"No tasks to export after {watermark}" in result.stdout
+        assert "Exported task" not in result.stdout
 
     def read_manifest(self, name: str = "bulk_export.csv") -> list[dict]:
         with (self.tmp_path / name).open(newline="") as f:
@@ -312,6 +453,20 @@ class TestExamples:
         assert "Exported 2 of 2 task(s)" in result.stdout
         for task in tasks:
             assert (self.tmp_path / "out" / f"task_{task.id}.zip").is_file()
+
+    def test_bulk_export_reports_ids_filtered_out_by_status(self):
+        project = self.make_project()
+        task = self.make_task_in_project(project, name="Still in annotation")
+
+        result = self.run_recipe(
+            "dataset_bulk_export.py",
+            args=["--task-id", str(task.id), "--status", "completed", "--output-dir", "out"],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+
+        assert f"Skipping task {task.id}: status is annotation, not completed" in result.stdout
+        assert "The selection is empty" in result.stderr
 
     def test_bulk_export_requires_a_selector(self):
         result = self.run_recipe(
@@ -645,7 +800,7 @@ class TestExamples:
         )
         assert "error out-of-bounds" in result.stdout
 
-    def test_data_lint_reports_empty_frames_on_a_clean_project(self):
+    def test_data_lint_accepts_a_clean_project(self):
         project = self.make_project(name="Clean project")
         task = self.make_task_in_project(project, name="Clean task")
         label_id = task.get_labels()[0].id
@@ -669,8 +824,8 @@ class TestExamples:
             with_cleanup=False,
         )
 
-        assert "0 error(s)" in result.stdout
-        assert "empty-frame" not in result.stdout
+        assert "Found 0 issue(s)" in result.stdout
+        assert self.read_manifest("data_lint.csv") == []
 
     def test_data_lint_detects_duplicate_objects(self):
         project = self.make_project(name="Duplicate project")
@@ -702,6 +857,90 @@ class TestExamples:
             expect_failure=True,
         )
         assert "not found in project" in result.stderr
+
+    @pytest.mark.timeout(180)
+    def test_data_lint_checks_geometry_beyond_the_first_frame_of_a_video(self):
+        # A video task reports a single frame meta for the whole video, so the
+        # frame count has to come from `size`; taking it from `frames` used to
+        # silence every check past frame 0.
+        project = self.make_project(name="Video lint project")
+        task = self.make_video_task_in_project(project, num_frames=4)
+        label_id = task.get_labels()[0].id
+        task.set_annotations(
+            models.LabeledDataRequest(
+                shapes=[
+                    models.LabeledShapeRequest(
+                        type="rectangle", frame=2, label_id=label_id, points=[1.0, 1.0, 999.0, 8.0]
+                    )
+                ]
+            )
+        )
+
+        result = self.run_recipe(
+            "project_data_lint.py",
+            args=["--project-id", str(project.id)],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+
+        assert "error out-of-bounds" in result.stdout
+        assert f"task {task.id} frame 2" in result.stdout
+        rows = self.read_manifest("data_lint.csv")
+        assert [row["frame"] for row in rows if row["check"] == "out-of-bounds"] == ["2"]
+
+    def test_data_lint_accepts_unannotated_frames(self):
+        project = self.make_project(name="Partly annotated project")
+        task = self.make_task_in_project(project, name="Partly annotated task")
+        label_id = task.get_labels()[0].id
+        task.set_annotations(
+            models.LabeledDataRequest(
+                shapes=[
+                    models.LabeledShapeRequest(
+                        type="rectangle", frame=0, label_id=label_id, points=[1.0, 1.0, 4.0, 8.0]
+                    )
+                ]
+            )
+        )
+
+        result = self.run_recipe(
+            "project_data_lint.py",
+            args=["--project-id", str(project.id)],
+            with_cleanup=False,
+        )
+
+        assert "Found 0 issue(s)" in result.stdout
+        assert self.read_manifest("data_lint.csv") == []
+
+    def test_data_lint_reports_objects_left_on_a_deleted_frame(self):
+        project = self.make_project(name="Deleted frame project")
+        task = self.make_task_in_project(project, name="Deleted frame task")
+        label_id = task.get_labels()[0].id
+        task.set_annotations(
+            models.LabeledDataRequest(
+                shapes=[
+                    models.LabeledShapeRequest(
+                        type="rectangle",
+                        frame=frame,
+                        label_id=label_id,
+                        points=[1.0, 1.0, 4.0, 8.0],
+                    )
+                    for frame in (0, 1)
+                ]
+            )
+        )
+        task.remove_frames_by_ids([1])
+
+        result = self.run_recipe(
+            "project_data_lint.py",
+            args=["--project-id", str(project.id)],
+            with_cleanup=False,
+            expect_failure=True,
+        )
+
+        assert "error dead-object" in result.stdout
+        assert "was removed from the task" in result.stdout
+        rows = self.read_manifest("data_lint.csv")
+        assert [row["frame"] for row in rows if row["check"] == "dead-object"] == ["1"]
 
     @pytest.mark.timeout(180)
     def test_subtasks_create_one_task_per_label_group(self):
@@ -788,11 +1027,13 @@ class TestExamples:
         jobs = sorted(task.get_jobs(), key=lambda job: job.start_frame)
         assert [len(job.get_frames_info()) for job in jobs] == [2, 1, 1]
         rows = self.read_manifest("job_file_mapping.csv")
-        assert [row["file_name"] for row in rows] == [
-            "img_0.png",
-            "img_1.png",
-            "img_2.png",
-            "img_3.png",
+        assert set(rows[0]) == {"job_id", "frame", "file_name"}
+        # Each row names the frame its own file landed on, not the job's range.
+        assert [(row["job_id"], row["frame"], row["file_name"]) for row in rows] == [
+            (str(jobs[0].id), "0", "img_0.png"),
+            (str(jobs[0].id), "1", "img_1.png"),
+            (str(jobs[1].id), "2", "img_2.png"),
+            (str(jobs[2].id), "3", "img_3.png"),
         ]
         task.remove()
 


### PR DESCRIPTION
 ### Motivation and context

  The SDK examples include workflows users actually ask about on the
  forum and in support: ground truth / quality control setup, getting datasets out at
  scale, splitting annotation work, and checking data before an export.

  **Ground truth & quality control** — new docs page `Ground truth recipes`

  | Recipe | What it shows |                                                                                                                                                        
  | --- | --- |
  | `task_create_with_validation.py` | Create a task with a gold set (`validation_params` in `gt` mode) — frames by name or a reproducible random sample — then upload the ground truth annotations into the created GT job |
  | `task_create_with_honeypots.py` | Create a task in `gt_pool` mode so every annotation job carries validation frames; print the pool→job layout, reshuffle it (`--refresh`), retire a bad pool frame (`--disable-frame`) |
  | `task_add_gt_frames.py` | Add a GT job with an exact frame list (by index or by file name) to a task that already exists; refuses to clobber an existing GT job without `--replace` |

  **Datasets at scale** — new docs page `Dataset recipes`

  | Recipe | What it shows |                                                                                                                                                        
  | --- | --- |
  | `dataset_incremental_download.py` | Re-export only the tasks changed since the previous run, tracked in a JSON state file; uses the `updated_date__gt` server-side filter, saves state after each export so an interrupted run resumes, and reports state entries whose tasks are gone |
  | `dataset_bulk_export.py` | Export a selection of tasks (by project, id, or status) locally and/or to a cloud storage, with a CSV manifest, `--skip-existing` resume, and optional worker threads (each worker uilds its own `Client` — a `Client` is not thread-safe). A failing task is recorded and the run exits 1 at the end instead of aborting |

  **Task structuring** — added to the existing `Tasks` page

  | Recipe | What it shows |
  | --- | --- |
  | `task_create_subtasks.py` | Split one image set into standalone tasks by object type / label group (`'boxes:rectangle:car,person'`), so shape types are annotated in parallel with per-subtask label sets |
  | `task_create_job_mapping.py` | Create a task with an explicit `job_file_mapping` — one job per camera/scene/batch, or chunked N files per job — then read the jobs back and report the mapping the server
  actually built |

  **Data quality** — added to the existing `Annotations` page

  | Recipe | What it shows |                                                                                                                                                        
  | --- | --- |
  | `project_data_lint.py` | Lint a project before export: out-of-frame shapes, near-zero-area boxes, duplicated objects (errors); unannotated frames, empty completed jobs (warnings); unused labels (info). Prints findings by severity, writes a CSV, exits 1 on any error so it can gate a pipeline (`--no-fail` opts out) |

  Docs changes:

  - New pages `site/content/en/docs/api_sdk/sdk/examples/ground-truth.md` and `datasets.md`.                                                                    
  - `tasks.md` and `annotations.md` extended with the new recipes, their flag tables, and                                                                                           
    the relevant "Other SDK options" entries.
  - `_index.md` now lists every example category — the `Annotations` and `Webhooks` pages
    existed but were missing from the index; `cloud-storage.md` / `webhooks.md` weights
    bumped to make room for the two new pages.
  - `cvat-sdk/examples/README.md` table extended with the 8 recipes.

  ### How has this been tested?

  36 new tests in `tests/python/sdk/test_examples.py`, run against a live CVAT
  stack the same way the existing example tests are:

  - **Validation / honeypots / GT frames**: the requested frames land in the GT job; the
    random `--frame-count` path; ground truth import lands the expected objects;
    `--refresh` changes the honeypot mapping; `--disable-frame` retires a frame;
    adding GT frames by index and by name; refusal to overwrite an existing GT job;
    out-of-range frames rejected; `--cleanup` removes only the job it created.
  - **Incremental download**: first run exports everything, second run exports nothing,
    a touched task is the only one re-exported, a state file from another project is                                                                            
    rejected, deleted tasks are reported.                                                                                                                                           
  - **Bulk export**: whole project, explicit id list, `--skip-existing`, run continues and
    still exits non-zero after a per-task failure, two worker threads, missing selector
    rejected.
  - **Data lint**: geometry errors reported and the exit code is 1, `--no-fail` exits 0,
    empty-frame warnings on an otherwise clean project, duplicate detection, a task
    outside the project rejected.
  - **Subtasks / job mapping**: one task per label group with correctly typed labels,
    explicit job groups and `--files-per-job` verified against the jobs the server
    returns, malformed specs / unknown label types / unassigned or unknown files rejected.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
