### PR TITLE
Restore mask position after dragging it outside the image

### DIFF
--- a/changelog.d/20260903_062534_sekachev.bs.md
+++ b/changelog.d/20260903_062534_sekachev.bs.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - Mask position is restored when it is moved completely outside the image
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/11145>)

--- a/changelog.d/20260903_062534_sekachev.bs.md
+++ b/changelog.d/20260903_062534_sekachev.bs.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Mask position is restored when it is moved completely outside the image
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/cvat-core/src/annotations-objects/mask-shape.ts
+++ b/cvat-core/src/annotations-objects/mask-shape.ts
@@ -36,7 +36,11 @@ export class MaskShape extends Shape {
         super.validateStateBeforeSave(data, updated, frame);
         if (updated.points) {
             const { width, height } = this.framesInfo[frame];
-            return cropMask(data.points, width, height);
+            const croppedPoints = cropMask(data.points, width, height);
+
+            // Reject an edit that moves the whole mask outside the image instead of
+            // replacing it with the empty-mask sentinel at the top-left corner.
+            return croppedPoints.length < 6 ? [] : croppedPoints;
         }
         return [];
     }

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -237,11 +237,22 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
                         expect(targetX).to.be.lessThan(canvasBox.right);
 
                         cy.get('#cvat_canvas_shape_1')
-                            .trigger('mousedown', { clientX: centerX, clientY: centerY, button: 0 });
+                            .trigger('mousedown', {
+                                clientX: centerX,
+                                clientY: centerY,
+                                button: 0,
+                                buttons: 1,
+                                which: 1,
+                            });
                         cy.get('.cvat-canvas-container')
-                            .trigger('mousemove', { clientX: targetX, clientY: centerY });
+                            .trigger('mousemove', { clientX: targetX, clientY: centerY, buttons: 1 });
                         cy.get('.cvat-canvas-container')
-                            .trigger('mouseup', { clientX: targetX, clientY: centerY });
+                            .trigger('mouseup', {
+                                clientX: targetX,
+                                clientY: centerY,
+                                button: 0,
+                                buttons: 0,
+                            });
 
                         cy.get('#cvat_canvas_shape_1').should(($updatedMask) => {
                             const updatedBox = $updatedMask[0].getBoundingClientRect();
@@ -291,6 +302,106 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
             });
 
             cy.hideTooltips();
+            cy.startMaskDrawing();
+            cy.drawMask([{ method: 'underlying-pixels', value: false }]);
+            cy.finishMaskDrawing();
+        });
+
+        it('Underlying pixels are not removed when a mask is dragged', () => {
+            const firstMask = [{
+                method: 'brush-size',
+                value: 100,
+            }, {
+                method: 'brush',
+                coordinates: [[350, 350]],
+            }];
+            const secondMask = [{
+                method: 'brush',
+                coordinates: [[650, 350]],
+            }, {
+                method: 'underlying-pixels',
+                value: true,
+            }];
+
+            cy.startMaskDrawing();
+            cy.drawMask(firstMask);
+            cy.get('.cvat-brush-tools-continue').click();
+            cy.hideTooltips();
+            cy.drawMask(secondMask);
+            cy.finishMaskDrawing();
+
+            cy.get('#cvat_canvas_shape_1').then(([$firstMask]) => {
+                const firstMaskBox = $firstMask.getBoundingClientRect();
+                const target = {
+                    x: firstMaskBox.left + firstMaskBox.width / 2,
+                    y: firstMaskBox.top + firstMaskBox.height / 2,
+                };
+
+                cy.get('#cvat_canvas_shape_2').then(([$secondMask]) => {
+                    const secondMaskBox = $secondMask.getBoundingClientRect();
+                    const start = {
+                        x: secondMaskBox.left + secondMaskBox.width / 2,
+                        y: secondMaskBox.top + secondMaskBox.height / 2,
+                    };
+
+                    cy.wrap($secondMask).trigger('mousemove', {
+                        clientX: start.x, clientY: start.y, bubbles: true,
+                    });
+                    cy.wrap($secondMask).trigger('mousedown', {
+                        clientX: start.x, clientY: start.y, button: 0, bubbles: true,
+                    });
+                    cy.get('.cvat-canvas-container').trigger('mousemove', {
+                        clientX: target.x, clientY: target.y, bubbles: true,
+                    });
+                    cy.get('.cvat-canvas-container').trigger('mouseup', {
+                        clientX: target.x, clientY: target.y, bubbles: true,
+                    });
+                });
+            });
+
+            cy.get('#cvat_canvas_shape_1').should('exist').and('be.visible');
+            cy.get('.cvat-empty-masks-notification').should('not.exist');
+
+            cy.startMaskDrawing();
+            cy.drawMask([{ method: 'underlying-pixels', value: false }]);
+            cy.finishMaskDrawing();
+        });
+
+        it('Underlying pixels are removed when a mask is redrawn', () => {
+            const firstMask = [{
+                method: 'brush-size',
+                value: 100,
+            }, {
+                method: 'brush',
+                coordinates: [[350, 350]],
+            }];
+            const secondMask = [{
+                method: 'brush',
+                coordinates: [[650, 350]],
+            }, {
+                method: 'underlying-pixels',
+                value: true,
+            }];
+
+            cy.startMaskDrawing();
+            cy.drawMask(firstMask);
+            cy.get('.cvat-brush-tools-continue').click();
+            cy.hideTooltips();
+            cy.drawMask(secondMask);
+            cy.finishMaskDrawing();
+
+            cy.interactAnnotationObjectMenu('#cvat-objects-sidebar-state-item-2', 'Edit');
+            cy.drawMask([{
+                method: 'brush',
+                coordinates: [[350, 350]],
+            }]);
+            cy.finishMaskDrawing();
+
+            cy.get('#cvat_canvas_shape_1').should('not.exist');
+            cy.get('#cvat_canvas_shape_2').should('exist').and('be.visible');
+            cy.get('.cvat-empty-masks-notification').should('be.visible');
+            cy.closeNotification('.cvat-empty-masks-notification');
+
             cy.startMaskDrawing();
             cy.drawMask([{ method: 'underlying-pixels', value: false }]);
             cy.finishMaskDrawing();

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -190,6 +190,36 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
             cy.finishMaskDrawing();
         });
 
+        it('Moving a mask completely outside the image is canceled', () => {
+            cy.startMaskDrawing();
+            cy.drawMask(drawingActions);
+            cy.finishMaskDrawing();
+
+            cy.get('#cvat_canvas_shape_1').then(([$mask]) => {
+                const initialBox = $mask.getBoundingClientRect();
+                const centerX = initialBox.x + initialBox.width / 2;
+                const centerY = initialBox.y + initialBox.height / 2;
+                const targetX = -initialBox.width;
+                const targetY = -initialBox.height;
+
+                cy.get('#cvat_canvas_shape_1').trigger('mousemove');
+                cy.get('#cvat_canvas_shape_1').trigger('mouseover');
+                cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
+                cy.get('#cvat_canvas_shape_1')
+                    .trigger('mousedown', { clientX: centerX, clientY: centerY, button: 0 });
+                cy.get('body').trigger('mousemove', { clientX: targetX, clientY: targetY });
+                cy.get('body').trigger('mouseup', { clientX: targetX, clientY: targetY });
+
+                cy.get('#cvat_canvas_shape_1').should(($updatedMask) => {
+                    const updatedBox = $updatedMask[0].getBoundingClientRect();
+                    expect(updatedBox.x).to.be.closeTo(initialBox.x, 1);
+                    expect(updatedBox.y).to.be.closeTo(initialBox.y, 1);
+                    expect(updatedBox.width).to.be.closeTo(initialBox.width, 1);
+                    expect(updatedBox.height).to.be.closeTo(initialBox.height, 1);
+                });
+            });
+        });
+
         it('Underlying pixels are removed on enabling "Remove underlying pixels" tool', () => {
             const mask1 = [{
                 method: 'brush',

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -662,7 +662,7 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
                 coordinates: [[450, 250], [600, 400], [450, 550], [300, 400]],
             }, {
                 method: 'polygon-minus',
-                coordinates: [[100, 100], [700, 100], [700, 700], [100, 700]],
+                coordinates: [[50, 50], [750, 50], [750, 650], [50, 650]],
             }];
 
             cy.startMaskDrawing();

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -195,6 +195,14 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
             cy.drawMask(drawingActions);
             cy.finishMaskDrawing();
 
+            cy.get('#cvat-objects-sidebar-state-item-1').within(() => {
+                cy.get('.cvat-object-item-button-pinned-enabled').click();
+            });
+            cy.get('#cvat-objects-sidebar-state-item-1').trigger('mouseenter');
+            cy.get('#cvat_canvas_shape_1')
+                .should('have.class', 'cvat_canvas_shape_activated')
+                .and('have.class', 'cvat_canvas_shape_draggable');
+
             cy.get('#cvat_canvas_shape_1').then(([$mask]) => {
                 const initialBox = $mask.getBoundingClientRect();
                 const centerX = initialBox.x + initialBox.width / 2;
@@ -202,9 +210,6 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
                 const targetX = -initialBox.width;
                 const targetY = -initialBox.height;
 
-                cy.get('#cvat_canvas_shape_1').trigger('mousemove');
-                cy.get('#cvat_canvas_shape_1').trigger('mouseover');
-                cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
                 cy.get('#cvat_canvas_shape_1')
                     .trigger('mousedown', { clientX: centerX, clientY: centerY, button: 0 });
                 cy.get('body').trigger('mousemove', { clientX: targetX, clientY: targetY });

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -195,6 +195,10 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
             cy.drawMask(drawingActions);
             cy.finishMaskDrawing();
 
+            for (let i = 0; i < 6; i++) {
+                cy.get('.cvat-canvas-container').trigger('wheel', { deltaY: 8 });
+            }
+
             cy.get('#cvat-objects-sidebar-state-item-1').within(() => {
                 cy.get('.cvat-object-item-button-pinned-enabled').click();
             });
@@ -203,26 +207,38 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
                 .should('have.class', 'cvat_canvas_shape_activated')
                 .and('have.class', 'cvat_canvas_shape_draggable');
 
-            cy.get('#cvat_canvas_shape_1').then(([$mask]) => {
-                const initialBox = $mask.getBoundingClientRect();
-                const centerX = initialBox.x + initialBox.width / 2;
-                const centerY = initialBox.y + initialBox.height / 2;
-                const targetX = -initialBox.width;
-                const targetY = -initialBox.height;
+            cy.get('.cvat-canvas-container').then(([$canvas]) => {
+                const canvasBox = $canvas.getBoundingClientRect();
 
-                cy.get('#cvat_canvas_shape_1')
-                    .trigger('mousedown', { clientX: centerX, clientY: centerY, button: 0 });
-                cy.get('body').trigger('mousemove', { clientX: targetX, clientY: targetY });
-                cy.get('body').trigger('mouseup', { clientX: targetX, clientY: targetY });
+                cy.get('#cvat_canvas_background').then(([$background]) => {
+                    const imageBox = $background.getBoundingClientRect();
 
-                cy.get('#cvat_canvas_shape_1').should(($updatedMask) => {
-                    const updatedBox = $updatedMask[0].getBoundingClientRect();
-                    expect(updatedBox.x).to.be.closeTo(initialBox.x, 1);
-                    expect(updatedBox.y).to.be.closeTo(initialBox.y, 1);
-                    expect(updatedBox.width).to.be.closeTo(initialBox.width, 1);
-                    expect(updatedBox.height).to.be.closeTo(initialBox.height, 1);
+                    cy.get('#cvat_canvas_shape_1').then(([$mask]) => {
+                        const initialBox = $mask.getBoundingClientRect();
+                        const centerX = initialBox.x + initialBox.width / 2;
+                        const centerY = initialBox.y + initialBox.height / 2;
+                        const targetX = imageBox.right + initialBox.width / 2 + 1;
+                        expect(targetX).to.be.lessThan(canvasBox.right);
+
+                        cy.get('#cvat_canvas_shape_1')
+                            .trigger('mousedown', { clientX: centerX, clientY: centerY, button: 0 });
+                        cy.get('.cvat-canvas-container')
+                            .trigger('mousemove', { clientX: targetX, clientY: centerY });
+                        cy.get('.cvat-canvas-container')
+                            .trigger('mouseup', { clientX: targetX, clientY: centerY });
+
+                        cy.get('#cvat_canvas_shape_1').should(($updatedMask) => {
+                            const updatedBox = $updatedMask[0].getBoundingClientRect();
+                            expect(updatedBox.x).to.be.closeTo(initialBox.x, 1);
+                            expect(updatedBox.y).to.be.closeTo(initialBox.y, 1);
+                            expect(updatedBox.width).to.be.closeTo(initialBox.width, 1);
+                            expect(updatedBox.height).to.be.closeTo(initialBox.height, 1);
+                        });
+                    });
                 });
             });
+
+            cy.get('#cvat_canvas_content').dblclick();
         });
 
         it('Underlying pixels are removed on enabling "Remove underlying pixels" tool', () => {

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -71,6 +71,10 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
         });
     });
 
+    beforeEach(() => {
+        cy.get('.cvat-fit-control').click();
+    });
+
     describe('Tests to make sure that basic features work with masks', () => {
         beforeEach(() => {
             cy.removeAnnotations();
@@ -264,8 +268,6 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
                     });
                 });
             });
-
-            cy.get('#cvat_canvas_content').dblclick();
         });
 
         it('Underlying pixels are removed on enabling "Remove underlying pixels" tool', () => {


### PR DESCRIPTION
### Motivation and context

Dragging a mask completely outside the image replaced it with a single pixel in the top-left corner. A fully cropped mask was interpreted as an empty-mask sentinel with a `(0, 0)–(0, 0)` bounding box.

This change rejects that position update, causing the mask to return to its original location. It also adds a Cypress regression test covering the behavior.

### How has this been tested?

- Manually 
### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.