### PR TITLE
Restore objects after canceling redraw

### DIFF
--- a/changelog.d/20260903_070415_sekachev.bs.md
+++ b/changelog.d/20260903_070415_sekachev.bs.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - Canceling shape or mask redraw not restoring the original object on the canvas
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/11146>)

--- a/changelog.d/20260903_070415_sekachev.bs.md
+++ b/changelog.d/20260903_070415_sekachev.bs.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Canceling shape or mask redraw not restoring the original object on the canvas
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -267,6 +267,14 @@ export class CanvasViewImpl implements CanvasView, Listener {
         this.canvas.dispatchEvent(event);
     }
 
+    private restoreDrawHiddenObjects(): void {
+        const hiddenBecauseOfDraw = Object.keys(this.innerObjectsFlags.drawHidden)
+            .map((_clientID): number => +_clientID);
+        for (const clientID of hiddenBecauseOfDraw) {
+            this.setupInnerFlags(clientID, 'drawHidden', false);
+        }
+    }
+
     private resetViewPosition(clientID: number): void {
         const drawnState = this.drawnStates[clientID];
         const drawnShape = this.svgShapes[clientID];
@@ -345,13 +353,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
         continueDraw?: boolean,
         prevDrawData?: DrawData,
     ): void => {
-        const hiddenBecauseOfDraw = Object.keys(this.innerObjectsFlags.drawHidden)
-            .map((_clientID): number => +_clientID);
-        if (hiddenBecauseOfDraw.length) {
-            for (const hidden of hiddenBecauseOfDraw) {
-                this.setupInnerFlags(hidden, 'drawHidden', false);
-            }
-        }
+        this.restoreDrawHiddenObjects();
 
         if (data) {
             const { clientID, elements } = data as any;
@@ -2591,6 +2593,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 } else {
                     this.drawHandler.cancel();
                 }
+                this.restoreDrawHiddenObjects();
             } else if (this.mode === Mode.INTERACT) {
                 this.interactionHandler.cancel();
             } else if (this.mode === Mode.MERGE) {

--- a/tests/cypress/e2e/actions_objects/case_54_redraw_feature.js
+++ b/tests/cypress/e2e/actions_objects/case_54_redraw_feature.js
@@ -155,5 +155,24 @@ context('Redraw feature.', () => {
                 expect($sidebarItem.length).to.be.equal(5);
             });
         });
+
+        it('Restores a shape after canceling a partial redraw.', () => {
+            cy.removeAnnotations();
+            cy.createRectangle(createRectangleShape2Points);
+            cy.get('.cvat-canvas-container').trigger('mousemove', 200, 400);
+            cy.get('.cvat_canvas_shape').should('have.class', 'cvat_canvas_shape_activated');
+
+            cy.get('body').trigger('keydown', { keyCode: keyCodeN, code: 'KeyN', shiftKey: true });
+            cy.get('.cvat-canvas-container').click(
+                createRectangleShape2Points.firstX,
+                createRectangleShape2Points.firstY - 50,
+            );
+            cy.get('body').type('{esc}');
+
+            cy.get('.cvat_canvas_shape')
+                .should('have.length', 1)
+                .and('be.visible')
+                .and('not.have.class', 'cvat_canvas_hidden');
+        });
     });
 });

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -190,6 +190,22 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
             cy.finishMaskDrawing();
         });
 
+        it('Restores a mask after canceling redraw', () => {
+            cy.startMaskDrawing();
+            cy.drawMask(drawingActions);
+            cy.finishMaskDrawing();
+            cy.get('.cvat-canvas-container').trigger('mousemove', 450, 300);
+            cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
+
+            cy.get('body').trigger('keydown', { keyCode: 78, code: 'KeyN', shiftKey: true });
+            cy.get('.cvat-brush-tools-toolbox').should('exist').and('be.visible');
+            cy.get('body').type('{esc}');
+
+            cy.get('#cvat_canvas_shape_1')
+                .should('be.visible')
+                .and('not.have.class', 'cvat_canvas_hidden');
+        });
+
         it('Underlying pixels are removed on enabling "Remove underlying pixels" tool', () => {
             const mask1 = [{
                 method: 'brush',


### PR DESCRIPTION
### Motivation and context

Canceling a redraw could leave the original object invisible even though it remained in the annotation collection.

This occurred because the original object’s temporary `drawHidden` flag was normally cleared by the draw-completion callback. Partial redraws of rectangles, polygons, polylines, points, and cuboids bypassed that callback during cancellation. Masks always bypassed it.

Restore redraw-hidden objects explicitly when drawing is canceled, making cancellation consistent across all supported shape types.

### How has this been tested?

- Added Cypress coverage for canceling a partially drawn rectangle redraw.
- Added Cypress coverage for canceling a mask redraw before drawing.

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.