### PR TITLE
Prevent underlying pixel removal when dragging masks

### DIFF
--- a/changelog.d/20260903_064848_sekachev.bs.md
+++ b/changelog.d/20260903_064848_sekachev.bs.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - The **Remove underlying pixels** option affecting masks when they are dragged
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/11152>)

--- a/changelog.d/20260903_064848_sekachev.bs.md
+++ b/changelog.d/20260903_064848_sekachev.bs.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- The **Remove underlying pixels** option affecting masks when they are dragged
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/cvat-core/src/annotations-objects/mask-shape.ts
+++ b/cvat-core/src/annotations-objects/mask-shape.ts
@@ -14,6 +14,8 @@ import { Shape } from './shape';
 import { computeNewSource } from './utils';
 import type { AnnotationInjection } from './types';
 
+type ValidatedMaskPoints = number[] & { initialPoints: number[] };
+
 export class MaskShape extends Shape {
     public left: number;
     public top: number;
@@ -34,11 +36,14 @@ export class MaskShape extends Shape {
 
     protected validateStateBeforeSave(data: ObjectState, updated: ObjectState['updateFlags'], frame?: number): number[] {
         super.validateStateBeforeSave(data, updated, frame);
+        const maskPoints: ValidatedMaskPoints = Object.assign([], { initialPoints: data.points });
+        // Cropping can change the RLE when a mask is dragged outside the frame. Keep the original points
+        // temporarily so savePoints can distinguish translation of unchanged pixels from an actual redraw.
         if (updated.points) {
             const { width, height } = this.framesInfo[frame];
-            return cropMask(data.points, width, height);
+            maskPoints.push(...cropMask(data.points, width, height));
         }
-        return [];
+        return maskPoints;
     }
 
     public removeUnderlyingPixels(frame: number):
@@ -149,6 +154,18 @@ export class MaskShape extends Shape {
     }
 
     protected savePoints(maskPoints: number[], frame: number): void {
+        const validatedMaskPoints = maskPoints as ValidatedMaskPoints;
+        const { initialPoints } = validatedMaskPoints;
+        delete validatedMaskPoints.initialPoints;
+
+        const [initialLeft, initialTop, initialRight, initialBottom] = initialPoints.slice(-4);
+        const initialRLE = initialPoints.slice(0, -4);
+        const isTranslation =
+            initialRight - initialLeft === this.right - this.left &&
+            initialBottom - initialTop === this.bottom - this.top &&
+            initialRLE.length === this.points.length &&
+            initialRLE.every((value, index) => value === this.points[index]);
+
         const undoPoints = this.points;
         const undoLeft = this.left;
         const undoRight = this.right;
@@ -183,7 +200,7 @@ export class MaskShape extends Shape {
         };
 
         redo();
-        if (config.removeUnderlyingMaskPixels.enabled) {
+        if (config.removeUnderlyingMaskPixels.enabled && !isTranslation) {
             const {
                 clientIDs,
                 emptyMaskOccurred,


### PR DESCRIPTION
### Motivation and context

The **Remove underlying pixels** option should affect only newly drawn or redrawn masks. Previously, moving an existing mask over another mask also removed pixels from the underlying mask.

This change detects pure mask translations by comparing the original, uncropped RLE and dimensions with the current mask. Original points are preserved temporarily during validation because cropping a mask at the frame boundary can otherwise make a translation appear to be a redraw.

### How has this been tested?

- Manually

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- ~~I have linked related issues~~

### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.