### PR TITLE
Prevent slice tool from creating empty masks

### DIFF
--- a/changelog.d/20260904_084710_sekachev.bs.md
+++ b/changelog.d/20260904_084710_sekachev.bs.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- The slice tool could create an empty mask when slicing between disconnected mask regions
+  (<https://github.com/cvat-ai/cvat/pull/XXXX>)

--- a/changelog.d/20260904_084710_sekachev.bs.md
+++ b/changelog.d/20260904_084710_sekachev.bs.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - The slice tool could create an empty mask when slicing between disconnected mask regions
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/11153>)

--- a/cvat-canvas/src/typescript/sliceHandler.ts
+++ b/cvat-canvas/src/typescript/sliceHandler.ts
@@ -363,6 +363,12 @@ export class SliceHandlerImpl implements SliceHandler {
                 drawOverOffscreenCanvas(context, shape as any as SVGImageElement);
                 applyOffscreenCanvasMask(context, polygon2);
                 const secondShape = imageDataToRLE(context.getImageData(0, 0, width, height).data);
+
+                if (firstShape.length < 2 || secondShape.length < 2) {
+                    this.slice({ enabled: false });
+                    return;
+                }
+
                 this.onSliceDone(sliceData.state, [firstShape, secondShape], Date.now() - this.startTimestamp);
             } else if (sliceData.shapeType === 'polygon') {
                 this.onSliceDone(


### PR DESCRIPTION
### Motivation and context

The slice tool could produce an empty mask when slicing through the gap between disconnected mask regions. This caused an invisible object to be created and could prevent annotations from being saved.

Cancel the slicing operation when either generated mask contains no foreground pixels. The original mask remains unchanged and the slice tool exits cleanly.

Resolved #11143.

### How has this been tested?

- Manually

### Checklist

- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment
- [x] ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] I have linked related issues

### License

- [x] I submit _my code changes_ under the same [[MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE)](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.