### PR TITLE
API documentation for organization filters

### DIFF
--- a/changelog.d/20260615_120000_document_org_filters.md
+++ b/changelog.d/20260615_120000_document_org_filters.md
@@ -1,0 +1,5 @@
+### Added
+
+- \[Server API\] Documentation for organization filtering parameters (`org`, `org_id`,
+  and the `X-Organization` header) for endpoints that return object lists and others
+  (<https://github.com/cvat-ai/cvat/issues/10776>)

--- a/cvat/apps/iam/filters.py
+++ b/cvat/apps/iam/filters.py
@@ -5,27 +5,45 @@
 from drf_spectacular.utils import OpenApiParameter
 from rest_framework.filters import BaseFilterBackend
 
+ORG_SLUG_PARAM_DESCRIPTION = """\
+Organization unique slug.
+If omitted, results from all organizations available to the user are returned
+(unfiltered). An empty value ("") selects the personal sandbox workspace only.
+A non-empty value selects that organization.
+"""
+
+ORG_ID_PARAM_DESCRIPTION = """\
+Organization unique id.
+If omitted, results from all organizations available to the user are returned
+(unfiltered). An empty value ("") selects the personal sandbox workspace only.
+A positive integer selects that organization.
+"""
+
+
 ORGANIZATION_OPEN_API_PARAMETERS = [
     OpenApiParameter(
         name="org",
         type=str,
         required=False,
         location=OpenApiParameter.QUERY,
-        description="Organization unique slug",
+        description=ORG_SLUG_PARAM_DESCRIPTION,
+        allow_blank=True,
     ),
     OpenApiParameter(
         name="org_id",
         type=int,
         required=False,
         location=OpenApiParameter.QUERY,
-        description="Organization identifier",
+        description=ORG_ID_PARAM_DESCRIPTION,
+        allow_blank=True,
     ),
     OpenApiParameter(
         name="X-Organization",
         type=str,
         required=False,
         location=OpenApiParameter.HEADER,
-        description="Organization unique slug",
+        description=ORG_SLUG_PARAM_DESCRIPTION,
+        allow_blank=True,
     ),
 ]
 
@@ -48,18 +66,25 @@ class OrganizationFilterBackend(BaseFilterBackend):
         for parameter in ORGANIZATION_OPEN_API_PARAMETERS:
             parameter_type = None
 
-            if parameter.type == int:
+            if parameter.type is int:
                 parameter_type = "integer"
-            elif parameter.type == str:
+            elif parameter.type is str:
                 parameter_type = "string"
 
-            parameters.append(
-                {
-                    "name": parameter.name,
-                    "in": parameter.location,
-                    "description": parameter.description,
-                    "schema": {"type": parameter_type},
-                }
-            )
+            param = {
+                "name": parameter.name,
+                "in": parameter.location,
+                "description": parameter.description,
+                "schema": {"type": parameter_type},
+            }
+
+            # allowEmptyValue is deprecated in OpenAPI 3: https://spec.openapis.org/oas/v3.0.3.html
+            # We use it here to show the option to pass an empty value in the Swagger UI.
+            # The empty value has been used in CVAT for quite a while already,
+            # and removing it is expected to be a huge breaking change to the API.
+            if parameter.allow_blank:
+                param["allowEmptyValue"] = True
+
+            parameters.append(param)
 
         return parameters

--- a/cvat/apps/iam/filters.py
+++ b/cvat/apps/iam/filters.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
+# Copyright (C) CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/iam/tests/test_organization_middleware.py
+++ b/cvat/apps/iam/tests/test_organization_middleware.py
@@ -1,0 +1,79 @@
+# Copyright (C) CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.test import RequestFactory, TestCase
+from rest_framework.exceptions import ValidationError
+
+from cvat.apps.iam.middleware import get_organization
+from cvat.apps.organizations.models import Organization
+
+
+class OrganizationMiddlewareTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = self._create_user("tester")
+        admin_group, _ = Group.objects.get_or_create(name="admin")
+        self.user.groups.add(admin_group)
+        self.organization = Organization.objects.create(slug="testorg", name="Test Org")
+
+    @staticmethod
+    def _create_user(username: str):
+        return get_user_model().objects.create_user(username=username, password="pass")
+
+    def _get_context(self, query_string: str = "", *, headers: dict[str, Any] | None = None):
+        request = self.factory.get(f"/api/tasks{query_string}", headers=headers)
+        request.user = self.user
+        return get_organization(request)
+
+    def test_no_org_parameter_returns_all_organizations(self):
+        context = self._get_context()
+
+        assert context["organization"] is None
+        assert context["organization_specified"] is False
+
+    def test_empty_org_parameter_returns_sandbox(self):
+        context = self._get_context("?org=")
+
+        assert context["organization"] is None
+        assert context["organization_specified"] is True
+
+    def test_empty_org_id_parameter_returns_sandbox(self):
+        context = self._get_context("?org_id=")
+
+        assert context["organization"] is None
+        assert context["organization_specified"] is True
+
+    def test_org_slug_selects_organization(self):
+        context = self._get_context("?org=testorg")
+
+        assert context["organization"] == self.organization
+        assert context["organization_specified"] is True
+
+    def test_org_id_selects_organization(self):
+        context = self._get_context(f"?org_id={self.organization.id}")
+
+        assert context["organization"] == self.organization
+        assert context["organization_specified"] is True
+
+    def test_org_filters_cannot_be_used_together(self):
+        with self.assertRaisesRegex(ValidationError, r"cannot specify \"org_id\".*with.*\"org\""):
+            self._get_context(f"?org_id={self.organization.id}&org={self.organization.slug}")
+
+        with self.assertRaisesRegex(ValidationError, r"cannot specify \"org_id\".*with.*\"org\""):
+            self._get_context(
+                f"?org_id={self.organization.id}",
+                headers={"X-Organization": self.organization.slug},
+            )
+
+        with self.assertRaisesRegex(
+            ValidationError, r"cannot specify \"org\".*and.*\"X-Organization\""
+        ):
+            self._get_context(
+                f"?org={self.organization.slug}",
+                headers={"X-Organization": "not" + self.organization.slug},
+            )

--- a/cvat/schema.yml
+++ b/cvat/schema.yml
@@ -482,9 +482,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: credentials_type
         in: query
         description: A simple equality filter for the credentials_type field
@@ -519,14 +524,24 @@ paths:
           type: string
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: owner
         in: query
         description: A simple equality filter for the owner field
@@ -597,17 +612,29 @@ paths:
         name: X-Organization
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org_id
         schema:
           type: integer
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
       tags:
       - cloudstorages
       requestBody:
@@ -944,9 +971,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: filter
         required: false
         in: query
@@ -980,14 +1012,24 @@ paths:
           type: integer
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: owner
         in: query
         description: A simple equality filter for the owner field
@@ -1042,17 +1084,29 @@ paths:
         name: X-Organization
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org_id
         schema:
           type: integer
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
       tags:
       - comments
       requestBody:
@@ -1191,9 +1245,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: filter
         required: false
         in: query
@@ -1212,14 +1271,24 @@ paths:
           type: string
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: page
         required: false
         in: query
@@ -1406,17 +1475,29 @@ paths:
         name: X-Organization
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org_id
         schema:
           type: integer
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
       tags:
       - events
       requestBody:
@@ -1743,9 +1824,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: accepted
         in: query
         description: A simple equality filter for the accepted field
@@ -1769,14 +1855,24 @@ paths:
           type: string
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: owner
         in: query
         description: A simple equality filter for the owner field
@@ -1836,17 +1932,29 @@ paths:
         name: X-Organization
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org_id
         schema:
           type: integer
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
       tags:
       - invitations
       requestBody:
@@ -2002,9 +2110,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: assignee
         in: query
         description: A simple equality filter for the assignee field
@@ -2038,14 +2151,24 @@ paths:
           type: integer
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: owner
         in: query
         description: A simple equality filter for the owner field
@@ -2111,17 +2234,29 @@ paths:
         name: X-Organization
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org_id
         schema:
           type: integer
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
       tags:
       - issues
       requestBody:
@@ -2231,9 +2366,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: assignee
         in: query
         description: A simple equality filter for the assignee field
@@ -2283,14 +2423,24 @@ paths:
           - interpolation
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: page
         required: false
         in: query
@@ -3108,7 +3258,11 @@ paths:
         name: X-Organization
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - name: color
         in: query
         description: A simple equality filter for the color field
@@ -3144,12 +3298,20 @@ paths:
         name: org
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org_id
         schema:
           type: integer
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
       - name: page
         required: false
         in: query
@@ -3419,17 +3581,29 @@ paths:
         name: X-Organization
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org_id
         schema:
           type: integer
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
       tags:
       - lambda
       requestBody:
@@ -3508,9 +3682,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: filter
         required: false
         in: query
@@ -3529,14 +3708,24 @@ paths:
           type: string
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: page
         required: false
         in: query
@@ -3863,9 +4052,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: assignee
         in: query
         description: A simple equality filter for the assignee field
@@ -3894,14 +4088,24 @@ paths:
           type: string
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: owner
         in: query
         description: A simple equality filter for the owner field
@@ -3966,17 +4170,29 @@ paths:
         name: X-Organization
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org_id
         schema:
           type: integer
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
       tags:
       - projects
       requestBody:
@@ -4343,7 +4559,11 @@ paths:
         name: X-Organization
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: cloud_storage_id
         schema:
@@ -4367,12 +4587,20 @@ paths:
         name: org
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org_id
         schema:
           type: integer
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
       tags:
       - projects
       requestBody:
@@ -4404,9 +4632,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: filter
         required: false
         in: query
@@ -4435,14 +4668,24 @@ paths:
           type: integer
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: page
         required: false
         in: query
@@ -4533,9 +4776,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: filter
         required: false
         in: query
@@ -4565,14 +4813,24 @@ paths:
           type: integer
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: page
         required: false
         in: query
@@ -4829,9 +5087,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: filter
         required: false
         in: query
@@ -4855,14 +5118,24 @@ paths:
           type: boolean
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: page
         required: false
         in: query
@@ -5012,9 +5285,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: annotation_type
         in: query
         description: A simple equality filter for the annotation_type field
@@ -5053,14 +5331,24 @@ paths:
           type: string
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: page
         required: false
         in: query
@@ -5675,9 +5963,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: assignee
         in: query
         description: A simple equality filter for the assignee field
@@ -5739,14 +6032,24 @@ paths:
           type: string
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: owner
         in: query
         description: A simple equality filter for the owner field
@@ -5844,17 +6147,29 @@ paths:
         name: X-Organization
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org_id
         schema:
           type: integer
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
       tags:
       - tasks
       requestBody:
@@ -6767,7 +7082,11 @@ paths:
         name: X-Organization
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: cloud_storage_id
         schema:
@@ -6791,12 +7110,20 @@ paths:
         name: org
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org_id
         schema:
           type: integer
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
       tags:
       - tasks
       requestBody:
@@ -6828,9 +7155,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: filter
         required: false
         in: query
@@ -6864,14 +7196,24 @@ paths:
           type: string
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: page
         required: false
         in: query
@@ -7027,9 +7369,14 @@ paths:
       parameters:
       - name: X-Organization
         in: header
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: filter
         required: false
         in: query
@@ -7048,14 +7395,24 @@ paths:
           type: string
       - name: org
         in: query
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
         schema:
           type: string
+        allowEmptyValue: true
       - name: org_id
         in: query
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
         schema:
           type: integer
+        allowEmptyValue: true
       - name: owner
         in: query
         description: A simple equality filter for the owner field
@@ -7130,17 +7487,29 @@ paths:
         name: X-Organization
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org
         schema:
           type: string
-        description: Organization unique slug
+        description: |
+          Organization unique slug.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A non-empty value selects that organization.
       - in: query
         name: org_id
         schema:
           type: integer
-        description: Organization identifier
+        description: |
+          Organization unique id.
+          If omitted, results from all organizations available to the user are returned
+          (unfiltered). An empty value ("") selects the personal sandbox workspace only.
+          A positive integer selects that organization.
       tags:
       - webhooks
       requestBody:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Related https://github.com/cvat-ai/cvat/issues/10776
Finalization of https://github.com/cvat-ai/cvat/pull/10811

- Added API documentation for `org`, `org_id`, and `X-Organization` parameters

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Unit tests

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
