### PR TITLE
Enable the default backing CS migration for video tasks

### DIFF
--- a/changelog.d/20260910_193140_roman_HEAD.md
+++ b/changelog.d/20260910_193140_roman_HEAD.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Eligible video tasks are now automatically moved to the default backing
+  cloud storage upon creation (if the storage is configured and is S3-like)
+  (<https://github.com/cvat-ai/cvat/pull/11169>)

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -2062,11 +2062,7 @@ def initialize_task(
     if not (is_data_in_cloud and is_backup_restore):
         _create_task_preview(db_task)
 
-    # TODO: remove the condition.
-    # We don't yet have production experience with videos in backing CS,
-    # so let's be cautious and not move them automatically.
-    if db_task.mode != models.TaskMode.INTERPOLATION:
-        _move_to_backing_cs_if_configured(db_data)
+    _move_to_backing_cs_if_configured(db_data)
 
 
 def _create_task_preview(db_task: models.Task):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Production experience hasn't surfaced any problems with backing CS for videos, so I think this can now be enabled.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
