### PR TITLE
Audio: fix annotation showing all label types as available for intervals

### DIFF
--- a/changelog.d/20260911_122553_aleksey.zinovyev_interval_label_type.md
+++ b/changelog.d/20260911_122553_aleksey.zinovyev_interval_label_type.md
@@ -1,0 +1,5 @@
+### Added
+
+- Added the `interval` label type for audio annotation. New audio intervals can only use
+  `interval` and `any` labels.
+  (<https://github.com/cvat-ai/cvat/pull/11172>)

--- a/cvat-core/src/enums.ts
+++ b/cvat-core/src/enums.ts
@@ -273,6 +273,7 @@ export enum LabelType {
     POINTS = 'points',
     ELLIPSE = 'ellipse',
     CUBOID = 'cuboid',
+    INTERVAL = 'interval',
     SKELETON = 'skeleton',
     MASK = 'mask',
     TAG = 'tag',

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/audio-interval-header.tsx
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/audio-interval-header.tsx
@@ -6,10 +6,11 @@ import React from 'react';
 import { Col, Row } from 'antd/lib/grid';
 import classNames from 'classnames';
 
-import { AudioIntervalState, Label } from 'cvat-core-wrapper';
+import { AudioIntervalState, Label, LabelType } from 'cvat-core-wrapper';
 import { formatMilliseconds, formatTimeShort } from 'audio/utils/format-audio-time';
 import { ColorBy } from 'reducers';
 import LabelSelector from 'components/label-selector/label-selector';
+import { filterApplicableForType } from 'utils/filter-applicable-labels';
 import AudioIntervalActions, { AudioIntervalActionShortcuts } from './audio-interval-actions';
 import AudioIntervalMoreActions from './audio-interval-more-actions';
 import { intervalDurationSeconds, intervalEndSeconds, intervalStartSeconds } from './utils/audio-interval';
@@ -45,6 +46,7 @@ export default function AudioIntervalHeader({
     const start = intervalStartSeconds(interval);
     const end = intervalEndSeconds(interval);
     const duration = intervalDurationSeconds(interval);
+    const applicableLabels = filterApplicableForType(LabelType.INTERVAL, labels);
 
     const labelSelector = (
         <LabelSelector
@@ -52,7 +54,7 @@ export default function AudioIntervalHeader({
             className='cvat-audio-interval-header-label-selector'
             popupClassName='cvat-audio-interval-header-label-dropdown'
             popupMatchSelectWidth={false}
-            labels={labels}
+            labels={applicableLabels}
             value={interval.label.id ?? null}
             disabled={isReadonly}
             tooltip='Change current label'

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/audio-interval-header.tsx
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/audio-interval-header.tsx
@@ -47,6 +47,11 @@ export default function AudioIntervalHeader({
     const end = intervalEndSeconds(interval);
     const duration = intervalDurationSeconds(interval);
     const applicableLabels = filterApplicableForType(LabelType.INTERVAL, labels);
+    // Old intervals may have labels that are not applicable for intervals anymore,
+    // so we need to add them to the list of labels for the selector
+    const labelsForSelector = applicableLabels.some((label) => label.id === interval.label.id) ?
+        applicableLabels :
+        [interval.label, ...applicableLabels];
 
     const labelSelector = (
         <LabelSelector
@@ -54,7 +59,7 @@ export default function AudioIntervalHeader({
             className='cvat-audio-interval-header-label-selector'
             popupClassName='cvat-audio-interval-header-label-dropdown'
             popupMatchSelectWidth={false}
-            labels={applicableLabels}
+            labels={labelsForSelector}
             value={interval.label.id ?? null}
             disabled={isReadonly}
             tooltip='Change current label'

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/controls-side-bar/controls-side-bar.tsx
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/controls-side-bar/controls-side-bar.tsx
@@ -5,9 +5,11 @@
 import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Layout from 'antd/lib/layout';
+import { LabelType } from 'cvat-core-wrapper';
 
 import { ActiveControl, CombinedState } from 'reducers';
 import { shallowEqual, ThunkDispatch } from 'utils/redux';
+import { filterApplicableForType } from 'utils/filter-applicable-labels';
 import { updateActiveControl } from 'actions/annotation-actions';
 import {
     audioActions,
@@ -55,6 +57,7 @@ export default function AudioControlsSideBarComponent(): JSX.Element {
         labels: state.annotation.job.labels,
         activeLabelId: state.audio.player.activeLabelId,
     }), shallowEqual);
+    const applicableLabels = filterApplicableForType(LabelType.INTERVAL, labels);
 
     const updateAudioActiveControl = useCallback((control: ActiveControl): void => {
         dispatch(updateActiveControl(control));
@@ -90,7 +93,7 @@ export default function AudioControlsSideBarComponent(): JSX.Element {
                 createRegionShortkey={normalizedKeyMap.CREATE_AUDIO_REGION}
                 recordRegionShortkey={normalizedKeyMap.RECORD_AUDIO_REGION}
                 extendRegionShortkey={normalizedKeyMap.EXTEND_AUDIO_REGION_FROM_LAST}
-                labels={labels}
+                labels={applicableLabels}
                 activeLabelId={activeLabelId}
                 onExtendRegion={onExtendRegion}
                 onSetActiveLabel={onSetActiveLabel}

--- a/cvat-ui/src/audio/components/annotation-page/audio-workspace/objects-side-bar/audio-labels-list.tsx
+++ b/cvat-ui/src/audio/components/annotation-page/audio-workspace/objects-side-bar/audio-labels-list.tsx
@@ -23,6 +23,8 @@ import { registerComponentShortcuts } from 'actions/shortcuts-actions';
 import { subKeyMap } from 'utils/component-subkeymap';
 import { useResetShortcutsOnUnmount } from 'utils/hooks';
 import { getCVATStore } from 'cvat-store';
+import { LabelType } from 'cvat-core-wrapper';
+import { filterApplicableForType } from 'utils/filter-applicable-labels';
 
 const componentShortcuts: Record<string, KeyMapItem> = {};
 
@@ -126,12 +128,16 @@ function AudioLabelsList(): JSX.Element {
     }), shallowEqual);
 
     const labelIDs = useMemo(() => labels.map((label: any): number => label.id), [labels]);
+    const applicableLabelIDs = useMemo(
+        () => filterApplicableForType(LabelType.INTERVAL, labels).map((label) => label.id as number),
+        [labels],
+    );
 
     useResetShortcutsOnUnmount(componentShortcuts);
 
     const keyToLabelMapping = useMemo(() => Object.fromEntries(
-        labelIDs.slice(0, 10).map((labelID: number, idx: number) => [(idx + 1) % 10, labelID]),
-    ), [labelIDs]);
+        applicableLabelIDs.slice(0, 10).map((labelID: number, idx: number) => [(idx + 1) % 10, labelID]),
+    ), [applicableLabelIDs]);
 
     useEffect(() => {
         const updated = JSON.parse(JSON.stringify(componentShortcuts));

--- a/cvat-ui/src/components/annotation-page/annotation-page.tsx
+++ b/cvat-ui/src/components/annotation-page/annotation-page.tsx
@@ -10,7 +10,7 @@ import notification from 'antd/lib/notification';
 import Button from 'antd/lib/button';
 
 import './styles.scss';
-import { Job } from 'cvat-core-wrapper';
+import { DimensionType, Job, LabelType } from 'cvat-core-wrapper';
 import AttributeAnnotationWorkspace from 'components/annotation-page/attribute-annotation-workspace/attribute-annotation-workspace';
 import SingleShapeWorkspace from 'components/annotation-page/single-shape-workspace/single-shape-workspace';
 import ReviewAnnotationsWorkspace from 'components/annotation-page/review-workspace/review-workspace';
@@ -27,6 +27,7 @@ import { usePrevious } from 'utils/hooks';
 import EventRecorder from 'utils/event-recorder';
 import { readLatestFrame } from 'utils/remember-latest-frame';
 import { EventScope } from 'cvat-core/src/enums';
+import { filterApplicableForType } from 'utils/filter-applicable-labels';
 import SearchFramesModal from './top-bar/search-modal';
 
 interface Props {
@@ -109,14 +110,17 @@ export default function AnnotationPageComponent(props: Props): JSX.Element {
 
             EventRecorder.logger = job.logger;
 
-            if (!job.labels.length) {
+            const applicableLabels = job.dimension === DimensionType.DIMENSION_1D ?
+                filterApplicableForType(LabelType.INTERVAL, job.labels) :
+                job.labels;
+            if (!applicableLabels.length) {
                 notification.warning({
                     message: 'No labels',
                     description: (
                         <span>
                             {`${job.projectId ? 'Project' : 'Task'} ${
                                 job.projectId || job.taskId
-                            } does not contain any labels. `}
+                            } does not contain any compatible labels. `}
                             <a href={`/${job.projectId ? 'projects' : 'tasks'}/${job.projectId || job.taskId}/`}>
                                 Add
                             </a>

--- a/cvat-ui/src/reducers/audio-reducer.ts
+++ b/cvat-ui/src/reducers/audio-reducer.ts
@@ -2,11 +2,15 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { AnyAction } from 'redux';
 import { AnnotationActionTypes } from 'actions/annotation-actions';
-import { AudioActionTypes } from 'actions/audio-actions';
+import { AudioActions, AudioActionTypes } from 'actions/audio-actions';
 import { BoundariesActionTypes } from 'actions/boundaries-actions';
 import { limitZoom } from 'audio/utils/waveform-geometry';
+import {
+    DimensionType, LabelType,
+} from 'cvat-core-wrapper';
+import { filterApplicableForType } from 'utils/filter-applicable-labels';
+
 import { ActiveControl, AudioState } from '.';
 
 const defaultState: AudioState = {
@@ -40,16 +44,30 @@ const defaultState: AudioState = {
     },
 };
 
-export default function audioReducer(state: AudioState = defaultState, action: AnyAction): AudioState {
+type AudioReducerAction =
+    | AudioActions
+    | {
+        type:
+            | BoundariesActionTypes.RESET_AFTER_ERROR
+            | AnnotationActionTypes.GET_JOB_SUCCESS
+            | AnnotationActionTypes.UPDATE_ACTIVE_CONTROL
+            | AnnotationActionTypes.FETCH_ANNOTATIONS_SUCCESS;
+        payload: any;
+    };
+
+export default function audioReducer(state: AudioState = defaultState, action: AudioReducerAction): AudioState {
     switch (action.type) {
         case BoundariesActionTypes.RESET_AFTER_ERROR:
         case AnnotationActionTypes.GET_JOB_SUCCESS: {
             const { job } = action.payload;
+            const labels = job.dimension === DimensionType.DIMENSION_1D ?
+                filterApplicableForType(LabelType.INTERVAL, job.labels) :
+                job.labels;
             return {
                 ...defaultState,
                 player: {
                     ...defaultState.player,
-                    activeLabelId: job.labels.length ? job.labels[0].id : null,
+                    activeLabelId: (labels.length ? labels[0].id : null) ?? null,
                 },
             };
         }

--- a/tests/cypress/e2e/actions_projects_models/case_57_project_label_deleting_feature.js
+++ b/tests/cypress/e2e/actions_projects_models/case_57_project_label_deleting_feature.js
@@ -82,7 +82,7 @@ context('Delete a label from a project.', () => {
         it('Open a job with no labels in the project. "No labels" notification is shown.', () => {
             cy.openTaskJob(taskName);
             cy.get('.cvat-disabled-canvas-control').should('exist');
-            cy.contains('.cvat-notification-no-labels', 'does not contain any labels').should('exist').and('be.visible');
+            cy.contains('.cvat-notification-no-labels', 'does not contain any compatible labels').should('exist').and('be.visible');
         });
     });
 });

--- a/tests/cypress/e2e/actions_tasks/case_58_task_label_deleting_feature.js
+++ b/tests/cypress/e2e/actions_tasks/case_58_task_label_deleting_feature.js
@@ -44,7 +44,7 @@ context('Delete a label from a task.', () => {
         it('Try to open a job with no labels. Successful.', () => {
             cy.openJob();
             cy.get('.cvat-disabled-canvas-control').should('exist');
-            cy.contains('.cvat-notification-no-labels', 'does not contain any labels').should('exist').and('be.visible');
+            cy.contains('.cvat-notification-no-labels', 'does not contain any compatible labels').should('exist').and('be.visible');
         });
     });
 });


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Creating a project with different label types and then creating an audio task in this project results in all the labels of various types to be available as interval labels.

This change introduces dedicated interval label type and starts filtering only applicable labels (interval/any) to be available for new intervals in an audio task. Old annotations with incompatible labels remain available.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Tested manually.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
