### PR TITLE
fix e2e native_functions.js for release 2.75

### DIFF
--- a/tests/cypress/support/commands_annotations_actions.js
+++ b/tests/cypress/support/commands_annotations_actions.js
@@ -18,9 +18,8 @@ Cypress.Commands.add('openAnnotationsActionsModal', () => {
 Cypress.Commands.add('runAnnotationsAction', () => {
     cy.get('.cvat-action-runner-run-btn').click();
     cy.get('.cvat-action-runner-run-btn').should('be.disabled');
+    cy.get('.cvat-action-runner-cancel-btn').should('have.text', 'Cancel');
     cy.get('.cvat-action-runner-progress').should('exist').and('be.visible');
-    cy.contains(/Actions? initialization/).should('exist').and('be.visible');
-    cy.contains(/Actions? initialization/).should('not.exist');
 });
 
 Cypress.Commands.add('cancelAnnotationsAction', () => {


### PR DESCRIPTION
Changes from #11163 fail release checks in private repo: https://github.com/cvat-ai/app.cvat.ai/actions/runs/34509385280/job/103177466445?pr=1058

- Replaced the path-specific “Action initialization” assertion with the stable Cancel button state.
- Retained the visible progress check to prevent waitAnnotationsAction from completing before progress begins.
- Kept the existing 30-second completion timeout unchanged.